### PR TITLE
Impro 176 recursive filter

### DIFF
--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -307,9 +307,8 @@ class RecursiveFilter(object):
                 emsg = ("A value for alpha must be set if alphas_cube is "
                         "set to None: alpha is currently set as: {}")
                 raise ValueError(emsg.format(alpha))
-            else:
-                alphas_cube = cube.copy(
-                    data=np.ones(cube.data.shape) * alpha)
+            alphas_cube = cube.copy(
+                data=np.ones(cube.data.shape) * alpha)
 
         if alphas_cube is not None:
             if alphas_cube.data.shape != cube.data.shape:

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module to apply a recursive filter to neighbourhooded data."""
+
+import iris
+import numpy as np
+
+from improver.nbhood.square_kernel import SquareNeighbourhood
+
+
+class RecursiveFilter(object):
+
+    """
+    Apply a recursive filter to the input cube.
+    """
+
+    def __init__(self, alpha_x=None, alpha_y=None, iterations=5, edge_width=1):
+        """
+        Initialise the class.
+
+        Args:
+
+        """
+        if alpha_x is not None:
+            self.alpha_x = alpha_x
+        if alpha_y is not None:
+            self.alpha_y = alpha_y
+        self.iterations = iterations
+        self.edge_width = edge_width
+
+
+    def __repr__(self):
+        """Represent the configured plugin instance as a string."""
+        result = ('<RecursiveFilter: alpha_x: {}, alpha_y: {}, iterations: {},'
+                  ' edge_width: {}')
+        return result.format(self.alpha_x, self.alpha_y, self.iterations,
+                             self.edge_width)
+
+    @staticmethod
+    def recurse_forward_x(grid, alphas):
+        nx, ny = grid.shape
+        for i in range(1, nx):
+            grid[i, :] = ((1. - alphas[i, :]) * grid[i, :] +
+                          alphas[i, :] * grid[i-1, :])
+        return grid
+
+    @staticmethod
+    def recurse_backwards_x(grid, alphas):
+        nx, ny = grid.shape
+        for i in range(nx-2, -1, -1):
+            grid[i, :] = ((1. - alphas[i, :]) * grid[i, :] +
+                          alphas[i, :] * grid[i+1, :])
+        return grid
+
+    @staticmethod
+    def recurse_forward_y(grid, alphas):
+        nx, ny = grid.shape
+        for i in range(1, ny):
+            grid[:, i] = ((1. - alphas[:, i]) * grid[:, i] +
+                          alphas[:, i] * grid[:, i-1])
+        return grid
+
+    @staticmethod
+    def recurse_backwards_y(grid, alphas):
+        nx, ny = grid.shape
+        for i in range(ny-2, -1, -1):
+            grid[:, i] = ((1. - alphas[:, i]) * grid[:, i] +
+                          alphas[:, i] * grid[:, i+1])
+        return grid
+
+    @staticmethod
+    def run_recursion(cube, alphas_x, alphas_y, iterations):
+        output = cube.data
+        for i in range(iterations):
+            output = RecursiveFilter.recurse_forward_x(output, alphas_x.data)
+            output = RecursiveFilter.recurse_backwards_x(output, alphas_x.data)
+            output = RecursiveFilter.recurse_forward_y(output, alphas_y.data)
+            output = RecursiveFilter.recurse_backwards_y(output, alphas_y.data)
+
+        cube.data = output
+        return cube
+
+
+
+    def process(self, cube, alphas_x=None, alphas_y=None):
+        """
+        Set up the alpha parameters and run the recursive filter.
+
+        """
+        padded_cube = SquareNeighbourhood().pad_cube_with_halo(
+            cube, self.edge_width, self.edge_width)
+
+        if alphas_x is None:
+            alphas_x = padded_cube.copy(data=np.ones(padded_cube.data.shape) *
+                                        self.alpha_x)
+        else:
+            alphas_x = SquareNeighbourhood().pad_cube_with_halo(
+                alphas_x, self.edge_width, self.edge_width)
+
+        if alphas_y is None:
+            alphas_y = padded_cube.copy(data=np.ones(padded_cube.data.shape) *
+                                        self.alpha_y)
+        else:
+            alphas_y = SquareNeighbourhood().pad_cube_with_halo(
+                alphas_y, self.edge_width, self.edge_width)
+
+        cube = self.run_recursion(padded_cube, alphas_x, alphas_y,
+                                  self.iterations)
+        cube = SquareNeighbourhood().remove_halo_from_cube(
+            cube, self.edge_width, self.edge_width)
+
+        return cube

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -110,9 +110,9 @@ class RecursiveFilter(object):
             Recursive filtering is calculated as:
                 Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
 
-            Progressing from gridpoint i-1 to i ......
-            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-            Bi-1 = New value at gridpoint i-1
+            Progressing from gridpoint i-1 to i:
+                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+                Bi-1 = New value at gridpoint i-1
 
         Args:
             grid (numpy array):
@@ -144,9 +144,9 @@ class RecursiveFilter(object):
             Recursive filtering is calculated as:
                 Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
 
-            Progressing from gridpoint i+1 to i ......
-            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-            Bi+1 = New value at gridpoint i+1
+            Progressing from gridpoint i+1 to i:
+                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+                Bi+1 = New value at gridpoint i+1
 
         Args:
             grid (numpy array):
@@ -178,9 +178,9 @@ class RecursiveFilter(object):
             Recursive filtering is calculated as:
                 Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
 
-            Progressing from gridpoint i-1 to i ......
-            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-            Bi-1 = New value at gridpoint i-1
+            Progressing from gridpoint i-1 to i:
+                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+                Bi-1 = New value at gridpoint i-1
 
         Args:
             grid (numpy array):
@@ -212,9 +212,9 @@ class RecursiveFilter(object):
             Recursive filtering is calculated as:
                 Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
 
-            Progressing from gridpoint i+1 to i ......
-            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-            Bi+1 = New value at gridpoint i+1
+            Progressing from gridpoint i+1 to i:.
+                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+                Bi+1 = New value at gridpoint i+1
 
         Args:
             grid (numpy array):
@@ -246,17 +246,17 @@ class RecursiveFilter(object):
             Recursive filtering is calculated as:
                 Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
 
-            Progressing from gridpoint i-1 to i ......
-            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-            Bi-1 = New value at gridpoint i-1
+            Progressing from gridpoint i-1 to i:
+                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+                Bi-1 = New value at gridpoint i-1
 
         In the backwards direction:
             Recursive filtering is calculated as:
                 Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
 
-            Progressing from gridpoint i+1 to i ......
-            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-            Bi+1 = New value at gridpoint i+1
+            Progressing from gridpoint i+1 to i:
+                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+                Bi+1 = New value at gridpoint i+1
 
         Args:
             cube (Iris.cube.Cube):

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -47,17 +47,17 @@ class RecursiveFilter(object):
         """
         Initialise the class.
 
-        Args:
+        Keyword Args:
 
-            alpha_x : Float or None
+            alpha_x {Float or None}:
                 Filter parameter: A constant used to weight the recursive filter 
                 along the x-axis. Defined such that 0.0 <= alpha_x <= 1.0
-            alpha_y : Float or None
+            alpha_y {Float or None}:
                 Filter parameter: A constant used to weight the recursive filter 
                 along the y-axis. Defined such that 0.0 <= alpha_y <= 1.0
-            iterations : integer or None
+            iterations {integer or None}:
                 The number of iterations of the recursive filter.
-            edge_width : integer
+            edge_width {integer}:
                 The width of the padding applied to the grid cells when adding the 
                 SquareNeighbourhood halo.
 
@@ -71,28 +71,27 @@ class RecursiveFilter(object):
         """
 
         if alpha_x is not None:
-            self.alpha_x = alpha_x
-            if not 0 <= alpha_x <= 1:
+            if not 0 < alpha_x < 1:
                 raise ValueError(
-                    "Invalid alpha_x: {}. Must be >= 0 and <= 1".format(
+                    "Invalid alpha_x: must be >= 0 and <= 1: {}".format(
                         alpha_x))
 
         if alpha_y is not None:
-            self.alpha_y = alpha_y
-            if not 0 <= alpha_y <= 1:
+            if not 0. <= alpha_y <= 1.:
                 raise ValueError(
-                    "Invalid alpha_y: {}. Must be >= 0 and <= 1".format(
+                    "Invalid alpha_y: must be >= 0 and <= 1: {}".format(
                         alpha_y))
 
         if iterations is not None:
-            self.iterations = iterations
             if not iterations >= 1:
                 raise ValueError(
-                    "Invalid number of iterations: {}. Must be >= 1".format(
+                    "Invalid number of iterations: must be >= 1: {}".format(
                         iterations))
 
+        self.alpha_x = alpha_x
+        self.alpha_y = alpha_y
+        self.iterations = iterations        
         self.edge_width = edge_width
-
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -108,18 +107,18 @@ class RecursiveFilter(object):
 
         Args:
 
-            grid : Iris.cube.Cube
-                Cube containing the input data to which the recursive filter
+            grid {numpy array}:
+                Array containing the input data to which the recursive filter
                 will be applied.
-            alphas : Iris.cube.Cube
-                Cube containing an array of alpha values that will be used when applying
+            alphas {numpy array}:
+                Array of alpha values that will be used when applying
                 the recursive filter along the x-axis.
 
         Returns
 
-            grid : Iris.cube.Cube 
-                Cube containing the smoothed field after the recursive filter
-                method has been applied to the input cube in the forward x-direction.
+            grid {numpy array}:
+                Array containing the smoothed field after the recursive filter
+                method has been applied to the input array in the forward x-direction.
         """
 
         nx, ny = grid.shape
