### PR TITLE
Add neighbourhood processing CLI acceptance tests and enhance improver tests interface

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -18,52 +18,89 @@ function echo_ok {
     echo -e "\033[1;32m[OK]\033[0m $1"
 }
 
+function improver_test_pep8 {
+    # PEP8 testing.
+    ${PEP8:-pep8} improver
+    echo_ok "pep8"
+}
+
+function improver_test_pylint {
+    # Pylint obvious-errors-only testing.
+    ${PYLINT:-pylint} --rcfile=../etc/pylintrc improver
+}
+
+function improver_test_pylintE {
+    # Pylint obvious-errors-only testing.
+    ${PYLINT:-pylint} -E --rcfile=../etc/pylintrc improver
+    echo_ok "pylint -E"
+}
+
+function improver_test_doc {
+    # Build documentation as test.
+    cd $IMPROVER_DIR/doc
+    make html 1>/dev/null
+    echo_ok "sphinx-build -b html"
+    cd -
+}
+
+function improver_test_unit {
+    # Unit tests.
+    python -m unittest discover
+    echo_ok "Unit tests"
+}
+
+function improver_test_cli {
+    # CLI testing.
+    PATH="$IMPROVER_DIR/tests/bin/:$PATH"
+    if [[ ${1:-} != '--debug' ]] && type prove &>/dev/null; then
+        prove -j $(nproc) -r -e "bats --tap" \
+            --ext ".bats" "$IMPROVER_DIR/tests/"
+    else
+        bats $(find "$IMPROVER_DIR/tests/" -name "*.bats")
+    fi
+    echo_ok "CLI tests"
+}
+
+cd $IMPROVER_DIR/lib
+
 if [[ ${1:-} == '--help' ]] || [[ ${1:-} == '-h' ]]; then
     cat <<'__USAGE__'
-improver tests [--debug]
+improver tests [--debug] [SUBTEST] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
     --debug         Run in verbose mode (may take longer for CLI)
     -h, --help          Show this message and exit
+
+Arguments:
+    SUBTEST         Name of a subtest to run without running the rest.
+                    Valid names are: pep8, pylint, pylintE, unit, cli.
+                    pep8, pylintE, unit, and cli are the default tests.
 __USAGE__
     exit 0
 fi
-if [[ -n "${1:-}" && ${1:-} != '--debug' ]]; then
+
+DEBUG_OPT=
+if [[ "${1:-}" == '--debug' ]]; then
+    DEBUG_OPT='--debug'
+    shift
+fi
+
+if [[ -n "${1:-}" ]]; then
+    TEST_NAME="improver_test_$1"
+    shift
+    if [[ $(type -t $TEST_NAME) == 'function' ]]; then
+        "$TEST_NAME" "$@" "$DEBUG_OPT"
+        exit 0
+    fi
     improver tests --help
     exit 2
 fi
 
