### PR TITLE
Added mask handling to recursive filter.

### DIFF
--- a/bin/improver-recursive-filter
+++ b/bin/improver-recursive-filter
@@ -76,9 +76,20 @@ def main():
     parser.add_argument("--iterations", metavar="ITERATIONS",
                         default=1, type=int,
                         help="Number of cycles over which to apply the filter")
+    parser.add_argument('--input_mask_filepath', metavar='INPUT_MASK_FILE',
+                        help='A path to an input mask NetCDF file to be '
+                        'used to mask the input file.')
+    parser.add_argument("--re_mask", action='store_true', default=False,
+                        help="Re-apply mask to recursively filtered output.")
 
     args = parser.parse_args()
+
     cube = iris.load_cube(args.input_filepath)
+    if args.input_mask_filepath:
+        mask_cube = iris.load_cube(args.input_mask_filepath)
+    else:
+        mask_cube = None
+
     alphas_x_cube = None
     alphas_y_cube = None
     if args.input_filepath_alphas_x is not None:
@@ -88,8 +99,9 @@ def main():
 
     result = RecursiveFilter(
         alpha_x=args.alpha_x, alpha_y=args.alpha_y,
-        iterations=args.iterations).process(
-            cube, alphas_x=alphas_x_cube, alphas_y=alphas_y_cube)
+        iterations=args.iterations, re_mask=args.re_mask).process(
+            cube, alphas_x=alphas_x_cube, alphas_y=alphas_y_cube,
+            mask_cube=mask_cube)
 
     iris.save(result, args.output_filepath, unlimited_dimensions=[])
 

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -409,5 +409,4 @@ class RecursiveFilter(object):
         new_cube = recursed_cube.merge_cube()
         new_cube = check_cube_coordinates(cube, new_cube)
 
-
         return new_cube

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -35,7 +35,6 @@ import numpy as np
 
 from improver.nbhood.square_kernel import SquareNeighbourhood
 from improver.utilities.cube_checker import check_cube_coordinates
-from improver.nbhood.square_kernel import SquareNeighbourhood
 
 
 class RecursiveFilter(object):

--- a/tests/improver-recursive-filter/00-null.bats
+++ b/tests/improver-recursive-filter/00-null.bats
@@ -37,8 +37,9 @@ usage: improver-recursive-filter [-h] [--input_filepath_alphas_x ALPHAS_X]
                                  [--input_filepath_alphas_y ALPHAS_Y]
                                  [--alpha_x ALPHA_X] [--alpha_y ALPHA_Y]
                                  [--iterations ITERATIONS]
+                                 [--input_mask_filepath INPUT_MASK_FILE]
+                                 [--re_mask]
                                  INPUT_FILE OUTPUT_FILE
-
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-recursive-filter/01-help.bats
+++ b/tests/improver-recursive-filter/01-help.bats
@@ -37,6 +37,8 @@ usage: improver-recursive-filter [-h] [--input_filepath_alphas_x ALPHAS_X]
                                  [--input_filepath_alphas_y ALPHAS_Y]
                                  [--alpha_x ALPHA_X] [--alpha_y ALPHA_Y]
                                  [--iterations ITERATIONS]
+                                 [--input_mask_filepath INPUT_MASK_FILE]
+                                 [--re_mask]
                                  INPUT_FILE OUTPUT_FILE
 
 Run a recursive filter to convert a square neighbourhood into a Gaussian-like
@@ -65,6 +67,10 @@ optional arguments:
                         every grid square in the y direction.
   --iterations ITERATIONS
                         Number of cycles over which to apply the filter
+  --input_mask_filepath INPUT_MASK_FILE
+                        A path to an input mask NetCDF file to be used to mask
+                        the input file.
+  --re_mask             Re-apply mask to recursively filtered output.
 __HELP__
   [[ "$output" == "$expected" ]]
 }


### PR DESCRIPTION
Mark noticed that we are not handling masked data correctly. The mask fill values were being recursively filtered and dominating the output. When using the nbhood CLI with an external mask the recursive filter smeared values into the masked region and the re-mask option was not being employed to tidy up at the end.

The plugin changes are:

- zero masked data before applying the recursive filter, where this may be the mask embedded in the input cube or an external mask.
- add a re-mask option that will take the mask (regardless of the source) and re-apply it after the recursive filter has been applied.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s) - Needs to be done