### PR TITLE
CLI for threshold plugin

### DIFF
--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -37,7 +37,6 @@ import iris
 import cf_units
 
 from improver.threshold import BasicThreshold
-from improver.utilities.cube_manipulation import concatenate_cubes
 from improver.spotdata.extract_data import ExtractData
 
 
@@ -45,7 +44,9 @@ def main():
     """Load in arguments and get going."""
     parser = argparse.ArgumentParser(
         description="Calculate the threshold truth value of cube data "
-        "relative to the provided threshold value. A fuzzy factor may be "
+        "relative to the provided threshold value. By default data are "
+        "tested to be above the thresholds, though the --below_threshold "
+        "flag enables testing below thresholds. A fuzzy factor may be "
         "provided to capture data that is within this factor of the "
         "threshold.")
     parser.add_argument("input_filepath", metavar="INPUT_FILE",
@@ -56,19 +57,19 @@ def main():
                         nargs="+", type=float,
                         help="Threshold value or values about which to "
                         "calculate the truth values; e.g. 270 300")
-    parser.add_argument("--threshold_units", metavar="THRESHOLD_UNTIS",
+    parser.add_argument("--threshold_units", metavar="THRESHOLD_UNITS",
                         default=None, type=str,
                         help="Units of the threshold values. If not provided "
                         "the units are assumed to be the same as those of the "
                         "input cube. Specifying the units here will allow a "
                         "suitable conversion to match the cube units if "
                         "possible.")
-    parser.add_argument("--below_threshold", metavar="BELOW_THRESHOLD",
-                        default=False, type=bool,
+    parser.add_argument("--below_threshold", default=False,
+                        action='store_true',
                         help="By default truth values of 1 are returned for "
-                        "data ABOVE the threshold value(s). Setting this "
-                        "to TRUE changes this behaviour to return 1 for data "
-                        "below the threshold values.")
+                        "data ABOVE the threshold value(s). Using this flag "
+                        "changes this behaviour to return 1 for data below "
+                        "the threshold values.")
     parser.add_argument("--fuzzy_factor", metavar="FUZZY_FACTOR",
                         default=None, type=float,
                         help="A decimal fraction defining the factor about "
@@ -85,7 +86,6 @@ def main():
         threshold_unit = cf_units.Unit(args.threshold_units)
         args.threshold_values = [threshold_unit.convert(threshold, cube.units)
                                  for threshold in args.threshold_values]
-        print args.threshold_values
 
     thresholded_cubes = iris.cube.CubeList()
     for threshold in args.threshold_values:
@@ -95,7 +95,7 @@ def main():
         result = iris.util.new_axis(result, 'threshold')
         thresholded_cubes.append(result)
 
-    result = concatenate_cubes(thresholded_cubes)
+    result, = thresholded_cubes.concatenate()
     result = ExtractData.make_stat_coordinate_first(result)
 
     iris.save(result, args.output_filepath, unlimited_dimensions=[])

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -34,10 +34,12 @@
 import argparse
 
 import iris
+import cf_units
 
 from improver.threshold import BasicThreshold
 from improver.utilities.cube_manipulation import concatenate_cubes
 from improver.spotdata.extract_data import ExtractData
+
 
 def main():
     """Load in arguments and get going."""
@@ -75,7 +77,6 @@ def main():
                         "threshold value may return a fractional truth value "
                         "if they fall within this fuzzy factor region.")
 
-
     args = parser.parse_args()
     cube = iris.load_cube(args.input_filepath)
 
@@ -84,6 +85,7 @@ def main():
         threshold_unit = cf_units.Unit(args.threshold_units)
         args.threshold_values = [threshold_unit.convert(threshold, cube.units)
                                  for threshold in args.threshold_values]
+        print args.threshold_values
 
     thresholded_cubes = iris.cube.CubeList()
     for threshold in args.threshold_values:

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to apply thresholding to a cube."""
+
+import argparse
+
+import iris
+
+from improver.threshold import BasicThreshold
+from improver.utilities.cube_manipulation import concatenate_cubes
+from improver.spotdata.extract_data import ExtractData
+
+def main():
+    """Load in arguments and get going."""
+    parser = argparse.ArgumentParser(
+        description="Calculate the threshold truth value of cube data "
+        "relative to the provided threshold value. A fuzzy factor may be "
+        "provided to capture data that is within this factor of the "
+        "threshold.")
+    parser.add_argument("input_filepath", metavar="INPUT_FILE",
+                        help="A path to an input NetCDF file to be processed")
+    parser.add_argument("output_filepath", metavar="OUTPUT_FILE",
+                        help="The output path for the processed NetCDF")
+    parser.add_argument("threshold_values", metavar="THRESHOLD_VALUES",
+                        nargs="+", type=float,
+                        help="Threshold value or values about which to "
+                        "calculate the truth values; e.g. 270 300")
+    parser.add_argument("--threshold_units", metavar="THRESHOLD_UNTIS",
+                        default=None, type=str,
+                        help="Units of the threshold values. If not provided "
+                        "the units are assumed to be the same as those of the "
+                        "input cube. Specifying the units here will allow a "
+                        "suitable conversion to match the cube units if "
+                        "possible.")
+    parser.add_argument("--below_threshold", metavar="BELOW_THRESHOLD",
+                        default=False, type=bool,
+                        help="By default truth values of 1 are returned for "
+                        "data ABOVE the threshold value(s). Setting this "
+                        "to TRUE changes this behaviour to return 1 for data "
+                        "below the threshold values.")
+    parser.add_argument("--fuzzy_factor", metavar="FUZZY_FACTOR",
+                        default=None, type=float,
+                        help="A decimal fraction defining the factor about "
+                        "the threshold value(s) which should be treated as "
+                        "fuzzy. Data which fail a test against the hard "
+                        "threshold value may return a fractional truth value "
+                        "if they fall within this fuzzy factor region.")
+
+
+    args = parser.parse_args()
+    cube = iris.load_cube(args.input_filepath)
+
+    # Allow for threshold value unit conversion.
+    if args.threshold_units is not None:
+        threshold_unit = cf_units.Unit(args.threshold_units)
+        args.threshold_values = [threshold_unit.convert(threshold, cube.units)
+                                 for threshold in args.threshold_values]
+
+    thresholded_cubes = iris.cube.CubeList()
+    for threshold in args.threshold_values:
+        result = BasicThreshold(
+            threshold, fuzzy_factor=args.fuzzy_factor,
+            below_thresh_ok=args.below_threshold).process(cube)
+        result = iris.util.new_axis(result, 'threshold')
+        thresholded_cubes.append(result)
+
+    result = concatenate_cubes(thresholded_cubes)
+    result = ExtractData.make_stat_coordinate_first(result)
+
+    iris.save(result, args.output_filepath, unlimited_dimensions=[])
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -121,7 +121,7 @@ class BasicThreshold(object):
                 (cube.data - lower_threshold) /
                 ((self.threshold * (2. - self.fuzzy_factor)) - lower_threshold)
             )
-        truth_value = np.clip(truth_value, 0., 1.)
+        truth_value = np.clip(truth_value, 0., 1.).astype(np.float64)
         if self.below_thresh_ok:
             truth_value = 1. - truth_value
         cube.data = truth_value

--- a/tests/improver-threshold/00-null.bats
+++ b/tests/improver-threshold/00-null.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "threshold no arguments" {
+  run improver threshold
+  [[ "$status" -eq 2 ]]
+  expected="usage: improver-threshold [-h] [--threshold_units THRESHOLD_UNITS]
+                          [--below_threshold] [--fuzzy_factor FUZZY_FACTOR]
+                          INPUT_FILE OUTPUT_FILE THRESHOLD_VALUES
+                          [THRESHOLD_VALUES ...]"
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "threshold -h" {
+  run improver threshold -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__HELP__' || true
+usage: improver-threshold [-h] [--threshold_units THRESHOLD_UNITS]
+                          [--below_threshold] [--fuzzy_factor FUZZY_FACTOR]
+                          INPUT_FILE OUTPUT_FILE THRESHOLD_VALUES
+                          [THRESHOLD_VALUES ...]
+
+Calculate the threshold truth value of cube data relative to the provided
+threshold value. By default data are tested to be above the thresholds, though
+the --below_threshold flag enables testing below thresholds. A fuzzy factor
+may be provided to capture data that is within this factor of the threshold.
+
+positional arguments:
+  INPUT_FILE            A path to an input NetCDF file to be processed
+  OUTPUT_FILE           The output path for the processed NetCDF
+  THRESHOLD_VALUES      Threshold value or values about which to calculate the
+                        truth values; e.g. 270 300
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --threshold_units THRESHOLD_UNITS
+                        Units of the threshold values. If not provided the
+                        units are assumed to be the same as those of the input
+                        cube. Specifying the units here will allow a suitable
+                        conversion to match the cube units if possible.
+  --below_threshold     By default truth values of 1 are returned for data
+                        ABOVE the threshold value(s). Using this flag changes
+                        this behaviour to return 1 for data below the
+                        threshold values.
+  --fuzzy_factor FUZZY_FACTOR
+                        A decimal fraction defining the factor about the
+                        threshold value(s) which should be treated as fuzzy.
+                        Data which fail a test against the hard threshold
+                        value may return a fractional truth value if they fall
+                        within this fuzzy factor region.
+__HELP__
+  [[ "$output" == "$expected" ]]
+}

--- a/tests/improver-threshold/02-basic.bats
+++ b/tests/improver-threshold/02-basic.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output 280" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      280
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}

--- a/tests/improver-threshold/03-below_threshold.bats
+++ b/tests/improver-threshold/03-below_threshold.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output 280 --below_threshold" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      280 --below_threshold
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/threshold/below_threshold/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}

--- a/tests/improver-threshold/04-multiple_thresholds.bats
+++ b/tests/improver-threshold/04-multiple_thresholds.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output 270 280 290" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      270 280 290
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/threshold/multiple_thresholds/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}

--- a/tests/improver-threshold/05-threshold_units.bats
+++ b/tests/improver-threshold/05-threshold_units.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output 6.85 --threshold_units celsius" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      6.85 --threshold_units celsius
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/threshold/threshold_units/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}

--- a/tests/improver-threshold/06-fuzzy_factor.bats
+++ b/tests/improver-threshold/06-fuzzy_factor.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output 280 --fuzzy_factor 0.2" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      280 --fuzzy_factor 0.2
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/threshold/fuzzy_factor/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}


### PR DESCRIPTION
Issue #98 

A CLI to accept a single or multiple thresholds to apply to a cube. When multiple thresholds are provided it produces a concatenated cube with a threshold dimension coordinate.

Acceptance tests to be added following first review.
