### PR TITLE
Weighted-blending with a 0 linear_starting_point.

### DIFF
--- a/bin/improver-weighted-blending
+++ b/bin/improver-weighted-blending
@@ -106,7 +106,7 @@ def main():
     linear.add_argument('--y0val', metavar='LINEAR_STARTING_POINT', type=float,
                         help='The relative value of the weighting start '
                              'point for choosing default linear weights. '
-                             'This must be a positive float. If not set, '
+                             'This must be a positive float or 0. If not set, '
                              'default values of y0val=20.0 and ynval=2.0 '
                              'are set.')
     nonlinear = parser.add_argument_group('nonlinear weights options',

--- a/lib/improver/blending/weights.py
+++ b/lib/improver/blending/weights.py
@@ -292,8 +292,8 @@ class ChooseDefaultWeightsLinear(object):
         if num_of_weights == 1:
             weights = np.array([1.0])
             return weights
-        if not isinstance(self.y0val, float) or self.y0val <= 0.0:
-            msg = ('y0val must be a float > 0.0, '
+        if not isinstance(self.y0val, float) or self.y0val < 0.0:
+            msg = ('y0val must be a float >= 0.0, '
                    'y0val = {0:s}'.format(str(self.y0val)))
             raise ValueError(msg)
         if self.ynval is not None:

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -54,7 +54,7 @@ class Test_linear_weights(IrisTest):
 
     def test_fails_y0val_set_wrong(self):
         """Test it fails if y0val not set properly """
-        msg = ('y0val must be a float > 0.0')
+        msg = ('y0val must be a float >= 0.0')
         with self.assertRaisesRegexp(ValueError, msg):
             LinearWeights(y0val=-0.1).linear_weights(3)
         with self.assertRaisesRegexp(ValueError, msg):
@@ -132,7 +132,7 @@ class Test_process(IrisTest):
     def test_fails_y0val_lessthan_zero(self):
         """Test it raises a Value Error if y0val less than zero. """
         plugin = LinearWeights(y0val=-10.0)
-        msg = ('y0val must be a float > 0.0')
+        msg = ('y0val must be a float >= 0.0')
         with self.assertRaisesRegexp(ValueError, msg):
             plugin.process(self.cube, self.coord_name, self.coord_vals)
 

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -89,6 +89,24 @@ class Test_linear_weights(IrisTest):
                                     0.13333333, 0.11111111])
         self.assertArrayAlmostEqual(result, expected_result)
 
+    def test_returns_correct_values_y0val_is_0_ynval_set(self):
+        """Test it returns the correct values when y0val=0 and ynval set"""
+        result = LinearWeights(y0val=0.0, ynval=5.0).linear_weights(5)
+        expected_result = np.array([0.0, 0.1, 0.2, 0.3, 0.4])
+        self.assertArrayAlmostEqual(result, expected_result)
+
+    def test_returns_correct_values_y0val_is_0_slope_set(self):
+        """Test it returns the correct values when y0val=0 and slope set."""
+        result = LinearWeights(y0val=0.0, slope=1.0).linear_weights(5)
+        expected_result = np.array([0.0, 0.1, 0.2, 0.3, 0.4])
+        self.assertArrayAlmostEqual(result, expected_result)
+
+    def test_returns_correct_values_y0val_is_0_slope_is_0(self):
+        """Test it raises an error when y0val=0 and slope=0."""
+        msg = "Sum of weights must be > 0.0"
+        with self.assertRaisesRegexp(ValueError, msg):
+            LinearWeights(y0val=0.0, slope=0.0).linear_weights(5)
+
 
 class Test_process(IrisTest):
     """Test the Default Linear Weights plugin. """

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -101,6 +101,12 @@ class Test_linear_weights(IrisTest):
         expected_result = np.array([0.0, 0.1, 0.2, 0.3, 0.4])
         self.assertArrayAlmostEqual(result, expected_result)
 
+    def test_returns_correct_values_y0val_is_0_ynval_is_0(self):
+        """Test it raises an error when y0val=0 and ynval=0."""
+        msg = "Sum of weights must be > 0.0"
+        with self.assertRaisesRegexp(ValueError, msg):
+            LinearWeights(y0val=0.0, slope=0.0).linear_weights(5)
+
     def test_returns_correct_values_y0val_is_0_slope_is_0(self):
         """Test it raises an error when y0val=0 and slope=0."""
         msg = "Sum of weights must be > 0.0"

--- a/tests/improver-weighted-blending/01-help.bats
+++ b/tests/improver-weighted-blending/01-help.bats
@@ -99,7 +99,7 @@ linear weights options:
   --y0val LINEAR_STARTING_POINT
                         The relative value of the weighting start point for
                         choosing default linear weights. This must be a
-                        positive float. If not set, default values of
+                        positive float or 0. If not set, default values of
                         y0val=20.0 and ynval=2.0 are set.
 
 nonlinear weights options:


### PR DESCRIPTION
A Fix to allow a linear_starting_point of zero to be provided to the weighted-blending plugin.

Testing:
 - [x] Ran tests and they passed OK