### PR TITLE
144: add cli sub-test option

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -89,6 +89,8 @@ Arguments:
                     Valid names are tasks which appear in /improver/tests/
                     without the "improver-" prefix. The default is to run all
                     cli tests in the /improver/tests/ directory.
+                    e.g. 'improver tests cli nbhood' will run neighbourhood
+                    processing cli tests only.
 __USAGE__
 }
 

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -52,18 +52,20 @@ function improver_test_unit {
 function improver_test_cli {
     # CLI testing.
     PATH="$IMPROVER_DIR/tests/bin/:$PATH"
-    test_dir=$IMPROVER_DIR/tests/improver-*$CLISUBTEST*/
-    test_dir="$(echo -e "${test_dir}" | tr -d '[:space:]')"
-    if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
-        PROVE_VERBOSE_OPT=
-        if [[ -n $DEBUG_OPT ]]; then
-            PROVE_VERBOSE_OPT='-v'
+    for SUBTEST in $CLISUBTEST; do
+        test_dir=$IMPROVER_DIR/tests/improver-*$SUBTEST*/
+        test_dir="$(echo -e "${test_dir}" | tr -d '[:space:]')"
+        if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
+            PROVE_VERBOSE_OPT=
+            if [[ -n $DEBUG_OPT ]]; then
+                PROVE_VERBOSE_OPT='-v'
+            fi
+            prove $PROVE_VERBOSE_OPT --directives -r \
+                -e "bats --tap" --ext ".bats" $test_dir
+        else
+            bats $(find $test_dir -name "*.bats")
         fi
-        prove $PROVE_VERBOSE_OPT --directives -r \
-            -e "bats --tap" --ext ".bats" $test_dir
-    else
-        bats $(find $test_dir -name "*.bats")
-    fi
+    done
     echo_ok "CLI tests"
 }
 
@@ -137,10 +139,11 @@ else
     TESTS="pep8 pylintE doc unit cli"
 fi
 
-# If cli sub test is not specified by user, do all cli tests (*).
+# If cli sub test is not specified by user, do all cli tests.
 # Otherwise set CLISUBTEST to the sub test to run.
-CLISUBTEST="*"
-if [ $TESTS == "cli" ]; then
+CLISUBTEST=$cli_tasks
+STRIPPED_TEST="$(echo -e "${TESTS}" | tr -d '[:space:]')"
+if [[ $STRIPPED_TEST == "cli" ]]; then
     if [[ -n "$SUBCLI" ]]; then
         CLISUBTEST="$SUBCLI"
     fi

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -85,6 +85,10 @@ Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
                     Valid names are: pep8, pylint, pylintE, doc, unit, cli.
                     pep8, pylintE, doc, unit, and cli are the default tests.
+    SUBCLI          Name(s) of cli subtests to run without running the rest.
+                    Valid names are tasks which appear in /improver/tests/
+                    without the "improver-" prefix. The default is to run all
+                    cli tests in the /improver/tests/ directory.
 __USAGE__
 }
 

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -52,15 +52,17 @@ function improver_test_unit {
 function improver_test_cli {
     # CLI testing.
     PATH="$IMPROVER_DIR/tests/bin/:$PATH"
+    test_dir=$IMPROVER_DIR/tests/improver-*$CLISUBTEST*/
+    test_dir="$(echo -e "${test_dir}" | tr -d '[:space:]')"
     if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
         PROVE_VERBOSE_OPT=
         if [[ -n $DEBUG_OPT ]]; then
             PROVE_VERBOSE_OPT='-v'
         fi
         prove $PROVE_VERBOSE_OPT --directives -r \
-            -e "bats --tap" --ext ".bats" "$IMPROVER_DIR/tests/"
+            -e "bats --tap" --ext ".bats" $test_dir
     else
-        bats $(find "$IMPROVER_DIR/tests/" -name "*.bats")
+        bats $(find $test_dir -name "*.bats")
     fi
     echo_ok "CLI tests"
 }
@@ -86,9 +88,22 @@ __USAGE__
 
 cd $IMPROVER_DIR/lib
 
+# Find cli test options and format to work with case statement
+shopt -s extglob
+opts=../tests/*
+cli_tasks=('+(')
+for i in $opts; do
+  fname=${i##*/}
+  if [[ "$fname" != "bin" ]] && [[ "$fname" != "lib" ]]; then
+    cli_tasks+="${fname##*improver-}|"
+  fi
+done
+cli_tasks+=')'
+
 BATS_OPT=
 DEBUG_OPT=
 SUBTESTS=
