### PR TITLE
Ensemble Calibration CLI

### DIFF
--- a/bin/improver-ensemble-calibration
+++ b/bin/improver-ensemble-calibration
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to run ensemble calibration."""
+
+import argparse
+
+import iris
+
+from improver.ensemble_calibration.ensemble_calibration import (
+    EnsembleCalibration)
+from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
+    GeneratePercentilesFromMeanAndVariance, EnsembleReordering)
+
+
+def main():
+    """Load in arguments and get going."""
+    parser = argparse.ArgumentParser(
+    description='Apply the requested ensemble calibration method using '
+                'historical forecast and "truth" data.')
+    parser.add_argument('calibration_method',
+                        metavar='ENSEMBLE_CALIBRATION_METHOD',
+                        choices=['ensemble model output statistics',
+                                 'nonhomogeneous gaussian regression'],
+                        help='The calibration method that will be applied. '
+                             'Supported methods are: "emos" (ensemble model '
+                             'output statistics) and "ngr" (nonhomogeneous '
+                             'gaussian regression).')
+    parser.add_argument('units', metavar='UNITS_TO_CALIBRATE_IN',
+                        help='The unit that calibration should be undertaken '
+                             'in. The current forecast, historical forecast '
+                             'and truth will be converted as required.')
+    parser.add_argument('distribution', metavar='DISTRIBUTION',
+                        choices=['gaussian', 'truncated gaussian'],
+                        help='The distribution that will be used for '
+                             'calibration. This will be dependent upon the '
+                             'input phenomenon. This has to be supported by '
+                             'the minimisation functions in '
+                             'ContinuousRankedProbabilityScoreMinimisers.')
+
+    parser.add_argument('input_filepath', metavar='INPUT_FILE',
+                        help='A path to an input NetCDF file containing the '
+                             'current forecast to be processed.')
+    parser.add_argument('historic_filepath', metavar='HISTORIC_DATA_FILE',
+                        help='A path to an input NetCDF file containing the '
+                             'historic forecast used for calibration.')
+    parser.add_argument('truth_filepath', metavar='TRUTH_DATA_FILE',
+                        help='A path to an input NetCDF file containing the '
+                             'historic truth analyses used for calibration.')
+    parser.add_argument('output_filepath', metavar='OUTPUT_FILE',
+                        help='The output path for the processed NetCDF')
+
+    parser.add_argument('--predictor_of_mean', metavar='CALIBRATE_MEAN_FLAG',
+                        choices=['mean', 'members'], default='mean',
+                        help='String to specify the input to calculate the '
+                             'calibrated mean. Currently the ensemble mean '
+                             '("mean") and the ensemble members ("members") '
+                             'are supported as the predictors. Default: '
+                             '"mean".')
+    parser.add_argument('--save_mean_variance', metavar='MEAN_VARIANCE_FILE',
+                        default=False,
+                        help='Option to save output mean and variance from '
+                             'EnsembleCalibration plugin. If used, a path '
+                             'to save the output to must be provided.')
+    parser.add_argument('--num_members', metavar='NUMBER_OF_MEMBERS',
+                        default=None,
+                        help='Optional argument to specify the number of '
+                             'ensemble members to produce. Default will be '
+                             'the number in the raw input file.')
+    parser.add_argument('--random_ordering', default=False,
+                        action='store_true',
+                        help='Option to reorder the post-processed forecasts '
+                             'randomly. If not set, the ordering of the raw '
+                             'ensemble is used.')
+    args = parser.parse_args()
+    current_forecast = iris.load(args.input_filepath)
+    historic_forecast = iris.load(args.historic_filepath)
+    truth = iris.load(args.truth_filepath)
+    if not args.num_members:
+        args.num_members = len(current_forecast[0].coord('realization').points)
+
+    forecast_predictor_and_variance = EnsembleCalibration(
+        args.calibration_method, args.distribution, args.units,
+        args.predictor_of_mean).process(
+            current_forecast, historic_forecast, truth)
+    if args.save_mean_variance: 
+        mean_variance = [x for y in forecast_predictor_and_variance for x in y]
+        mean_variance = iris.cube.CubeList(mean_variance)
+        iris.save(mean_variance, args.save_mean_variance,
+                  unlimited_dimensions=[])
+
+    percentiles = GeneratePercentilesFromMeanAndVariance().process(
+        forecast_predictor_and_variance, args.num_members)
+    result = EnsembleReordering().process(percentiles, current_forecast,
+        args.random_ordering)
+    iris.save(result, args.output_filepath, unlimited_dimensions=[])
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/improver-ensemble-calibration
+++ b/bin/improver-ensemble-calibration
@@ -42,10 +42,20 @@ from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
 
 
 def main():
-    """Load in arguments and get going."""
+    """Load in arguments for ensemble calibration. 3 sources of input data
+       must be provided: current forecast (to be calibrated), historical
+       forecasts and historical truth data (to use in calibration). Output from
+       EnsembleCalibration plugin can be written to file if required. 
+
+       The mean and variance calculated by this plugin are passed to
+       GeneratePercentilesFromMeanAndVariance and EnsembleReordering plugins
+       to regenerate members.
+    """
     parser = argparse.ArgumentParser(
     description='Apply the requested ensemble calibration method using '
-                'historical forecast and "truth" data.')
+                'historical forecast and "truth" data. Then apply ensemble '
+                'copula coupling to regenerate ensemble members from output.')
+    # Arguments for EnsembleCalibration
     parser.add_argument('calibration_method',
                         metavar='ENSEMBLE_CALIBRATION_METHOD',
                         choices=['ensemble model output statistics',
@@ -65,19 +75,19 @@ def main():
                              'input phenomenon. This has to be supported by '
                              'the minimisation functions in '
                              'ContinuousRankedProbabilityScoreMinimisers.')
-
+    # Filepaths for current, historic and truth data.
     parser.add_argument('input_filepath', metavar='INPUT_FILE',
                         help='A path to an input NetCDF file containing the '
                              'current forecast to be processed.')
     parser.add_argument('historic_filepath', metavar='HISTORIC_DATA_FILE',
                         help='A path to an input NetCDF file containing the '
-                             'historic forecast used for calibration.')
+                             'historic forecast(s) used for calibration.')
     parser.add_argument('truth_filepath', metavar='TRUTH_DATA_FILE',
                         help='A path to an input NetCDF file containing the '
                              'historic truth analyses used for calibration.')
     parser.add_argument('output_filepath', metavar='OUTPUT_FILE',
                         help='The output path for the processed NetCDF')
-
+    # Optional arguments.
     parser.add_argument('--predictor_of_mean', metavar='CALIBRATE_MEAN_FLAG',
                         choices=['mean', 'members'], default='mean',
                         help='String to specify the input to calculate the '
@@ -100,27 +110,41 @@ def main():
                         help='Option to reorder the post-processed forecasts '
                              'randomly. If not set, the ordering of the raw '
                              'ensemble is used.')
+    parser.add_argument('--random_seed', default=None,
+                        help='Option to specify a value for the random seed for testing '
+                             'purposes, otherwise, the default random seed behaviour is '
+                             'utilised. The random seed is used in the generation of the '
+                             'random numbers used for either the random_ordering option to '
+                             'order the input percentiles randomly, rather than use the '
+                             'ordering from the raw ensemble, or for splitting tied values '
+                             'within the raw ensemble, so that the values from the input '
+                             'percentiles can be ordered to match the raw ensemble.')
     args = parser.parse_args()
-    current_forecast = iris.load(args.input_filepath)
+
+    current_forecast = iris.load_cube(args.input_filepath)
     historic_forecast = iris.load(args.historic_filepath)
     truth = iris.load(args.truth_filepath)
+    # Default number of ensemble members is the number in the raw forecast.
     if not args.num_members:
-        args.num_members = len(current_forecast[0].coord('realization').points)
+        args.num_members = len(current_forecast.coord('realization').points)
 
+    # Ensemble-Calibration to calculate the mean and variance.
     forecast_predictor_and_variance = EnsembleCalibration(
         args.calibration_method, args.distribution, args.units,
-        args.predictor_of_mean).process(
+        predictor_of_mean_flag=args.predictor_of_mean).process(
             current_forecast, historic_forecast, truth)
+    # If required, save the mean and variance.
     if args.save_mean_variance: 
         mean_variance = [x for y in forecast_predictor_and_variance for x in y]
         mean_variance = iris.cube.CubeList(mean_variance)
         iris.save(mean_variance, args.save_mean_variance,
                   unlimited_dimensions=[])
 
+    # Ensemble-Copula-Coupling to generate members from mean and variance.
     percentiles = GeneratePercentilesFromMeanAndVariance().process(
         forecast_predictor_and_variance, args.num_members)
     result = EnsembleReordering().process(percentiles, current_forecast,
-        args.random_ordering)
+        random_ordering=args.random_ordering, random_seed=args.random_seed)
     iris.save(result, args.output_filepath, unlimited_dimensions=[])
 
 

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -389,10 +389,8 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         will be used.
 
         Default values have been chosen based on Figure 8 in the
-        ensemble calibration documentation in
-        https://exxreldocs:8099/display/TEPPV/Science+Plugin+Documents
-        or
-        http://www-nwp/~gevans/reports/EMOS_report_20170327.pdf
+        ensemble calibration documentation in which can be found on the
+        Science Plugin Documents page on Confluence.
 
         Parameters
         ----------

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -763,7 +763,7 @@ class EnsembleReordering(object):
 
     def process(
             self, post_processed_forecast, raw_forecast,
-            random_ordering=False, random_seed=False):
+            random_ordering=False, random_seed=None):
         """
         Reorder post-processed forecast using the ordering of the
         raw ensemble.

