### PR TITLE
Exclude temporary tilda files from pep8 and pylint checks.

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -21,7 +21,8 @@ function echo_ok {
 function get_python_files {
     FILES_TO_TEST=`find $IMPROVER_DIR -type f \( -name '*.py' \
                                               -o -name 'improver-*' \
-                                               ! -name 'improver-tests' \)`
+                                               ! -name 'improver-tests' \
+                                               ! -name '*~' \)`
 }
 
 function improver_test_pep8 {
@@ -78,7 +79,7 @@ function improver_test_cli {
 function print_usage {
     # Output CLI usage information.
     cat <<'__USAGE__'
-improver tests [OPTIONS] [SUBTEST...] 
+improver tests [OPTIONS] [SUBTEST...]
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -33,7 +33,7 @@
   run improver tests -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [OPTIONS] [SUBTEST...] 
+improver tests [OPTIONS] [SUBTEST...]
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -33,7 +33,7 @@
   run improver tests --silly-option
   [[ "$status" -eq 2 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [OPTIONS] [SUBTEST...] 
+improver tests [OPTIONS] [SUBTEST...]
 
 Run pep8, pylint, documentation, unit and CLI acceptance tests.
 


### PR DESCRIPTION
Fiona stumbled across an improver-<plugin>~ file being checked, so I have added an exclusion for files ending in a tilda to the pep8/pylint file check list.

Removed trailing white space from improver-tests and associated bats tests.