### PR TITLE
Recursive filter fixes

### DIFF
--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -70,7 +70,6 @@ class RecursiveFilter(object):
                         that iterations is not >= 1
 
         """
-
         if alpha_x is not None:
             if not 0 <= alpha_x < 1:
                 raise ValueError(
@@ -290,6 +289,7 @@ class RecursiveFilter(object):
                 when applying the recursive filter in a specific direction.
 
         Raises:
+            ValueError: If both alphas_cube and alpha are provided.
             ValueError: If alpha and alphas_cube are both set to None
             ValueError: If dimension of alphas array is less than dimension
                         of data array
@@ -301,6 +301,11 @@ class RecursiveFilter(object):
                 Cube containing a padded array of alpha values
                 for the specified direction.
         """
+        if alpha is not None and alphas_cube is not None:
+            emsg = ("A cube of alpha values and a single float value for alpha"
+                    " have both been provded. Only one of these options can be"
+                    " set.")
+            raise ValueError(emsg)
 
         if alphas_cube is None:
             if alpha is None:

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -106,6 +106,7 @@ class Test_RecursiveFilter(IrisTest):
                                             'longitude', units='degrees'), 1)
         self.alphas_cube2 = alphas_cube2
 
+
 class Test__init__(Test_RecursiveFilter):
 
     """Test plugin initialisation."""

--- a/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/nbhood/test_RecursiveFilter.py
@@ -89,34 +89,27 @@ class Test_RecursiveFilter(IrisTest):
         self.cube = cube
 
         # Generate alphas_cube with dimensions 5 x 5
-        alphas_data1 = np.ones((1, 5, 5)) * 0.5
+        alphas_data1 = np.ones((5, 5)) * 0.5
         alphas_cube1 = Cube(alphas_data1)
         alphas_cube1.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 5),
-                                            'latitude', units='degrees'), 1)
+                                            'latitude', units='degrees'), 0)
         alphas_cube1.add_dim_coord(DimCoord(np.linspace(120, 180, 5),
-                                            'longitude', units='degrees'), 2)
-        time_origin = "hours since 1970-01-01 00:00:00"
-        calendar = "gregorian"
-        tunit = Unit(time_origin, calendar)
-        alphas_cube1.add_dim_coord(DimCoord([402192.5], "time",
-                                            units=tunit), 0)
+                                            'longitude', units='degrees'), 1)
         self.alphas_cube1 = alphas_cube1
 
         # Generate alphas_cube with dimensions 6 x 6
-        alphas_data2 = np.ones((1, 6, 6)) * 0.5
+        alphas_data2 = np.ones((6, 6)) * 0.5
         alphas_cube2 = Cube(alphas_data2)
         alphas_cube2.add_dim_coord(DimCoord(np.linspace(-45.0, 45.0, 6),
-                                            'latitude', units='degrees'), 1)
+                                            'latitude', units='degrees'), 0)
         alphas_cube2.add_dim_coord(DimCoord(np.linspace(120, 180, 6),
-                                            'longitude', units='degrees'), 2)
-        time_origin = "hours since 1970-01-01 00:00:00"
-        calendar = "gregorian"
-        tunit = Unit(time_origin, calendar)
-        alphas_cube2.add_dim_coord(DimCoord([402192.5], "time",
-                                            units=tunit), 0)
+                                            'longitude', units='degrees'), 1)
         self.alphas_cube2 = alphas_cube2
 
-    # Test for raised errors when invalid KeyWord arguments are used
+class Test__init__(Test_RecursiveFilter):
+
+    """Test plugin initialisation."""
+
     def test_alpha_x_gt_unity(self):
         """Test when an alpha_x value > unity is given (invalid)."""
         alpha_x = 1.1
@@ -157,19 +150,171 @@ class Test_RecursiveFilter(IrisTest):
             RecursiveFilter(alpha_x=None, alpha_y=None,
                             iterations=iterations, edge_width=1)
 
