### PR TITLE
Metadata added into spotdata (plus rejigging).

### DIFF
--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -2,5 +2,5 @@
 extension-pkg-whitelist=numpy,scipy
 
 [TYPECHECK]
-ignored-classes=tuple,WeightedAggregator,MaskedArray,PercentileAggregator,LambertConformal
+ignored-classes=tuple,WeightedAggregator,MaskedArray,PercentileAggregator,LambertConformal,TransverseMercator
 ignored-modules=numpy,scipy,scipy.stats

--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -1,7 +1,6 @@
 [MASTER]
 extension-pkg-whitelist=numpy,scipy
-disable=C0103
 
 [TYPECHECK]
-ignored-classes=tuple,WeightedAggregator,MaskedArray,PercentileAggregator,LambertConformal,TransverseMercator
-ignored-modules=numpy,scipy,scipy.stats
+ignored-classes=tuple,WeightedAggregator,MaskedArray,PercentileAggregator
+ignored-modules=numpy,scipy,scipy.stats,cartopy.crs

--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
 extension-pkg-whitelist=numpy,scipy
+disable=C0103
 
 [TYPECHECK]
 ignored-classes=tuple,WeightedAggregator,MaskedArray,PercentileAggregator,LambertConformal,TransverseMercator

--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -202,7 +202,7 @@ class ExtractData(object):
     @staticmethod
     def _aux_coords_to_make():
         """
-        Define coordinates that need to made for the cube to be produced.
+        Define coordinates that need to be made for the cube to be produced.
 
         Returns:
         --------
@@ -317,8 +317,8 @@ class ExtractData(object):
         # Record existing scalar coordinates on source cube. Aux coords
         # associated with dimensions cannot be preserved as the dimensions will
         # be reshaped and the auxiliarys no longer compatible.
-        scalar_coordinates = [coord.name() for coord in cube.aux_coords if
-                              cube.coord_dims(coord.name()) == ()]
+        scalar_coordinates = [coord.name() for coord in
+                              cube.coords(dimensions=[])]
 
         # Build a forecast_period dimension.
         forecast_periods = (cube.coord('time').points -

--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -313,8 +313,8 @@ class ExtractData(object):
 
         forecast_ref_time.convert_units('seconds since 1970-01-01 00:00:00')
         forecast_periods = cube.coord('time').points - forecast_ref_time.points
-        forecast_period =  self._build_coordinate(forecast_periods,
-            'forecast_period', units='seconds')
+        forecast_period = self._build_coordinate(
+            forecast_periods, 'forecast_period', units='seconds')
 
         # Build the auxiliary coordinates.
         crds = self._aux_coords_to_make()
@@ -347,7 +347,7 @@ class ExtractData(object):
 
         # Promote any statistical coordinates to be first.
         result_cube = self.make_stat_coordinate_first(result_cube)
-        return result_cube        
+        return result_cube
 
     def use_nearest(self, cube, sites, neighbours):
         """

--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -187,7 +187,7 @@ class ExtractData(object):
 
         Returns:
         --------
-        iris coodinate : Dim or Auxcoord as chosen.
+        iris coordinate : Dim or Auxcoord as chosen.
 
         """
         data = np.array(data, data_type)
@@ -231,7 +231,7 @@ class ExtractData(object):
         Returns:
         --------
         cube : iris.cube.Cube
-        Cube with the statitical coordinate moved to be first.
+        Cube with the statistical coordinate moved to be first.
 
         Raises:
         -------
@@ -309,7 +309,7 @@ class ExtractData(object):
             forecast_ref_time = cube.coord('forecast_reference_time')
         except CoordinateNotFoundError:
             raise CoordinateNotFoundError(
-                'No forcast reference time found on source cube.')
+                'No forecast reference time found on source cube.')
 
         forecast_ref_time.convert_units('seconds since 1970-01-01 00:00:00')
         forecast_periods = cube.coord('time').points - forecast_ref_time.points

--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -204,6 +204,10 @@ class ExtractData(object):
         """
         Define coordinates that need to made for the cube to be produced.
 