@@ -135,18 +134,18 @@ class RecursiveFilter(object):
 
         Args:
 
-            grid : Iris.cube.Cube
-                Cube containing the input data to which the recursive filter
+            grid {numpy array}:
+                Array containing the input data to which the recursive filter
                 will be applied.
-            alphas : Iris.cube.Cube
-                Cube containing an array of alpha values that will be used when applying
+            alphas {numpy array}:
+                Array of alpha values that will be used when applying
                 the recursive filter along the x-axis.
 
         Returns
 
-            grid : Iris.cube.Cube 
-                Cube containing the smoothed field after the recursive filter
-                method has been applied to the input cube in the backwards x-direction.
+            grid {numpy array}:
+                Array containing the smoothed field after the recursive filter
+                method has been applied to the input array in the backwards x-direction.
         """
 
         nx, ny = grid.shape
@@ -162,18 +161,18 @@ class RecursiveFilter(object):
 
         Args:
 
-            grid : Iris.cube.Cube
-                Cube containing the input data to which the recursive filter
+            grid {numpy array}:
+                Array containing the input data to which the recursive filter
                 will be applied.
-            alphas : Iris.cube.Cube
-                Cube containing an array of alpha values that will be used when applying
+            alphas {numpy array}:
+                Array of alpha values that will be used when applying
                 the recursive filter along the y-axis.
 
         Returns
 
-            grid : Iris.cube.Cube 
-                Cube containing the smoothed field after the recursive filter
-                method has been applied to the input cube in the forward y-direction.
+            grid {numpy array}:
+                Array containing the smoothed field after the recursive filter
+                method has been applied to the input array in the forward y-direction.
         """
 
         nx, ny = grid.shape
@@ -189,18 +188,18 @@ class RecursiveFilter(object):
 
         Args:
 
-            grid : Iris.cube.Cube
-                Cube containing the input data to which the recursive filter
+            grid {numpy array}:
+                Array containing the input data to which the recursive filter
                 will be applied.
-            alphas : Iris.cube.Cube
-                Cube containing an array of alpha values that will be used when applying
+            alphas {numpy array}:
+                Array of alpha values that will be used when applying
                 the recursive filter along the y-axis.
 
         Returns
 
-            grid : Iris.cube.Cube 
-                Cube containing the smoothed field after the recursive filter
-                method has been applied to the input cube in the backwards y-direction.
+            grid {numpy array}:
+                Array containing the smoothed field after the recursive filter
+                method has been applied to the input arary in the backwards y-direction.
         """
 
         nx, ny = grid.shape
@@ -222,21 +221,21 @@ class RecursiveFilter(object):
 
         Args:
 
-            cube : Iris.cube.Cube
+            cube {Iris.cube.Cube}:
                 Cube containing the input data to which the recursive filter
                 will be applied.
-            alphas_x : Iris.cube.Cube
-                Cube containing an array of alpha values that will be used when applying
+            alphas_x {Iris.cube.Cube}:
+                Cube containing array of alpha values that will be used when applying
                 the recursive filter along the x-axis.
-            alphas_y : Iris.cube.Cube
-                Cube containing an array of alpha values that will be used when applying
+            alphas_y {Iris.cube.Cube}:
+                Cube containing array of alpha values that will be used when applying
                 the recursive filter along the y-axis.
-            iterations : integer
+            iterations {integer}:
                 The number of iterations of the recursive filter
 
         Returns
 
-            cube : Iris.cube.Cube 
+            cube {Iris.cube.Cube}: 
                 Cube containing the smoothed field after the recursive filter
                 method has been applied to the input cube.
         """
@@ -260,32 +259,40 @@ class RecursiveFilter(object):
 
         Args:
 
-            cube : Iris.cube.Cube
+            cube {Iris.cube.Cube}:
                 Cube containing the input data to which the recursive filter
                 will be applied.
-            alpha : 
+            alpha {Float}:
                 The constant used to weight the recursive filter in that direction: 
                 Defined such that 0.0 <= alpha <= 1.0
-
-            alphas_cube : Iris.cube.Cube or None
-                Cube containing an array of alpha values that will be used when applying
-                the recursive filter in a specific direction. If not set
-                uses an array where all values are set to 1.0 * alpha       
+            alphas_cube {Iris.cube.Cube or None}:
+                Cube containing array of alpha values that will be used 
+                when applying the recursive filter in a specific direction.                     
 
         Returns
 
-            alphas_cube : Iris.cube.Cube 
-                Padded cube containing array of alpha values for specified direction.
+            alphas_cube {Iris.cube.Cube}:
+                Cube containing a padded array of alpha values for specified direction.
         """
 
         if alphas_cube is None:
             alphas_cube = cube.copy(
                 data=np.ones(cube.data.shape) * alpha)
 
+        if alphas_cube is not None:
+            length_alphas_array=len(alphas_cube.data[0])
+            length_data_array=len(cube.data[0])
+            if length_alphas_array < length_data_array:
+                raise ValueError("Dimensions of alphas array < dimensions of data array: {}<{}  ".format(
+                    length_alphas_array,length_data_array))
+            if length_alphas_array > length_data_array:
+                raise ValueError("Dimensions of alphas array > dimensions of data array: {}>{}".format(
+                    length_alphas_array,length_data_array))
+
+
         alphas_cube = SquareNeighbourhood().pad_cube_with_halo(
             alphas_cube, self.edge_width, self.edge_width)
         return alphas_cube
-
 
     def process(self, cube, alphas_x=None, alphas_y=None):
         """
@@ -309,29 +316,25 @@ class RecursiveFilter(object):
 
         Args:
 
-            cube : Iris.cube.Cube
+            cube {Iris.cube.Cube}:
                 Cube containing the input data to which the recursive filter
                 will be applied.
-            alphas_x : Iris.cube.Cube or None
-                Cube containing an array of alpha values that will be used when applying
+
+        Keyword Args:
+
+            alphas_x {Iris.cube.Cube or None}:
+                Cube containing array of alpha values that will be used when applying
                 the recursive filter along the x-axis.
-            alphas_y : Iris.cube.Cube or None
-                Cube containing an array of alpha values that will be used when applying
+            alphas_y {Iris.cube.Cube or None}:
+                Cube containing array of alpha values that will be used when applying
                 the recursive filter along the y-axis.
-
-        Raises:
-
-            ValueError: If a np.nan value is detected within the input cube.
 
         Returns
 
-            new_cube : Iris.cube.Cube
+            new_cube {Iris.cube.Cube}:
                 Cube containing the smoothed field after the recursive filter
                 method has been applied.
         """
-
-        if np.isnan(cube.data).any():
-            raise ValueError("Error: NaN detected in input cube data")
 
         cube_format = next(cube.slices([cube.coord(axis='y'),
                                         cube.coord(axis='x')]))

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -106,6 +106,14 @@ class RecursiveFilter(object):
         """
         Method to run the recursive filter in the forward x-direction.
 
+        In the forward direction:
+            Recursive filtering is calculated as:
+                Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
+
+            Progressing from gridpoint i-1 to i ......
+            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+            Bi-1 = New value at gridpoint i-1
+
         Args:
             grid (numpy array):
                 Array containing the input data to which the recursive filter
@@ -131,6 +139,14 @@ class RecursiveFilter(object):
     def recurse_backwards_x(grid, alphas):
         """
         Method to run the recursive filter in the backwards x-direction.
+
+        In the backwards direction:
+            Recursive filtering is calculated as:
+                Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
+
+            Progressing from gridpoint i+1 to i ......
+            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+            Bi+1 = New value at gridpoint i+1
 
         Args:
             grid (numpy array):
@@ -158,6 +174,14 @@ class RecursiveFilter(object):
         """
         Method to run the recursive filter in the forward y-direction.
 
+        In the forward direction:
+            Recursive filtering is calculated as:
+                Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
+
+            Progressing from gridpoint i-1 to i ......
+            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+            Bi-1 = New value at gridpoint i-1
+
         Args:
             grid (numpy array):
                 Array containing the input data to which the recursive filter
