### PR TITLE
make location of IMPROVER site-init file configurable through environment

### DIFF
--- a/bin/improver
+++ b/bin/improver
@@ -19,7 +19,7 @@
 
 set -eu
 
-export IMPROVER_DIR=${IMPROVER_DIR-$(cd $(dirname $0)/../ && pwd -P)}
+export IMPROVER_DIR=$(cd $(dirname $0)/../ && pwd -P)
 
 # List all improver subcommands or operations.
 get_operations() {

--- a/bin/improver
+++ b/bin/improver
@@ -66,7 +66,7 @@ OPER=$1
 shift
 
 # Apply site-specific setup if necessary.
-if [[ -f "${IMPROVER_SITE_INIT=$IMPROVER_DIR/etc/site-init}" ]]; then
+if [[ -f "${IMPROVER_SITE_INIT:=$IMPROVER_DIR/etc/site-init}" ]]; then
     . "$IMPROVER_SITE_INIT"
 fi
 

--- a/bin/improver
+++ b/bin/improver
@@ -19,7 +19,7 @@
 
 set -eu
 
-export IMPROVER_DIR=$(cd $(dirname $0)/../ && pwd -P)
+export IMPROVER_DIR="$(cd $(dirname $0)/../ && pwd -P)"
 
 # List all improver subcommands or operations.
 get_operations() {

--- a/bin/improver
+++ b/bin/improver
@@ -19,7 +19,7 @@
 
 set -eu
 
-export IMPROVER_DIR="$(cd $(dirname $0)/../ && pwd -P)"
+export IMPROVER_DIR=${IMPROVER_DIR-$(cd $(dirname $0)/../ && pwd -P)}
 
 # List all improver subcommands or operations.
 get_operations() {
@@ -66,8 +66,8 @@ OPER=$1
 shift
 
 # Apply site-specific setup if necessary.
-if [[ -f "$IMPROVER_DIR/etc/site-init" ]]; then
-    . "$IMPROVER_DIR/etc/site-init"
+if [[ -f "${IMPROVER_SITE_INIT=$IMPROVER_DIR/etc/site-init}" ]]; then
+    . "$IMPROVER_SITE_INIT"
 fi
 
 # Put our library and scripts in the paths.


### PR DESCRIPTION
Make location of IMPROVER site-init file configurable through environment, so it can be changed for read-only installations of IMPROVER.