+        Returns:
+        --------
+        Dictionary of coordinates that are required for a spotdata cube.
+
         """
         return {'latitude': {'units': 'degrees', 'data_type': float,
                              'coord_type': AuxCoord},
@@ -248,9 +252,8 @@ class ExtractData(object):
         for crd in stat_coordinates:
             stat_coord += [coord for coord in cube_dimension_order.keys()
                            if crd in coord]
-
         if len(stat_coord) > 1:
-            stat_coord = stat_coord[0]
+            stat_coord = [stat_coord[0]]
             msg = ('More than one statistical coordinate found. Promoting the '
                    'first found, {}, to the leading dimension.'.format(
                     stat_coord))
@@ -339,7 +342,7 @@ class ExtractData(object):
                            aux_coords_and_dims=aux_coords,
                            **metadata_dict)
         result_cube.add_aux_coord(forecast_ref_time)
-        result_cube.add_aux_coord(forecast_period, 0)
+        result_cube.add_aux_coord(forecast_period, cube.coord_dims('time'))
 
         # Enables use of long_name above for any name, and then moves it
         # to a standard name if possible.

--- a/lib/improver/spotdata/extrema.py
+++ b/lib/improver/spotdata/extrema.py
@@ -234,8 +234,8 @@ def make_local_time_cube(cube):
     # Exclude forecast period as it is somewhat confusing on a local time
     # cube (e.g. may be +2 for a time 8 hours before forecast reference time).
     for coord in cube.aux_coords:
-        if (coord.name() != 'forecast_reference_time' and 
-            coord.name() != 'forecast_period'):
+        if (coord.name() != 'forecast_reference_time' and
+                coord.name() != 'forecast_period'):
             new_cube.add_aux_coord(coord, cube.coord_dims(coord.name()))
 
     return new_cube

--- a/lib/improver/spotdata/extrema.py
+++ b/lib/improver/spotdata/extrema.py
@@ -31,6 +31,7 @@
 """Calculate extrema values for diagnostics."""
 
 import numpy as np
+import copy
 import datetime
 from datetime import datetime as dt
 import iris
@@ -220,7 +221,7 @@ def make_local_time_cube(cube):
     new_data = np.ma.masked_invalid(new_data)
 
     # Return cube on local time.
-    metadata_dict = cube.metadata._asdict()
+    metadata_dict = copy.deepcopy(cube.metadata._asdict())
     new_cube = Cube(new_data,
                     dim_coords_and_dims=[(local_time_coord, 0),
                                          (cube.coord('index'), 1)],

--- a/lib/improver/spotdata/extrema.py
+++ b/lib/improver/spotdata/extrema.py
@@ -219,14 +219,24 @@ def make_local_time_cube(cube):
     # Mask invalid/unset data points.
     new_data = np.ma.masked_invalid(new_data)
 
-#    # Return cube on local time.
+    # Return cube on local time.
+    metadata_dict = cube.metadata._asdict()
     new_cube = Cube(new_data,
-                    long_name=cube.name(),
                     dim_coords_and_dims=[(local_time_coord, 0),
                                          (cube.coord('index'), 1)],
-                    units=cube.units)
+                    **metadata_dict)
+
+    forecast_ref_time = cube.coord('forecast_reference_time')
+    forecast_ref_time.points = forecast_ref_time.points[0]*len(local_times)
+    new_cube.add_aux_coord(forecast_ref_time,
+                           cube.coord_dims('forecast_reference_time'))
+
+    # Exclude forecast period as it is somewhat confusing on a local time
+    # cube (e.g. may be +2 for a time 8 hours before forecast reference time).
     for coord in cube.aux_coords:
-        new_cube.add_aux_coord(coord, 1)
+        if (coord.name() != 'forecast_reference_time' and 
+            coord.name() != 'forecast_period'):
+            new_cube.add_aux_coord(coord, cube.coord_dims(coord.name()))
 
     return new_cube
 

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -95,13 +95,17 @@ class Test_setup(IrisTest):
         forecast_ref_time = time[0].copy()
         forecast_ref_time.rename('forecast_reference_time')
 
+        height = AuxCoord([1.5], standard_name='height', units='m')
+
         cube = Cube(data,
-                    long_name="air_temperature",
+                    standard_name="air_temperature",
                     dim_coords_and_dims=[(time, 0),
                                          (latitude, 1),
                                          (longitude, 2)],
                     units="K")
         cube.add_aux_coord(forecast_ref_time)
+        cube.add_aux_coord(height)
+        cube.attributes['institution'] = 'Met Office'
 
         orography = Cube(np.ones((20, 20)),
                          long_name="surface_altitude",
@@ -414,6 +418,16 @@ class Test_make_cube(Test_setup):
         msg = 'No forecast reference time found on source cube.'
         with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
             plugin(self.cube, data, self.sites)
+
+    def test_aux_coord_and_metadata(self):
+        """Test that the plugin returns cubes with expected metadata and
+        coordinates."""
+        plugin = Plugin().make_cube
+        data = np.array([123])
+        result = plugin(self.cube, data, self.sites)
+        self.assertEqual(result.coord('forecast_reference_time'),
+                         self.cube.coord('forecast_reference_time'))
+        self.assertEqual(result.metadata, self.cube.metadata)
 
 
 class Test_use_nearest(Test_setup):

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -229,7 +229,7 @@ class Test_setup(IrisTest):
         trg_crs = ccrs.TransverseMercator(
             central_latitude=0, central_longitude=0)
         trg_crs_iris = coord_systems.TransverseMercator(0, 0, 0, 0, 1.0)
-            
+
         lons = [-50, 50]
         lats = [-25, 25]
         x, y = [], []
@@ -297,6 +297,7 @@ class Test_setup(IrisTest):
                 self.cube, self.sites, self.neighbour_list,
                 ancillary_data, additional_data)
 
+
 class Test_ExtractData(Test_setup):
     """Test the overall class for raise returns etc."""
 
@@ -345,7 +346,7 @@ class Test_make_stat_coordinate_first(Test_setup):
                 (0, 0, 2, 2), (1, 0, 3, 3), (0, 1, 0, 0), (1, 1, 2, 1)),
             num_time_points=2, num_grid_points=5, num_realization_points=2)
         incorrect_cube = cube.copy()
-        incorrect_cube.transpose([1,2,0,3])
+        incorrect_cube.transpose([1, 2, 0, 3])
         result = plugin(incorrect_cube)
         self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
 
@@ -359,7 +360,7 @@ class Test_make_stat_coordinate_first(Test_setup):
             num_time_points=2, num_grid_points=5, num_realization_points=2)
         cube.coords()[0].rename('percentile_over_time')
         incorrect_cube = cube.copy()
-        incorrect_cube.transpose([1,2,0,3])
+        incorrect_cube.transpose([1, 2, 0, 3])
         result = plugin(incorrect_cube)
         self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
 

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -317,7 +317,7 @@ class Test__build_coordinate(Test_setup):
 
     def test_build_latitude_coordinate(self):
         """