@@ -184,6 +208,14 @@ class RecursiveFilter(object):
         """
         Method to run the recursive filter in the backwards y-direction.
 
+        In the backwards direction:
+            Recursive filtering is calculated as:
+                Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
+
+            Progressing from gridpoint i+1 to i ......
+            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+            Bi+1 = New value at gridpoint i+1
+
         Args:
             grid (numpy array):
                 Array containing the input data to which the recursive filter
@@ -195,7 +227,7 @@ class RecursiveFilter(object):
         Returns:
             grid (numpy array):
                 Array containing the smoothed field after the recursive
-                filter method has been applied to the input arary in the
+                filter method has been applied to the input array in the
                 backwards y-direction.
         """
 
@@ -210,12 +242,21 @@ class RecursiveFilter(object):
         """
         Method to run the recursive filter.
 
-        Recursive filtering is calculated as:
-            Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
+        In the forward direction:
+            Recursive filtering is calculated as:
+                Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
 
-        Progressing from gridpoint i-1 to i ......
-        Bi = new value at gridpoint i, Ai =  Old value at gridpoint i
-        Bi-1 = New value at gridpoint i-1
+            Progressing from gridpoint i-1 to i ......
+            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+            Bi-1 = New value at gridpoint i-1
+
+        In the backwards direction:
+            Recursive filtering is calculated as:
+                Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
+
+            Progressing from gridpoint i+1 to i ......
+            Bi = new value at gridpoint i, Ai = Old value at gridpoint i
+            Bi+1 = New value at gridpoint i+1
 
         Args:
             cube (Iris.cube.Cube):
@@ -302,7 +343,7 @@ class RecursiveFilter(object):
         2. Construct an array of filter parameters (alphas_x and alphas_y) for
            each cube slice that are used to weight the recursive filter in
            the x- and y-directions.
-        3. Pad each cube slice with a square-neighboorhood halo and apply
+        3. Pad each cube slice with a square-neighbourhood halo and apply
            the recursive filter for the required number of iterations.
         4. Remove the halo from the cube slice and append the recursed cube
            slice to a 'recursed cube'.

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -290,6 +290,7 @@ class RecursiveFilter(object):
                 when applying the recursive filter in a specific direction.
 
         Raises:
+            ValueError: If alpha and alphas_cube are both set to None
             ValueError: If dimension of alphas array is less than dimension
                         of data array
             ValueError: If dimension of alphas array is greater than dimension

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -72,7 +72,7 @@ class RecursiveFilter(object):
         """
 
         if alpha_x is not None:
-            if not 0 < alpha_x < 1:
+            if not 0 <= alpha_x < 1:
                 raise ValueError(
                     "Invalid alpha_x: must be >= 0 and < 1: {}".format(
                         alpha_x))

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -52,11 +52,11 @@ class RecursiveFilter(object):
             alpha_x (Float or None):
                 Filter parameter: A constant used to weight the
                 recursive filter along the x-axis. Defined such
-                that 0.0 <= alpha_x <= 1.0
+                that 0 <= alpha_x < 1.0
             alpha_y (Float or None):
                 Filter parameter: A constant used to weight the
                 recursive filter along the y-axis. Defined such
-                that 0.0 <= alpha_y <= 1.0
+                that 0 <= alpha_y < 1.0
             iterations (integer or None):
                 The number of iterations of the recursive filter.
             edge_width (integer):
@@ -64,23 +64,23 @@ class RecursiveFilter(object):
                 when adding the SquareNeighbourhood halo.
 
         Raises:
-            ValueError: If alpha_x is not set such that 0 <= alpha_x <= 1
-            ValueError: If alpha_y is not set such that 0 <= alpha_y <= 1
+            ValueError: If alpha_x is not set such that 0 <= alpha_x < 1
+            ValueError: If alpha_y is not set such that 0 <= alpha_y < 1
             ValueError: If number of iterations is not None and is set such
-            that iterations is not >= 1
+                        that iterations is not >= 1
 
         """
 
         if alpha_x is not None:
             if not 0 < alpha_x < 1:
                 raise ValueError(
-                    "Invalid alpha_x: must be >= 0 and <= 1: {}".format(
+                    "Invalid alpha_x: must be >= 0 and < 1: {}".format(
                         alpha_x))
 
         if alpha_y is not None:
-            if not 0. <= alpha_y <= 1.:
+            if not 0 <= alpha_y < 1:
                 raise ValueError(
-                    "Invalid alpha_y: must be >= 0 and <= 1: {}".format(
+                    "Invalid alpha_y: must be >= 0 and < 1: {}".format(
                         alpha_y))
 
         if iterations is not None:
@@ -242,22 +242,6 @@ class RecursiveFilter(object):
         """
         Method to run the recursive filter.
 
-        In the forward direction:
-            Recursive filtering is calculated as:
-                Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
-
-            Progressing from gridpoint i-1 to i:
-                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-                Bi-1 = New value at gridpoint i-1
-
-        In the backwards direction:
-            Recursive filtering is calculated as:
-                Bi = ((1-alpha) * Ai) + (alpha * Bi+1)
-
-            Progressing from gridpoint i+1 to i:
-                Bi = new value at gridpoint i, Ai = Old value at gridpoint i
-                Bi+1 = New value at gridpoint i+1
-
         Args:
             cube (Iris.cube.Cube):
                 Cube containing the input data to which the recursive filter
@@ -318,8 +302,13 @@ class RecursiveFilter(object):
         """
 
         if alphas_cube is None:
-            alphas_cube = cube.copy(
-                data=np.ones(cube.data.shape) * alpha)
+            if alpha is None:
+                emsg = ("A value for alpha must be set if alphas_cube is "
+                        "set to None: alpha is currently set as: {}")
+                raise ValueError(emsg.format(alpha))
+            else:
+                alphas_cube = cube.copy(
+                    data=np.ones(cube.data.shape) * alpha)
 
         if alphas_cube is not None:
             if alphas_cube.data.shape != cube.data.shape:

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -43,30 +43,31 @@ class RecursiveFilter(object):
     Apply a recursive filter to the input cube.
     """
 
-    def __init__(self, alpha_x=None, alpha_y=None, iterations=None, edge_width=1):
+    def __init__(self, alpha_x=None, alpha_y=None, iterations=None,
+                 edge_width=1):
         """
         Initialise the class.
 
         Keyword Args:
-
             alpha_x {Float or None}:
-                Filter parameter: A constant used to weight the recursive filter 
-                along the x-axis. Defined such that 0.0 <= alpha_x <= 1.0
+                Filter parameter: A constant used to weight the
+                recursive filter along the x-axis. Defined such
+                that 0.0 <= alpha_x <= 1.0
             alpha_y {Float or None}:
-                Filter parameter: A constant used to weight the recursive filter 
-                along the y-axis. Defined such that 0.0 <= alpha_y <= 1.0
+                Filter parameter: A constant used to weight the
+                recursive filter along the y-axis. Defined such
+                that 0.0 <= alpha_y <= 1.0
             iterations {integer or None}:
                 The number of iterations of the recursive filter.
             edge_width {integer}:
-                The width of the padding applied to the grid cells when adding the 
-                SquareNeighbourhood halo.
+                The width of the padding applied to the grid cells
+                when adding the SquareNeighbourhood halo.
 
         Raises:
-
             ValueError: If alpha_x is not set such that 0 <= alpha_x <= 1
             ValueError: If alpha_y is not set such that 0 <= alpha_y <= 1
-            ValueError: If number of iterations is not None and 
-                          is set such that iterations is not >= 1
+            ValueError: If number of iterations is not None and is set such
+            that iterations is not >= 1
 
         """
 
@@ -90,7 +91,7 @@ class RecursiveFilter(object):
 
         self.alpha_x = alpha_x
         self.alpha_y = alpha_y
-        self.iterations = iterations        
+        self.iterations = iterations
         self.edge_width = edge_width
 
     def __repr__(self):
@@ -106,7 +107,6 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the forward x-direction.
 
         Args:
-
             grid {numpy array}:
                 Array containing the input data to which the recursive filter
                 will be applied.
@@ -115,14 +115,14 @@ class RecursiveFilter(object):
                 the recursive filter along the x-axis.
 
         Returns
-
             grid {numpy array}:
-                Array containing the smoothed field after the recursive filter
-                method has been applied to the input array in the forward x-direction.
+                Array containing the smoothed field after the recursive
+                filter method has been applied to the input array in the
+                forward x-direction.
         """
 
-        nx, ny = grid.shape
-        for i in range(1, nx):
+        x_lim = grid.shape[0]
+        for i in range(1, x_lim):
             grid[i, :] = ((1. - alphas[i, :]) * grid[i, :] +
                           alphas[i, :] * grid[i-1, :])
         return grid
@@ -133,7 +133,6 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the backwards x-direction.
 
         Args:
-
             grid {numpy array}:
                 Array containing the input data to which the recursive filter
                 will be applied.
@@ -142,14 +141,14 @@ class RecursiveFilter(object):
                 the recursive filter along the x-axis.
 
         Returns
-
             grid {numpy array}:
-                Array containing the smoothed field after the recursive filter
-                method has been applied to the input array in the backwards x-direction.
+                Array containing the smoothed field after the recursive
+                filtermethod has been applied to the input array in the
+                backwards x-direction.
         """
 
