### PR TITLE
Fixed a bug in generation of topography masks

### DIFF
--- a/lib/improver/generate_ancillaries/generate_ancillary.py
+++ b/lib/improver/generate_ancillaries/generate_ancillary.py
@@ -228,10 +228,11 @@ class GenerateOrographyBandAncils(object):
                 orog_band (numpy array):
                     The binary array to which the landmask will be applied.
             """
+            points_to_mask = np.logical_not(landmask)
             mask_data = np.ma.masked_where(
-                np.logical_not(landmask), orog_band)
+                points_to_mask, orog_band)
             sea_fillvalue = np.ma.default_fill_value(mask_data.data)
-            mask_data.data[mask_data.mask] = sea_fillvalue
+            mask_data.data[points_to_mask] = sea_fillvalue
             return mask_data
 
         coords = standard_orography.coords()

--- a/lib/improver/tests/generate_ancillaries/test_GenerateOrographyBandAncils.py
+++ b/lib/improver/tests/generate_ancillaries/test_GenerateOrographyBandAncils.py
@@ -167,6 +167,19 @@ class Test_gen_orography_masks(IrisTest):
             GenOrogMasks().gen_orography_masks(
                 self.orography, self.landmask, key, threshold)
 
+    def test_all_land_points(self):
+        """Test that a correct mask is produced when the landsea mask only has
+           land points in it."""
+        land_mask_cube = self.landmask.copy()
+        land_mask_cube.data = np.ones((3, 3))
+        result = GenOrogMasks().gen_orography_masks(
+            self.orography, land_mask_cube, self.land_key,
+            self.valley_threshold)
+        expected_data = np.array([[[1.0, 1.0, 1.0],
+                                   [0.0, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0]]])
+        self.assertArrayAlmostEqual(result.data, expected_data)
+
 
 class Test_process(IrisTest):
     """


### PR DESCRIPTION
Bug occured when there were no sea points in the input landsea mask.

Added a new unit test to check this works.

Reference issue if exists

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