-        Test buiding a latitude coordinate.
+        Test building a latitude coordinate.
 
         """
         plugin = Plugin()._build_coordinate
@@ -386,7 +386,7 @@ class Test_make_cube(Test_setup):
         plugin = Plugin().make_cube
         data = np.array([123])
         self.cube.remove_coord('forecast_reference_time')
-        msg = 'No forcast reference time found on source cube.'
+        msg = 'No forecast reference time found on source cube.'
         with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
             plugin(self.cube, data, self.sites)
 

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -222,7 +222,6 @@ class Test_setup(IrisTest):
     def different_projection(self, method, ancillary_data, additional_data,
                              expected, **kwargs):
         """Test that the plugin copes with non-lat/lon grids."""
-        from improver.spotdata.neighbour_finding import PointSelection
 
         trg_crs = None
         src_crs = ccrs.PlateCarree()
@@ -260,8 +259,6 @@ class Test_setup(IrisTest):
             for ad in additional_data.keys():
                 additional_data[ad] = additional_data[ad].regrid(
                     new_cube, iris.analysis.Nearest())
-
-        new_crds = PointSelection().fast_nearest_neighbour(cube, self.sites)
 
         # Define neighbours on this new projection
         self.neighbour_list['i'] = 11

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -46,11 +46,14 @@ from iris.coord_systems import GeogCS
 from iris.cube import Cube
 from iris.tests import IrisTest
 from iris.time import PartialDateTime
+from iris.exceptions import CoordinateNotFoundError
 
+from improver.tests.nbhood.nbhood.test_NeighbourhoodProcessing import (
+    set_up_cube)
 from improver.spotdata.extract_data import ExtractData as Plugin
 
 
-class Test_ExtractData(IrisTest):
+class Test_setup(IrisTest):
 
     """Test the extract data plugin."""
 
@@ -87,6 +90,8 @@ class Test_ExtractData(IrisTest):
         time_dt = dt(2017, 2, 17, 6, 0)
         time_extract = Constraint(time=PartialDateTime(
             time_dt.year, time_dt.month, time_dt.day, time_dt.hour))
+        forecast_ref_time = time[0].copy()
+        forecast_ref_time.rename('forecast_reference_time')
 
         cube = Cube(data,
                     long_name="air_temperature",
@@ -94,6 +99,7 @@ class Test_ExtractData(IrisTest):
                                          (latitude, 1),
                                          (longitude, 2)],
                     units="K")
+        cube.add_aux_coord(forecast_ref_time)
 
         orography = Cube(np.ones((20, 20)),
                          long_name="surface_altitude",
@@ -188,6 +194,9 @@ class Test_ExtractData(IrisTest):
         self.sites = sites
         self.time_extract = time_extract
         self.neighbour_list = neighbour_list
+        self.latitudes = latitudes
+        self.latitude = latitude
+        self.forecast_ref_time = forecast_ref_time
 
     def return_type(self, method, ancillary_data, additional_data, **kwargs):
         """Test that the plugin returns an iris.cube.Cube."""
@@ -213,35 +222,55 @@ class Test_ExtractData(IrisTest):
     def different_projection(self, method, ancillary_data, additional_data,
                              expected, **kwargs):
         """Test that the plugin copes with non-lat/lon grids."""
+        from improver.spotdata.neighbour_finding import PointSelection
 
         trg_crs = None
         src_crs = ccrs.PlateCarree()
-        trg_crs = ccrs.LambertConformal(central_longitude=50,
-                                        central_latitude=10)
-        trg_crs_iris = coord_systems.LambertConformal(
-            central_lon=50, central_lat=10)
-        lons = self.cube.coord('longitude').points
-        lats = self.cube.coord('latitude').points
+        trg_crs = ccrs.TransverseMercator(
+            central_latitude=0, central_longitude=0)
+        trg_crs_iris = coord_systems.TransverseMercator(0, 0, 0, 0, 1.0)
+            
+        lons = [-50, 50]
+        lats = [-25, 25]
         x, y = [], []
         for lon, lat in zip(lons, lats):
             x_trg, y_trg = trg_crs.transform_point(lon, lat, src_crs)
             x.append(x_trg)
             y.append(y_trg)
 
-        new_x = AuxCoord(x, standard_name='projection_x_coordinate',
+        new_x = DimCoord(np.linspace(x[0], x[1], 20),
+                         standard_name='projection_x_coordinate',
                          units='m', coord_system=trg_crs_iris)
-        new_y = AuxCoord(y, standard_name='projection_y_coordinate',
+        new_y = DimCoord(np.linspace(y[0], y[1], 20),
+                         standard_name='projection_y_coordinate',
                          units='m', coord_system=trg_crs_iris)
 
-        cube = Cube(self.cube.data,
-                    long_name="air_temperature",
-                    dim_coords_and_dims=[(self.cube.coord('time'), 0)],
-                    aux_coords_and_dims=[(new_y, 1), (new_x, 2)],
-                    units="K")
+        new_cube = Cube(np.zeros(400).reshape(20, 20),
+                        long_name="air_temperature",
+                        dim_coords_and_dims=[(new_y, 0), (new_x, 1)],
+                        units="K")
+
+        cube = self.cube.copy()
+        cube = cube.regrid(new_cube, iris.analysis.Nearest())
+
+        if ancillary_data is not None:
+            ancillary_data['orography'] = ancillary_data['orography'].regrid(
+                new_cube, iris.analysis.Nearest())
+        if additional_data is not None:
+            for ad in additional_data.keys():
+                additional_data[ad] = additional_data[ad].regrid(
+                    new_cube, iris.analysis.Nearest())
+
+        new_crds = PointSelection().fast_nearest_neighbour(cube, self.sites)
+
+        # Define neighbours on this new projection
+        self.neighbour_list['i'] = 11
+        self.neighbour_list['j'] = 11
 
         plugin = Plugin(method)
         with iris.FUTURE.context(cell_datetime_objects=True):
             cube = cube.extract(self.time_extract)
+
         result = plugin.process(cube, self.sites, self.neighbour_list,
                                 ancillary_data, additional_data, **kwargs)
 
@@ -268,9 +297,8 @@ class Test_ExtractData(IrisTest):
                 self.cube, self.sites, self.neighbour_list,
                 ancillary_data, additional_data)
 
-
-class Test_miscellaneous(Test_ExtractData):
-    """Test miscellaneous other features."""
+class Test_ExtractData(Test_setup):
+    """Test the overall class for raise returns etc."""
 
     def test_invalid_method(self):
         """