-        nx, ny = grid.shape
-        for i in range(nx-2, -1, -1):
+        x_lim = grid.shape[0]
+        for i in range(x_lim-2, -1, -1):
             grid[i, :] = ((1. - alphas[i, :]) * grid[i, :] +
                           alphas[i, :] * grid[i+1, :])
         return grid
@@ -160,7 +159,6 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the forward y-direction.
 
         Args:
-
             grid {numpy array}:
                 Array containing the input data to which the recursive filter
                 will be applied.
@@ -169,14 +167,14 @@ class RecursiveFilter(object):
                 the recursive filter along the y-axis.
 
         Returns
-
             grid {numpy array}:
-                Array containing the smoothed field after the recursive filter
-                method has been applied to the input array in the forward y-direction.
+                Array containing the smoothed field after the recursive
+                filter method has been applied to the input array in the
+                forward y-direction.
         """
 
-        nx, ny = grid.shape
-        for i in range(1, ny):
+        y_lim = grid.shape[1]
+        for i in range(1, y_lim):
             grid[:, i] = ((1. - alphas[:, i]) * grid[:, i] +
                           alphas[:, i] * grid[:, i-1])
         return grid
@@ -187,7 +185,6 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the backwards y-direction.
 
         Args:
-
             grid {numpy array}:
                 Array containing the input data to which the recursive filter
                 will be applied.
@@ -196,14 +193,14 @@ class RecursiveFilter(object):
                 the recursive filter along the y-axis.
 
         Returns
-
             grid {numpy array}:
-                Array containing the smoothed field after the recursive filter
-                method has been applied to the input arary in the backwards y-direction.
+                Array containing the smoothed field after the recursive
+                filter method has been applied to the input arary in the
+                backwards y-direction.
         """
 
-        nx, ny = grid.shape
-        for i in range(ny-2, -1, -1):
+        y_lim = grid.shape[1]
+        for i in range(y_lim-2, -1, -1):
             grid[:, i] = ((1. - alphas[:, i]) * grid[:, i] +
                           alphas[:, i] * grid[:, i+1])
         return grid
@@ -213,35 +210,34 @@ class RecursiveFilter(object):
         """
         Method to run the recursive filter.
 
-        Recursive filtering is calculated as Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
+        Recursive filtering is calculated as:
+            Bi = ((1-alpha) * Ai) + (alpha * Bi-1)
 
         Progressing from gridpoint i-1 to i ......
         Bi = new value at gridpoint i, Ai =  Old value at gridpoint i
         Bi-1 = New value at gridpoint i-1
 
         Args:
-
             cube {Iris.cube.Cube}:
                 Cube containing the input data to which the recursive filter
                 will be applied.
             alphas_x {Iris.cube.Cube}:
-                Cube containing array of alpha values that will be used when applying
-                the recursive filter along the x-axis.
+                Cube containing array of alpha values that will be used
+                when applying the recursive filter along the x-axis.
             alphas_y {Iris.cube.Cube}:
-                Cube containing array of alpha values that will be used when applying
-                the recursive filter along the y-axis.
+                Cube containing array of alpha values that will be used
+                when applying the recursive filter along the y-axis.
             iterations {integer}:
                 The number of iterations of the recursive filter
 
         Returns
-
-            cube {Iris.cube.Cube}: 
+            cube {Iris.cube.Cube}:
                 Cube containing the smoothed field after the recursive filter
                 method has been applied to the input cube.
         """
 
         output = cube.data
