### PR TITLE
Adds rescale function to utilities with unit tests for #263.

### DIFF
--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -69,25 +69,19 @@ class Test_rescale(IrisTest):
         self.assertIsInstance(result, np.ndarray)
 
     def test_zero_range_input(self):
-        """
-        Test that the method returns the expected error
-        """
+        """Test that the method returns the expected error"""
         msg = "Cannot rescale a zero input range"
         with self.assertRaisesRegexp(ValueError, msg):
             rescale(self.cube.data, data_range=[0, 0])
 
     def test_zero_range_output(self):
-        """
-        Test that the method returns the expected error
-        """
+        """Test that the method returns the expected error"""
         msg = "Cannot rescale a zero output range"
         with self.assertRaisesRegexp(ValueError, msg):
             rescale(self.cube.data, scale_range=[4, 4])
 
     def test_rescaling_inrange(self):
-        """
-        Test that the method returns the expected values when in range
-        """
+        """Test that the method returns the expected values when in range"""
         expected = self.cube.data.copy()
         expected[...] = 110.
         expected[0, 0, 7, 7] = 100.
@@ -96,9 +90,7 @@ class Test_rescale(IrisTest):
         self.assertArrayAlmostEqual(result, expected)
 
     def test_rescaling_outrange(self):
-        """
-        Test that the method returns the expected values when out of range
-        """
+        """Test that the method gives the expected values when out of range"""
         expected = self.cube.data.copy()
         expected[...] = 108.
         expected[0, 0, 7, 7] = 98.
@@ -107,9 +99,7 @@ class Test_rescale(IrisTest):
         self.assertArrayAlmostEqual(result, expected)
 
     def test_clip(self):
-        """
-        Test that the method clips values when out of range
-        """
+        """Test that the method clips values when out of range"""
         expected = self.cube.data.copy()
         expected[...] = 108.
         expected[0, 0, 7, 7] = 100.

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -68,7 +68,7 @@ class Test_rescale(IrisTest):
         result = rescale(self.cube.data)
         self.assertIsInstance(result, np.ndarray)
 
-    def test_zerorange_input(self):
+    def test_zero_range_input(self):
         """
         Test that the method returns the expected error
         """
@@ -76,7 +76,7 @@ class Test_rescale(IrisTest):
         with self.assertRaisesRegexp(ValueError, msg):
             rescale(self.cube.data, data_range=[0, 0])
 
-    def test_zerorange_output(self):
+    def test_zero_range_output(self):
         """
         Test that the method returns the expected error
         """

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -83,7 +83,7 @@ class Test_rescale(IrisTest):
         """
         msg = "Cannot rescale a zero input range"
         with self.assertRaisesRegexp(ValueError, msg):
-            rescale(self.cube.data, datarange=[0, 0])
+            rescale(self.cube.data, data_range=[0, 0])
 
     def test_zerorange_output(self):
         """
@@ -91,7 +91,7 @@ class Test_rescale(IrisTest):
         """
         msg = "Cannot rescale a zero output range"
         with self.assertRaisesRegexp(ValueError, msg):
-            rescale(self.cube.data, scalerange=[4, 4])
+            rescale(self.cube.data, scale_range=[4, 4])
 
     def test_rescaling_inrange(self):
         """
@@ -100,8 +100,8 @@ class Test_rescale(IrisTest):
         expected = self.cube.data.copy()
         expected[...] = 110.
         expected[0, 0, 7, 7] = 100.
-        result = rescale(self.cube.data, datarange=(0., 1.),
-                         scalerange=(100., 110.))
+        result = rescale(self.cube.data, data_range=(0., 1.),
+                         scale_range=(100., 110.))
         self.assertArrayAlmostEqual(result, expected)
 
     def test_rescaling_outrange(self):
@@ -111,8 +111,8 @@ class Test_rescale(IrisTest):
         expected = self.cube.data.copy()
         expected[...] = 108.
         expected[0, 0, 7, 7] = 98.
-        result = rescale(self.cube.data, datarange=(0.2, 1.2),
-                         scalerange=(100., 110.))
+        result = rescale(self.cube.data, data_range=(0.2, 1.2),
+                         scale_range=(100., 110.))
         self.assertArrayAlmostEqual(result, expected)
 
     def test_clip(self):