@@ -285,25 +313,61 @@ class Test_miscellaneous(Test_ExtractData):
             plugin.process(cube, self.sites, self.neighbour_list, {}, None,
                            **self.kwargs)
 
-    def test__build_coordinates(self):
+
+class Test__build_coordinate(Test_setup):
+    """Test the _build_coordinate function."""
+
+    def test_build_latitude_coordinate(self):
         """
-        Test the _build_coordinates private function.
+        Test buiding a latitude coordinate.
 
         """
-        plugin = Plugin()._build_coordinates
-        points = np.array([0, 1, 2])
-        indices, latitude, longitude, altitude, utc_offset, wmo_site = (
-            plugin(points, points, points, points[::-1], points))
-        self.assertArrayEqual(indices.points, points)
-        self.assertArrayEqual(altitude.points, points)
-        self.assertArrayEqual(utc_offset.points, points[::-1])
-        self.assertEqual(latitude.name(), 'latitude')
-        self.assertEqual(longitude.name(), 'longitude')
-        self.assertEqual(wmo_site.name(), 'wmo_site')
-        self.assertIsInstance(indices, DimCoord)
-        self.assertIsInstance(latitude, AuxCoord)
+        plugin = Plugin()._build_coordinate
+        coord_system = iris.coord_systems.GeogCS(6371229.0)
+        result = plugin(self.latitudes, 'latitude', units='degrees',
+                        coord_system=coord_system)
+        self.assertArrayEqual(result.points, self.latitudes)
+        self.assertEqual(result.name(), 'latitude')
+        self.assertIsInstance(result, DimCoord)
+        self.assertEqual(result.units, 'degrees')
 