-        for i in range(iterations):
+        for _ in range(iterations):
             output = RecursiveFilter.recurse_forward_x(output,
                                                        alphas_x.data)
             output = RecursiveFilter.recurse_backwards_x(output,
@@ -258,21 +254,26 @@ class RecursiveFilter(object):
         Set up the alpha parameter.
 
         Args:
-
             cube {Iris.cube.Cube}:
                 Cube containing the input data to which the recursive filter
                 will be applied.
             alpha {Float}:
-                The constant used to weight the recursive filter in that direction: 
-                Defined such that 0.0 <= alpha <= 1.0
+                The constant used to weight the recursive filter in that
+                direction: Defined such that 0.0 <= alpha <= 1.0
             alphas_cube {Iris.cube.Cube or None}:
-                Cube containing array of alpha values that will be used 
-                when applying the recursive filter in a specific direction.                     
+                Cube containing array of alpha values that will be used
+                when applying the recursive filter in a specific direction.
+
+        Raises:
+            ValueError: If dimension of alphas array is less than dimension
+                        of data array
+            ValueError: If dimension of alphas array is greater than dimension
+                        of data array
 
         Returns
-
             alphas_cube {Iris.cube.Cube}:
-                Cube containing a padded array of alpha values for specified direction.
+                Cube containing a padded array of alpha values
+                for the specified direction.
         """
 
         if alphas_cube is None:
@@ -280,15 +281,11 @@ class RecursiveFilter(object):
                 data=np.ones(cube.data.shape) * alpha)
 
         if alphas_cube is not None:
-            length_alphas_array=len(alphas_cube.data[0])
-            length_data_array=len(cube.data[0])
-            if length_alphas_array < length_data_array:
-                raise ValueError("Dimensions of alphas array < dimensions of data array: {}<{}  ".format(
-                    length_alphas_array,length_data_array))
-            if length_alphas_array > length_data_array:
-                raise ValueError("Dimensions of alphas array > dimensions of data array: {}>{}".format(
-                    length_alphas_array,length_data_array))
-
+            if alphas_cube.data.shape != cube.data.shape:
+                emsg = ("Dimensions of alphas array do not match dimensions "
+                        "of data array: {} < {}")
+                raise ValueError(emsg.format(alphas_cube.data.shape,
+                                             cube.data.shape))
 
         alphas_cube = SquareNeighbourhood().pad_cube_with_halo(
             alphas_cube, self.edge_width, self.edge_width)
@@ -301,36 +298,33 @@ class RecursiveFilter(object):
         The steps undertaken are:
         1. Split the input cube into slices determined by the co-ordinates in
            the x and y directions.
-        2. Construct an array of filter parameters (alphas_x and alphas_y) for 
+        2. Construct an array of filter parameters (alphas_x and alphas_y) for
            each cube slice that are used to weight the recursive filter in
            the x- and y-directions.
-        3. Pad each cube slice with a square-neighboorhood halo and apply 
+        3. Pad each cube slice with a square-neighboorhood halo and apply
            the recursive filter for the required number of iterations.
-        4. Remove the halo from the cube slice and append the recursed cube slice
-           to a 'recursed cube'.
+        4. Remove the halo from the cube slice and append the recursed cube
+           slice to a 'recursed cube'.
         5. Merge all the cube slices in the 'recursed cube' into a 'new cube'.
         6. Modify the 'new cube' so that its scalar dimension co-ordinates are
-           consistent with those in the original input cube. 
-        7. Return the 'new cube' which now contains the recursively filtered values
-           for the original input cube.
+           consistent with those in the original input cube.
+        7. Return the 'new cube' which now contains the recursively filtered
+           values for the original input cube.
 
         Args:
-
             cube {Iris.cube.Cube}:
                 Cube containing the input data to which the recursive filter
                 will be applied.
 
         Keyword Args:
-
             alphas_x {Iris.cube.Cube or None}:
-                Cube containing array of alpha values that will be used when applying
-                the recursive filter along the x-axis.
+                Cube containing array of alpha values that will be used when
+                applying the recursive filter along the x-axis.
             alphas_y {Iris.cube.Cube or None}:
-                Cube containing array of alpha values that will be used when applying
-                the recursive filter along the y-axis.
+                Cube containing array of alpha values that will be used when
+                applying the recursive filter along the y-axis.
 
         Returns
-
             new_cube {Iris.cube.Cube}:
                 Cube containing the smoothed field after the recursive filter
                 method has been applied.

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -49,17 +49,17 @@ class RecursiveFilter(object):
         Initialise the class.
 
         Keyword Args:
-            alpha_x {Float or None}:
+            alpha_x (Float or None):
                 Filter parameter: A constant used to weight the
                 recursive filter along the x-axis. Defined such
                 that 0.0 <= alpha_x <= 1.0
-            alpha_y {Float or None}:
+            alpha_y (Float or None):
                 Filter parameter: A constant used to weight the
                 recursive filter along the y-axis. Defined such
                 that 0.0 <= alpha_y <= 1.0
-            iterations {integer or None}:
+            iterations (integer or None):
                 The number of iterations of the recursive filter.
-            edge_width {integer}:
+            edge_width (integer):
                 The width of the padding applied to the grid cells
                 when adding the SquareNeighbourhood halo.
 
@@ -107,15 +107,15 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the forward x-direction.
 
         Args:
-            grid {numpy array}:
+            grid (numpy array):
                 Array containing the input data to which the recursive filter
                 will be applied.
-            alphas {numpy array}:
+            alphas (numpy array):
                 Array of alpha values that will be used when applying
                 the recursive filter along the x-axis.
 
-        Returns
-            grid {numpy array}:
+        Returns:
+            grid (numpy array):
                 Array containing the smoothed field after the recursive
                 filter method has been applied to the input array in the
                 forward x-direction.
@@ -133,15 +133,15 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the backwards x-direction.
 
         Args:
-            grid {numpy array}:
+            grid (numpy array):
                 Array containing the input data to which the recursive filter
                 will be applied.
-            alphas {numpy array}:
+            alphas (numpy array):
                 Array of alpha values that will be used when applying
                 the recursive filter along the x-axis.
 
-        Returns
-            grid {numpy array}:
+        Returns:
+            grid (numpy array):
                 Array containing the smoothed field after the recursive
                 filtermethod has been applied to the input array in the
                 backwards x-direction.
@@ -159,15 +159,15 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the forward y-direction.
 
         Args:
-            grid {numpy array}:
+            grid (numpy array):
                 Array containing the input data to which the recursive filter
                 will be applied.
-            alphas {numpy array}:
+            alphas (numpy array):
                 Array of alpha values that will be used when applying
                 the recursive filter along the y-axis.
 
-        Returns
-            grid {numpy array}:
+        Returns:
+            grid (numpy array):
                 Array containing the smoothed field after the recursive
                 filter method has been applied to the input array in the
                 forward y-direction.
@@ -185,15 +185,15 @@ class RecursiveFilter(object):
         Method to run the recursive filter in the backwards y-direction.
 
         Args:
-            grid {numpy array}:
+            grid (numpy array):
                 Array containing the input data to which the recursive filter
                 will be applied.
-            alphas {numpy array}:
+            alphas (numpy array):
                 Array of alpha values that will be used when applying
                 the recursive filter along the y-axis.
 
-        Returns
-            grid {numpy array}:
+        Returns:
+            grid (numpy array):
                 Array containing the smoothed field after the recursive
                 filter method has been applied to the input arary in the
                 backwards y-direction.
@@ -218,20 +218,20 @@ class RecursiveFilter(object):
         Bi-1 = New value at gridpoint i-1
 
         Args:
-            cube {Iris.cube.Cube}:
+            cube (Iris.cube.Cube):
                 Cube containing the input data to which the recursive filter
                 will be applied.
-            alphas_x {Iris.cube.Cube}:
+            alphas_x (Iris.cube.Cube):
                 Cube containing array of alpha values that will be used
                 when applying the recursive filter along the x-axis.
-            alphas_y {Iris.cube.Cube}:
+            alphas_y (Iris.cube.Cube):
                 Cube containing array of alpha values that will be used
                 when applying the recursive filter along the y-axis.
-            iterations {integer}:
+            iterations (integer):
                 The number of iterations of the recursive filter
 
-        Returns
-            cube {Iris.cube.Cube}:
+        Returns:
+            cube (Iris.cube.Cube):
                 Cube containing the smoothed field after the recursive filter
                 method has been applied to the input cube.
         """
@@ -254,13 +254,13 @@ class RecursiveFilter(object):
         Set up the alpha parameter.
 
         Args:
-            cube {Iris.cube.Cube}:
+            cube (Iris.cube.Cube):
                 Cube containing the input data to which the recursive filter
                 will be applied.
-            alpha {Float}:
+            alpha (Float):
                 The constant used to weight the recursive filter in that
                 direction: Defined such that 0.0 <= alpha <= 1.0
-            alphas_cube {Iris.cube.Cube or None}:
+            alphas_cube (Iris.cube.Cube or None):
                 Cube containing array of alpha values that will be used
                 when applying the recursive filter in a specific direction.
 
@@ -270,8 +270,8 @@ class RecursiveFilter(object):
             ValueError: If dimension of alphas array is greater than dimension
                         of data array
 
-        Returns
-            alphas_cube {Iris.cube.Cube}:
+        Returns:
+            alphas_cube (Iris.cube.Cube):
                 Cube containing a padded array of alpha values
                 for the specified direction.
         """
@@ -296,6 +296,7 @@ class RecursiveFilter(object):
         Set up the alpha parameters and run the recursive filter.
 
         The steps undertaken are:
+
         1. Split the input cube into slices determined by the co-ordinates in
            the x and y directions.
         2. Construct an array of filter parameters (alphas_x and alphas_y) for
@@ -312,20 +313,20 @@ class RecursiveFilter(object):
            values for the original input cube.
 
         Args:
-            cube {Iris.cube.Cube}:
+            cube (Iris.cube.Cube):
                 Cube containing the input data to which the recursive filter
                 will be applied.
 
         Keyword Args:
-            alphas_x {Iris.cube.Cube or None}:
+            alphas_x (Iris.cube.Cube or None):
                 Cube containing array of alpha values that will be used when
                 applying the recursive filter along the x-axis.
-            alphas_y {Iris.cube.Cube or None}:
+            alphas_y (Iris.cube.Cube or None):
                 Cube containing array of alpha values that will be used when
                 applying the recursive filter along the y-axis.
 
-        Returns
-            new_cube {Iris.cube.Cube}:
+        Returns:
+            new_cube (Iris.cube.Cube):
                 Cube containing the smoothed field after the recursive filter
                 method has been applied.
         """

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -120,7 +120,7 @@ class Test_RecursiveFilter(IrisTest):
     def test_alpha_x_gt_unity(self):
         """Test when an alpha_x value > unity is given (invalid)."""
         alpha_x = 1.1
-        msg = "Invalid alpha_x: must be >= 0 and <= 1: 1.1"
+        msg = "Invalid alpha_x: must be >= 0 and < 1: 1.1"
         with self.assertRaisesRegexp(ValueError, msg):
             RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
                             iterations=None, edge_width=1)
@@ -128,7 +128,7 @@ class Test_RecursiveFilter(IrisTest):
     def test_alpha_x_lt_zero(self):
         """Test when an alpha_x value < zero is given (invalid)."""
         alpha_x = -0.5
-        msg = "Invalid alpha_x: must be >= 0 and <= 1: -0.5"
+        msg = "Invalid alpha_x: must be >= 0 and < 1: -0.5"
         with self.assertRaisesRegexp(ValueError, msg):
             RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
                             iterations=None, edge_width=1)
@@ -136,7 +136,7 @@ class Test_RecursiveFilter(IrisTest):
     def test_alpha_y_gt_unity(self):
         """Test when an alpha_y value > unity is given (invalid)."""
         alpha_y = 1.1
-        msg = "Invalid alpha_y: must be >= 0 and <= 1: 1.1"
+        msg = "Invalid alpha_y: must be >= 0 and < 1: 1.1"
         with self.assertRaisesRegexp(ValueError, msg):
             RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
                             iterations=None, edge_width=1)
@@ -144,7 +144,7 @@ class Test_RecursiveFilter(IrisTest):
     def test_alpha_y_lt_zero(self):
         """Test when an alpha_y value < zero is given (invalid)."""
         alpha_y = -0.5
-        msg = "Invalid alpha_y: must be >= 0 and <= 1: -0.5"
+        msg = "Invalid alpha_y: must be >= 0 and < 1: -0.5"
         with self.assertRaisesRegexp(ValueError, msg):
             RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
                             iterations=None, edge_width=1)
@@ -224,6 +224,18 @@ class Test_set_alphas(Test_RecursiveFilter):
         # Check shape: Array should be padded with 4 extra rows/columns
         expected_shape = (9, 9)
         self.assertEqual(result.shape, expected_shape)
