### PR TITLE
IMPRO-227 ECC conventions updated + acceptance of percentile list.

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_utilities.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_utilities.py
@@ -132,7 +132,8 @@ def choose_set_of_percentiles(no_of_percentiles, sampling="quantile"):
     return [item*100 for item in percentiles]
 
 
-def create_cube_with_percentiles(percentiles, template_cube, cube_data):
+def create_cube_with_percentiles(percentiles, template_cube, cube_data,
+                                 custom_name=None):
     """
     Create a cube with a percentile coordinate based on a template cube.
     The resulting cube will have an extra percentile coordinate compared with
@@ -164,9 +165,13 @@ def create_cube_with_percentiles(percentiles, template_cube, cube_data):
         template cube.
 
     """
+    percentile_coord_name = custom_name
+    if percentile_coord_name is None:
+        percentile_coord_name = "percentile_over_realization"
+
     percentile_coord = iris.coords.DimCoord(
-        np.float32(percentiles), long_name="percentile_over_realization",
-        units=unit.Unit("1"), var_name="percentile_over_realization")
+        np.float32(percentiles), long_name=percentile_coord_name,
+        units=unit.Unit("%"), var_name=percentile_coord_name)
 
     metadata_dict = copy.deepcopy(template_cube.metadata._asdict())
     result = iris.cube.Cube(cube_data, **metadata_dict)

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -36,7 +36,9 @@ Unit tests for the
 import numpy as np
 import unittest
 
+import cf_units as unit
 from iris.cube import Cube
+from iris.coords import DimCoord
 from iris.tests import IrisTest
 
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
@@ -149,6 +151,31 @@ class Test__probabilities_to_percentiles(IrisTest):
         result = plugin._probabilities_to_percentiles(
             cube, percentiles, bounds_pairing)
         self.assertIsInstance(result, Cube)