-    def test_make_cube(self):
+
+class Test_make_stat_coordinate_first(Test_setup):
+    """Test the function to reorder a cube to ensure the statistical coordinate
+    is the first dimension."""
+
+    def test_cube_reorder_realization(self):
+        """Test reordering a cube with a realization coordinate to make it come
+        first."""
+        plugin = Plugin().make_stat_coordinate_first
+        cube = set_up_cube(
+            zero_point_indices=(
+                (0, 0, 2, 2), (1, 0, 3, 3), (0, 1, 0, 0), (1, 1, 2, 1)),
+            num_time_points=2, num_grid_points=5, num_realization_points=2)
+        incorrect_cube = cube.copy()
+        incorrect_cube.transpose([1,2,0,3])
+        result = plugin(incorrect_cube)
+        self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
+
+    def test_cube_reorder_percentile(self):
+        """Test reordering a cube with a percentile coordinate to make it come
+        first."""
+        plugin = Plugin().make_stat_coordinate_first
+        cube = set_up_cube(
+            zero_point_indices=(
+                (0, 0, 2, 2), (1, 0, 3, 3), (0, 1, 0, 0), (1, 1, 2, 1)),
+            num_time_points=2, num_grid_points=5, num_realization_points=2)
+        cube.coords()[0].rename('percentile_over_time')
+        incorrect_cube = cube.copy()
+        incorrect_cube.transpose([1,2,0,3])
+        result = plugin(incorrect_cube)
+        self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
+
+
+class Test_make_cube(Test_setup):
+    """Test the creation of spotdata cubes."""
+
+    def test_make_spotdata_cube(self):
         """
         Test the make_cube function.
 
@@ -315,8 +379,21 @@ class Test_miscellaneous(Test_ExtractData):
         self.assertEqual(result.data, data)
         self.assertEqual(result.name(), 'air_temperature')
 
+    def test_missing_forecast_ref_time_in_source(self):
+        """
+        Ensure an error is raised if a source cube is missing a forecast
+        reference time.
 
-class Test_use_nearest(Test_ExtractData):
+        """
+        plugin = Plugin().make_cube
+        data = np.array([123])
+        self.cube.remove_coord('forecast_reference_time')
+        msg = 'No forcast reference time found on source cube.'
+        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+            plugin(self.cube, data, self.sites)
+
+
+class Test_use_nearest(Test_setup):
     """Test the use_nearest grid point method."""
 
     method = 'use_nearest'
@@ -337,8 +414,12 @@ class Test_use_nearest(Test_ExtractData):
                                   expected)
 
 
-class Test_orography_derived_temperature_lapse_rate(Test_ExtractData):
-    """Test the orography_derived_temperature_lapse_rate method."""
+class Test_orography_derived_temperature_lapse_rate(Test_setup):
+    """Test the orography_derived_temperature_lapse_rate method. Note that the
+    region used to calculate the temperature gradient is bases on cells rather
+    than geographic coordinates. Therefore the size of the region used to
+    determine the orography range will change with grid resolution. This is not
+    desirable, but this method is not currently expected to be used."""
 
     method = 'orography_derived_temperature_lapse_rate'
 
@@ -376,18 +457,20 @@ class Test_orography_derived_temperature_lapse_rate(Test_ExtractData):
         """
         Test that the plugin copes with non-lat/lon grids.
 