@@ -122,8 +122,8 @@ class Test_rescale(IrisTest):
         expected = self.cube.data.copy()
         expected[...] = 108.
         expected[0, 0, 7, 7] = 100.
-        result = rescale(self.cube.data, datarange=(0.2, 1.2),
-                         scalerange=(100., 110.), clip=True)
+        result = rescale(self.cube.data, data_range=(0.2, 1.2),
+                         scale_range=(100., 110.), clip=True)
         self.assertArrayAlmostEqual(result, expected)
 
 

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the rescale function from rescale.py."""
+
+import unittest
+import numpy as np
+import StringIO
+import sys
+
+from iris.tests import IrisTest
+
+from improver.utilities.rescale import rescale
+from improver.tests.nbhood.nbhood.test_BaseNeighbourhoodProcessing import (
+    set_up_cube)
+from improver.tests.ensemble_calibration.ensemble_calibration.helper_functions\
+    import add_forecast_reference_time_and_forecast_period
+
+
+class Test_rescale(IrisTest):
+
+    """Test the utilities.rescale rescale function."""
+
+    def setUp(self):
+        """
+        Create a cube with a single non-zero point.
+        Trap standard output
+        """
+        self.cube = add_forecast_reference_time_and_forecast_period(
+            set_up_cube())
+        self.stdout = StringIO.StringIO()
+        sys.stdout = self.stdout  # Redirect standard out.
+
+    def tearDown(self):
+        """Reset standard out stream."""
+        sys.stdout = sys.__stdout__  # Reset standard out.
+
+    def test_basic(self):
+        """Test that the method returns the expected array type"""
+        result = rescale(self.cube.data)
+        self.assertIsInstance(result, np.ndarray)
+
+    def test_debug(self):
+        """
+        Test that the method returns the expected array type in debug mode
+        """
+        expected = "Rescaling data so that 0.0 -> 0.0 and 1.0 -> 1.0\n"
+        result = rescale(self.cube.data, debug=True)
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(self.stdout.getvalue(), expected)
+
+    def test_zerorange_input(self):
+        """
+        Test that the method returns the expected error
+        """
+        msg = "Cannot rescale a zero input range"
+        with self.assertRaisesRegexp(ValueError, msg):
+            rescale(self.cube.data, datarange=[0, 0])
+
+    def test_zerorange_output(self):
+        """
+        Test that the method returns the expected error
+        """
+        msg = "Cannot rescale a zero output range"
+        with self.assertRaisesRegexp(ValueError, msg):
+            rescale(self.cube.data, scalerange=[4, 4])
+
+    def test_rescaling_inrange(self):
+        """
+        Test that the method returns the expected values when in range
+        """
+        expected = self.cube.data.copy()
+        expected[...] = 110.
+        expected[0, 0, 7, 7] = 100.
+        result = rescale(self.cube.data, datarange=(0., 1.),
+                         scalerange=(100., 110.))
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_rescaling_outrange(self):
+        """
+        Test that the method returns the expected values when out of range
+        """
+        expected = self.cube.data.copy()
+        expected[...] = 108.
+        expected[0, 0, 7, 7] = 98.
+        result = rescale(self.cube.data, datarange=(0.2, 1.2),
+                         scalerange=(100., 110.))
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_clip(self):
+        """
+        Test that the method clips values when out of range
+        """
+        expected = self.cube.data.copy()
+        expected[...] = 108.
+        expected[0, 0, 7, 7] = 100.
+        result = rescale(self.cube.data, datarange=(0.2, 1.2),
+                         scalerange=(100., 110.), clip=True)
+        self.assertArrayAlmostEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -32,8 +32,6 @@
 
 import unittest
 import numpy as np
-import StringIO
-import sys
 
 from iris.tests import IrisTest
 
@@ -55,13 +53,6 @@ class Test_rescale(IrisTest):
         """
         self.cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube())