+
+    def test_alphas_cube_and_alpha_not_set(self):
+        """Test error is raised when both alphas_cube and alpha are set
+           to None (invalid)."""
+        alpha_x = None
+        alpha_y = None
+        alphas_cube = None
+        plugin = RecursiveFilter(alpha_x=alpha_x, alpha_y=alpha_y,
+                                 iterations=self.iterations)
+        msg = "A value for alpha must be set if alphas_cube is "
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.set_alphas(self.cube, alpha_x, alphas_cube)
 
 
 class Test_recurse_forward_x(Test_RecursiveFilter):

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -25,13 +25,283 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for the nbhood.RecursiveFilter plugin."""
 
-
 import unittest
-
-from cf_units import Unit
+import warnings
 import iris
-from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 from iris.tests import IrisTest
+from iris.coords import DimCoord
+from cf_units import Unit
 import numpy as np
- 
+from improver.nbhood.recursive_filter import RecursiveFilter
+from improver.nbhood.square_kernel import SquareNeighbourhood
+        
+class Test__repr__(IrisTest):
+
+    """Test the repr method."""
+
+    def test_basic(self):
+        """Test that the __repr__ returns the expected string."""
+        alpha_x = None
+        alpha_y = None
+        iterations = None
+        edge_width = 1
+        result = str(RecursiveFilter(alpha_x, alpha_y, iterations, edge_width))
+        msg = ('<RecursiveFilter: alpha_x: {}, alpha_y: {}, iterations: {},'
+                  ' edge_width: {}'.format(
+                alpha_x, alpha_y, iterations, edge_width))
+        self.assertEqual(result, msg)
+
+
+class Test_RecursiveFilter(IrisTest):
+
+    """Test class for the RecursiveFilter tests, setting up cubes."""
+
+    def setUp(self):
+        """Create test cubes."""
+
+        self.alpha_x = 0.5
+        self.alpha_y = 0.5
+        self.iterations = 1
+
+        # Generate data cube with dimensions 5 x 5
+        data = np.zeros((1, 5, 5))
+        data[0][0][2] = 0.1
+        data[0][1][2] = 0.25
+        data[0][2][2] = 0.5
+        data[0][3][2] = 0.25
+        data[0][4][2] = 0.1
+        data[0][2][4] = 0.1
+        data[0][2][3] = 0.25
+        data[0][2][1] = 0.25
+        data[0][2][0] = 0.1
+
+        cube = Cube(data, standard_name="precipitation_amount",
+                    units="kg m^-2 s^-1")
+        cube.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 5), 'latitude',
+                                    units='degrees'), 1)
+        cube.add_dim_coord(DimCoord(np.linspace(120, 180, 5), 'longitude',
+                                    units='degrees'), 2)
+        time_origin = "hours since 1970-01-01 00:00:00"
+        calendar = "gregorian"
+        tunit = Unit(time_origin, calendar)
+        cube.add_dim_coord(DimCoord([402192.5],
+                                    "time", units=tunit), 0)
+        self.cube = cube
+
+        # Generate alphas_cube with dimensions 4 x 4
+        alphas_data1 = np.ones((1, 4, 4)) * 0.5
+        alphas_cube1 = Cube(alphas_data1)
+        alphas_cube1.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 4), 'latitude',
+                                    units='degrees'), 1)
+        alphas_cube1.add_dim_coord(DimCoord(np.linspace(120, 180, 4), 'longitude',
+                                    units='degrees'), 2)
+        time_origin = "hours since 1970-01-01 00:00:00"
+        calendar = "gregorian"
+        tunit = Unit(time_origin, calendar)
+        alphas_cube1.add_dim_coord(DimCoord([402192.5],"time", units=tunit), 0)
+        self.alphas_cube1 = alphas_cube1
+
+        # Generate alphas_cube with dimensions 6 x 6
+        alphas_data2 = np.ones((1, 6, 6)) * 0.5
+        alphas_cube2 = Cube(alphas_data2)
+        alphas_cube2.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 6), 'latitude',
+                                    units='degrees'), 1)
+        alphas_cube2.add_dim_coord(DimCoord(np.linspace(120, 180, 6), 'longitude',
+                                    units='degrees'), 2)
+        time_origin = "hours since 1970-01-01 00:00:00"
+        calendar = "gregorian"
+        tunit = Unit(time_origin, calendar)
+        alphas_cube2.add_dim_coord(DimCoord([402192.5], "time", units=tunit), 0)
+        self.alphas_cube2 = alphas_cube2
+
+        # Generate alphas_cube with dimensions 5 x 5
+        alphas_data3 = np.ones((1, 5, 5)) * 0.5
+        alphas_cube3 = Cube(alphas_data3)
+        alphas_cube3.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 5), 'latitude',
+                                    units='degrees'), 1)
+        alphas_cube3.add_dim_coord(DimCoord(np.linspace(120, 180, 5), 'longitude',
+                                    units='degrees'), 2)
+        time_origin = "hours since 1970-01-01 00:00:00"
+        calendar = "gregorian"
+        tunit = Unit(time_origin, calendar)
+        alphas_cube3.add_dim_coord(DimCoord([402192.5], "time", units=tunit), 0)
+        self.alphas_cube3 = alphas_cube3
+
+    def test_basic(self):
+        """Test that the RecursiveFilter plugin returns an iris.cube.Cube."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
+        self.assertIsInstance(result, Cube)
+
+    def test_alpha_x_gt_unity(self):
+        """Test when an alpha_x value > unity is given (invalid)."""
+        msg = "Invalid alpha_x: must be >= 0 and <= 1: 1.1"
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter(alpha_x=1.1, alpha_y=None, iterations=None, edge_width=1)
+
+    def test_alpha_x_lt_zero(self):
+        """Test when an alpha_x value < zero is given (invalid)."""
+        msg = "Invalid alpha_x: must be >= 0 and <= 1: -0.5"
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter(alpha_x=-0.5, alpha_y=None, iterations=None, edge_width=1)
+
+    def test_alpha_y_gt_unity(self):
+        """Test when an alpha_y value > unity is given (invalid)."""
+        msg = "Invalid alpha_y: must be >= 0 and <= 1: 1.1"
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter(alpha_x=None, alpha_y=1.1, iterations=None, edge_width=1)
+
+    def test_alpha_y_lt_zero(self):
+        """Test when an alpha_y value < zero is given (invalid)."""
+        alpha_y = -0.5
+        msg = "Invalid alpha_y: must be >= 0 and <= 1: -0.5"
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter(alpha_x=None, alpha_y=-0.5, iterations=None, edge_width=1)
+
+    def test_iterations(self):
+        """Test when iterations value less than unity is given (invalid)."""
+        iterations = 0
+        msg = "Invalid number of iterations: must be >= 1: 0"
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter(alpha_x=None, alpha_y=None, iterations=0, edge_width=1)
+
+    def test_process(self):
+        """Test that the RecursiveFilter plugin returns the correct data"""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
+        expected = 0.13382206
+        self.assertAlmostEqual(result.data[0][2][2], expected)
+
+
+class Test_set_alphas(Test_RecursiveFilter):
+
+    """Test the set_alphas function"""
+
+    def test_alphas_array_as_expected_when_alphas_is_none(self):
+        """Test that the returned alphas array has the expected result when alphas=None."""
+        alphas=None
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.set_alphas(self.cube, self.alpha_x, alphas)
+        expected_result = 0.5
+        self.assertIsInstance(result.data, np.ndarray)
+        self.assertEqual(result.data[0][2], expected_result)
+        # Array should be padded with 4 extra rows/columns
+        length_result_array = 9
+        self.assertEqual(len(result.data[0,:]), length_result_array)
+        self.assertEqual(len(result.data[:,0]), length_result_array)
+   
+    def test_if_alphas_array_size_less_than_data_array_when_alphas_not_none(self):
+        """Test if array dimensions of alphas array is less than dimensions of
+           data_array when alphas is not set to None (invalid)."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        msg = "Dimensions of alphas array < dimensions of data array"
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube1)
+
+    def test_if_alphas_array_size_greater_than_data_array_when_alphas_not_none(self):
+        """Test if array dimensions of alphas array is greater than dimensions of
+           data_array when alphas is not set to None (invalid)."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        msg = "Dimensions of alphas array > dimensions of data array"
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube2)
+
+    def test_alphas_array_as_expected_when_alphas_is_not_none(self):
+        """Test that the returned alphas array has the expected result when alphas=None."""
+        alphas=None
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube3)
+        expected_result = 0.5
+        self.assertIsInstance(result.data, np.ndarray)
+        self.assertEqual(result.data[0][2], expected_result)
+        # Array should be padded with 4 extra rows/columns
+        length_result_array = 9
+        self.assertEqual(len(result.data[0,:]), length_result_array)
+        self.assertEqual(len(result.data[:,0]), length_result_array)
+
+class Test_recurse_forward_x(Test_RecursiveFilter):
+
+    """Test the recurse_forward_x method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_forward_x array has the expected type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.recurse_forward_x(self.cube.data[0,:], self.alphas_cube3.data[0,:])     
+        expected_result = 0.196875
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[4][2], expected_result)
+
+
+class Test_recurse_backwards_x(Test_RecursiveFilter):
+
+    """Test the recurse_backwards_x method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_backwards_x array has the expected type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.recurse_backwards_x(self.cube.data[0,:], self.alphas_cube3.data[0,:])     
+        expected_result = 0.196875
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[0][2], expected_result)
+
+class Test_recurse_forward_y(Test_RecursiveFilter):
+
+    """Test the recurse_forward_y method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_forward_y array has the expected type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.recurse_forward_y(self.cube.data[:,0], self.alphas_cube3.data[:,0])     
+        expected_result = 0.0125
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[0][4], expected_result)
+
+
+class Test_recurse_backwards_y(Test_RecursiveFilter):
+
+    """Test the recurse_backwards_y method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_backwards_y array has the expected type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        result = plugin.recurse_backwards_y(self.cube.data[:,0], self.alphas_cube3.data[:,0])     
+        expected_result = 0.0125
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[0][0], expected_result)
+
+
+class Test_run_recursion(Test_RecursiveFilter):
+
+    """Test the run_recursion method"""
+
+    def test_basic(self):
+        """Test that the run_recursion method returns an iris.cube.Cube."""
+        edge_width = 1
+        alphas_x = None
+        alphas_y = None
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        alphas_x = plugin.set_alphas(self.cube, self.alpha_x, alphas_x)
+        alphas_y = plugin.set_alphas(self.cube, self.alpha_y, alphas_y)
+        padded_cube=SquareNeighbourhood().pad_cube_with_halo(
+                     self.cube, edge_width, edge_width)
+        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y, self.iterations)
+        self.assertIsInstance(result, Cube)
+
+
+    def test_expected_result(self):
+        """Test that the run_recursion method returns an iris.cube.Cube."""
+        edge_width = 1
+        alphas_x = None
+        alphas_y = None
+        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        alphas_x = plugin.set_alphas(self.cube, self.alpha_x, alphas_x)
+        alphas_y = plugin.set_alphas(self.cube, self.alpha_y, alphas_y)
+        padded_cube=SquareNeighbourhood().pad_cube_with_halo(
+                     self.cube, edge_width, edge_width)
+        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y, self.iterations)
+        expected_result = 0.13382206
+        self.assertAlmostEqual(result.data[4][4], expected_result)
+   
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -26,8 +26,6 @@
 """Unit tests for the nbhood.RecursiveFilter plugin."""
 
 import unittest