+
+    def test_return_name(self):
+        """Test that the plugin returns an Iris.cube.Cube with an appropriate
+        name.
+        """
+        cube = self.current_temperature_forecast_cube
+        percentiles = [10, 50, 90]
+        bounds_pairing = (-40, 50)
+        plugin = Plugin()
+        result = plugin._probabilities_to_percentiles(
+            cube, percentiles, bounds_pairing)
+        self.assertEqual(result.name(), 'air_temperature')
+
+    def test_return_coord_units(self):
+        """Test that the plugin returns an Iris.cube.Cube with an appropriate
+        percentile coordinate with suitable units.
+        """
+        cube = self.current_temperature_forecast_cube
+        percentiles = [10, 50, 90]
+        bounds_pairing = (-40, 50)
+        plugin = Plugin()
+        result = plugin._probabilities_to_percentiles(
+            cube, percentiles, bounds_pairing)
+        self.assertIsInstance(result.coord('percentile'), DimCoord)
+        self.assertEqual(result.coord('percentile').units, unit.Unit("%"))
 
     def test_transpose_cube_dimensions(self):
         """
@@ -296,11 +323,11 @@ class Test__probabilities_to_percentiles(IrisTest):
                            [-16., 8., -30.4],
                            [-30.4, -34., -35.2]]],
                          [[[31., 10., 12.],
-                           [10., 10.,  8.],
+                           [10., 10., 8.],
                            [8., -10., -16.]]],
                          [[[46.2, 31., 42.4],
                            [31., 11.6, 12.],
-                           [11., 9.,  3.2]]]])
+                           [11., 9., 3.2]]]])
 
         cube = self.current_temperature_forecast_cube
         percentiles = [10, 50, 90]
@@ -317,7 +344,7 @@ class Test__probabilities_to_percentiles(IrisTest):
         constructing the percentiles.
         """
         data = np.array([[[[12.2, 8., 12.2],
-                           [-16.,  8., -30.4],
+                           [-16., 8., -30.4],
                            [-30.4, -34., -35.2]]],
                          [[[29., 26.66666667, 29.],
                            [23.75, 26.66666667, 8.],
@@ -375,35 +402,35 @@ class Test__probabilities_to_percentiles(IrisTest):
         requested.
         """
         data = np.array([[[[13.9, -16., 10.2],
-                          [-28., -16., -35.2],
-                          [-35.2, -37., -37.6]]],
-                        [[[17.7, 8.25, 10.6],
-                          [-4., 8.25, -25.6],
-                          [-25.6, -31., -32.8]]],
-                        [[[21.5, 8.75, 11.],
-                          [8.33333333, 8.75, -16.],
-                          [-16., -25., -28.]]],
-                        [[[25.3, 9.25, 11.4],
-                          [9., 9.25,  -6.4],
-                          [-6.4, -19., -23.2]]],
-                        [[[29.1, 9.75, 11.8],
-                          [9.66666667, 9.75,  3.2],
-                          [3.2, -13., -18.4]]],
-                        [[[32.9, 10.33333333, 15.8],
-                          [10.33333333, 10.2,  8.5],
-                          [8.33333333, -7., -13.6]]],
-                        [[[36.7, 11., 23.4],
-                          [11., 10.6, 9.5],
-                          [9., -1., -8.8]]],
-                        [[[40.5, 11.66666667, 31.],
-                          [11.66666667, 11., 10.5],
-                          [9.66666667, 5., -4.]]],
-                        [[[44.3, 21.5, 38.6],
-                          [21.5, 11.4, 11.5],
-                          [10.5, 8.5, 0.8]]],
-                        [[[48.1, 40.5, 46.2],
-                          [40.5, 11.8, 31.],
-                          [11.5, 9.5, 5.6]]]])
+                           [-28., -16., -35.2],
+                           [-35.2, -37., -37.6]]],
+                         [[[17.7, 8.25, 10.6],
+                           [-4., 8.25, -25.6],
+                           [-25.6, -31., -32.8]]],
+                         [[[21.5, 8.75, 11.],
+                           [8.33333333, 8.75, -16.],
+                           [-16., -25., -28.]]],
+                         [[[25.3, 9.25, 11.4],
+                           [9., 9.25, -6.4],
+                           [-6.4, -19., -23.2]]],
+                         [[[29.1, 9.75, 11.8],
+                           [9.66666667, 9.75, 3.2],
+                           [3.2, -13., -18.4]]],
+                         [[[32.9, 10.33333333, 15.8],
+                           [10.33333333, 10.2, 8.5],
+                           [8.33333333, -7., -13.6]]],
+                         [[[36.7, 11., 23.4],
+                           [11., 10.6, 9.5],
+                           [9., -1., -8.8]]],
+                         [[[40.5, 11.66666667, 31.],
+                           [11.66666667, 11., 10.5],
+                           [9.66666667, 5., -4.]]],
+                         [[[44.3, 21.5, 38.6],
+                           [21.5, 11.4, 11.5],
+                           [10.5, 8.5, 0.8]]],
+                         [[[48.1, 40.5, 46.2],
+                           [40.5, 11.8, 31.],
+                           [11.5, 9.5, 5.6]]]])
 
         cube = self.current_temperature_forecast_cube
         percentiles = np.arange(5, 100, 10)
@@ -450,7 +477,7 @@ class Test_process(IrisTest):
             add_forecast_reference_time_and_forecast_period(
                 set_up_probability_above_threshold_temperature_cube()))
 
-    def test_check_data_specifying_percentiles(self):
+    def test_check_data_specifying_no_of_percentiles(self):
         """
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific number of percentiles.
@@ -466,10 +493,32 @@ class Test_process(IrisTest):
                            [9.66666667, 5., -4.]]]])
 
         cube = self.current_temperature_forecast_cube
