### PR TITLE
Increase decimal place rounding within Ensemble Copula Coupling

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -385,9 +385,9 @@ class GeneratePercentilesFromProbabilities(object):
             forecast_probabilities, coord=threshold_coord.name())
 
         # The requirement below for a monotonically changing probability
-        # across thresholds can be thwarted by precision errors of order 1E-11,
-        # as such, here we round to a precision of 10 decimal places.
-        prob_slices = np.around(prob_slices, 10)
+        # across thresholds can be thwarted by precision errors of order 1E-10,
+        # as such, here we round to a precision of 9 decimal places.
+        prob_slices = np.around(prob_slices, 9)
 
         # Invert probabilities for data thresholded above thresholds.
         relation = forecast_probabilities.attributes['relative_to_threshold']


### PR DESCRIPTION
Increase the rounding of the from 10 decimal places to 9 decimal places, based on test runs for temperature post-processing, which failed if rounding was done to 10 decimal places, rather than 9 decimal places.

This is essentially an adjustment of #288. 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
