### PR TITLE
Fixes a bug in selecting 2D slices in OccurrenceWithinVicinity.

### DIFF
--- a/lib/improver/tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/lib/improver/tests/utilities/test_OccurrenceWithinVicinity.py
@@ -87,29 +87,6 @@ class Test__repr__(IrisTest):
         self.assertEqual(result, msg)
 
 
-class Test_find_slices_over_coordinate(IrisTest):
-
-    """Test the find_slices_over_coordinate."""
-
-    def setUp(self):
-        """Set up the cube."""
-        self.distance = 2000
-        self.cube = set_up_thresholded_cube()
-
-    def test_basic(self):
-        """Test that a _SliceIterator is returned for iterating."""
-        result = OccurrenceWithinVicinity(
-                     self.distance).find_slices_over_coordinate(
-                         self.cube, "realization")
-        self.assertIsInstance(result, iris.cube._SliceIterator)
-
-    def test_missing_coord(self):
-        """Test that a CubeList is returned for iterating."""
-        result = OccurrenceWithinVicinity(
-            self.distance).find_slices_over_coordinate(self.cube, "foo")
-        self.assertIsInstance(result, CubeList)
-
-
 class Test_maximum_within_vicinity(IrisTest):
 
     """Test the maximum_within_vicinity method."""

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -328,6 +328,8 @@ class OccurrenceWithinVicinity(object):
         grid_cells = (2 * grid_cell_y) + 1
 
         max_cube = cube.copy()
+        # The following command finds the maximum value for each grid point
+        # from within a square of length "size"
         max_cube.data = (
             scipy.ndimage.filters.maximum_filter(cube.data, size=grid_cells))
         return max_cube
@@ -347,13 +349,9 @@ class OccurrenceWithinVicinity(object):
                 xy 2d slice, which have been merged back together.
 
         """
-        slices_over_realization = (
-            self.find_slices_over_coordinate(cube, "realization"))
 
         max_cubes = CubeList([])
-        for realization_slice in slices_over_realization:
-            slices_over_time = (
-                self.find_slices_over_coordinate(realization_slice, "time"))
-            for time_slice in slices_over_time:
-                max_cubes.append(self.maximum_within_vicinity(time_slice))
+        for cube_slice in cube.slices([cube.coord(axis='y'),
+                                       cube.coord(axis='x')]):
+            max_cubes.append(self.maximum_within_vicinity(cube_slice))
         return max_cubes.merge_cube()

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -272,30 +272,6 @@ class OccurrenceWithinVicinity(object):
         result = ('<OccurrenceWithinVicinity: distance: {}>')
         return result.format(self.distance)
 
-    @staticmethod
-    def find_slices_over_coordinate(cube, coord_name):
-        """
-        Try slicing over the given coordinate. If the requested coordinate is
-        not a dimension coordinate then still return an iterable.
-
-        Args:
-            cube (iris.cube.Cube):
-                Cube to be sliced.
-            coord_name (String):
-                Name of the coordinate to be used for slicing.
-
-        Returns:
-            slices_over_coord (iris.cube._SliceIterator or iris.cube.CubeList):
-                Iterable returned to slice over the requested coordinate, or
-                a CubeList.
-        """
-        try:
-            cube.coord(coord_name, dim_coords=True)
-            slices_over_coord = cube.slices_over(coord_name)
-        except CoordinateNotFoundError:
-            slices_over_coord = CubeList([cube])
-        return slices_over_coord
-
     def maximum_within_vicinity(self, cube):
         """
         Find grid points where a phenomenon occurs within a defined distance.


### PR DESCRIPTION
#145 implemented the OccurrenceWithinVicinity plugin.
The process method states that it will ensure that 2D slices are passed to to the maximum_within_vicinity method, but it only slices_over realization and time coordinates.
This PR replaces the slices_over statements with a slices statement to explicitly select slices over y and x only. This allows the plugin to work when other coordinates are present, such as threshold.
Without this bug-fix, the plugin appears to work successfully, but returns the maximum value across each additional dimension as well as x and y.

I have also included an additional comment to try to make it clearer that this plugin uses a square kernel to find the maximum value in the vicinity.

The existing tests seem adequate to cover this change so I have not added any more.

The existing CLI tests for improver-nbhood-vicinity fail because the kgo.nc file contains output from this bug.

Testing:
 - [X] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)
