### PR TITLE
Fix to avoid zeroing valid altitudes.

### DIFF
--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -237,7 +237,7 @@ class ExtractData(object):
 
         latitudes = [float(site['latitude']) for site in sites.itervalues()]
         longitudes = [float(site['longitude']) for site in sites.itervalues()]
-        altitudes = [np.nanmin([site['altitude'], 0.])
+        altitudes = [np.nan_to_num(site['altitude'])
                      for site in sites.itervalues()]
         utc_offsets = [float(site['utc_offset'])
                        for site in sites.itervalues()]


### PR DESCRIPTION
A bug fix to avoid zeroing valid altitudes set for sites. I had used a nanmin(<num>, 0) to set NaNs to zero if they cropped up. Unfortunately I failed to note that this would obviously set any positive altitude to zero as well. I have now replaced nanmin with nan_to_num which replaces the NaNs with zeros whilst leaving valid entries unchanged.