+
+class Test_set_alphas(Test_RecursiveFilter):
+
+    """Test the set_alphas function"""
+
+    def test_alpha_x_used_result(self):
+        """Test that the returned alphas array has the expected result
+           when alphas_cube=None."""
+        result = RecursiveFilter().set_alphas(self.cube, self.alpha_x, None)
+        expected_result = 0.5
+        self.assertIsInstance(result.data, np.ndarray)
+        self.assertEqual(result.data[0][2], expected_result)
+        # Check shape: Array should be padded with 4 extra rows/columns
+        expected_shape = (9, 9)
+        self.assertEqual(result.shape, expected_shape)
+
+    def test_alphas_cube_used_result(self):
+        """Test that the returned alphas array has the expected result
+           when alphas_cube is not None."""
+        result = RecursiveFilter().set_alphas(self.cube[0, :], None,
+                                              self.alphas_cube1)
+        expected_result = 0.5
+        self.assertIsInstance(result.data, np.ndarray)
+        self.assertEqual(result.data[0][2], expected_result)
+        # Check shape: Array should be padded with 4 extra rows/columns
+        expected_shape = (9, 9)
+        self.assertEqual(result.shape, expected_shape)
+
+    def test_mismatched_dimensions_alphas_cube_data_cube(self):
+        """Test that an error is raised if the alphas_cube is of a different
+        shape to the data cube."""
+        msg = "Dimensions of alphas array do not match dimensions "
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter().set_alphas(self.cube, None, self.alphas_cube2)
+
+    def test_alphas_cube_and_alpha_not_set(self):
+        """Test error is raised when both alphas_cube and alpha are set
+           to None (invalid)."""
+        alpha = None
+        alphas_cube = None
+        msg = "A value for alpha must be set if alphas_cube is "
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter().set_alphas(self.cube, alpha, alphas_cube)
+
+    def test_alphas_cube_and_alpha_both_set(self):
+        """Test error is raised when both alphas_cube and alpha are set."""
+        alpha = 0.5
+        alphas_cube = self.alphas_cube1
+        msg = "A cube of alpha values and a single float value for"
+        with self.assertRaisesRegexp(ValueError, msg):
+            RecursiveFilter().set_alphas(self.cube, alpha, alphas_cube)
+
+
+class Test_recurse_forward_x(Test_RecursiveFilter):
+
+    """Test the recurse_forward_x method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_forward_x array has the expected
+           type and result."""
+        result = RecursiveFilter().recurse_forward_x(
+            self.cube.data[0, :], self.alphas_cube1.data)
+        expected_result = 0.196875
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[4][2], expected_result)
+
+
+class Test_recurse_backwards_x(Test_RecursiveFilter):
+
+    """Test the recurse_backwards_x method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_backwards_x array has the expected
+           type and result."""
+        result = RecursiveFilter().recurse_backwards_x(
+            self.cube.data[0, :], self.alphas_cube1.data)
+        expected_result = 0.196875
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[0][2], expected_result)
+
+
+class Test_recurse_forward_y(Test_RecursiveFilter):
+
+    """Test the recurse_forward_y method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_forward_y array has the expected
+           type and result."""
+        result = RecursiveFilter().recurse_forward_y(
+            self.cube.data[0, :], self.alphas_cube1.data)
+        expected_result = 0.0125
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[0][4], expected_result)
+
+
+class Test_recurse_backwards_y(Test_RecursiveFilter):
+
+    """Test the recurse_backwards_y method"""
+
+    def test_basic_method(self):
+        """Test that the returned recurse_backwards_y array has the expected
+           type and result."""
+        result = RecursiveFilter().recurse_backwards_y(
+            self.cube.data[0, :], self.alphas_cube1.data)
+        expected_result = 0.0125
+        self.assertIsInstance(result, np.ndarray)
+        self.assertAlmostEqual(result[0][0], expected_result)
+
+
+class Test_run_recursion(Test_RecursiveFilter):
+
+    """Test the run_recursion method"""
+
+    def test_return_type(self):
+        """Test that the run_recursion method returns an iris.cube.Cube."""
+        edge_width = 1
+        alphas_x = RecursiveFilter().set_alphas(self.cube, self.alpha_x, None)
+        alphas_y = RecursiveFilter().set_alphas(self.cube, self.alpha_y, None)
+        padded_cube = SquareNeighbourhood().pad_cube_with_halo(
+            self.cube, edge_width, edge_width)
+        result = RecursiveFilter().run_recursion(
+            padded_cube, alphas_x, alphas_y, self.iterations)
+        self.assertIsInstance(result, Cube)
+
+    def test_expected_result(self):
+        """Test that the run_recursion method returns the expected value."""
+        edge_width = 1
+        alphas_x = RecursiveFilter().set_alphas(self.cube, self.alpha_x, None)
+        alphas_y = RecursiveFilter().set_alphas(self.cube, self.alpha_y, None)
+        padded_cube = SquareNeighbourhood().pad_cube_with_halo(
+            self.cube, edge_width, edge_width)
+        result = RecursiveFilter().run_recursion(
+            padded_cube, alphas_x, alphas_y, self.iterations)
+        expected_result = 0.13382206
+        self.assertAlmostEqual(result.data[4][4], expected_result)
+
+
+class Test_process(Test_RecursiveFilter):
+
+    """Test the process method. """
+
     # Test output from plugin returns expected values
