### PR TITLE
CLI debug info extension

### DIFF
--- a/tests/bin/bats-exec-test
+++ b/tests/bin/bats-exec-test
@@ -254,6 +254,7 @@ bats_exit_trap() {
 
   if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
     echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    echo ${output}
     bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
     bats_print_failed_command "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" "$BATS_ERROR_STATUS" >&3
     sed -e "s/^/# /" < "$BATS_OUT" >&3


### PR DESCRIPTION
Additional echo statement to give information about the failure of a bats test when run with the --debug flag.

Testing:
 - [x] Ran acceptance tests and they passed OK