### PR TITLE
Fix 'improver tests doc'

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -101,7 +101,7 @@ for arg in "$@"; do
         print_usage
         exit 0
         ;;
-        pep8|pylint|pylintE|unit|cli)
+        pep8|pylint|pylintE|doc|unit|cli)
         SUBTESTS="$SUBTESTS $arg"
         ;;
         *)


### PR DESCRIPTION
Fix the `improver tests` subcommand when `doc` is passed in as an argument (e.g. `improver tests doc`).

The command `improver tests doc` now does something and passes.
