### PR TITLE
Extended testing to all python files within IMPROVER.

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -14,14 +14,14 @@
 
 set -eu
 
-FILES_TO_TEST=''
-
 function echo_ok {
     echo -e "\033[1;32m[OK]\033[0m $1"
 }
 
 function get_python_files {
-    FILES_TO_TEST=`find $IMPROVER_DIR -type f \( -name '*.py' -o -name 'improver-*' \)`
+    FILES_TO_TEST=`find $IMPROVER_DIR -type f \( -name '*.py' \
+                                              -o -name 'improver-*' \
+                                               ! -name 'improver-tests' \)`
 }
 
 function improver_test_pep8 {
@@ -163,6 +163,7 @@ if [[ $STRIPPED_TEST == "cli" ]]; then
 fi
 
 # Build a list of python files throughout IMPROVER.
+FILES_TO_TEST=''
 get_python_files
 
 for TEST_NAME in $TESTS; do

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -14,24 +14,30 @@
 
 set -eu
 
+FILES_TO_TEST=''
+
 function echo_ok {
     echo -e "\033[1;32m[OK]\033[0m $1"
 }
 
+function get_python_files {
+    FILES_TO_TEST=`find $IMPROVER_DIR -type f \( -name '*.py' -o -name 'improver-*' \)`
+}
+
 function improver_test_pep8 {
     # PEP8 testing.
-    ${PEP8:-pep8} improver
+    ${PEP8:-pep8} $FILES_TO_TEST
     echo_ok "pep8"
 }
 
 function improver_test_pylint {
     # Pylint score generation.
-    ${PYLINT:-pylint} --rcfile=../etc/pylintrc improver
+    ${PYLINT:-pylint} --rcfile=../etc/pylintrc $FILES_TO_TEST
 }
 
 function improver_test_pylintE {
     # Pylint obvious-errors-only testing.
-    ${PYLINT:-pylint} -E --rcfile=../etc/pylintrc improver
+    ${PYLINT:-pylint} -E --rcfile=../etc/pylintrc $FILES_TO_TEST
     echo_ok "pylint -E"
 }
 
@@ -95,6 +101,7 @@ __USAGE__
 }
 
 cd $IMPROVER_DIR/lib
+#cd $IMPROVER_DIR
 
 # Find cli test options and format to work with case statement
 shopt -s extglob
@@ -154,6 +161,9 @@ if [[ $STRIPPED_TEST == "cli" ]]; then
         CLISUBTEST="$SUBCLI"
     fi
 fi
+
+# Build a list of python files throughout IMPROVER.
+get_python_files
 
 for TEST_NAME in $TESTS; do
     "improver_test_$TEST_NAME" "$DEBUG_OPT" "$@" "$CLISUBTEST"


### PR DESCRIPTION
Added a use of `find` to identify all python files in the IMPROVER respository, including those in the /bin directory.

Tests fail, awaiting clean up of /bin directory.