-        Cube is transformed into a LambertConformal projection. The usual
+        Cube is transformed Transverse Mercator projection. The usual
         latitude/longitude coordinates are used to query the grid, with iris
         functionality used to convert the query coordinates to the correct
         projection.
 
         The returned cube has latitude/longitude dimensions.
 
-        The expected value should be the same as the PlateCarree() projection
-        case above.
+        The expected value will be different to that above given by the
+        PlateCarree() projection, as the spatial smaller region used to make
+        this projection work gives a different spatial range over which to
+        calculate the temperature gradient.
 
         """
-        expected = 20.5
+        expected = 20. + (1./9.)
         self.different_projection(self.method, self.ancillary_data, None,
                                   expected)
 
@@ -399,7 +482,7 @@ class Test_orography_derived_temperature_lapse_rate(Test_ExtractData):
         self.missing_ancillary_data(self.method, {}, None)
 
 
-class Test_model_level_temperature_lapse_rate(Test_ExtractData):
+class Test_model_level_temperature_lapse_rate(Test_setup):
     """Test the model_level_temperature_lapse_rate method."""
 
     method = 'model_level_temperature_lapse_rate'

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -60,8 +60,7 @@ class Test_setup(IrisTest):
     """Test the extract data plugin."""
 
     def setUp(self):
-        """
-        Create a cube containing a regular lat-lon grid.
+        """Create a cube containing a regular lat-lon grid.
 
         Data is formatted to increase linearly in x/y dimensions,
         e.g.
@@ -69,8 +68,8 @@ class Test_setup(IrisTest):
               1 2 3 4
               2 3 4 5
               3 4 5 6
-
         """
+
         data = np.arange(0, 20, 1)
         for i in range(1, 20):
             data = np.append(data, np.arange(i, 20+i))
@@ -285,6 +284,7 @@ class Test_setup(IrisTest):
 
     def missing_ancillary_data(self, method, ancillary_data, additional_data):
         """Test that the plugin copes with missing ancillary data."""
