### PR TITLE
Updated percentile CLI to accept a number of percentiles

### DIFF
--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -39,6 +39,8 @@ import warnings
 from improver.percentile import PercentileConverter
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import \
     GeneratePercentilesFromProbabilities
+from improver.ensemble_copula_coupling.ensemble_copula_coupling_utilities \
+    import choose_set_of_percentiles
 
 
 def main():
@@ -49,7 +51,10 @@ def main():
         "(member) data into percentiled data, but may calculate over any "
         "dimension coordinate. Alternatively, calling this CLI with a cube "
         "containing probabilities will convert those to percentiles using "
-        "the ensemble copula coupling plugin.")
+        "the ensemble copula coupling plugin. If no particular percentiles "
+        "are given at which to calculate values or no number of percentiles "
+        "to calculate are specified, the following defaults will be used: "
+        "[0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]")
     parser.add_argument("input_filepath", metavar="INPUT_FILE",
                         help="A path to an input NetCDF file to be processed")
     parser.add_argument("output_filepath", metavar="OUTPUT_FILE",
@@ -63,16 +68,23 @@ def main():
                         "coordinates to create percentiles, but is redundant "
                         "when converting probabilities to percentiles and may "
                         "be omitted.")
-    parser.add_argument("--percentiles", metavar="PERCENTILES",
-                        nargs="+", default=None, type=float,
-                        help="Optional definition of percentiles at which"
-                        " to calculate data, otherwise default values are"
-                        " used, e.g. --percentiles 0 33.3 66.6 100 ; "
-                        " defaults = [0, 5, 10, 20, 25, 30, 40, 50, 60, 70,"
-                        " 75, 80, 90, 95, 100]")
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("--percentiles", metavar="PERCENTILES",
+                       nargs="+", default=None, type=float,
+                       help="Optional definition of percentiles at which to "
+                       "calculate data, e.g. --percentiles 0 33.3 66.6 100")
+    group.add_argument('--no_of_percentiles', default=None, type=int,
+                       metavar='NUMBER_OF_PERCENTILES',
+                       help="Optional definition of the number of percentiles "
+                       "to be generated, these distributed regularly with the "
+                       "aim of dividing into blocks of equal probability.")
 
     args = parser.parse_args()
     cube = iris.load_cube(args.input_filepath)
+    percentiles = args.percentiles
+    if args.no_of_percentiles is not None:
+        percentiles = choose_set_of_percentiles(args.no_of_percentiles,
+                                                sampling="quantile")
     # TODO: Correct when formal cf-standards exists
     if 'probability_of_' in cube.name():
         if args.coordinates:
@@ -81,14 +93,14 @@ def main():
                           "not be used.")
 
         result = GeneratePercentilesFromProbabilities().process(
-            cube, percentiles=args.percentiles)
+            cube, percentiles=percentiles)
     else:
         if not args.coordinates:
             raise ValueError("To collapse a coordinate to calculate "
                              "percentiles, a coordinate or list of "
                              "coordinates must be provided.")
         result = PercentileConverter(
-            args.coordinates, percentiles=args.percentiles).process(cube)
+            args.coordinates, percentiles=percentiles).process(cube)
 
     iris.save(result, args.output_filepath, unlimited_dimensions=[])
 

--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -52,8 +52,8 @@ def main():
         "dimension coordinate. Alternatively, calling this CLI with a cube "
         "containing probabilities will convert those to percentiles using "
         "the ensemble copula coupling plugin. If no particular percentiles "
-        "are given at which to calculate values or no number of percentiles "
-        "to calculate are specified, the following defaults will be used: "
+        "are given at which to calculate values and no 'number of percentiles'"
+        " to calculate are specified, the following defaults will be used: "
         "[0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]")
     parser.add_argument("input_filepath", metavar="INPUT_FILE",
                         help="A path to an input NetCDF file to be processed")
@@ -73,7 +73,7 @@ def main():
                        nargs="+", default=None, type=float,
                        help="Optional definition of percentiles at which to "
                        "calculate data, e.g. --percentiles 0 33.3 66.6 100")
-    group.add_argument('--no_of_percentiles', default=None, type=int,
+    group.add_argument('--no-of-percentiles', default=None, type=int,
                        metavar='NUMBER_OF_PERCENTILES',
                        help="Optional definition of the number of percentiles "
                        "to be generated, these distributed regularly with the "

--- a/tests/improver-percentile/00-null.bats
+++ b/tests/improver-percentile/00-null.bats
@@ -35,7 +35,7 @@
   expected="usage: improver-percentile [-h]
                            [--coordinates COORDINATES_TO_COLLAPSE [COORDINATES_TO_COLLAPSE ...]]
                            [--percentiles PERCENTILES [PERCENTILES ...] |
-                           --no_of_percentiles NUMBER_OF_PERCENTILES]
+                           --no-of-percentiles NUMBER_OF_PERCENTILES]
                            INPUT_FILE OUTPUT_FILE"
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -36,7 +36,7 @@
 usage: improver-percentile [-h]
                            [--coordinates COORDINATES_TO_COLLAPSE [COORDINATES_TO_COLLAPSE ...]]
                            [--percentiles PERCENTILES [PERCENTILES ...] |
-                           --no_of_percentiles NUMBER_OF_PERCENTILES]
+                           --no-of-percentiles NUMBER_OF_PERCENTILES]
                            INPUT_FILE OUTPUT_FILE
 
 Calculate percentiled data over a cube coordinate by collapsing that