-cd $IMPROVER_DIR/lib
-
-# PEP8 testing.
-${PEP8:-pep8} improver
-echo_ok "pep8"
-
-# Pylint obvious-errors-only testing.
-${PYLINT:-pylint} -E --rcfile=../etc/pylintrc improver
-echo_ok "pylint -E"
-
-# Build documentation as test.
-cd $IMPROVER_DIR/doc
-make html 1>/dev/null
-echo_ok "sphinx-build -b html"
-cd -
-
-# Unit tests.
-python -m unittest discover
-echo_ok "Unit tests"
-
-# CLI testing.
-PATH="$IMPROVER_DIR/tests/bin/:$PATH"
-if [[ ${1:-} != '--debug' ]] && type prove &>/dev/null; then
-    prove -j $(nproc) -r -e "bats --tap" \
-        --ext ".bats" "$IMPROVER_DIR/tests/"
-else
-    bats $(find "$IMPROVER_DIR/tests/" -name "*.bats")
-fi
-echo_ok "CLI tests"
+for test_name in pep8 pylintE doc unit cli; do
+    "improver_test_$test_name" "$DEBUG_OPT" "$@"
+done
 
 # No errors found (or script would have exited).
 echo_ok "All tests passed."

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -52,9 +52,9 @@ function improver_test_unit {
 function improver_test_cli {
     # CLI testing.
     PATH="$IMPROVER_DIR/tests/bin/:$PATH"
-    if type prove &>/dev/null; then
+    if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
         PROVE_VERBOSE_OPT=
-        if [[ ${1:-} == '--debug' ]]; then
+        if [[ -n $DEBUG_OPT ]]; then
             PROVE_VERBOSE_OPT='-v'
         fi
         prove $PROVE_VERBOSE_OPT --directives -r \
@@ -68,13 +68,14 @@ function improver_test_cli {
 function print_usage {
     # Output CLI usage information.
     cat <<'__USAGE__'
-improver tests [--debug] [SUBTEST...] 
+improver tests [OPTIONS] [SUBTEST...] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
+    --bats          Run CLI tests using BATS instead of the default prove
     --debug         Run in verbose mode (may take longer for CLI)
-    -h, --help          Show this message and exit
+    -h, --help      Show this message and exit
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
@@ -85,10 +86,14 @@ __USAGE__
 
 cd $IMPROVER_DIR/lib
 
+BATS_OPT=
 DEBUG_OPT=
 SUBTESTS=
 for arg in "$@"; do
     case $arg in
+        --bats)
+        BATS_OPT='--bats'
+        ;;
         --debug)
         DEBUG_OPT='--debug'
         ;;

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -52,9 +52,13 @@ function improver_test_unit {
 function improver_test_cli {
     # CLI testing.
     PATH="$IMPROVER_DIR/tests/bin/:$PATH"
-    if [[ ${1:-} != '--debug' ]] && type prove &>/dev/null; then
-        prove --directives -r -e "bats --tap" \
-            --ext ".bats" "$IMPROVER_DIR/tests/"
+    if type prove &>/dev/null; then
+        PROVE_VERBOSE_OPT=
+        if [[ ${1:-} == '--debug' ]]; then
+            PROVE_VERBOSE_OPT='-v'
+        fi
+        prove $PROVE_VERBOSE_OPT --directives -r \
+            -e "bats --tap" --ext ".bats" "$IMPROVER_DIR/tests/"
     else
         bats $(find "$IMPROVER_DIR/tests/" -name "*.bats")
     fi

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -53,7 +53,7 @@ function improver_test_cli {
     # CLI testing.
     PATH="$IMPROVER_DIR/tests/bin/:$PATH"
     if [[ ${1:-} != '--debug' ]] && type prove &>/dev/null; then
-        prove -j $(nproc) -r -e "bats --tap" \
+        prove --directives -r -e "bats --tap" \
             --ext ".bats" "$IMPROVER_DIR/tests/"
     else
         bats $(find "$IMPROVER_DIR/tests/" -name "*.bats")
@@ -61,11 +61,10 @@ function improver_test_cli {
     echo_ok "CLI tests"
 }
 
-cd $IMPROVER_DIR/lib
-
-if [[ ${1:-} == '--help' ]] || [[ ${1:-} == '-h' ]]; then
+function print_usage {
+    # Output CLI usage information.
     cat <<'__USAGE__'
-improver tests [--debug] [SUBTEST] 
+improver tests [--debug] [SUBTEST...] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
@@ -74,33 +73,47 @@ Optional arguments:
     -h, --help          Show this message and exit
 
 Arguments:
-    SUBTEST         Name of a subtest to run without running the rest.
-                    Valid names are: pep8, pylint, pylintE, unit, cli.
-                    pep8, pylintE, unit, and cli are the default tests.
+    SUBTEST         Name(s) of a subtest to run without running the rest.
+                    Valid names are: pep8, pylint, pylintE, doc, unit, cli.
+                    pep8, pylintE, doc, unit, and cli are the default tests.
 __USAGE__
-    exit 0
-fi
+}
+
+cd $IMPROVER_DIR/lib
 
 DEBUG_OPT=
-if [[ "${1:-}" == '--debug' ]]; then
-    DEBUG_OPT='--debug'
-    shift
-fi
-
-if [[ -n "${1:-}" ]]; then
-    TEST_NAME="improver_test_$1"
-    shift
-    if [[ $(type -t $TEST_NAME) == 'function' ]]; then
-        "$TEST_NAME" "$@" "$DEBUG_OPT"
+SUBTESTS=
+for arg in "$@"; do
+    case $arg in
+        --debug)
+        DEBUG_OPT='--debug'
+        ;;
+        -h|--help)
+        print_usage
         exit 0
-    fi
-    improver tests --help
-    exit 2
-fi
-
-for test_name in pep8 pylintE doc unit cli; do
-    "improver_test_$test_name" "$DEBUG_OPT" "$@"
+        ;;
+        pep8|pylint|pylintE|unit|cli)
+        SUBTESTS="$SUBTESTS $arg"
+        ;;
+        *)
+        print_usage
+        exit 2
+        ;;
+    esac
 done
 
-# No errors found (or script would have exited).
-echo_ok "All tests passed."
+if [[ -n "$SUBTESTS" ]]; then
+    # Custom selection of tests.
+    TESTS="$SUBTESTS"
+else
+    # Default tests.
+    TESTS="pep8 pylintE doc unit cli"
+fi
+
+for TEST_NAME in $TESTS; do
+    "improver_test_$TEST_NAME" "$DEBUG_OPT" "$@"
+done
+
+if [[ -z "$SUBTESTS" ]]; then
+    echo_ok "All tests passed."
+fi

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -25,7 +25,7 @@ function improver_test_pep8 {
 }
 
 function improver_test_pylint {
-    # Pylint obvious-errors-only testing.
+    # Pylint score generation.
     ${PYLINT:-pylint} --rcfile=../etc/pylintrc improver
 }
 

--- a/tests/bin/bats-exec-test
+++ b/tests/bin/bats-exec-test
@@ -248,7 +248,7 @@ bats_exit_trap() {
   if [ -n "$BATS_TEST_SKIPPED" ]; then
     skipped=" # skip"
     if [ "1" != "$BATS_TEST_SKIPPED" ]; then
-      skipped+=" ($BATS_TEST_SKIPPED)"
+      skipped+=" $BATS_TEST_SKIPPED"
     fi
   fi
 
@@ -259,7 +259,7 @@ bats_exit_trap() {
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
-    echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}" >&3
+    echo "ok ${BATS_TEST_NUMBER} ${BATS_TEST_DESCRIPTION}${skipped}" >&3
     status=0
   fi
 

--- a/tests/bin/bats-format-tap-stream
+++ b/tests/bin/bats-format-tap-stream
@@ -144,7 +144,7 @@ while IFS= read -r line; do
     flush
     ;;
   "ok "* )
-    skip_expr="ok $index # skip (\(([^)]*)\))?"
+    skip_expr="ok $index .* # skip (([^)]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       let skipped+=1
       buffer skip "${BASH_REMATCH[2]}"

--- a/tests/improver-nbhood/00-null.bats
+++ b/tests/improver-nbhood/00-null.bats
@@ -1,4 +1,33 @@
 #!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 @test "nbhood no arguments" {
   run improver nbhood

--- a/tests/improver-nbhood/01-help.bats
+++ b/tests/improver-nbhood/01-help.bats
@@ -1,4 +1,33 @@
 #!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 @test "nbhood -h" {
   run improver nbhood -h

--- a/tests/improver-nbhood/02-basic.bats
+++ b/tests/improver-nbhood/02-basic.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+@test "nbhood --radius-in-km=20 input output" {
+  TEST_DIR=$(mktemp -d)
+  if [[ -z "${IMPROVER_ACC_TEST_DIR:-}" ]]; then
+    skip "Acceptance test directory not defined"
+  fi
+  if ! which nccmp 1>/dev/null 2>&1; then
+    skip "nccmp not installed"
+  fi
+  # Run neighbourhood processing and check it passes.
+  run improver nbhood --radius-in-km=20 \
+      "$IMPROVER_ACC_TEST_DIR/nbhood/basic/input.nc" "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  run nccmp -dmNs "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/nbhood/basic/kgo.nc"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "are identical." ]]
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}

--- a/tests/improver-nbhood/02-basic.bats
+++ b/tests/improver-nbhood/02-basic.bats
@@ -5,7 +5,7 @@
   if [[ -z "${IMPROVER_ACC_TEST_DIR:-}" ]]; then
     skip "Acceptance test directory not defined"
   fi
-  if ! which nccmp 1>/dev/null 2>&1; then
+  if ! type -f nccmp 1>/dev/null 2>&1; then
     skip "nccmp not installed"
   fi
   # Run neighbourhood processing and check it passes.

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -1,4 +1,33 @@
 #!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 @test "tests -h" {
   run improver tests -h

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -33,13 +33,14 @@
   run improver tests -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [--debug] [SUBTEST...] 
+improver tests [OPTIONS] [SUBTEST...] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
+    --bats          Run CLI tests using BATS instead of the default prove
     --debug         Run in verbose mode (may take longer for CLI)
-    -h, --help          Show this message and exit
+    -h, --help      Show this message and exit
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -33,7 +33,7 @@
   run improver tests -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [--debug] [SUBTEST] 
+improver tests [--debug] [SUBTEST...] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
@@ -42,9 +42,9 @@ Optional arguments:
     -h, --help          Show this message and exit
 
 Arguments:
-    SUBTEST         Name of a subtest to run without running the rest.
-                    Valid names are: pep8, pylint, pylintE, unit, cli.
-                    pep8, pylintE, unit, and cli are the default tests.
+    SUBTEST         Name(s) of a subtest to run without running the rest.
+                    Valid names are: pep8, pylint, pylintE, doc, unit, cli.
+                    pep8, pylintE, doc, unit, and cli are the default tests.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -4,13 +4,18 @@
   run improver tests -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [--debug]
+improver tests [--debug] [SUBTEST] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
     --debug         Run in verbose mode (may take longer for CLI)
     -h, --help          Show this message and exit
+
+Arguments:
+    SUBTEST         Name of a subtest to run without running the rest.
+                    Valid names are: pep8, pylint, pylintE, unit, cli.
+                    pep8, pylintE, unit, and cli are the default tests.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -1,4 +1,33 @@
 #!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 @test "tests bad option" {
   run improver tests --silly-option

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -4,13 +4,18 @@
   run improver tests --silly-option
   [[ "$status" -eq 2 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [--debug]
+improver tests [--debug] [SUBTEST] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
     --debug         Run in verbose mode (may take longer for CLI)
     -h, --help          Show this message and exit
+
+Arguments:
+    SUBTEST         Name of a subtest to run without running the rest.
+                    Valid names are: pep8, pylint, pylintE, unit, cli.
+                    pep8, pylintE, unit, and cli are the default tests.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -33,7 +33,7 @@
   run improver tests --silly-option
   [[ "$status" -eq 2 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [--debug] [SUBTEST] 
+improver tests [--debug] [SUBTEST...] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
@@ -42,9 +42,9 @@ Optional arguments:
     -h, --help          Show this message and exit
 
 Arguments:
-    SUBTEST         Name of a subtest to run without running the rest.
-                    Valid names are: pep8, pylint, pylintE, unit, cli.
-                    pep8, pylintE, unit, and cli are the default tests.
+    SUBTEST         Name(s) of a subtest to run without running the rest.
+                    Valid names are: pep8, pylint, pylintE, doc, unit, cli.
+                    pep8, pylintE, doc, unit, and cli are the default tests.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -33,13 +33,14 @@
   run improver tests --silly-option
   [[ "$status" -eq 2 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [--debug] [SUBTEST...] 
+improver tests [OPTIONS] [SUBTEST...] 
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
+    --bats          Run CLI tests using BATS instead of the default prove
     --debug         Run in verbose mode (may take longer for CLI)
-    -h, --help          Show this message and exit
+    -h, --help      Show this message and exit
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.

--- a/tests/lib/utils
+++ b/tests/lib/utils
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+#!/bin/bash
 # -----------------------------------------------------------------------------
 # (C) British Crown Copyright 2017 Met Office.
 # All rights reserved.
@@ -28,21 +28,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+# Utilities for BATS tests.
 
-. $IMPROVER_DIR/tests/lib/utils
+function improver_check_skip_acceptance {
+  if [[ -z "${IMPROVER_ACC_TEST_DIR:-}" ]]; then
+    skip "Acceptance test directory not defined"
+  fi
+  if ! type -f nccmp 1>/dev/null 2>&1; then
+    skip "nccmp not installed"
+  fi
+}
 
-@test "nbhood --radius-in-km=20 input output" {
-  TEST_DIR=$(mktemp -d)
-  improver_check_skip_acceptance
-
-  # Run neighbourhood processing and check it passes.
-  run improver nbhood --radius-in-km=20 \
-      "$IMPROVER_ACC_TEST_DIR/nbhood/basic/input.nc" "$TEST_DIR/output.nc"
-  [[ "$status" -eq 0 ]]
-
+function improver_compare_output {
   # Run nccmp to compare the output and kgo.
-  improver_compare_output "$TEST_DIR/output.nc" \
-      "$IMPROVER_ACC_TEST_DIR/nbhood/basic/kgo.nc"
-  rm "$TEST_DIR/output.nc"
-  rmdir "$TEST_DIR"
+  run nccmp -dmNs "$1" "$2"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "are identical." ]]
 }

--- a/tests/lib/utils
+++ b/tests/lib/utils
@@ -40,7 +40,13 @@ function improver_check_skip_acceptance {
 }
 
 function improver_compare_output {
-  # Run nccmp to compare the output and kgo.
+  # Run nccmp to compare the output and known good output.
+  # nccmp options:
+  #    -d means compare data
+  #    -m also compare metadata
+  #    -N ignore NaN comparisons
+  #    -s report 'Files X and Y are identical' if they really are.
+
   run nccmp -dmNs "$1" "$2"
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "are identical." ]]


### PR DESCRIPTION
This closes #59.

If an IMPROVER_ACC_TEST_DIR environment is set in the `etc/site-init` file (or elsewhere) (refer to our internal New Developer Guide for details here) then look for a neighbourhood processing specific input file within that directory, run neighbourhood processing on it, produce an output file and compare with a known good file using `nccmp`.

If IMPROVER_ACC_TEST_DIR is not set, skip - same goes for if `nccmp` is not installed.

I have also rationalised the test command a bit - you can now just run a subset of tests with e.g.:
`improver tests cli`
or
`improver tests pep8`

Tests pass with and without the new environment variable in the `etc/site-init` script.

This pull request also adds the functionality to individually test `pep8`, `pylint -E`, `pylint`, `unit` tests, and `cli` tests.