-import warnings
-import iris
 from iris.cube import Cube
 from iris.tests import IrisTest
 from iris.coords import DimCoord
@@ -35,7 +33,8 @@ from cf_units import Unit
 import numpy as np
 from improver.nbhood.recursive_filter import RecursiveFilter
 from improver.nbhood.square_kernel import SquareNeighbourhood
-        
+
+
 class Test__repr__(IrisTest):
 
     """Test the repr method."""
@@ -48,8 +47,8 @@ class Test__repr__(IrisTest):
         edge_width = 1
         result = str(RecursiveFilter(alpha_x, alpha_y, iterations, edge_width))
         msg = ('<RecursiveFilter: alpha_x: {}, alpha_y: {}, iterations: {},'
-                  ' edge_width: {}'.format(
-                alpha_x, alpha_y, iterations, edge_width))
+               ' edge_width: {}'.format(alpha_x, alpha_y,
+                                        iterations, edge_width))
         self.assertEqual(result, msg)
 
 
@@ -71,10 +70,10 @@ class Test_RecursiveFilter(IrisTest):
         data[0][2][2] = 0.5
         data[0][3][2] = 0.25
         data[0][4][2] = 0.1
-        data[0][2][4] = 0.1
-        data[0][2][3] = 0.25
-        data[0][2][1] = 0.25
         data[0][2][0] = 0.1
+        data[0][2][1] = 0.25
+        data[0][2][3] = 0.25
+        data[0][2][4] = 0.1
 
         cube = Cube(data, standard_name="precipitation_amount",
                     units="kg m^-2 s^-1")
@@ -89,89 +88,101 @@ class Test_RecursiveFilter(IrisTest):
                                     "time", units=tunit), 0)
         self.cube = cube
 
-        # Generate alphas_cube with dimensions 4 x 4
-        alphas_data1 = np.ones((1, 4, 4)) * 0.5
+        # Generate alphas_cube with dimensions 5 x 5
+        alphas_data1 = np.ones((1, 5, 5)) * 0.5
         alphas_cube1 = Cube(alphas_data1)
-        alphas_cube1.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 4), 'latitude',
-                                    units='degrees'), 1)
-        alphas_cube1.add_dim_coord(DimCoord(np.linspace(120, 180, 4), 'longitude',
-                                    units='degrees'), 2)
+        alphas_cube1.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 5),
+                                            'latitude', units='degrees'), 1)
+        alphas_cube1.add_dim_coord(DimCoord(np.linspace(120, 180, 5),
+                                            'longitude', units='degrees'), 2)
         time_origin = "hours since 1970-01-01 00:00:00"
         calendar = "gregorian"
         tunit = Unit(time_origin, calendar)
-        alphas_cube1.add_dim_coord(DimCoord([402192.5],"time", units=tunit), 0)
+        alphas_cube1.add_dim_coord(DimCoord([402192.5], "time",
+                                            units=tunit), 0)
         self.alphas_cube1 = alphas_cube1
 
         # Generate alphas_cube with dimensions 6 x 6
         alphas_data2 = np.ones((1, 6, 6)) * 0.5
         alphas_cube2 = Cube(alphas_data2)
-        alphas_cube2.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 6), 'latitude',
-                                    units='degrees'), 1)
-        alphas_cube2.add_dim_coord(DimCoord(np.linspace(120, 180, 6), 'longitude',
-                                    units='degrees'), 2)
+        alphas_cube2.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 6),
+                                            'latitude', units='degrees'), 1)
+        alphas_cube2.add_dim_coord(DimCoord(np.linspace(120, 180, 6),
+                                            'longitude', units='degrees'), 2)
         time_origin = "hours since 1970-01-01 00:00:00"
         calendar = "gregorian"
         tunit = Unit(time_origin, calendar)
-        alphas_cube2.add_dim_coord(DimCoord([402192.5], "time", units=tunit), 0)
+        alphas_cube2.add_dim_coord(DimCoord([402192.5], "time",
+                                            units=tunit), 0)
         self.alphas_cube2 = alphas_cube2
 
-        # Generate alphas_cube with dimensions 5 x 5
-        alphas_data3 = np.ones((1, 5, 5)) * 0.5
-        alphas_cube3 = Cube(alphas_data3)
-        alphas_cube3.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 5), 'latitude',
-                                    units='degrees'), 1)
-        alphas_cube3.add_dim_coord(DimCoord(np.linspace(120, 180, 5), 'longitude',
-                                    units='degrees'), 2)
-        time_origin = "hours since 1970-01-01 00:00:00"
-        calendar = "gregorian"
-        tunit = Unit(time_origin, calendar)
-        alphas_cube3.add_dim_coord(DimCoord([402192.5], "time", units=tunit), 0)
-        self.alphas_cube3 = alphas_cube3
-
-    def test_basic(self):
-        """Test that the RecursiveFilter plugin returns an iris.cube.Cube."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
-        self.assertIsInstance(result, Cube)
-
+    # Test for raised errors when invalid KeyWord arguments are used
     def test_alpha_x_gt_unity(self):
         """Test when an alpha_x value > unity is given (invalid)."""
+        alpha_x = 1.1
         msg = "Invalid alpha_x: must be >= 0 and <= 1: 1.1"
         with self.assertRaisesRegexp(ValueError, msg):
-            RecursiveFilter(alpha_x=1.1, alpha_y=None, iterations=None, edge_width=1)
+            RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
+                            iterations=None, edge_width=1)
 
     def test_alpha_x_lt_zero(self):
         """Test when an alpha_x value < zero is given (invalid)."""
+        alpha_x = -0.5
         msg = "Invalid alpha_x: must be >= 0 and <= 1: -0.5"
         with self.assertRaisesRegexp(ValueError, msg):
-            RecursiveFilter(alpha_x=-0.5, alpha_y=None, iterations=None, edge_width=1)
+            RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
+                            iterations=None, edge_width=1)
 
     def test_alpha_y_gt_unity(self):
         """Test when an alpha_y value > unity is given (invalid)."""
+        alpha_y = 1.1
         msg = "Invalid alpha_y: must be >= 0 and <= 1: 1.1"
         with self.assertRaisesRegexp(ValueError, msg):
-            RecursiveFilter(alpha_x=None, alpha_y=1.1, iterations=None, edge_width=1)
+            RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
+                            iterations=None, edge_width=1)
 
     def test_alpha_y_lt_zero(self):
         """Test when an alpha_y value < zero is given (invalid)."""
         alpha_y = -0.5
         msg = "Invalid alpha_y: must be >= 0 and <= 1: -0.5"
         with self.assertRaisesRegexp(ValueError, msg):
-            RecursiveFilter(alpha_x=None, alpha_y=-0.5, iterations=None, edge_width=1)
+            RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
+                            iterations=None, edge_width=1)
 
     def test_iterations(self):
         """Test when iterations value less than unity is given (invalid)."""
         iterations = 0
         msg = "Invalid number of iterations: must be >= 1: 0"
         with self.assertRaisesRegexp(ValueError, msg):
-            RecursiveFilter(alpha_x=None, alpha_y=None, iterations=0, edge_width=1)
+            RecursiveFilter(alpha_x=None, alpha_y=None,
+                            iterations=iterations, edge_width=1)
+
+    # Test output from plugin returns expected values
+    def test_basic(self):
+        """Test that the RecursiveFilter plugin returns an iris.cube.Cube."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
+        self.assertIsInstance(result, Cube)
 
     def test_process(self):
         """Test that the RecursiveFilter plugin returns the correct data"""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
         result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
         expected = 0.13382206
         self.assertAlmostEqual(result.data[0][2][2], expected)