@@ -44,9 +44,9 @@ coordinate. Typically used to convert realization (member) data into
 percentiled data, but may calculate over any dimension coordinate.
 Alternatively, calling this CLI with a cube containing probabilities will
 convert those to percentiles using the ensemble copula coupling plugin. If no
-particular percentiles are given at which to calculate values or no number of
-percentiles to calculate are specified, the following defaults will be used:
-[0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]
+particular percentiles are given at which to calculate values and no 'number
+of percentiles' to calculate are specified, the following defaults will be
+used: [0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]
 
 positional arguments:
   INPUT_FILE            A path to an input NetCDF file to be processed
@@ -64,7 +64,7 @@ optional arguments:
   --percentiles PERCENTILES [PERCENTILES ...]
                         Optional definition of percentiles at which to
                         calculate data, e.g. --percentiles 0 33.3 66.6 100
-  --no_of_percentiles NUMBER_OF_PERCENTILES
+  --no-of-percentiles NUMBER_OF_PERCENTILES
                         Optional definition of the number of percentiles to be
                         generated, these distributed regularly with the aim of
                         dividing into blocks of equal probability.

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -35,14 +35,18 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-percentile [-h]
                            [--coordinates COORDINATES_TO_COLLAPSE [COORDINATES_TO_COLLAPSE ...]]
-                           [--percentiles PERCENTILES [PERCENTILES ...]]
+                           [--percentiles PERCENTILES [PERCENTILES ...] |
+                           --no_of_percentiles NUMBER_OF_PERCENTILES]
                            INPUT_FILE OUTPUT_FILE
 
 Calculate percentiled data over a cube coordinate by collapsing that
 coordinate. Typically used to convert realization (member) data into
 percentiled data, but may calculate over any dimension coordinate.
 Alternatively, calling this CLI with a cube containing probabilities will
-convert those to percentiles using the ensemble copula coupling plugin.
+convert those to percentiles using the ensemble copula coupling plugin. If no
+particular percentiles are given at which to calculate values or no number of
+percentiles to calculate are specified, the following defaults will be used:
+[0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]
 
 positional arguments:
   INPUT_FILE            A path to an input NetCDF file to be processed
@@ -59,9 +63,11 @@ optional arguments:
                         probabilities to percentiles and may be omitted.
   --percentiles PERCENTILES [PERCENTILES ...]
                         Optional definition of percentiles at which to
-                        calculate data, otherwise default values are used,
-                        e.g. --percentiles 0 33.3 66.6 100 ; defaults = [0, 5,
-                        10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]
+                        calculate data, e.g. --percentiles 0 33.3 66.6 100
+  --no_of_percentiles NUMBER_OF_PERCENTILES
+                        Optional definition of the number of percentiles to be
+                        generated, these distributed regularly with the aim of
+                        dividing into blocks of equal probability.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-percentile/05-number_of_percentiles.bats
+++ b/tests/improver-percentile/05-number_of_percentiles.bats
@@ -38,7 +38,7 @@
   # Run percentile processing and check it passes.
   run improver percentile \
       "$IMPROVER_ACC_TEST_DIR/percentile/basic/input.nc" "$TEST_DIR/output.nc" \
-      --coordinates realization --no_of_percentiles 3
+      --coordinates realization --no-of-percentiles 3
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo.

--- a/tests/improver-percentile/05-number_of_percentiles.bats
+++ b/tests/improver-percentile/05-number_of_percentiles.bats
@@ -29,13 +29,21 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-@test "percentile no arguments" {
-  run improver percentile
-  [[ "$status" -eq 2 ]]
-  expected="usage: improver-percentile [-h]
-                           [--coordinates COORDINATES_TO_COLLAPSE [COORDINATES_TO_COLLAPSE ...]]
-                           [--percentiles PERCENTILES [PERCENTILES ...] |
-                           --no_of_percentiles NUMBER_OF_PERCENTILES]
-                           INPUT_FILE OUTPUT_FILE"
-  [[ "$output" =~ "$expected" ]]
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "percentile input output --coordinates realization --no_of_percentiles 3" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run percentile processing and check it passes.
+  run improver percentile \
+      "$IMPROVER_ACC_TEST_DIR/percentile/basic/input.nc" "$TEST_DIR/output.nc" \
+      --coordinates realization --no_of_percentiles 3
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/percentile/basic/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
 }


### PR DESCRIPTION
Updated percentile CLI to accept a number of percentiles as an optional argument. This then uses the ecc choose_set_of_percentiles function to produce the list of percentiles that will be generated.

Implemented to remove some hard coding in a patch script implemented in IMPRO-336.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
