### PR TITLE
Set division to NaN in Neighbourhood Processing

### DIFF
--- a/lib/improver/nbhood/square_kernel.py
+++ b/lib/improver/nbhood/square_kernel.py
@@ -551,7 +551,7 @@ class SquareNeighbourhood(object):
             with np.errstate(invalid='ignore', divide='ignore'):
                 divided_data = np.true_divide(
                     neighbourhood_averaged_cube.data, mask_cube.data)
-                divided_data[~np.isfinite(divided_data)] = 0
+                divided_data[~np.isfinite(divided_data)] = np.nan
                 neighbourhood_averaged_cube.data = divided_data
             if self.re_mask:
                 original_mask_cube, = (

--- a/lib/improver/tests/nbhood/square_kernel/test_SquareNeighbourhood.py
+++ b/lib/improver/tests/nbhood/square_kernel/test_SquareNeighbourhood.py
@@ -883,8 +883,8 @@ class Test__remove_padding_and_mask(IrisTest):
         """Test that removing a halo of points from the data on a cube
         has worked as intended when the input data has an associated mask."""
         expected = np.array(
-            [[1., 0., 1.],
-             [1., 0., 1.],
+            [[1., np.nan, 1.],
+             [1., np.nan, 1.],
              [1., 1., 1.]])
         grid_cells_x = grid_cells_y = 1
         padded_cube = self.padded_cube
@@ -917,8 +917,8 @@ class Test__remove_padding_and_mask(IrisTest):
         has worked as intended when the input data has an associated mask
         and re-masking using the original data is required."""
         expected = np.array(
-            [[1., 0., 1.],
-             [1., 0., 1.],
+            [[1., np.nan, 1.],
+             [1., np.nan, 1.],
              [1., 1., 0.]])
         grid_cells_x = grid_cells_y = 1
         padded_cube = self.padded_cube
@@ -1027,8 +1027,8 @@ class Test_run(IrisTest):
             [[[[0.000000, 0.000000, 0.571429, 0.500000, 0.000000],
                [0.000000, 0.750000, 0.571429, 0.428571, 0.000000],
                [0.000000, 0.000000, 0.714286, 0.571429, 0.200000],
-               [0.000000, 0.000000, 0.666667, 0.571429, 0.000000],
-               [0.000000, 0.000000, 0.666667, 0.666667, 0.000000]]]])
+               [np.nan, 0.000000, 0.666667, 0.571429, 0.000000],
+               [np.nan, 0.000000, 0.666667, 0.666667, 0.000000]]]])
         cube.data = np.ma.masked_where(mask == 0, cube.data)
         result = SquareNeighbourhood().run(cube, self.RADIUS)
         self.assertArrayAlmostEqual(result.data, expected_array)
@@ -1053,8 +1053,8 @@ class Test_run(IrisTest):
             [[[[1.000000, 0.500000, 0.571429, 0.500000, 0.666667],
                [1.000000, 0.750000, 0.571429, 0.428571, 0.200000],
                [1.000000, 1.000000, 0.714286, 0.571429, 0.200000],
-               [0.000000, 1.000000, 0.666667, 0.571429, 0.200000],
-               [0.000000, 1.000000, 0.666667, 0.666667, 0.333333]]]])
+               [np.nan, 1.000000, 0.666667, 0.571429, 0.200000],
+               [np.nan, 1.000000, 0.666667, 0.666667, 0.333333]]]])
         cube.data = np.ma.masked_where(mask == 0, cube.data)
         result = SquareNeighbourhood(re_mask=False).run(cube, self.RADIUS)
         self.assertArrayAlmostEqual(result.data, expected_array)
@@ -1110,11 +1110,11 @@ class Test_run(IrisTest):
                            [0, 0, 1, 1, 0],
                            [0, 0, 1, 1, 0]]]])
         expected_array = np.array(
-            [[[[0.000000, 0.000000, 0.571429, 0.500000, 0.000000],
+            [[[[np.nan, 0.000000, 0.571429, 0.500000, 0.000000],
                [0.000000, 0.750000, 0.571429, 0.428571, 0.000000],
                [0.000000, 0.000000, 0.714286, 0.571429, 0.200000],
-               [0.000000, 0.000000, 0.666667, 0.571429, 0.000000],
-               [0.000000, 0.000000, 0.666667, 0.666667, 0.000000]]]])
+               [np.nan, 0.000000, 0.666667, 0.571429, 0.000000],
+               [np.nan, 0.000000, 0.666667, 0.666667, 0.000000]]]])
         cube.data = np.ma.masked_where(mask == 0, cube.data)
         result = SquareNeighbourhood().run(cube, self.RADIUS)
         self.assertArrayAlmostEqual(result.data, expected_array)
@@ -1136,11 +1136,11 @@ class Test_run(IrisTest):
                            [0, 0, 1, 1, 0],
                            [0, 0, 1, 1, 0]]]])
         expected_array = np.array(
-            [[[[0.000000, 0.500000, 0.571429, 0.500000, 0.666667],
+            [[[[np.nan, 0.500000, 0.571429, 0.500000, 0.666667],
                [1.000000, 0.750000, 0.571429, 0.428571, 0.200000],
                [1.000000, 1.000000, 0.714286, 0.571429, 0.200000],
-               [0.000000, 1.000000, 0.666667, 0.571429, 0.200000],
-               [0.000000, 1.000000, 0.666667, 0.666667, 0.333333]]]])
+               [np.nan, 1.000000, 0.666667, 0.571429, 0.200000],
+               [np.nan, 1.000000, 0.666667, 0.666667, 0.333333]]]])
         cube.data = np.ma.masked_where(mask == 0, cube.data)
         result = SquareNeighbourhood(re_mask=False).run(cube, self.RADIUS)
         self.assertArrayAlmostEqual(result.data, expected_array)
@@ -1201,13 +1201,13 @@ class Test_run(IrisTest):
             [[[[1.000000, 0.500000, 0.571429, 0.500000, 0.666667],
                [1.000000, 0.750000, 0.571429, 0.428571, 0.200000],
                [1.000000, 1.000000, 0.714286, 0.571429, 0.200000],
-               [0.000000, 1.000000, 0.666667, 0.571429, 0.200000],
-               [0.000000, 1.000000, 0.666667, 0.666667, 0.333333]],
+               [np.nan, 1.000000, 0.666667, 0.571429, 0.200000],
+               [np.nan, 1.000000, 0.666667, 0.666667, 0.333333]],
               [[1.000000, 0.500000, 0.571429, 0.500000, 0.666667],
                [0.500000, 0.600000, 0.500000, 0.428571, 0.200000],
                [0.500000, 0.750000, 0.428571, 0.333333, 0.000000],
                [0.000000, 0.666667, 0.333333, 0.333333, 0.000000],
-               [0.000000, 1.000000, 0.400000, 0.400000, 0.000000]]]])
+               [np.nan, 1.000000, 0.400000, 0.400000, 0.000000]]]])
         result = SquareNeighbourhood(re_mask=False).run(cube, self.RADIUS)
         self.assertArrayAlmostEqual(result.data, expected_array)
 

--- a/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -136,21 +136,21 @@ class Test_process(IrisTest):
         """Test that the expected result is returned, when the
         topographic_zone coordinate is iterated over."""
         expected = np.array(
-            [[[[1.00, 1.00, 1.00, 0.00, 0.00],
-               [1.00, 1.00, 1.00, 0.00, 0.00],
-               [1.00, 1.00, 1.00, 0.00, 0.00],
-               [1.00, 1.00, 1.00, 0.00, 0.00],
-               [0.00, 0.00, 0.00, 0.00, 0.00]]],
-             [[[0.00, 1.00, 1.00, 1.00, 1.00],
-               [0.00, 0.50, 0.75, 0.75, 1.00],
-               [0.00, 0.50, 0.75, 0.75, 1.00],
-               [0.00, 0.00, 0.50, 0.50, 1.00],
-               [0.00, 0.00, 0.00, 0.00, 0.00]]],
-             [[[0.00, 0.00, 0.00, 0.00, 0.00],
-               [0.00, 0.00, 0.00, 0.00, 0.00],
-               [0.00, 0.00, 1.00, 1.00, 1.00],
-               [0.00, 0.00, 1.00, 1.00, 1.00],
-               [0.00, 0.00, 1.00, 1.00, 1.00]]]])
+            [[[[1.00, 1.00, 1.00, np.nan, np.nan],
+               [1.00, 1.00, 1.00, np.nan, np.nan],
+               [1.00, 1.00, 1.00, np.nan, np.nan],
+               [1.00, 1.00, 1.00, np.nan, np.nan],
+               [np.nan, np.nan, np.nan, np.nan, np.nan]]],
+             [[[np.nan, 1.00, 1.00, 1.00, 1.00],
+               [np.nan, 0.50, 0.75, 0.75, 1.00],
+               [np.nan, 0.50, 0.75, 0.75, 1.00],
+               [np.nan, 0.00, 0.50, 0.50, 1.00],
+               [np.nan, np.nan, np.nan, np.nan, np.nan]]],
+             [[[np.nan, np.nan, np.nan, np.nan, np.nan],
+               [np.nan, np.nan, np.nan, np.nan, np.nan],
+               [np.nan, np.nan, 1.00, 1.00, 1.00],
+               [np.nan, np.nan, 1.00, 1.00, 1.00],
+               [np.nan, np.nan, 1.00, 1.00, 1.00]]]])
         coord_for_masking = "topographic_zone"
         radii = 2000
         result = ApplyNeighbourhoodProcessingWithAMask(


### PR DESCRIPTION
Edit so that if division within neighbourhood processing results in a non-finite number, then this number is set to NaN, rather than zero. This is for the purposes of the triangular weighting that will need to be done to collapse the topographic band coordinate, as a NaN will indicate that there are no values within a topographic zone, so the triangular weighting will be adjusted to only include topographic zones with values within the weighting.

#283 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