+
+    def test_dimensions_of_output_array_is_as_expected(self):
+        """Test that the RecursiveFilter plugin returns a data array with
+           the correct dimensions"""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
+        # Output data array should have same dimensions as input data array
+        expected_shape = (1, 5, 5)
+        self.assertEqual(result.data.shape, expected_shape)
+        self.assertEqual(result.data.shape, expected_shape)
 
 
 class Test_set_alphas(Test_RecursiveFilter):
@@ -179,55 +190,53 @@ class Test_set_alphas(Test_RecursiveFilter):
     """Test the set_alphas function"""
 
     def test_alphas_array_as_expected_when_alphas_is_none(self):
-        """Test that the returned alphas array has the expected result when alphas=None."""
-        alphas=None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        """Test that the returned alphas array has the expected result
+           when alphas=None."""
+        alphas = None
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
         result = plugin.set_alphas(self.cube, self.alpha_x, alphas)
         expected_result = 0.5
         self.assertIsInstance(result.data, np.ndarray)
         self.assertEqual(result.data[0][2], expected_result)
-        # Array should be padded with 4 extra rows/columns
-        length_result_array = 9
-        self.assertEqual(len(result.data[0,:]), length_result_array)
-        self.assertEqual(len(result.data[:,0]), length_result_array)
-   
-    def test_if_alphas_array_size_less_than_data_array_when_alphas_not_none(self):
-        """Test if array dimensions of alphas array is less than dimensions of
-           data_array when alphas is not set to None (invalid)."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        msg = "Dimensions of alphas array < dimensions of data array"
-        with self.assertRaisesRegexp(ValueError, msg):
-            plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube1)
+        # Check shape: Array should be padded with 4 extra rows/columns
+        expected_shape = (9, 9)
+        self.assertEqual(result.shape, expected_shape)
 
-    def test_if_alphas_array_size_greater_than_data_array_when_alphas_not_none(self):
-        """Test if array dimensions of alphas array is greater than dimensions of
+    def test_alphas_shape_does_not_match_data_shape_when_alphas_not_none(self):
+        """Test if array dimensions of alphas array do not match dimensions of
            data_array when alphas is not set to None (invalid)."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        msg = "Dimensions of alphas array > dimensions of data array"
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        msg = "Dimensions of alphas array do not match dimensions "
         with self.assertRaisesRegexp(ValueError, msg):
             plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube2)
 
     def test_alphas_array_as_expected_when_alphas_is_not_none(self):
-        """Test that the returned alphas array has the expected result when alphas=None."""
-        alphas=None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        result = plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube3)
+        """Test that the returned alphas array has the expected result
+           when alphas=None."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube1)
         expected_result = 0.5
         self.assertIsInstance(result.data, np.ndarray)
         self.assertEqual(result.data[0][2], expected_result)
-        # Array should be padded with 4 extra rows/columns
-        length_result_array = 9
-        self.assertEqual(len(result.data[0,:]), length_result_array)
-        self.assertEqual(len(result.data[:,0]), length_result_array)
+        # Check shape: Array should be padded with 4 extra rows/columns
+        expected_shape = (9, 9)
+        self.assertEqual(result.shape, expected_shape)
+
 
 class Test_recurse_forward_x(Test_RecursiveFilter):
 
     """Test the recurse_forward_x method"""
 
     def test_basic_method(self):
-        """Test that the returned recurse_forward_x array has the expected type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        result = plugin.recurse_forward_x(self.cube.data[0,:], self.alphas_cube3.data[0,:])     
+        """Test that the returned recurse_forward_x array has the expected
+           type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.recurse_forward_x(self.cube.data[0, :],
+                                          self.alphas_cube1.data[0, :])
         expected_result = 0.196875
         self.assertIsInstance(result, np.ndarray)
         self.assertAlmostEqual(result[4][2], expected_result)
@@ -238,21 +247,28 @@ class Test_recurse_backwards_x(Test_RecursiveFilter):
     """Test the recurse_backwards_x method"""
 
     def test_basic_method(self):
-        """Test that the returned recurse_backwards_x array has the expected type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        result = plugin.recurse_backwards_x(self.cube.data[0,:], self.alphas_cube3.data[0,:])     
+        """Test that the returned recurse_backwards_x array has the expected
+           type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.recurse_backwards_x(self.cube.data[0, :],
+                                            self.alphas_cube1.data[0, :])
         expected_result = 0.196875
         self.assertIsInstance(result, np.ndarray)
         self.assertAlmostEqual(result[0][2], expected_result)
+
 
 class Test_recurse_forward_y(Test_RecursiveFilter):
 
     """Test the recurse_forward_y method"""
 
     def test_basic_method(self):
-        """Test that the returned recurse_forward_y array has the expected type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        result = plugin.recurse_forward_y(self.cube.data[:,0], self.alphas_cube3.data[:,0])     
+        """Test that the returned recurse_forward_y array has the expected
+           type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.recurse_forward_y(self.cube.data[:, 0],
+                                          self.alphas_cube1.data[:, 0])
         expected_result = 0.0125
         self.assertIsInstance(result, np.ndarray)
         self.assertAlmostEqual(result[0][4], expected_result)
@@ -263,9 +279,12 @@ class Test_recurse_backwards_y(Test_RecursiveFilter):
     """Test the recurse_backwards_y method"""
 
     def test_basic_method(self):
-        """Test that the returned recurse_backwards_y array has the expected type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
-        result = plugin.recurse_backwards_y(self.cube.data[:,0], self.alphas_cube3.data[:,0])     
+        """Test that the returned recurse_backwards_y array has the expected
+           type and result."""
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
+        result = plugin.recurse_backwards_y(self.cube.data[:, 0],
+                                            self.alphas_cube1.data[:, 0])
         expected_result = 0.0125
         self.assertIsInstance(result, np.ndarray)
         self.assertAlmostEqual(result[0][0], expected_result)
@@ -280,28 +299,33 @@ class Test_run_recursion(Test_RecursiveFilter):
         edge_width = 1
         alphas_x = None
         alphas_y = None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
         alphas_x = plugin.set_alphas(self.cube, self.alpha_x, alphas_x)
         alphas_y = plugin.set_alphas(self.cube, self.alpha_y, alphas_y)
-        padded_cube=SquareNeighbourhood().pad_cube_with_halo(
-                     self.cube, edge_width, edge_width)
-        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y, self.iterations)
+        padded_cube = SquareNeighbourhood().pad_cube_with_halo(self.cube,
+                                                               edge_width,
+                                                               edge_width)
+        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y,
+                                      self.iterations)
         self.assertIsInstance(result, Cube)
-
 
     def test_expected_result(self):
         """Test that the run_recursion method returns an iris.cube.Cube."""
         edge_width = 1
         alphas_x = None
         alphas_y = None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x,alpha_y=self.alpha_y, iterations=self.iterations)
+        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
+                                 iterations=self.iterations)
         alphas_x = plugin.set_alphas(self.cube, self.alpha_x, alphas_x)
         alphas_y = plugin.set_alphas(self.cube, self.alpha_y, alphas_y)
-        padded_cube=SquareNeighbourhood().pad_cube_with_halo(
-                     self.cube, edge_width, edge_width)
-        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y, self.iterations)
+        padded_cube = SquareNeighbourhood().pad_cube_with_halo(self.cube,
+                                                               edge_width,
+                                                               edge_width)
+        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y,
+                                      self.iterations)
         expected_result = 0.13382206
         self.assertAlmostEqual(result.data[4][4], expected_result)
-   
+
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -1,0 +1,37 @@
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the nbhood.RecursiveFilter plugin."""
+
+
+import unittest
+
+from cf_units import Unit
+import iris
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+from iris.tests import IrisTest
+import numpy as np
+ 

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -327,5 +327,6 @@ class Test_run_recursion(Test_RecursiveFilter):
         expected_result = 0.13382206
         self.assertAlmostEqual(result.data[4][4], expected_result)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds the capability to run a recursive filter to convert a square neighbourhood into a Gaussian-like kernel or simply to smooth over short distances. The recursive filter uses an "alpha" parameter that controls what proportion of stuff (probability) is passed along to the next grid square. 

Implementation  allows the alpha parameter to be set on a grid square by grid square basis (e.g. an array of alpha parameters equivalent in dimensions to the domain). Each grid square has a pair of alpha parameters to allow for orthogonally discrete functionality, e.g. one to act in the N-S direction, and another to act in the E-W direction.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