-    def test_basic(self):
+    def test_return_type(self):
         """Test that the RecursiveFilter plugin returns an iris.cube.Cube."""
         plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
                                  iterations=self.iterations)
         result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
         self.assertIsInstance(result, Cube)
 
-    def test_process(self):
-        """Test that the RecursiveFilter plugin returns the correct data"""
+    def test_alpha_floats(self):
+        """Test that the RecursiveFilter plugin returns the correct data
+        when using float alpha values."""
         plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
                                  iterations=self.iterations)
         result = plugin.process(self.cube, alphas_x=None, alphas_y=None)
+        expected = 0.13382206
+        self.assertAlmostEqual(result.data[0][2][2], expected)
+
+    def test_alpha_cubes(self):
+        """Test that the RecursiveFilter plugin returns the correct data
+        when using alpha cubes."""
+        plugin = RecursiveFilter(alpha_x=None, alpha_y=None,
+                                 iterations=self.iterations)
+        result = plugin.process(self.cube, alphas_x=self.alphas_cube1,
+                                alphas_y=self.alphas_cube1)
         expected = 0.13382206
         self.assertAlmostEqual(result.data[0][2][2], expected)
 
@@ -183,161 +328,6 @@ class Test_RecursiveFilter(IrisTest):
         expected_shape = (1, 5, 5)
         self.assertEqual(result.data.shape, expected_shape)
         self.assertEqual(result.data.shape, expected_shape)