-        self.stdout = StringIO.StringIO()
-        sys.stdout = self.stdout  # Redirect standard out.
-
-    @staticmethod
-    def tearDown():
-        """Reset standard out stream."""
-        sys.stdout = sys.__stdout__  # Reset standard out.
 
     def test_basic(self):
         """Test that the method returns the expected array type"""

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -68,15 +68,6 @@ class Test_rescale(IrisTest):
         result = rescale(self.cube.data)
         self.assertIsInstance(result, np.ndarray)
 
-    def test_debug(self):
-        """
-        Test that the method returns the expected array type in debug mode
-        """
-        expected = "Rescaling data so that 0.0 -> 0.0 and 1.0 -> 1.0\n"
-        result = rescale(self.cube.data, debug=True)
-        self.assertIsInstance(result, np.ndarray)
-        self.assertEqual(self.stdout.getvalue(), expected)
-
     def test_zerorange_input(self):
         """
         Test that the method returns the expected error

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -58,7 +58,8 @@ class Test_rescale(IrisTest):
         self.stdout = StringIO.StringIO()
         sys.stdout = self.stdout  # Redirect standard out.
 
-    def tearDown(self):
+    @staticmethod
+    def tearDown():
         """Reset standard out stream."""
         sys.stdout = sys.__stdout__  # Reset standard out.
 

--- a/lib/improver/utilities/rescale.py
+++ b/lib/improver/utilities/rescale.py
@@ -33,10 +33,11 @@
 import numpy as np
 
 
-def rescale(data, datarange=None, scalerange=(0., 1.),
+def rescale(data, data_range=None, scale_range=(0., 1.),
             clip=False, debug=False):
     """
-    Rescale data array so that datamin => scalemin and datamax => scale max.
+    Rescale data array so that data_min => scale_min
+    and data_max => scale max.
     All adjustments are linear
 
     Args:
@@ -44,11 +45,11 @@ def rescale(data, datarange=None, scalerange=(0., 1.),
             Source values
 
     Keyword Args:
-        datarange (list):
+        data_range (list):
             List containing two floats
             Lowest and highest source value to rescale.
             Defaults to [min(data), max(data)]
-        scalerange (list):
+        scale_range (list):
             List containing two floats
             Lowest and highest value after rescaling.
             Defaults to (0., 1.)
@@ -64,26 +65,26 @@ def rescale(data, datarange=None, scalerange=(0., 1.),
         result (numpy.ndarray):
             Output array of scaled data. Has same shape as data.
     """
-    datamin = np.min(data) if datarange is None else datarange[0]
-    datamax = np.max(data) if datarange is None else datarange[1]
-    scalemin = scalerange[0]
-    scalemax = scalerange[1]
+    data_min = np.min(data) if data_range is None else data_range[0]
+    data_max = np.max(data) if data_range is None else data_range[1]
+    scale_min = scale_range[0]
+    scale_max = scale_range[1]
     if debug:
-        print "Rescaling data so that {} -> {} and {} -> {}".format(datamin,
-                                                                    scalemin,
-                                                                    datamax,
-                                                                    scalemax)
+        print "Rescaling data so that {} -> {} and {} -> {}".format(data_min,
+                                                                    scale_min,
+                                                                    data_max,
+                                                                    scale_max)
     # Range check
-    if datamin == datamax:
+    if data_min == data_max:
         raise ValueError("Cannot rescale a zero input range " +
-                         "({} -> {})".format(datamin, datamax))
+                         "({} -> {})".format(data_min, data_max))
 
-    if scalemin == scalemax:
+    if scale_min == scale_max:
         raise ValueError("Cannot rescale a zero output range " +
-                         "({} -> {})".format(scalemin, scalemax))
+                         "({} -> {})".format(scale_min, scale_max))
 
-    result = ((data - datamin) * (scalemax - scalemin) /
-              (datamax - datamin)) + scalemin
+    result = ((data - data_min) * (scale_max - scale_min) /
+              (data_max - data_min)) + scale_min
     if clip:
-        result = np.clip(result, scalemin, scalemax)
+        result = np.clip(result, scale_min, scale_max)
     return result

--- a/lib/improver/utilities/rescale.py
+++ b/lib/improver/utilities/rescale.py
@@ -34,7 +34,7 @@ import numpy as np
 
 
 def rescale(data, data_range=None, scale_range=(0., 1.),
-            clip=False, debug=False):
+            clip=False):
     """
     Rescale data array so that data_min => scale_min
     and data_max => scale max.
@@ -58,8 +58,6 @@ def rescale(data, data_range=None, scale_range=(0., 1.),
             will be set to the scale min or max appropriately.
             Default is False which continues the scaling beyond min and
             max.
-        debug (boolean):
-            Causes a printout of the min and max values.
 
     Returns:
         result (numpy.ndarray):
@@ -69,11 +67,6 @@ def rescale(data, data_range=None, scale_range=(0., 1.),
     data_max = np.max(data) if data_range is None else data_range[1]
     scale_min = scale_range[0]
     scale_max = scale_range[1]
-    if debug:
-        print "Rescaling data so that {} -> {} and {} -> {}".format(data_min,
-                                                                    scale_min,
-                                                                    data_max,
-                                                                    scale_max)
     # Range check
     if data_min == data_max:
         raise ValueError("Cannot rescale a zero input range " +

--- a/lib/improver/utilities/rescale.py
+++ b/lib/improver/utilities/rescale.py
@@ -48,7 +48,7 @@ def rescale(data, data_range=None, scale_range=(0., 1.),
         data_range (list):
             List containing two floats
             Lowest and highest source value to rescale.
-            Defaults to [min(data), max(data)]
+            Default value of None is converted to [min(data), max(data)]
         scale_range (list):
             List containing two floats
             Lowest and highest value after rescaling.

--- a/lib/improver/utilities/rescale.py
+++ b/lib/improver/utilities/rescale.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Provides support utility for rescaling data."""
+
+import numpy as np
+
+
+def rescale(data, datarange=None, scalerange=(0., 1.),
+            clip=False, debug=False):
+    """
+    Rescale data array so that datamin => scalemin and datamax => scale max.
+    All adjustments are linear
+
+    Args:
+        data (numpy.ndarray):
+            Source values
+
+    Keyword Args:
+        datarange (list):
+            List containing two floats
+            Lowest and highest source value to rescale.
+            Defaults to [min(data), max(data)]
+        scalerange (list):
+            List containing two floats
+            Lowest and highest value after rescaling.
+            Defaults to (0., 1.)
+        clip (boolean):
+            If True, points where data were outside the scaling range
+            will be set to the scale min or max appropriately.
+            Default is False which continues the scaling beyond min and
+            max.
+        debug (boolean):
+            Causes a printout of the min and max values.
+
+    Returns:
+        result (numpy.ndarray):
+            Output array of scaled data. Has same shape as data.
+    """
+    datamin = np.min(data) if datarange is None else datarange[0]
+    datamax = np.max(data) if datarange is None else datarange[1]
+    scalemin = scalerange[0]
+    scalemax = scalerange[1]
+    if debug:
+        print "Rescaling data so that {} -> {} and {} -> {}".format(datamin,
+                                                                    scalemin,
+                                                                    datamax,
+                                                                    scalemax)
+    # Range check
+    if datamin == datamax:
+        raise ValueError("Cannot rescale a zero input range " +
+                         "({} -> {})".format(datamin, datamax))
+
+    if scalemin == scalemax:
+        raise ValueError("Cannot rescale a zero output range " +
+                         "({} -> {})".format(scalemin, scalemax))
+
+    result = ((data - datamin) * (scalemax - scalemin) /
+              (datamax - datamin)) + scalemin
+    if clip:
+        result = np.clip(result, scalemin, scalemax)
+    return result


### PR DESCRIPTION
For #263 

This PR adds a linear rescaling function to the utilities area. This has come from work on a nowcast lightning plugin (in work stream for next FY). Links to this can be found on the JIRA ticket and this has been reviewed once by Gavin, but not in an IMPROVER context.

The intention is to use this function to calculate probability-of-event based on fuzzy thresholds supplied as lower, mid and upper bounds.

Testing:
 - [X] Ran tests and they passed OK
 - [X] Added new tests for the new feature(s)