+SUBCLI=
 for arg in "$@"; do
     case $arg in
         --bats)
@@ -103,6 +118,9 @@ for arg in "$@"; do
         ;;
         pep8|pylint|pylintE|doc|unit|cli)
         SUBTESTS="$SUBTESTS $arg"
+        ;;
+        $cli_tasks)
+        SUBCLI="$SUBCLI $arg"
         ;;
         *)
         print_usage
@@ -119,8 +137,17 @@ else
     TESTS="pep8 pylintE doc unit cli"
 fi
 
+# If cli sub test is not specified by user, do all cli tests (*).
+# Otherwise set CLISUBTEST to the sub test to run.
+CLISUBTEST="*"
+if [ $TESTS == "cli" ]; then
+    if [[ -n "$SUBCLI" ]]; then
+        CLISUBTEST="$SUBCLI"
+    fi
+fi
+
 for TEST_NAME in $TESTS; do
-    "improver_test_$TEST_NAME" "$DEBUG_OPT" "$@"
+    "improver_test_$TEST_NAME" "$DEBUG_OPT" "$@" "$CLISUBTEST"
 done
 
 if [[ -z "$SUBTESTS" ]]; then

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -46,6 +46,10 @@ Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
                     Valid names are: pep8, pylint, pylintE, doc, unit, cli.
                     pep8, pylintE, doc, unit, and cli are the default tests.
+    SUBCLI          Name(s) of cli subtests to run without running the rest.
+                    Valid names are tasks which appear in /improver/tests/
+                    without the "improver-" prefix. The default is to run all
+                    cli tests in the /improver/tests/ directory.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -50,6 +50,8 @@ Arguments:
                     Valid names are tasks which appear in /improver/tests/
                     without the "improver-" prefix. The default is to run all
                     cli tests in the /improver/tests/ directory.
+                    e.g. 'improver tests cli nbhood' will run neighbourhood
+                    processing cli tests only.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -46,6 +46,10 @@ Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
                     Valid names are: pep8, pylint, pylintE, doc, unit, cli.
                     pep8, pylintE, doc, unit, and cli are the default tests.
+    SUBCLI          Name(s) of cli subtests to run without running the rest.
+                    Valid names are tasks which appear in /improver/tests/
+                    without the "improver-" prefix. The default is to run all
+                    cli tests in the /improver/tests/ directory.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -50,6 +50,8 @@ Arguments:
                     Valid names are tasks which appear in /improver/tests/
                     without the "improver-" prefix. The default is to run all
                     cli tests in the /improver/tests/ directory.
+                    e.g. 'improver tests cli nbhood' will run neighbourhood
+                    processing cli tests only.
 __HELP__
   [[ "$output" == "$expected" ]]
 }


### PR DESCRIPTION
First attempt to add option to run only one of cli tests. 

Use as: `improver tests cli opt1 opt2 ...` where opt1, opt2 etc are the names of directories in `/improver/tests/` without the `improver-` at the beginning (ex: generate-landmask-ancillary, weighted-blending).

If passed in after another test type, the options will have no effect. Ie: `improver tests pep8 cli nbhood` will run pep8 and ALL cli tests in `/improver/tests/` .

Issue: #144 

Testing:
 - [x] Ran tests and they passed OK