-
-
-class Test_set_alphas(Test_RecursiveFilter):
-
-    """Test the set_alphas function"""
-
-    def test_alphas_array_as_expected_when_alphas_is_none(self):
-        """Test that the returned alphas array has the expected result
-           when alphas=None."""
-        alphas = None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        result = plugin.set_alphas(self.cube, self.alpha_x, alphas)
-        expected_result = 0.5
-        self.assertIsInstance(result.data, np.ndarray)
-        self.assertEqual(result.data[0][2], expected_result)
-        # Check shape: Array should be padded with 4 extra rows/columns
-        expected_shape = (9, 9)
-        self.assertEqual(result.shape, expected_shape)
-
-    def test_alphas_shape_does_not_match_data_shape_when_alphas_not_none(self):
-        """Test if array dimensions of alphas array do not match dimensions of
-           data_array when alphas is not set to None (invalid)."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        msg = "Dimensions of alphas array do not match dimensions "
-        with self.assertRaisesRegexp(ValueError, msg):
-            plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube2)
-
-    def test_alphas_array_as_expected_when_alphas_is_not_none(self):
-        """Test that the returned alphas array has the expected result
-           when alphas=None."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        result = plugin.set_alphas(self.cube, self.alpha_x, self.alphas_cube1)
-        expected_result = 0.5
-        self.assertIsInstance(result.data, np.ndarray)
-        self.assertEqual(result.data[0][2], expected_result)
-        # Check shape: Array should be padded with 4 extra rows/columns
-        expected_shape = (9, 9)
-        self.assertEqual(result.shape, expected_shape)
-
-    def test_alphas_cube_and_alpha_not_set(self):
-        """Test error is raised when both alphas_cube and alpha are set
-           to None (invalid)."""
-        alpha_x = None
-        alpha_y = None
-        alphas_cube = None
-        plugin = RecursiveFilter(alpha_x=alpha_x, alpha_y=alpha_y,
-                                 iterations=self.iterations)
-        msg = "A value for alpha must be set if alphas_cube is "
-        with self.assertRaisesRegexp(ValueError, msg):
-            plugin.set_alphas(self.cube, alpha_x, alphas_cube)
-
-
-class Test_recurse_forward_x(Test_RecursiveFilter):
-
-    """Test the recurse_forward_x method"""
-
-    def test_basic_method(self):
-        """Test that the returned recurse_forward_x array has the expected
-           type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        result = plugin.recurse_forward_x(self.cube.data[0, :],
-                                          self.alphas_cube1.data[0, :])
-        expected_result = 0.196875
-        self.assertIsInstance(result, np.ndarray)
-        self.assertAlmostEqual(result[4][2], expected_result)
-
-
-class Test_recurse_backwards_x(Test_RecursiveFilter):
-
-    """Test the recurse_backwards_x method"""
-
-    def test_basic_method(self):
-        """Test that the returned recurse_backwards_x array has the expected
-           type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        result = plugin.recurse_backwards_x(self.cube.data[0, :],
-                                            self.alphas_cube1.data[0, :])
-        expected_result = 0.196875
-        self.assertIsInstance(result, np.ndarray)
-        self.assertAlmostEqual(result[0][2], expected_result)
-
-
-class Test_recurse_forward_y(Test_RecursiveFilter):
-
-    """Test the recurse_forward_y method"""
-
-    def test_basic_method(self):
-        """Test that the returned recurse_forward_y array has the expected
-           type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        result = plugin.recurse_forward_y(self.cube.data[:, 0],
-                                          self.alphas_cube1.data[:, 0])
-        expected_result = 0.0125
-        self.assertIsInstance(result, np.ndarray)
-        self.assertAlmostEqual(result[0][4], expected_result)
-
-
-class Test_recurse_backwards_y(Test_RecursiveFilter):
-
-    """Test the recurse_backwards_y method"""
-
-    def test_basic_method(self):
-        """Test that the returned recurse_backwards_y array has the expected
-           type and result."""
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        result = plugin.recurse_backwards_y(self.cube.data[:, 0],
-                                            self.alphas_cube1.data[:, 0])
-        expected_result = 0.0125
-        self.assertIsInstance(result, np.ndarray)
-        self.assertAlmostEqual(result[0][0], expected_result)
-
-
-class Test_run_recursion(Test_RecursiveFilter):
-
-    """Test the run_recursion method"""
-
-    def test_basic(self):
-        """Test that the run_recursion method returns an iris.cube.Cube."""
-        edge_width = 1
-        alphas_x = None
-        alphas_y = None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        alphas_x = plugin.set_alphas(self.cube, self.alpha_x, alphas_x)
-        alphas_y = plugin.set_alphas(self.cube, self.alpha_y, alphas_y)
-        padded_cube = SquareNeighbourhood().pad_cube_with_halo(self.cube,
-                                                               edge_width,
-                                                               edge_width)
-        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y,
-                                      self.iterations)
-        self.assertIsInstance(result, Cube)
-
-    def test_expected_result(self):
-        """Test that the run_recursion method returns an iris.cube.Cube."""
-        edge_width = 1
-        alphas_x = None
-        alphas_y = None
-        plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=self.alpha_y,
-                                 iterations=self.iterations)
-        alphas_x = plugin.set_alphas(self.cube, self.alpha_x, alphas_x)
-        alphas_y = plugin.set_alphas(self.cube, self.alpha_y, alphas_y)
-        padded_cube = SquareNeighbourhood().pad_cube_with_halo(self.cube,
-                                                               edge_width,
-                                                               edge_width)
-        result = plugin.run_recursion(padded_cube, alphas_x, alphas_y,
-                                      self.iterations)
-        expected_result = 0.13382206
-        self.assertAlmostEqual(result.data[4][4], expected_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An additional exception for when alpha is set in two ways in the plugin. An additional unit test for this exception and multiple fixes to recursive filter unit tests missed in review.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