+
         plugin = Plugin(method)
         with self.assertRaises(KeyError):
             plugin.process(
@@ -293,6 +293,7 @@ class Test_setup(IrisTest):
 
     def missing_additional_data(self, method, ancillary_data, additional_data):
         """Test that the plugin copes with missing additional data."""
+
         plugin = Plugin(method)
         with self.assertRaises(KeyError):
             plugin.process(
@@ -304,10 +305,9 @@ class Test_ExtractData(Test_setup):
     """Test the overall class for raise returns etc."""
 
     def test_invalid_method(self):
-        """
-        Test that the plugin can handle an invalid method being passed in.
+        """Test that the plugin can handle an invalid method being passed
+        in."""
 
-        """
         plugin = Plugin('quantum_interpolation')
         msg = 'Unknown method'
         with iris.FUTURE.context(cell_datetime_objects=True):
@@ -321,10 +321,8 @@ class Test__build_coordinate(Test_setup):
     """Test the _build_coordinate function."""
 
     def test_build_latitude_coordinate(self):
-        """
-        Test building a latitude coordinate.
+        """Test building a latitude coordinate."""
 
-        """
         plugin = Plugin()._build_coordinate
         coord_system = iris.coord_systems.GeogCS(6371229.0)
         result = plugin(self.latitudes, 'latitude', units='degrees',
@@ -342,6 +340,7 @@ class Test_make_stat_coordinate_first(Test_setup):
     def test_cube_reorder_realization(self):
         """Test reordering a cube with a realization coordinate to make it come
         first."""
+
         plugin = Plugin().make_stat_coordinate_first
         cube = set_up_cube(
             zero_point_indices=(
@@ -356,6 +355,7 @@ class Test_make_stat_coordinate_first(Test_setup):
     def test_cube_reorder_percentile(self):
         """Test reordering a cube with a percentile coordinate to make it come
         first."""
+
         plugin = Plugin().make_stat_coordinate_first
         cube = set_up_cube(
             zero_point_indices=(
@@ -372,6 +372,7 @@ class Test_make_stat_coordinate_first(Test_setup):
         """Test reordering a cube with a percentile and a realization
         coordinate. Should produce a warning and promote the first statistical
         coordinate that is found."""
+
         plugin = Plugin().make_stat_coordinate_first
         cube = set_up_cube(
             zero_point_indices=(
@@ -395,10 +396,7 @@ class Test_make_cube(Test_setup):
     """Test the creation of spotdata cubes."""
 
     def test_make_spotdata_cube(self):
-        """
-        Test the make_cube function.
-
-        """
+        """Test the make_cube function."""
         plugin = Plugin().make_cube
         data = np.array([123])
         result = plugin(self.cube, data, self.sites)
@@ -407,11 +405,8 @@ class Test_make_cube(Test_setup):
         self.assertEqual(result.name(), 'air_temperature')
 
     def test_missing_forecast_ref_time_in_source(self):
-        """
-        Ensure an error is raised if a source cube is missing a forecast
-        reference time.
-
-        """
+        """Ensure an error is raised if a source cube is missing a forecast
+        reference time."""
         plugin = Plugin().make_cube
         data = np.array([123])
         self.cube.remove_coord('forecast_reference_time')
@@ -465,34 +460,28 @@ class Test_orography_derived_temperature_lapse_rate(Test_setup):
         self.return_type(self.method, self.ancillary_data, None)
 
     def test_extracted_value(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
 
         Fit line given data above is: T = 0.15*altitude + 19
-        Site defined with has altitude=10, so T+expected = 20.5.
-
-        """
+        Site defined with has altitude=10, so T+expected = 20.5."""
         expected = 20.5
         self.extracted_value(self.method, self.ancillary_data, None, expected)
 
     def test_extracted_value_larger_field(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
         Use a larger no_neighbours to extend the range of grid points over
         which the lapse rate is calculated.
 
         Fit line given data above over larger field is:
         T = 0.25*altitude + 18.5
-        Site defined with has altitude=10, so T+expected = 21.
+        Site defined with has altitude=10, so T+expected = 21."""
 
-        """
         expected = 21
         self.extracted_value(self.method, self.ancillary_data, None, expected,
                              no_neighbours=25)
 
     def test_different_projection(self):
-        """
-        Test that the plugin copes with non-lat/lon grids.
+        """Test that the plugin copes with non-lat/lon grids.
 
         Cube is transformed Transverse Mercator projection. The usual
         latitude/longitude coordinates are used to query the grid, with iris
@@ -504,9 +493,8 @@ class Test_orography_derived_temperature_lapse_rate(Test_setup):
         The expected value will be different to that above given by the
         PlateCarree() projection, as the spatial smaller region used to make
         this projection work gives a different spatial range over which to
-        calculate the temperature gradient.
+        calculate the temperature gradient."""
 
-        """
         expected = 20. + (1./9.)
         self.different_projection(self.method, self.ancillary_data, None,
                                   expected)
@@ -530,16 +518,14 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
                          **self.kwargs)
 
     def test_extracted_value_valley(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
 
         Site set to be ~3.65m in altitude, which is a dz of -6.35m from the
         nearest grid point (its neighbour). This should give a temperature of
         22C at the site height.
 
-        This is an extrapolation scenario, an 'unresolved valley'.
+        This is an extrapolation scenario, an 'unresolved valley'."""
 
-        """
         self.sites['100']['altitude'] = 3.6446955
         self.neighbour_list['dz'] = -6.3553045
         expected = 22.
@@ -547,16 +533,14 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
                              expected, **self.kwargs)
 
     def test_extracted_value_deep_valley(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
 
         Site set to be 100m or 70m below the land surface (90m or 60m below sea
         level). The enforcement of a maximum extrapolation down into valleys
         should result in the two site altitudes returning the same temperature.
 
-        This is an extrapolation scenario, an 'unresolved valley'.
+        This is an extrapolation scenario, an 'unresolved valley'."""
 
-        """
         # Temperatures set up to mimic a cold night with an inversion where
         # valley temperatures may be expected to fall considerably due to
         # katabatic drainage.
@@ -586,17 +570,15 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
         self.assertEqual(result_dz.data, result_70.data)
 
     def test_extracted_value_hill_mixed(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
 
         Site set to be 60m in altitude, which is a dz of +50m from the nearest
         grid point (its neighbour). As such it should fall on the 900hPa level
         and get a temperature of 10C.
 
         This is an interpolation scenario, an 'unresolved hill' in a well
-        mixed atmosphere.
+        mixed atmosphere."""
 
-        """
         self.sites['100']['altitude'] = 60.
         self.neighbour_list['dz'] = 50.
         expected = 10.
@@ -604,8 +586,7 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
                              expected, **self.kwargs)
 
     def test_extracted_value_hill_stable_lower_dthetadz(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
 
         Push the dthetadz_threshold value to be negative, such that the
         potential temperature gradient is recalculated between surface
@@ -624,9 +605,8 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
         The site altitude and dz are not important here as the atmosphere has
         been setup with a uniform pressure between the surface and lower model
         level, thus the surface temperature should just be replicated at any
-        height (T=20C).
+        height (T=20C)."""
 
-        """
         t_level0 = np.ones((1, 20, 20))*20.
         t_level1 = np.ones((1, 20, 20))*15.
         t_level2 = np.ones((1, 20, 20))*10.
@@ -650,17 +630,15 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
                              expected, **self.kwargs)
 
     def test_extracted_value_hill_stable(self):
-        """
-        Test that the plugin returns the correct value.
+        """Test that the plugin returns the correct value.
 
         Site set to be 60m in altitude, which is a dz of +50m from the nearest
         grid point (its neighbour). As such it should fall on the 900hPa level
         and get a temperature of 21C.
 
         This is an interpolation scenario, an 'unresolved hill' in a stable
-        atmosphere.
+        atmosphere."""
 
-        """
         t_level0 = np.ones((1, 20, 20))*20.
         t_level1 = np.ones((1, 20, 20))*21.
         t_level2 = np.ones((1, 20, 20))*22.
@@ -675,8 +653,7 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
                              expected, **self.kwargs)
 
     def test_different_projection(self):
-        """
-        Test that the plugin copes with non-lat/lon grids.
+        """Test that the plugin copes with non-lat/lon grids.
 
         Cube is transformed into a LambertConformal projection. The usual
         latitude/longitude coordinates are used to query the grid, with iris
@@ -686,9 +663,8 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
         The returned cube has latitude/longitude dimensions.
 
         The expected value should be the same as the PlateCarree() projection
-        case above.
+        case above."""
 
-        """
         self.sites['100']['altitude'] = 60.
         self.neighbour_list['dz'] = 50.
         expected = 10.
@@ -696,11 +672,9 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
                                   expected, **self.kwargs)
 
     def test_missing_additional_data(self):
-        """
-        Test for appropriate error message when required additional
-        diagnostics are unavailable.
+        """Test for appropriate error message when required additional
+        diagnostics are unavailable."""
 
-        """
         self.missing_additional_data(self.method, self.ancillary_data, {})
 
 

--- a/lib/improver/tests/spotdata/spotdata/test_extrema.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extrema.py
@@ -61,6 +61,9 @@ class Test_extrema(IrisTest):
                                    calendar='gregorian')
         time_coord = DimCoord(times, standard_name='time',
                               units=time_units)
+        forecast_ref_time = time_coord[0].copy()
+        forecast_ref_time.rename('forecast_reference_time')
+
         # UTC offset arranged to sequence -12 --> 14.
         utc_offsets = range(-12, 15) * int(n_data/24)
         utc_offset = AuxCoord(utc_offsets, long_name='utc_offset',
@@ -76,6 +79,7 @@ class Test_extrema(IrisTest):
                     dim_coords_and_dims=[(time_coord, 0), (indices, 1)],
                     aux_coords_and_dims=[(utc_offset, 1)],
                     units="K")
+        cube.add_aux_coord(forecast_ref_time)
         self.cube = cube
         self.time_coord = time_coord
         self.n_data = n_data

--- a/lib/improver/tests/spotdata/spotdata/test_main.py
+++ b/lib/improver/tests/spotdata/spotdata/test_main.py
@@ -74,6 +74,8 @@ class Test_main(IrisTest):
             [1487311200, 1487314800], standard_name='time',
             units=cf_units.Unit('seconds since 1970-01-01 00:00:00',
                                 calendar='gregorian'))
+        forecast_ref_time = time[0].copy()
+        forecast_ref_time.rename('forecast_reference_time')
 
         cube = Cube(data,
                     long_name="air_temperature",
@@ -81,6 +83,7 @@ class Test_main(IrisTest):
                                          (latitude, 1),
                                          (longitude, 2)],
                     units="K")
+        cube.add_aux_coord(forecast_ref_time)
 
         # Create the orography ancillary cube.
         orography = Cube(np.ones((20, 20)),


### PR DESCRIPTION
#235 

Adding metadata to spotdata cubes, including forecast reference time and forecast period. Also somewhat rewriting cube construction in spotdata in the hope that it can all get factored out to common utilities in a future ticket.

Testing:
 - [x] Tests need to be rewritten, don't currently work,
 - [x] CLI tests also fail.