### PR TITLE
Fix ECC dictionary key

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -448,6 +448,7 @@ class GeneratePercentilesFromProbabilities(object):
         """
         forecast_probabilities = concatenate_cubes(forecast_probabilities)
         threshold_coord = find_coordinate(forecast_probabilities, "threshold")
+        threshold_name = threshold_coord.name().replace("_threshold", "")
 
         if no_of_percentiles is None:
             no_of_percentiles = (
@@ -461,7 +462,7 @@ class GeneratePercentilesFromProbabilities(object):
             forecast_probabilities.coord(threshold_coord.name()).units)
         bounds_pairing = (
             get_bounds_of_distribution(
-                threshold_coord.name(), cube_units))
+                threshold_name, cube_units))
 
         forecast_at_percentiles = self._probabilities_to_percentiles(
             forecast_probabilities, percentiles, bounds_pairing)

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -48,7 +48,7 @@ bounds = namedtuple("bounds", "value units")
 # Tellus Series A, Dynamic Meteorology and Oceanography, 66, 22662.
 
 bounds_for_ecdf = {
-    "air_temperature_threshold": (
+    "air_temperature": (
         bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
-    "wind_speed_threshold": bounds((0, 50), "m s^-1"),
-    "air_pressure_at_sea_level_threshold": bounds((94000, 107000), "Pa")}
+    "wind_speed": bounds((0, 50), "m s^-1"),
+    "air_pressure_at_sea_level": bounds((94000, 107000), "Pa")}

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleCopulaCouplingUtilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleCopulaCouplingUtilities.py
@@ -362,7 +362,7 @@ class Test_get_bounds_of_distribution(IrisTest):
 
     def test_basic(self):
         """Test that the result is a numpy array."""
-        cube_name = "air_temperature_threshold"
+        cube_name = "air_temperature"
         cube_units = Unit("degreesC")
         result = get_bounds_of_distribution(cube_name, cube_units)
         self.assertIsInstance(result, np.ndarray)
@@ -371,7 +371,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         """
         Test that the expected results are returned for the bounds_pairing.
         """
-        cube_name = "air_temperature_threshold"
+        cube_name = "air_temperature"
         cube_units = Unit("degreesC")
         bounds_pairing = (-40, 50)
         result = (
@@ -384,7 +384,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         if the units of the bounds_pairings need to be converted to match
         the units of the forecast.
         """
-        cube_name = "air_temperature_threshold"
+        cube_name = "air_temperature"
         cube_units = Unit("fahrenheit")
         bounds_pairing = (-40, 122)  # In fahrenheit
         result = (

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -439,7 +439,7 @@ class Test_process(IrisTest):
         data[0] -= 1
         data[1] += 1
         data[2] += 3
-        cube = set_up_cube(data, "air_temperature_threshold", "degreesC")
+        cube = set_up_cube(data, "air_temperature", "degreesC")
         cube.coord("realization").rename("percentile")
         cube.coord("percentile").points = np.array([0.1, 0.5, 0.9])
         self.percentile_cube = (


### PR DESCRIPTION
Unify the expected key within the constants dictionary used by ECC so that the key is just the diagnostic name.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
