### PR TITLE
Fix Travis biggus install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
   # Add scitools requirements
   - conda config --add channels scitools
-  - conda config --add channels Scitools
+  - conda install -c Scitools biggus
   - conda install --quiet --file conda-requirements.txt
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
   # Add scitools requirements
   - conda config --add channels scitools
-  - conda install -c Scitools biggus
+  - conda install -c scitools/label/dev biggus
   - conda install --quiet --file conda-requirements.txt
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
 
   # Add scitools requirements
   - conda config --add channels scitools
+  - conda config --add channels Scitools
   - conda install --quiet --file conda-requirements.txt
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 


### PR DESCRIPTION
As a developer I want Improver travis fixed so that my automated tests can pick up real errors!

Currently, travis on master fails due to the removal of biggus from the scitools channel, as Iris 2 does not require it.

This fixes the problem by adding their less-controlled channel just for biggus.

When Iris 2 is out, we should migrate to that ASAP and avoid this.