### PR TITLE
Remove unnecessary globbing in CLI tests

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -60,7 +60,7 @@ function improver_test_cli {
     # CLI testing.
     PATH="$IMPROVER_DIR/tests/bin/:$PATH"
     for SUBTEST in $CLISUBTEST; do
-        test_dir=$IMPROVER_DIR/tests/improver-*$SUBTEST*/
+        test_dir=$IMPROVER_DIR/tests/improver-$SUBTEST/
         test_dir="$(echo -e "${test_dir}" | tr -d '[:space:]')"
         if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
             PROVE_VERBOSE_OPT=


### PR DESCRIPTION
As discussed in the Developer Catch-up, this removes the unnecessary use of wildcards in the globbing of CLI test names. This branch has been branched from the branch used in #312 to allow easier testing, therefore this branch shouldn't be merged until #312 has been merged. Only the final commit within the PR is relevant.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

