### PR TITLE
Adds fuzzy bounds option to threshold plugin and CLI for #263.

### DIFF
--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -67,7 +67,9 @@ def main():
                         "be interpreted as floats with the structure: "
                         " \"THRESHOLD_VALUE\": [LOWER_BOUND, UPPER_BOUND] "
                         "e.g: {\"280.0\": [278.0, 282.0], "
-                        "\"290.0\": [288.0, 292.0]}")
+                        "\"290.0\": [288.0, 292.0]}. "
+                        "Repeated thresholds with different bounds are not "
+                        "handled well. Only the last duplicate will be used.")
     parser.add_argument("--threshold_units", metavar="THRESHOLD_UNITS",
                         default=None, type=str,
                         help="Units of the threshold values. If not provided "

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -111,7 +111,8 @@ def main():
         except ValueError as e:
             # Extend error message with hint for common JSON error.
             raise type(e)(e.message + " in JSON file {}. \nHINT: Try adding a "
-                "zero after the decimal point.".format(args.threshold_config))
+                          "zero after the decimal point.".format(
+                              args.threshold_config))
         except Exception as e:
             # Extend any errors with message about WHERE this occurred.
             raise type(e)(e.message + " in JSON file {}".format(

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -99,15 +99,19 @@ def main():
     cube = iris.load_cube(args.input_filepath)
 
     if args.threshold_config:
-        # Read in threshold configuration from JSON file.
-        with open(args.threshold_config, 'r') as input_file:
-            thresholds_from_file = json.load(input_file)
-        thresholds = []
-        fuzzy_bounds = []
         try:
+            # Read in threshold configuration from JSON file.
+            with open(args.threshold_config, 'r') as input_file:
+                thresholds_from_file = json.load(input_file)
+            thresholds = []
+            fuzzy_bounds = []
             for key in thresholds_from_file.keys():
                 thresholds.append(float(key))
                 fuzzy_bounds.append(tuple(thresholds_from_file[key]))
+        except ValueError as e:
+            # Extend error message with hint for common JSON error.
+            raise type(e)(e.message + " in JSON file {}. \nHINT: Try adding a "
+                "zero after the decimal point.".format(args.threshold_config))
         except Exception as e:
             # Extend any errors with message about WHERE this occurred.
             raise type(e)(e.message + " in JSON file {}".format(

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -35,6 +35,7 @@ import argparse
 
 import iris
 import cf_units
+import json
 
 from improver.threshold import BasicThreshold
 
@@ -45,17 +46,23 @@ def main():
         description="Calculate the threshold truth value of cube data "
         "relative to the provided threshold value. By default data are "
         "tested to be above the thresholds, though the --below_threshold "
-        "flag enables testing below thresholds. A fuzzy factor may be "
-        "provided to capture data that is within this factor of the "
+        "flag enables testing below thresholds. A fuzzy factor or fuzzy "
+        "bounds may be provided to capture data that is close to the "
         "threshold.")
     parser.add_argument("input_filepath", metavar="INPUT_FILE",
                         help="A path to an input NetCDF file to be processed")
     parser.add_argument("output_filepath", metavar="OUTPUT_FILE",
                         help="The output path for the processed NetCDF")
     parser.add_argument("threshold_values", metavar="THRESHOLD_VALUES",
-                        nargs="+", type=float,
+                        nargs="*", type=float,
                         help="Threshold value or values about which to "
-                        "calculate the truth values; e.g. 270 300")
+                        "calculate the truth values; e.g. 270 300. "
+                        "Must be omitted if --threshold_config is used.")
+    parser.add_argument("--threshold_config", metavar="THRESHOLD_CONFIG",
+                        type=str,
+                        help="Threshold configuration JSON file containing "
+                        "thresholds and fuzzy bounds. Best used in "
+                        "combination  with --threshold_units.")
     parser.add_argument("--threshold_units", metavar="THRESHOLD_UNITS",
                         default=None, type=str,
                         help="Units of the threshold values. If not provided "
@@ -76,19 +83,52 @@ def main():
                         "fuzzy. Data which fail a test against the hard "
                         "threshold value may return a fractional truth value "
                         "if they fall within this fuzzy factor region. NB A "
-                        "fuzzy factor cannot be used with a zero threshold.")
+                        "fuzzy factor cannot be used with a zero threshold "
+                        "or a threshold_config file.")
 
     args = parser.parse_args()
+
+    # Deal with mutual-exclusions that ArgumentParser can't handle:
+    if args.threshold_values and args.threshold_config:
+        raise parser.error("--threshold_config option is not compatible "
+                           "with THRESHOLD_VALUES list.")
+    if args.fuzzy_factor and args.threshold_config:
+        raise parser.error("--threshold_config option is not compatible "
+                           "with --fuzzy_factor option.")
+
     cube = iris.load_cube(args.input_filepath)
+
+    if args.threshold_config:
+        # Read in threshold configuration from JSON file.
+        with open(args.threshold_config, 'r') as input_file:
+            thresholds_from_file = json.load(input_file)
+        thresholds = []
+        fuzzy_bounds = []
+        try:
+            for key in thresholds_from_file.keys():
+                thresholds.append(float(key))
+                fuzzy_bounds.append(tuple(thresholds_from_file[key]))
+        except Exception as e:
+            # Extend any errors with message about WHERE this occurred.
+            raise type(e)(e.message + " in JSON file {}".format(
+                args.threshold_config))
+    else:
+        thresholds = args.threshold_values
+        fuzzy_bounds = None
 
     # Allow for threshold value unit conversion.
     if args.threshold_units is not None:
         threshold_unit = cf_units.Unit(args.threshold_units)
-        args.threshold_values = [threshold_unit.convert(threshold, cube.units)
-                                 for threshold in args.threshold_values]
+        thresholds = [threshold_unit.convert(threshold, cube.units)
+                      for threshold in thresholds]
+        if fuzzy_bounds is not None:
+            fuzzy_bounds = [tuple(
+                [threshold_unit.convert(threshold, cube.units)
+                 for threshold in bounds]) for bounds in fuzzy_bounds]
 
     result = BasicThreshold(
-        args.threshold_values, fuzzy_factor=args.fuzzy_factor,
+        thresholds, fuzzy_factor=args.fuzzy_factor,
+        fuzzy_bounds=fuzzy_bounds,
         below_thresh_ok=args.below_threshold).process(cube)
 
     iris.save(result, args.output_filepath, unlimited_dimensions=[])

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -33,9 +33,9 @@
 
 import argparse
 
+import json
 import iris
 import cf_units
-import json
 
 from improver.threshold import BasicThreshold
 

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -62,7 +62,12 @@ def main():
                         type=str,
                         help="Threshold configuration JSON file containing "
                         "thresholds and fuzzy bounds. Best used in "
-                        "combination  with --threshold_units.")
+                        "combination  with --threshold_units. "
+                        "It should contain a dictionary of strings that can "
+                        "be interpreted as floats with the structure: "
+                        " \"THRESHOLD_VALUE\": [LOWER_BOUND, UPPER_BOUND] "
+                        "e.g: {\"280.0\": [278.0, 282.0], "
+                        "\"290.0\": [288.0, 292.0]}")
     parser.add_argument("--threshold_units", metavar="THRESHOLD_UNITS",
                         default=None, type=str,
                         help="Units of the threshold values. If not provided "
@@ -108,14 +113,14 @@ def main():
             for key in thresholds_from_file.keys():
                 thresholds.append(float(key))
                 fuzzy_bounds.append(tuple(thresholds_from_file[key]))
-        except ValueError as e:
+        except ValueError as err:
             # Extend error message with hint for common JSON error.
-            raise type(e)(e.message + " in JSON file {}. \nHINT: Try adding a "
-                          "zero after the decimal point.".format(
-                              args.threshold_config))
-        except Exception as e:
+            raise type(err)(err.message + " in JSON file {}. \nHINT: Try "
+                            "adding a zero after the decimal point.".format(
+                                args.threshold_config))
+        except Exception as err:
             # Extend any errors with message about WHERE this occurred.
-            raise type(e)(e.message + " in JSON file {}".format(
+            raise type(err)(err.message + " in JSON file {}".format(
                 args.threshold_config))
     else:
         thresholds = args.threshold_values

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -474,7 +474,7 @@ class Test_process(IrisTest):
         # Note that back-slashes are necessary to make regexp literal.
         msg = ("Threshold must be within bounds: "
                "\!\( {} <= {} <= {} \)".format(
-            fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
+                   fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
         with self.assertRaisesRegexp(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)
@@ -486,7 +486,7 @@ class Test_process(IrisTest):
         # Note that back-slashes are necessary to make regexp literal.
         msg = ("Threshold must be within bounds: "
                "\!\( {} <= {} <= {} \)".format(
-            fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
+                   fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
         with self.assertRaisesRegexp(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -50,33 +50,44 @@ class Test__repr__(IrisTest):
         """Test that the __repr__ returns the expected string."""
         threshold = [0.6]
         fuzzy_factor = None
+        fuzzy_bounds = [(0.6, 0.6)]
         below_thresh_ok = False
-        result = str(Threshold(threshold, fuzzy_factor, below_thresh_ok))
-        msg = ('<BasicThreshold: thresholds {}, fuzzy factor {}, '
+        result = str(Threshold(threshold,
+                               below_thresh_ok=below_thresh_ok))
+        msg = ('<BasicThreshold: thresholds {}, '
+               'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_factor, below_thresh_ok))
+                threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
     def test_multiple_thresholds(self):
         """Test that the __repr__ returns the expected string."""
         threshold = [0.6, 0.8]
         fuzzy_factor = None
+        fuzzy_bounds = [(0.6, 0.6), (0.8, 0.8)]
         below_thresh_ok = False
-        result = str(Threshold(threshold, fuzzy_factor, below_thresh_ok))
-        msg = ('<BasicThreshold: thresholds {}, fuzzy factor {}, '
+        result = str(Threshold(threshold,
+                               below_thresh_ok=below_thresh_ok))
+        msg = ('<BasicThreshold: thresholds {}, '
+               'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_factor, below_thresh_ok))
+                threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
     def test_below_fuzzy_threshold(self):
         """Test that the __repr__ returns the expected string."""
-        threshold = [0.6]
+        threshold = 0.6
         fuzzy_factor = 0.2
+        fuzzy_bounds = [(0.12, 1.08)]
         below_thresh_ok = True
-        result = str(Threshold(threshold, fuzzy_factor, below_thresh_ok))
-        msg = ('<BasicThreshold: thresholds {}, fuzzy factor {}, '
+        result = str(Threshold(threshold,
+                               fuzzy_factor=fuzzy_factor,
+                               below_thresh_ok=below_thresh_ok))
+        msg = ('<BasicThreshold: thresholds [{}], '
+               'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_factor, below_thresh_ok))
+                threshold, fuzzy_bounds, below_thresh_ok))
+        self.assertEqual(result, msg)
         self.assertEqual(result, msg)
 
 

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -445,12 +445,36 @@ class Test_process(IrisTest):
             Threshold(0.6, fuzzy_factor=fuzzy_factor,
                       fuzzy_bounds=fuzzy_bounds)
 
+    def test_invalid_bounds_toofew(self):
+        """Test when fuzzy_bounds contains one value (invalid)."""
+        threshold = 0.6
+        fuzzy_bounds = (0.4, )
+        # Regexp matches .* with any string.
+        msg = ("Invalid bounds for one threshold: .*. "
+               "Expected 2 floats.")
+        with self.assertRaisesRegexp(AssertionError, msg):
+            Threshold(threshold,
+                      fuzzy_bounds=fuzzy_bounds)
+
+    def test_invalid_bounds_toomany(self):
+        """Test when fuzzy_bounds contains three values (invalid)."""
+        threshold = 0.6
+        fuzzy_bounds = (0.4, 0.8, 1.2)
+        # Regexp matches .* with any string.
+        msg = ("Invalid bounds for one threshold: .*. "
+               "Expected 2 floats.")
+        with self.assertRaisesRegexp(AssertionError, msg):
+            Threshold(threshold,
+                      fuzzy_bounds=fuzzy_bounds)
+
     def test_invalid_upper_bound(self):
         """Test when fuzzy_bounds do not bound threshold (invalid)."""
         threshold = 0.6
         fuzzy_bounds = (0.4, 0.5)
-        msg = ("Upper bound error: {} !<= {}".format(threshold,
-                                                     fuzzy_bounds[1]))
+        # Note that back-slashes are necessary to make regexp literal.
+        msg = ("Threshold must be within bounds: "
+               "\!\( {} <= {} <= {} \)".format(
+            fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
         with self.assertRaisesRegexp(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)
@@ -459,8 +483,10 @@ class Test_process(IrisTest):
         """Test when fuzzy_bounds do not bound threshold (invalid)."""
         threshold = 0.6
         fuzzy_bounds = (0.7, 0.8)
-        msg = ("Lower bound error: {} !<= {}".format(fuzzy_bounds[0],
-                                                     threshold))
+        # Note that back-slashes are necessary to make regexp literal.
+        msg = ("Threshold must be within bounds: "
+               "\!\( {} <= {} <= {} \)".format(
+            fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
         with self.assertRaisesRegexp(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -234,7 +234,7 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
     def test_threshold_boundingzero_above(self):
-        """Test fuzzy threshold of zero."""
+        """Test fuzzy threshold of zero where data are above upper-bound."""
         bounds = (-0.1, 0.1)
         plugin = Threshold(0.0, fuzzy_bounds=bounds)
         result = plugin.process(self.cube)
@@ -253,8 +253,8 @@ class Test_process(IrisTest):
         expected_result_array[0][0][2][2] = 0.25
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
-    def test_threshold_assymetric_bounds_below(self):
-        """Test when a point is below assymmetric fuzzy threshold area."""
+    def test_threshold_asymmetric_bounds_below(self):
+        """Test when a point is below asymmetric fuzzy threshold area."""
         bounds = (0.51, 0.9)
         plugin = Threshold(0.6, fuzzy_bounds=bounds)
         result = plugin.process(self.cube)
@@ -262,8 +262,8 @@ class Test_process(IrisTest):
             1, 1, 5, 5)
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
-    def test_threshold_assymetric_bounds_lower(self):
-        """Test when a point is in lower assymmetric fuzzy threshold area."""
+    def test_threshold_asymmetric_bounds_lower(self):
+        """Test when a point is in lower asymmetric fuzzy threshold area."""
         bounds = (0.4, 0.9)
         plugin = Threshold(0.6, fuzzy_bounds=bounds)
         result = plugin.process(self.cube)
@@ -272,8 +272,8 @@ class Test_process(IrisTest):
         expected_result_array[0][0][2][2] = 0.25
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
-    def test_threshold_assymetric_bounds_middle(self):
-        """Test when a point is on the threshold with assymmetric fuzzy
+    def test_threshold_asymmetric_bounds_middle(self):
+        """Test when a point is on the threshold with asymmetric fuzzy
         bounds."""
         bounds = (0.4, 0.9)
         plugin = Threshold(0.5, fuzzy_bounds=bounds)
@@ -283,8 +283,8 @@ class Test_process(IrisTest):
         expected_result_array[0][0][2][2] = 0.5
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
-    def test_threshold_assymetric_bounds_upper(self):
-        """Test when a point is in upper assymmetric fuzzy threshold area."""
+    def test_threshold_asymmetric_bounds_upper(self):
+        """Test when a point is in upper asymmetric fuzzy threshold area."""
         bounds = (0.0, 0.6)
         plugin = Threshold(0.4, fuzzy_bounds=bounds)
         result = plugin.process(self.cube)
@@ -293,8 +293,8 @@ class Test_process(IrisTest):
         expected_result_array[0][0][2][2] = 0.75
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
-    def test_threshold_assymetric_bounds_above(self):
-        """Test when a point is above assymmetric fuzzy threshold area."""
+    def test_threshold_asymmetric_bounds_above(self):
+        """Test when a point is above asymmetric fuzzy threshold area."""
         bounds = (0.0, 0.45)
         plugin = Threshold(0.4, fuzzy_bounds=bounds)
         result = plugin.process(self.cube)
@@ -303,8 +303,8 @@ class Test_process(IrisTest):
         expected_result_array[0][0][2][2] = 1.
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
-    def test_threshold_assymetric_bounds_upper_below(self):
-        """Test when a point is in upper assymmetric fuzzy threshold area
+    def test_threshold_asymmetric_bounds_upper_below(self):
+        """Test when a point is in upper asymmetric fuzzy threshold area
         and below-threshold is requested."""
         bounds = (0.0, 0.6)
         plugin = Threshold(0.4, fuzzy_bounds=bounds, below_thresh_ok=True)

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -195,11 +195,13 @@ class Test_process(IrisTest):
 
     def test_threshold_negative(self):
         """Test a point when the threshold is negative."""
+        self.cube.data[0][2][2] = -0.75
         plugin = Threshold(
             -1.0, fuzzy_factor=self.fuzzy_factor, below_thresh_ok=True)
         result = plugin.process(self.cube)
-        expected_result_array = np.ones_like(self.cube.data).reshape(
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
             1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.25
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
     def test_threshold_below(self):

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -88,6 +88,35 @@ class Test__repr__(IrisTest):
                'below_thresh_ok: {}>'.format(
                 threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
+
+    def test_fuzzy_bounds_scalar(self):
+        """Test that the __repr__ returns the expected string."""
+        threshold = 0.6
+        fuzzy_factor = None
+        fuzzy_bounds = (0.4, 0.8)
+        below_thresh_ok = False
+        result = str(Threshold(threshold,
+                               fuzzy_bounds=fuzzy_bounds,
+                               below_thresh_ok=below_thresh_ok))
+        msg = ('<BasicThreshold: thresholds [{}], '
+               'fuzzy_bounds [{}], '
+               'below_thresh_ok: {}>'.format(
+                threshold, fuzzy_bounds, below_thresh_ok))
+        self.assertEqual(result, msg)
+
+    def test_fuzzy_bounds_list(self):
+        """Test that the __repr__ returns the expected string."""
+        threshold = [0.6, 2.0]
+        fuzzy_factor = None
+        fuzzy_bounds = [(0.4, 0.8), (1.8, 2.1)]
+        below_thresh_ok = False
+        result = str(Threshold(threshold,
+                               fuzzy_bounds=fuzzy_bounds,
+                               below_thresh_ok=below_thresh_ok))
+        msg = ('<BasicThreshold: thresholds {}, '
+               'fuzzy_bounds {}, '
+               'below_thresh_ok: {}>'.format(
+                threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
 
@@ -186,6 +215,107 @@ class Test_process(IrisTest):
         expected_result_array = np.zeros_like(self.cube.data).reshape(
             1, 1, 5, 5)
         expected_result_array[0][0][2][2] = 1.0/3.0
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_fuzzybounds(self):
+        """Test when a point is in the fuzzy threshold area."""
+        bounds = (0.6 * self.fuzzy_factor, 0.6 * (2. - self.fuzzy_factor))
+        plugin = Threshold(0.6, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 1.0/3.0
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_boundingzero(self):
+        """Test fuzzy threshold of zero."""
+        bounds = (-1.0, 1.0)
+        plugin = Threshold(0.0, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.full_like(
+            self.cube.data, fill_value=0.5).reshape(1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.75
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_boundingzero_above(self):
+        """Test fuzzy threshold of zero."""
+        bounds = (-0.1, 0.1)
+        plugin = Threshold(0.0, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.full_like(
+            self.cube.data, fill_value=0.5).reshape(1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 1.
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_boundingbelowzero(self):
+        """Test fuzzy threshold of below-zero."""
+        bounds = (-1.0, 1.0)
+        plugin = Threshold(0.0, fuzzy_bounds=bounds, below_thresh_ok=True)
+        result = plugin.process(self.cube)
+        expected_result_array = np.full_like(
+            self.cube.data, fill_value=0.5).reshape(1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.25
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_assymetric_bounds_below(self):
+        """Test when a point is below assymmetric fuzzy threshold area."""
+        bounds = (0.51, 0.9)
+        plugin = Threshold(0.6, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_assymetric_bounds_lower(self):
+        """Test when a point is in lower assymmetric fuzzy threshold area."""
+        bounds = (0.4, 0.9)
+        plugin = Threshold(0.6, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.25
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_assymetric_bounds_middle(self):
+        """Test when a point is on the threshold with assymmetric fuzzy
+        bounds."""
+        bounds = (0.4, 0.9)
+        plugin = Threshold(0.5, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.5
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_assymetric_bounds_upper(self):
+        """Test when a point is in upper assymmetric fuzzy threshold area."""
+        bounds = (0.0, 0.6)
+        plugin = Threshold(0.4, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.75
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_assymetric_bounds_above(self):
+        """Test when a point is above assymmetric fuzzy threshold area."""
+        bounds = (0.0, 0.45)
+        plugin = Threshold(0.4, fuzzy_bounds=bounds)
+        result = plugin.process(self.cube)
+        expected_result_array = np.zeros_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 1.
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
+
+    def test_threshold_assymetric_bounds_upper_below(self):
+        """Test when a point is in upper assymmetric fuzzy threshold area
+        and below-threshold is requested."""
+        bounds = (0.0, 0.6)
+        plugin = Threshold(0.4, fuzzy_bounds=bounds, below_thresh_ok=True)
+        result = plugin.process(self.cube)
+        expected_result_array = np.ones_like(self.cube.data).reshape(
+            1, 1, 5, 5)
+        expected_result_array[0][0][2][2] = 0.25
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
     def test_threshold_fuzzy_miss(self):
@@ -304,6 +434,36 @@ class Test_process(IrisTest):
         msg = "Invalid fuzzy_factor: must be >0 and <1: 2.0"
         with self.assertRaisesRegexp(ValueError, msg):
             Threshold(0.6, fuzzy_factor=fuzzy_factor)
+
+    def test_fuzzy_factor_and_fuzzy_bounds(self):
+        """Test when fuzzy_factor and fuzzy_bounds both set (ambiguous)."""
+        fuzzy_factor = 2.0
+        fuzzy_bounds = (0.4, 0.8)
+        msg = ("Invalid combination of keywords. Cannot specify "
+               "fuzzy_factor and fuzzy_bounds together")
+        with self.assertRaisesRegexp(ValueError, msg):
+            Threshold(0.6, fuzzy_factor=fuzzy_factor,
+                      fuzzy_bounds=fuzzy_bounds)
+
+    def test_invalid_upper_bound(self):
+        """Test when fuzzy_bounds do not bound threshold (invalid)."""
+        threshold = 0.6
+        fuzzy_bounds = (0.4, 0.5)
+        msg = ("Upper bound error: {} !<= {}".format(threshold,
+                                                     fuzzy_bounds[1]))
+        with self.assertRaisesRegexp(AssertionError, msg):
+            Threshold(threshold,
+                      fuzzy_bounds=fuzzy_bounds)
+
+    def test_invalid_lower_bound(self):
+        """Test when fuzzy_bounds do not bound threshold (invalid)."""
+        threshold = 0.6
+        fuzzy_bounds = (0.7, 0.8)
+        msg = ("Lower bound error: {} !<= {}".format(fuzzy_bounds[0],
+                                                     threshold))
+        with self.assertRaisesRegexp(AssertionError, msg):
+            Threshold(threshold,
+                      fuzzy_bounds=fuzzy_bounds)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -49,7 +49,6 @@ class Test__repr__(IrisTest):
     def test_single_threshold(self):
         """Test that the __repr__ returns the expected string."""
         threshold = [0.6]
-        fuzzy_factor = None
         fuzzy_bounds = [(0.6, 0.6)]
         below_thresh_ok = False
         result = str(Threshold(threshold,
@@ -57,13 +56,12 @@ class Test__repr__(IrisTest):
         msg = ('<BasicThreshold: thresholds {}, '
                'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_bounds, below_thresh_ok))
+                   threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
     def test_multiple_thresholds(self):
         """Test that the __repr__ returns the expected string."""
         threshold = [0.6, 0.8]
-        fuzzy_factor = None
         fuzzy_bounds = [(0.6, 0.6), (0.8, 0.8)]
         below_thresh_ok = False
         result = str(Threshold(threshold,
@@ -71,7 +69,7 @@ class Test__repr__(IrisTest):
         msg = ('<BasicThreshold: thresholds {}, '
                'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_bounds, below_thresh_ok))
+                   threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
     def test_below_fuzzy_threshold(self):
@@ -86,13 +84,12 @@ class Test__repr__(IrisTest):
         msg = ('<BasicThreshold: thresholds [{}], '
                'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_bounds, below_thresh_ok))
+                   threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
     def test_fuzzy_bounds_scalar(self):
         """Test that the __repr__ returns the expected string."""
         threshold = 0.6
-        fuzzy_factor = None
         fuzzy_bounds = (0.4, 0.8)
         below_thresh_ok = False
         result = str(Threshold(threshold,
@@ -101,13 +98,12 @@ class Test__repr__(IrisTest):
         msg = ('<BasicThreshold: thresholds [{}], '
                'fuzzy_bounds [{}], '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_bounds, below_thresh_ok))
+                   threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
     def test_fuzzy_bounds_list(self):
         """Test that the __repr__ returns the expected string."""
         threshold = [0.6, 2.0]
-        fuzzy_factor = None
         fuzzy_bounds = [(0.4, 0.8), (1.8, 2.1)]
         below_thresh_ok = False
         result = str(Threshold(threshold,
@@ -116,7 +112,7 @@ class Test__repr__(IrisTest):
         msg = ('<BasicThreshold: thresholds {}, '
                'fuzzy_bounds {}, '
                'below_thresh_ok: {}>'.format(
-                threshold, fuzzy_bounds, below_thresh_ok))
+                   threshold, fuzzy_bounds, below_thresh_ok))
         self.assertEqual(result, msg)
 
 
@@ -473,7 +469,7 @@ class Test_process(IrisTest):
         fuzzy_bounds = (0.4, 0.5)
         # Note that back-slashes are necessary to make regexp literal.
         msg = ("Threshold must be within bounds: "
-               "\!\( {} <= {} <= {} \)".format(
+               r"\!\( {} <= {} <= {} \)".format(
                    fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
         with self.assertRaisesRegexp(AssertionError, msg):
             Threshold(threshold,
@@ -485,7 +481,7 @@ class Test_process(IrisTest):
         fuzzy_bounds = (0.7, 0.8)
         # Note that back-slashes are necessary to make regexp literal.
         msg = ("Threshold must be within bounds: "
-               "\!\( {} <= {} <= {} \)".format(
+               r"\!\( {} <= {} <= {} \)".format(
                    fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
         with self.assertRaisesRegexp(AssertionError, msg):
             Threshold(threshold,

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -117,10 +117,13 @@ class BasicThreshold(object):
             if isinstance(fuzzy_bounds, tuple):
                 self.fuzzy_bounds = [fuzzy_bounds]
             for thr, bounds in zip(self.thresholds, self.fuzzy_bounds):
-                assert bounds[0] <= thr, (
-                    "Lower bound error: {} !<= {}".format(bounds[0], thr))
-                assert bounds[1] >= thr, (
-                    "Upper bound error: {} !<= {}".format(thr, bounds[1]))
+                assert len(bounds) == 2, (
+                    "Invalid bounds for one threshold: {}. "
+                    "Expected 2 floats.".format(bounds))
+                bounds_msg = ("Threshold must be within bounds: "
+                    "!( {} <= {} <= {} )".format(bounds[0], thr, bounds[1]))
+                assert bounds[0] <= thr, bounds_msg
+                assert bounds[1] >= thr, bounds_msg
 
         self.below_thresh_ok = below_thresh_ok
 

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -54,7 +54,9 @@ class BasicThreshold(object):
 
     Keyword Args:
         fuzzy_factor (float):
-            Percentage above or below threshold for fuzzy membership value.
+            Specifies lower bound for fuzzy membership value when multiplied
+            by each threshold. Upper bound is equivalent linear distance above
+            threshold.
             If None, no fuzzy_factor is applied.
         fuzzy_bounds (list of tuples):
             Lower and upper bounds for fuzziness.
@@ -79,7 +81,7 @@ class BasicThreshold(object):
                  fuzzy_bounds=None,
                  below_thresh_ok=False):
         """
-        Set up for processing an in-or-out of threshold binary field.
+        Set up for processing an in-or-out of threshold field.
         """
         # Ensure iterable threshold list provided, even if it's a single value.
         self.thresholds = thresholds
@@ -111,20 +113,19 @@ class BasicThreshold(object):
                 self.fuzzy_bounds.append((lower_thr, upper_thr))
         else:
             self.fuzzy_bounds = fuzzy_bounds
-        if self.fuzzy_bounds is not None:
-            # Ensure fuzzy_bounds is a list, even if a single tuple is
-            # supplied.
-            if isinstance(fuzzy_bounds, tuple):
-                self.fuzzy_bounds = [fuzzy_bounds]
-            for thr, bounds in zip(self.thresholds, self.fuzzy_bounds):
-                assert len(bounds) == 2, (
-                    "Invalid bounds for one threshold: {}. "
-                    "Expected 2 floats.".format(bounds))
-                bounds_msg = ("Threshold must be within bounds: "
-                              "!( {} <= {} <= {} )".format(bounds[0],
-                                                           thr, bounds[1]))
-                assert bounds[0] <= thr, bounds_msg
-                assert bounds[1] >= thr, bounds_msg
+        # Ensure fuzzy_bounds is a list, even if a single tuple is
+        # supplied.
+        if isinstance(fuzzy_bounds, tuple):
+            self.fuzzy_bounds = [fuzzy_bounds]
+        for thr, bounds in zip(self.thresholds, self.fuzzy_bounds):
+            assert len(bounds) == 2, (
+                "Invalid bounds for one threshold: {}. "
+                "Expected 2 floats.".format(bounds))
+            bounds_msg = ("Threshold must be within bounds: "
+                          "!( {} <= {} <= {} )".format(bounds[0],
+                                                       thr, bounds[1]))
+            assert bounds[0] <= thr, bounds_msg
+            assert bounds[1] >= thr, bounds_msg
 
         self.below_thresh_ok = below_thresh_ok
 

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -121,7 +121,8 @@ class BasicThreshold(object):
                     "Invalid bounds for one threshold: {}. "
                     "Expected 2 floats.".format(bounds))
                 bounds_msg = ("Threshold must be within bounds: "
-                    "!( {} <= {} <= {} )".format(bounds[0], thr, bounds[1]))
+                              "!( {} <= {} <= {} )".format(bounds[0],
+                                                           thr, bounds[1]))
                 assert bounds[0] <= thr, bounds_msg
                 assert bounds[1] >= thr, bounds_msg
 

--- a/tests/improver-threshold/00-null.bats
+++ b/tests/improver-threshold/00-null.bats
@@ -32,9 +32,10 @@
 @test "threshold no arguments" {
   run improver threshold
   [[ "$status" -eq 2 ]]
-  expected="usage: improver-threshold [-h] [--threshold_units THRESHOLD_UNITS]
+  expected="usage: improver-threshold [-h] [--threshold_config THRESHOLD_CONFIG]
+                          [--threshold_units THRESHOLD_UNITS]
                           [--below_threshold] [--fuzzy_factor FUZZY_FACTOR]
-                          INPUT_FILE OUTPUT_FILE THRESHOLD_VALUES
-                          [THRESHOLD_VALUES ...]"
+                          INPUT_FILE OUTPUT_FILE
+                          [THRESHOLD_VALUES [THRESHOLD_VALUES ...]]"
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -33,24 +33,30 @@
   run improver threshold -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-usage: improver-threshold [-h] [--threshold_units THRESHOLD_UNITS]
+usage: improver-threshold [-h] [--threshold_config THRESHOLD_CONFIG]
+                          [--threshold_units THRESHOLD_UNITS]
                           [--below_threshold] [--fuzzy_factor FUZZY_FACTOR]
-                          INPUT_FILE OUTPUT_FILE THRESHOLD_VALUES
-                          [THRESHOLD_VALUES ...]
+                          INPUT_FILE OUTPUT_FILE
+                          [THRESHOLD_VALUES [THRESHOLD_VALUES ...]]
 
 Calculate the threshold truth value of cube data relative to the provided
 threshold value. By default data are tested to be above the thresholds, though
-the --below_threshold flag enables testing below thresholds. A fuzzy factor
-may be provided to capture data that is within this factor of the threshold.
+the --below_threshold flag enables testing below thresholds. A fuzzy factor or
+fuzzy bounds may be provided to capture data that is close to the threshold.
 
 positional arguments:
   INPUT_FILE            A path to an input NetCDF file to be processed
   OUTPUT_FILE           The output path for the processed NetCDF
   THRESHOLD_VALUES      Threshold value or values about which to calculate the
-                        truth values; e.g. 270 300
+                        truth values; e.g. 270 300. Must be omitted if
+                        --threshold_config is used.
 
 optional arguments:
   -h, --help            show this help message and exit
+  --threshold_config THRESHOLD_CONFIG
+                        Threshold configuration JSON file containing
+                        thresholds and fuzzy bounds. Best used in combination
+                        with --threshold_units.
   --threshold_units THRESHOLD_UNITS
                         Units of the threshold values. If not provided the
                         units are assumed to be the same as those of the input
@@ -66,7 +72,8 @@ optional arguments:
                         Data which fail a test against the hard threshold
                         value may return a fractional truth value if they fall
                         within this fuzzy factor region. NB A fuzzy factor
-                        cannot be used with a zero threshold.
+                        cannot be used with a zero threshold or a
+                        threshold_config file.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -56,7 +56,11 @@ optional arguments:
   --threshold_config THRESHOLD_CONFIG
                         Threshold configuration JSON file containing
                         thresholds and fuzzy bounds. Best used in combination
-                        with --threshold_units.
+                        with --threshold_units. It should contain a dictionary
+                        of strings that can be interpreted as floats with the
+                        structure: "THRESHOLD_VALUE": [LOWER_BOUND,
+                        UPPER_BOUND] e.g: {"280.0": [278.0, 282.0], "290.0":
+                        [288.0, 292.0]}
   --threshold_units THRESHOLD_UNITS
                         Units of the threshold values. If not provided the
                         units are assumed to be the same as those of the input

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -60,7 +60,9 @@ optional arguments:
                         of strings that can be interpreted as floats with the
                         structure: "THRESHOLD_VALUE": [LOWER_BOUND,
                         UPPER_BOUND] e.g: {"280.0": [278.0, 282.0], "290.0":
-                        [288.0, 292.0]}
+                        [288.0, 292.0]}. Repeated thresholds with different
+                        bounds are not handled well. Only the last duplicate
+                        will be used.
   --threshold_units THRESHOLD_UNITS
                         Units of the threshold values. If not provided the
                         units are assumed to be the same as those of the input

--- a/tests/improver-threshold/07-fuzzy_bounds.bats
+++ b/tests/improver-threshold/07-fuzzy_bounds.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output 280 --fuzzy_factor 0.2" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      --threshold_config $IMPROVER_ACC_TEST_DIR/threshold/fuzzy_bounds/threshold_config.json
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/threshold/fuzzy_factor/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
+}


### PR DESCRIPTION
2nd PR from #263  (1st PR is #333).

This PR adds the option to specify fuzzy bounds to the threshold plugin and CLI. 
The changes are backward-compatible so any existing uses do not need updating unless they wish to benefit from this change.

Testing:
 - [X] Ran tests and they passed OK
 - [X] Added new tests for the new feature(s)