-        percentiles = [10, 50, 90]
+        no_of_percentiles = 3
         plugin = Plugin()
         result = plugin.process(
-            cube, no_of_percentiles=len(percentiles))
+            cube, no_of_percentiles=no_of_percentiles)
+        self.assertArrayAlmostEqual(result.data, data)
+
+    def test_check_data_specifying_percentiles(self):
+        """
+        Test that the plugin returns an Iris.cube.Cube with the expected
+        data values for a specific set of percentiles.
+        """
+        data = np.array([[[[21.5, 8.75, 11.],
+                           [8.33333333, 8.75, -16.],
+                           [-16., -25., -28.]]],
+                         [[[31., 10., 12.],
+                           [10., 10., 8.],
+                           [8., -10., -16.]]],
+                         [[[40.5, 11.66666667, 31.],
+                           [11.66666667, 11., 10.5],
+                           [9.66666667, 5., -4.]]]])
+
+        cube = self.current_temperature_forecast_cube
+        percentiles = [25, 50, 75]
+        plugin = Plugin()
+        result = plugin.process(
+            cube, percentiles=percentiles)
         self.assertArrayAlmostEqual(result.data, data)
 
     def test_check_data_not_specifying_percentiles(self):
@@ -491,6 +540,20 @@ class Test_process(IrisTest):
         plugin = Plugin()
         result = plugin.process(cube)
         self.assertArrayAlmostEqual(result.data, data)
+
+    def test_check_data_over_specifying_percentiles(self):
+        """
+        Test that the plugin raises a suitable error when both a number and set
+        or percentiles are specified.
+        """
+        no_of_percentiles = 3
+        percentiles = [25, 50, 75]
+        cube = self.current_temperature_forecast_cube
+        plugin = Plugin()
+        msg = "Cannot specify both no_of_percentiles and percentiles"
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.process(cube, no_of_percentiles=no_of_percentiles,
+                           percentiles=percentiles)
 
 
 if __name__ == '__main__':

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -171,3 +171,49 @@ def find_dimension_coordinate_mismatch(
     else:
         mismatch = list(set(second_dim_names) - set(first_dim_names))
     return mismatch
+
+
+def coord_exists_in_cube(cube, coord_name):
+    """
+    Test whether a coordinate exists within a cube, regardless of whether it
+    is a dimension, auxillary or scalar coordinate.
+
+    Args:
+        cube : iris.cube.Cube
+            The cube to be tested.
+        coord_name : str
+            The name of the coordinate to be looked for.
+
+    Returns:
+        bool
+            True if the coordinate is found within the cube, False if it is
+            not.
+
+    """
+
+    if [coord.name() for coord in cube.coords()
+            if coord_name in coord.name()]:
+        return True
+    return False
+
+
+def coord_is_dimension(cube, coord_name):
+    """
+    Test whether a coordinate is a dimension coordinate in the given cube.
+
+    Args:
+        cube : iris.cube.Cube
+            The cube to be tested.
+        coord_name : str
+            The name of the coordinate to be looked for.
+
+    Returns:
+        bool
+            True if the coordinate is found to be dimension coordinate on the
+            input cube. False if it is not.
+
+    """
+    if coord_exists_in_cube(cube, coord_name):
+        if cube.coord_dims(coord_name):
+            return True
+    return False

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -35,6 +35,8 @@ import numpy as np
 
 import iris
 from iris.coords import AuxCoord, DimCoord
+from improver.utilities.cube_checker import (coord_exists_in_cube,
+                                             coord_is_dimension)
 
 
 def _associate_any_coordinate_with_master_coordinate(
@@ -194,6 +196,14 @@ def concatenate_cubes(
 
     associated_master_cubelist = iris.cube.CubeList([])
     for cube in cubes:
+
+        # We could include this to promote the necessary coordinate to a
+        # dimension if it exists and there are other coordinates to be
+        # associated with it.
+        #        if (coord_exists_in_cube(cube, master_coord) and not
+        #                coord_is_dimension(cube, master_coord):
+        #            cube = iris.util.new_axis(cube, master_coord)
+
         associated_master_cubelist.append(
             _associate_any_coordinate_with_master_coordinate(
                 cube, master_coord=master_coord,


### PR DESCRIPTION
ECC updated to use relative to threshold information, to set correct units for percentile coordinate, to slice over realizations for memory reduction if necessary, and to accept a list of desired percentile values. New unit tests added.

Known CODACY failure - optional improvement to promotion of coordinates included but commented out, hence unused import.

Reference issue if exists #54 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