--- a/tests/improver-ensemble-calibration/00_null.bats
+++ b/tests/improver-ensemble-calibration/00_null.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+@test "ensemble-calibration no arguments" {
+  run improver ensemble-calibration
+  [[ "$status" -eq 2 ]]
+  expected="usage: improver-ensemble-calibration [-h]
+                                     [--predictor_of_mean CALIBRATE_MEAN_FLAG]
+                                     [--save_mean_variance MEAN_VARIANCE_FILE]
+                                     [--num_members NUMBER_OF_MEMBERS]
+                                     [--random_ordering]
+                                     ENSEMBLE_CALIBRATION_METHOD
+                                     UNITS_TO_CALIBRATE_IN DISTRIBUTION
+                                     INPUT_FILE HISTORIC_DATA_FILE
+                                     TRUTH_DATA_FILE OUTPUT_FILE
+"
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-ensemble-calibration/00_null.bats
+++ b/tests/improver-ensemble-calibration/00_null.bats
@@ -8,6 +8,7 @@
                                      [--save_mean_variance MEAN_VARIANCE_FILE]
                                      [--num_members NUMBER_OF_MEMBERS]
                                      [--random_ordering]
+                                     [--random_seed RANDOM_SEED]
                                      ENSEMBLE_CALIBRATION_METHOD
                                      UNITS_TO_CALIBRATE_IN DISTRIBUTION
                                      INPUT_FILE HISTORIC_DATA_FILE

--- a/tests/improver-ensemble-calibration/01_help.bats
+++ b/tests/improver-ensemble-calibration/01_help.bats
@@ -38,13 +38,15 @@ usage: improver-ensemble-calibration [-h]
                                      [--save_mean_variance MEAN_VARIANCE_FILE]
                                      [--num_members NUMBER_OF_MEMBERS]
                                      [--random_ordering]
+                                     [--random_seed RANDOM_SEED]
                                      ENSEMBLE_CALIBRATION_METHOD
                                      UNITS_TO_CALIBRATE_IN DISTRIBUTION
                                      INPUT_FILE HISTORIC_DATA_FILE
                                      TRUTH_DATA_FILE OUTPUT_FILE
 
 Apply the requested ensemble calibration method using historical forecast and
-"truth" data.
+"truth" data. Then apply ensemble copula coupling to regenerate ensemble
+members from output.
 
 positional arguments:
   ENSEMBLE_CALIBRATION_METHOD
@@ -62,7 +64,7 @@ positional arguments:
   INPUT_FILE            A path to an input NetCDF file containing the current
                         forecast to be processed.
   HISTORIC_DATA_FILE    A path to an input NetCDF file containing the historic
-                        forecast used for calibration.
+                        forecast(s) used for calibration.
   TRUTH_DATA_FILE       A path to an input NetCDF file containing the historic
                         truth analyses used for calibration.
   OUTPUT_FILE           The output path for the processed NetCDF
@@ -85,6 +87,16 @@ optional arguments:
   --random_ordering     Option to reorder the post-processed forecasts
                         randomly. If not set, the ordering of the raw ensemble
                         is used.
+  --random_seed RANDOM_SEED
+                        Option to specify a value for the random seed for
+                        testing purposes, otherwise, the default random seed
+                        behaviour is utilised. The random seed is used in the
+                        generation of the random numbers used for either the
+                        random_ordering option to order the input percentiles
+                        randomly, rather than use the ordering from the raw
+                        ensemble, or for splitting tied values within the raw
+                        ensemble, so that the values from the input
+                        percentiles can be ordered to match the raw ensemble.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-ensemble-calibration/01_help.bats
+++ b/tests/improver-ensemble-calibration/01_help.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "ensemble-calibration -h" {
+  run improver ensemble-calibration -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__HELP__' || true
+usage: improver-ensemble-calibration [-h]
+                                     [--predictor_of_mean CALIBRATE_MEAN_FLAG]
+                                     [--save_mean_variance MEAN_VARIANCE_FILE]
+                                     [--num_members NUMBER_OF_MEMBERS]
+                                     [--random_ordering]
+                                     ENSEMBLE_CALIBRATION_METHOD
+                                     UNITS_TO_CALIBRATE_IN DISTRIBUTION
+                                     INPUT_FILE HISTORIC_DATA_FILE
+                                     TRUTH_DATA_FILE OUTPUT_FILE
+
+Apply the requested ensemble calibration method using historical forecast and
+"truth" data.
+
+positional arguments:
+  ENSEMBLE_CALIBRATION_METHOD
+                        The calibration method that will be applied. Supported
+                        methods are: "emos" (ensemble model output statistics)
+                        and "ngr" (nonhomogeneous gaussian regression).
+  UNITS_TO_CALIBRATE_IN
+                        The unit that calibration should be undertaken in. The
+                        current forecast, historical forecast and truth will
+                        be converted as required.
+  DISTRIBUTION          The distribution that will be used for calibration.
+                        This will be dependent upon the input phenomenon. This
+                        has to be supported by the minimisation functions in
+                        ContinuousRankedProbabilityScoreMinimisers.
+  INPUT_FILE            A path to an input NetCDF file containing the current
+                        forecast to be processed.
+  HISTORIC_DATA_FILE    A path to an input NetCDF file containing the historic
+                        forecast used for calibration.
+  TRUTH_DATA_FILE       A path to an input NetCDF file containing the historic
+                        truth analyses used for calibration.
+  OUTPUT_FILE           The output path for the processed NetCDF
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --predictor_of_mean CALIBRATE_MEAN_FLAG
+                        String to specify the input to calculate the
+                        calibrated mean. Currently the ensemble mean ("mean")
+                        and the ensemble members ("members") are supported as
+                        the predictors. Default: "mean".
+  --save_mean_variance MEAN_VARIANCE_FILE
+                        Option to save output mean and variance from
+                        EnsembleCalibration plugin. If used, a path to save
+                        the output to must be provided.
+  --num_members NUMBER_OF_MEMBERS
+                        Optional argument to specify the number of ensemble
+                        members to produce. Default will be the number in the
+                        raw input file.
+  --random_ordering     Option to reorder the post-processed forecasts
+                        randomly. If not set, the ordering of the raw ensemble
+                        is used.
+__HELP__
+  [[ "$output" == "$expected" ]]
+}

--- a/tests/improver-ensemble-calibration/02_gaussian.bats
+++ b/tests/improver-ensemble-calibration/02_gaussian.bats
@@ -40,7 +40,7 @@
       'gaussian' "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/truth/*.nc" \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" --random_seed 0
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo members and check it passes.

--- a/tests/improver-ensemble-calibration/02_gaussian.bats
+++ b/tests/improver-ensemble-calibration/02_gaussian.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "ensemble-calibration emos gaussian kelvin input history truth output" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run ensemble calibration and check it passes.
+  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
+      'gaussian' "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/history/*.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/truth/*.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo members and check it passes.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}

--- a/tests/improver-ensemble-calibration/03_trunc_gaussian.bats
+++ b/tests/improver-ensemble-calibration/03_trunc_gaussian.bats
@@ -31,21 +31,22 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "ensemble-calibration emos gaussian kelvin input history truth output" {
+@test "ensemble-calibration emos truncated_gaussian m s-1 input history truth output" {
   TEST_DIR=$(mktemp -d)
   improver_check_skip_acceptance
 
   # Run ensemble calibration and check it passes.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/input.nc" \
-      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/history/*.nc" \
-      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/truth/*.nc" \
-      "$TEST_DIR/output.nc"
+  run improver ensemble-calibration 'ensemble model output statistics' \
+      'm s-1' 'truncated gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/truncated_gaussian/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/truncated_gaussian/history/*.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/truncated_gaussian/truth/*.nc" \
+      "$TEST_DIR/output.nc" --random_seed 0
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo members and check it passes.
   improver_compare_output "$TEST_DIR/output.nc" \
-      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/kgo.nc"
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/truncated_gaussian/kgo.nc"
   rm "$TEST_DIR/output.nc"
   rmdir "$TEST_DIR"
 }

--- a/tests/improver-ensemble-calibration/03_trunc_gaussian.bats
+++ b/tests/improver-ensemble-calibration/03_trunc_gaussian.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "ensemble-calibration emos gaussian kelvin input history truth output" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run ensemble calibration and check it passes.
+  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
+      'gaussian' "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/history/*.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/truth/*.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo members and check it passes.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}
+

--- a/tests/improver-ensemble-calibration/04_save_mean_and_var.bats
+++ b/tests/improver-ensemble-calibration/04_save_mean_and_var.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "ensemble-calibration emos gaussian save_mean_and_variance" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run ensemble calibration with saving of mean and variance and check it passes.
+  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
+      'gaussian' "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/history/*.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/truth/*.nc" \
+      "$TEST_DIR/output.nc" \
+      --save_mean_variance "$TEST_DIR/mean_and_variance.nc"
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output mean_and_variance and check it passes.
+  improver_compare_output "$TEST_DIR/mean_and_variance.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ens_calib/gaussian/mandv_kgo.nc"
+  rm "$TEST_DIR/mean_and_variance.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}


### PR DESCRIPTION
Provides CLI and acceptance tests for ensemble calibration plugins.
Calls EnsembleCalibration plugin and passes output to GeneratePercentilesFromMeanAndVariance and EnsembleReordering to create ensemble members from mean and variance produced. Has option to save mean and variance to file in addition to final ensemble members.

Added CLI AT for: no args, help, gaussian distribution, truncated gaussian distribution, saving out mean and variance.

Issue: #87 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
