### PR TITLE
IMPRO-319 - Precision error rounding.

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -381,6 +381,11 @@ class GeneratePercentilesFromProbabilities(object):
         prob_slices = convert_cube_data_to_2d(
             forecast_probabilities, coord=threshold_coord.name())
 
+        # The requirement below for a monatonically changing probability
+        # across thresholds can be thwarted by precision errors of order 1E-11,
+        # as such, here we round to a precision of 10 decimal places.
+        prob_slices = np.around(prob_slices, 10)
+
         # Invert probabilities for data thresholded above thresholds.
         relation = forecast_probabilities.attributes['relative_to_threshold']
         if relation == 'above':

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -381,7 +381,7 @@ class GeneratePercentilesFromProbabilities(object):
         prob_slices = convert_cube_data_to_2d(
             forecast_probabilities, coord=threshold_coord.name())
 
-        # The requirement below for a monatonically changing probability
+        # The requirement below for a monotonically changing probability
         # across thresholds can be thwarted by precision errors of order 1E-11,
         # as such, here we round to a precision of 10 decimal places.
         prob_slices = np.around(prob_slices, 10)


### PR DESCRIPTION
Added a rounding to ECC to avoid precision errors causing a non-monotonically increasing probability error.

Reference issue if exists

Testing:
 - [x] Ran tests and they passed OK
