### PR TITLE
Update pylintrc file to enable use of up-to-date pylint at our site

### DIFF
--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -2,5 +2,5 @@
 extension-pkg-whitelist=numpy,scipy
 
 [TYPECHECK]
-ignored-classes=tuple,WeightedAggregator,MaskedArray,PercentileAggregator
+ignored-classes=data,list,tuple,WeightedAggregator,MaskedArray,PercentileAggregator
 ignored-modules=numpy,scipy,scipy.stats,cartopy.crs


### PR DESCRIPTION
Updates pylintrc so that `pylint -E` in `improver tests` will pass using the latest pylint at our site.

There were quite a few new false-alarm 'membership' issues detected by this version of pylint, stemming from known pylint problems. It looks like pylint will be able to figure this stuff out in the future, but for now I think it is OK to skip them.

Test by removing the PYLINT override in `etc/site-init` and running `improver tests` with/without this change.
