### PR TITLE
Load wrapper

### DIFF
--- a/bin/improver-blend-adjacent-points
+++ b/bin/improver-blend-adjacent-points
@@ -39,6 +39,7 @@ from cf_units import Unit
 from improver.blending.blend_across_adjacent_points import \
     TriangularWeightedBlendAcrossAdjacentPoints
 from improver.argparser import ArgParser
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -91,7 +92,7 @@ def main():
 
     width = float(args.width)
 
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
 
     BlendingPlugin = TriangularWeightedBlendAcrossAdjacentPoints(
             args.coordinate, width, parameter_unit, args.weighting_mode)

--- a/bin/improver-combine
+++ b/bin/improver-combine
@@ -38,6 +38,7 @@ import json
 import warnings
 
 from improver.cube_combiner import CubeCombiner
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -82,7 +83,7 @@ def main():
     cubes = iris.cube.CubeList([])
     new_cube_name = args.new_name
     for filename in args.input_filenames:
-        new_cube = iris.load_cube(filename)
+        new_cube = load_cube(filename)
         cubes.append(new_cube)
         if new_cube_name is None:
             new_cube_name = new_cube.name()

--- a/bin/improver-ecc
+++ b/bin/improver-ecc
@@ -39,6 +39,7 @@ import numpy as np
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     RebadgePercentilesAsMembers, ResamplePercentiles, EnsembleReordering)
 from improver.argparser import ArgParser
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -132,7 +133,7 @@ def main():
                 'raw_forecast_filepath, random_ordering', 'rebadging')
 
     # Safe to now actually do the work...
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
 
     # TODO: For now, assume only doing percentiles -> percentiles.
     # TODO: Support for probabilities is not yet provided.
@@ -141,7 +142,7 @@ def main():
         sampling=args.sampling_method)
 
     if args.reordering:
-        raw_forecast = iris.load_cube(args.raw_forecast_filepath)
+        raw_forecast = load_cube(args.raw_forecast_filepath)
         result_cube = EnsembleReordering().process(
             result_cube, raw_forecast, random_ordering=args.random_ordering,
             random_seed=args.random_seed)

--- a/bin/improver-ensemble-calibration
+++ b/bin/improver-ensemble-calibration
@@ -39,6 +39,7 @@ from improver.ensemble_calibration.ensemble_calibration import (
     EnsembleCalibration)
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GeneratePercentilesFromMeanAndVariance, EnsembleReordering)
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -123,9 +124,9 @@ def main():
                         'ensemble.')
     args = parser.parse_args()
 
-    current_forecast = iris.load_cube(args.input_filepath)
-    historic_forecast = iris.load(args.historic_filepath)
-    truth = iris.load(args.truth_filepath)
+    current_forecast = load_cube(args.input_filepath)
+    historic_forecast = load_cube(args.historic_filepath)
+    truth = load_cube(args.truth_filepath)
     # Default number of ensemble members is the number in the raw forecast.
     if not args.num_members:
         args.num_members = len(current_forecast.coord('realization').points)

--- a/bin/improver-generate-landmask-ancillary
+++ b/bin/improver-generate-landmask-ancillary
@@ -37,8 +37,7 @@ import iris
 
 from improver.generate_ancillaries.generate_ancillary import (
     CorrectLandSeaMask)
-from improver.generate_ancillaries.generate_ancillary import (
-    find_standard_ancil)
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -60,7 +59,7 @@ def main():
 
     # Check if improver ancillary already exists.
     if not os.path.exists(args.output_filepath) or args.force:
-        landmask = find_standard_ancil(args.input_filepath_standard)
+        landmask = load_cube(args.input_filepath_standard)
         land_binary_mask = CorrectLandSeaMask().process(landmask)
         iris.save(land_binary_mask, args.output_filepath,
                   unlimited_dimensions=[])

--- a/bin/improver-generate-topography-bands-mask
+++ b/bin/improver-generate-topography-bands-mask
@@ -38,8 +38,7 @@ import json
 
 from improver.generate_ancillaries.generate_ancillary import (
     GenerateOrographyBandAncils)
-from improver.generate_ancillaries.generate_ancillary import (
-    find_standard_ancil)
+from improver.utilities.load import load_cube
 
 iris.FUTURE.netcdf_promote = True
 
@@ -101,11 +100,15 @@ def main():
         thresholds_dict = THRESHOLDS_DICT
 
     if not os.path.exists(args.output_filepath) or args.force:
-        orography = find_standard_ancil(args.input_filepath_standard_orography)
-        msg = ('Cannot locate land mask at {}; run '
-               'improver-generate-landmask-ancillary first.').format(
-                   args.input_filepath_landmask)
-        landmask = find_standard_ancil(args.input_filepath_landmask, msg)
+        orography = load_cube(args.input_filepath_standard_orography)
+        try:
+            landmask = load_cube(args.input_filepath_landmask)
+        except IOError as err:
+            msg = ("Loading land mask has been unsuccessful: {}. "
+                   "This may be because the land mask could not be "
+                   "located in {}; run "
+                   'improver-generate-landmask-ancillary first.').format(
+                       err, args.input_filepath_landmask)
         result = GenerateOrographyBandAncils().process(
             orography, landmask, thresholds_dict)
         result = result.concatenate_cube()

--- a/bin/improver-generate-topography-bands-weights
+++ b/bin/improver-generate-topography-bands-weights
@@ -38,8 +38,7 @@ import json
 
 from improver.generate_ancillaries.generate_topographic_zone_weights import (
     GenerateTopographicZoneWeights)
-from improver.generate_ancillaries.generate_ancillary import (
-    find_standard_ancil)
+from improver.utilities.load import load_cube
 
 iris.FUTURE.netcdf_promote = True
 
@@ -107,11 +106,11 @@ def main():
         thresholds_dict = THRESHOLDS_DICT
 
     if not os.path.exists(args.output_filepath) or args.force:
-        orography = find_standard_ancil(args.input_filepath_standard_orography)
+        orography = load_cube(args.input_filepath_standard_orography)
         msg = ('Cannot locate land mask at {}; run '
                'improver-generate-landmask-ancillary first.').format(
                    args.input_filepath_landmask)
-        landmask = find_standard_ancil(args.input_filepath_landmask, msg)
+        landmask = load_cube(args.input_filepath_landmask, msg)
         result = GenerateTopographicZoneWeights().process(
             orography, landmask, thresholds_dict)
         iris.save(result, args.output_filepath, unlimited_dimensions=[])

--- a/bin/improver-gradient
+++ b/bin/improver-gradient
@@ -35,6 +35,7 @@ import argparse
 import os
 import iris
 
+from improver.utilities.load import load_cube
 from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
 
 
@@ -57,7 +58,7 @@ def main():
     args = parser.parse_args()
     # Check if improver ancillary already exists.
     if not os.path.exists(args.output_filepath) or args.force:
-        input_field = iris.load_cube(args.input_filepath)
+        input_field = load_cube(args.input_filepath)
         gradients = DifferenceBetweenAdjacentGridSquares().process(input_field)
         iris.save(gradients, args.output_filepath, unlimited_dimensions=[])
     else:

--- a/bin/improver-nbhood
+++ b/bin/improver-nbhood
@@ -38,6 +38,7 @@ from improver.constants import DEFAULT_PERCENTILES
 from improver.nbhood.nbhood import (
     GeneratePercentilesFromANeighbourhood, NeighbourhoodProcessing)
 from improver.nbhood.recursive_filter import RecursiveFilter
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -188,7 +189,7 @@ def main():
         parser.wrong_args_error(
             'neighbourhood_shape=circular', 'input_mask_filepath')
 
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
     if args.radius:
         radius_or_radii = args.radius
         lead_times = None
@@ -197,7 +198,7 @@ def main():
         lead_times = args.radii_by_lead_time[1].split(",")
 
     if args.input_mask_filepath:
-        mask_cube = iris.load_cube(args.input_mask_filepath)
+        mask_cube = load_cube(args.input_mask_filepath)
     else:
         mask_cube = None
 
@@ -228,9 +229,9 @@ def main():
         alphas_y_cube = None
 
         if args.input_filepath_alphas_x_cube is not None:
-            alphas_x_cube = iris.load_cube(args.input_filepath_alphas_x_cube)
+            alphas_x_cube = load_cube(args.input_filepath_alphas_x_cube)
         if args.input_filepath_alphas_y_cube is not None:
-            alphas_y_cube = iris.load_cube(args.input_filepath_alphas_y_cube)
+            alphas_y_cube = load_cube(args.input_filepath_alphas_y_cube)
 
         result = RecursiveFilter(
             alpha_x=args.alpha_x, alpha_y=args.alpha_y,

--- a/bin/improver-nbhood-iterate-with-mask
+++ b/bin/improver-nbhood-iterate-with-mask
@@ -37,6 +37,7 @@ import iris
 
 from improver.argparser import ArgParser
 from improver.nbhood.use_nbhood import ApplyNeighbourhoodProcessingWithAMask
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -115,8 +116,8 @@ def main():
 
     args = parser.parse_args()
 
-    cube = iris.load_cube(args.input_filepath)
-    mask_cube = iris.load_cube(args.input_mask_filepath)
+    cube = load_cube(args.input_filepath)
+    mask_cube = load_cube(args.input_mask_filepath)
 
     if args.radius:
         radius_or_radii = args.radius

--- a/bin/improver-nbhood-vicinity
+++ b/bin/improver-nbhood-vicinity
@@ -36,6 +36,7 @@ import iris
 
 from improver.argparser import ArgParser
 from improver.nbhood.vicinity import ProbabilityOfOccurrence
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -108,7 +109,7 @@ def main():
 
     args = parser.parse_args()
 
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
     if args.radius:
         radius_or_radii = args.radius
         lead_times = None

--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -41,6 +41,7 @@ from improver.ensemble_copula_coupling.ensemble_copula_coupling import \
     GeneratePercentilesFromProbabilities
 from improver.ensemble_copula_coupling.ensemble_copula_coupling_utilities \
     import choose_set_of_percentiles
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -80,7 +81,7 @@ def main():
                        "aim of dividing into blocks of equal probability.")
 
     args = parser.parse_args()
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
     percentiles = args.percentiles
     if args.no_of_percentiles is not None:
         percentiles = choose_set_of_percentiles(args.no_of_percentiles,

--- a/bin/improver-recursive-filter
+++ b/bin/improver-recursive-filter
@@ -35,6 +35,7 @@ import argparse
 import iris
 
 from improver.nbhood.recursive_filter import RecursiveFilter
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -85,18 +86,18 @@ def main():
 
     args = parser.parse_args()
 
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
     if args.input_mask_filepath:
-        mask_cube = iris.load_cube(args.input_mask_filepath)
+        mask_cube = load_cube(args.input_mask_filepath)
     else:
         mask_cube = None
 
     alphas_x_cube = None
     alphas_y_cube = None
     if args.input_filepath_alphas_x is not None:
-        alphas_x_cube = iris.load_cube(args.input_filepath_alphas_x)
+        alphas_x_cube = load_cube(args.input_filepath_alphas_x)
     if args.input_filepath_alphas_y is not None:
-        alphas_y_cube = iris.load_cube(args.input_filepath_alphas_y)
+        alphas_y_cube = load_cube(args.input_filepath_alphas_y)
 
     result = RecursiveFilter(
         alpha_x=args.alpha_x, alpha_y=args.alpha_y,

--- a/bin/improver-snow-falling-level
+++ b/bin/improver-snow-falling-level
@@ -36,6 +36,7 @@ import iris
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
     FallingSnowLevel)
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -77,10 +78,10 @@ def main():
                               "derived value."))
     args = parser.parse_args()
 
-    temperature = iris.load_cube(args.temperature)
-    relative_humidity = iris.load_cube(args.relative_humidity)
-    pressure = iris.load_cube(args.pressure)
-    orog = iris.load_cube(args.orography)
+    temperature = load_cube(args.temperature)
+    relative_humidity = load_cube(args.relative_humidity)
+    pressure = load_cube(args.pressure)
+    orog = load_cube(args.orography)
 
     result = FallingSnowLevel(
         precision=args.precision,

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -37,9 +37,10 @@ import os
 
 from improver.spotdata.ancillaries import get_ancillary_data
 from improver.spotdata.main import run_spotdata
-from improver.spotdata.read_input import get_method_prerequisites, Load
+from improver.spotdata.read_input import get_method_prerequisites
 from improver.spotdata.site_data import ImportSiteData
 from improver.spotdata.write_output import WriteOutput
+from improver.utilities.load import load_cubelist
 
 
 def valid_latitude(value):
@@ -241,8 +242,7 @@ def main():
             raise IOError('No relevant data files found in {} for {}.'.format(
                 args.data_path, diagnostic_name_in_filename))
         # Load cubes into an iris.cube.CubeList.
-        diagnostics[diagnostic_key]["data"] = (
-            Load('multi_file').process(files_to_read))
+        diagnostics[diagnostic_key]["data"] = load_cubelist(files_to_read)
         # Check if additional diagnostics are needed (e.g. multi-level data).
         # If required, load into the additional_diagnostics dictionary.
         diagnostics[diagnostic_key]["additional_data"] = (

--- a/bin/improver-spotdb
+++ b/bin/improver-spotdb
@@ -38,6 +38,7 @@ import numpy as np
 
 from improver.database import VerificationTable
 from improver.argparser import ArgParser
+from improver.utilities.load import load_cubelist
 
 
 def main():
@@ -80,7 +81,7 @@ def main():
 
     args = parser.parse_args()
 
-    cubelist = iris.load(args.input_filepath)
+    cubelist = load_cubelist(args.input_filepath)
 
     if args.sqlite:
         output = 'sqlite'

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -38,6 +38,7 @@ import iris
 import cf_units
 
 from improver.threshold import BasicThreshold
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -103,7 +104,7 @@ def main():
         raise parser.error("--threshold_config option is not compatible "
                            "with --fuzzy_factor option.")
 
-    cube = iris.load_cube(args.input_filepath)
+    cube = load_cube(args.input_filepath)
 
     if args.threshold_config:
         try:

--- a/bin/improver-weighted-blending
+++ b/bin/improver-weighted-blending
@@ -41,6 +41,7 @@ from improver.blending.weights import (
 from improver.blending.weighted_blend import WeightedBlendAcrossWholeDimension
 from improver.utilities.cube_manipulation import merge_cubes
 from improver.argparser import ArgParser
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -173,7 +174,7 @@ def main():
     # Read in cubes and merge together if more than one found.
     cubelist = iris.cube.CubeList([])
     for ifile in args.input_filepaths:
-        cube_in = iris.load_cube(ifile)
+        cube_in = load_cube(ifile)
         cubelist.append(cube_in)
     if len(cubelist) == 1:
         cube = cubelist[0]

--- a/bin/improver-wet-bulb-temperature
+++ b/bin/improver-wet-bulb-temperature
@@ -38,6 +38,7 @@ import iris
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
     WetBulbTemperature)
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -71,9 +72,9 @@ def main():
                         ' iterations, the solution is accepted.')
 
     args = parser.parse_args()
-    temperature = iris.load_cube(args.temperature)
-    relative_humidity = iris.load_cube(args.relative_humidity)
-    pressure = iris.load_cube(args.pressure)
+    temperature = load_cube(args.temperature)
+    relative_humidity = load_cube(args.relative_humidity)
+    pressure = load_cube(args.pressure)
 
     result = (WetBulbTemperature(precision=args.convergence_condition).
               process(temperature, relative_humidity, pressure))

--- a/bin/improver-wind-downscaling
+++ b/bin/improver-wind-downscaling
@@ -37,6 +37,7 @@ import iris
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import wind_downscaling
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -80,18 +81,18 @@ def main():
                         help='Location of vegetative roughness length file.'
                              ' Units of field: m')
     args = parser.parse_args()
-    wind_speed = iris.load_cube(args.wind_speed_filepath)
-    silhouette_roughness_filepath = iris.load_cube(
+    wind_speed = load_cube(args.wind_speed_filepath)
+    silhouette_roughness_filepath = load_cube(
         args.silhouette_roughness_filepath)
-    sigma = iris.load_cube(args.sigma_filepath)
-    target_orog = iris.load_cube(args.target_orog_filepath)
-    standard_orog = iris.load_cube(args.standard_orog_filepath)
+    sigma = load_cube(args.sigma_filepath)
+    target_orog = load_cube(args.target_orog_filepath)
+    standard_orog = load_cube(args.standard_orog_filepath)
     if args.height_levels_filepath:
-        height_levels = iris.load_cube(args.height_levels_filepath)
+        height_levels = load_cube(args.height_levels_filepath)
     else:
         height_levels = None
     if args.veg_roughness_filepath:
-        veg_roughness_cube = iris.load_cube(args.veg_roughness_filepath)
+        veg_roughness_cube = load_cube(args.veg_roughness_filepath)
     else:
         veg_roughness_cube = None
     try:

--- a/bin/improver-wind-gust-diagnostic
+++ b/bin/improver-wind-gust-diagnostic
@@ -37,6 +37,7 @@ import iris
 import warnings
 
 from improver.wind_gust_diagnostic import WindGustDiagnostic
+from improver.utilities.load import load_cube
 
 
 def main():
@@ -83,8 +84,8 @@ def main():
                         " Default=95.0", type=float)
 
     args = parser.parse_args()
-    cube_wg = iris.load_cube(args.input_filegust)
-    cube_ws = iris.load_cube(args.input_filews)
+    cube_wg = load_cube(args.input_filegust)
+    cube_ws = load_cube(args.input_filews)
     result = (
         WindGustDiagnostic(args.percentile_gust,
                            args.percentile_ws).process(cube_wg, cube_ws))

--- a/bin/improver-wxcode
+++ b/bin/improver-wxcode
@@ -39,6 +39,7 @@ from argparse import RawTextHelpFormatter
 from improver.wxcode.weather_symbols import WeatherSymbols
 from improver.wxcode.wxcode_utilities import expand_nested_lists
 from improver.wxcode.wxcode_decision_tree import wxcode_decision_tree
+from improver.utilities.load import load_cubelist
 
 
 def interrogate_decision_tree():
@@ -116,7 +117,7 @@ def main():
                         help='The output path for the processed NetCDF.')
 
     args = parser.parse_args()
-    cubes = iris.load(args.input_filepaths)
+    cubes = load_cubelist(args.input_filepaths)
 
     result = (WeatherSymbols().process(cubes))
     iris.save(result, args.output_filepath, unlimited_dimensions=[])

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -42,9 +42,9 @@ import cf_units as unit
 import iris
 
 from improver.ensemble_calibration.ensemble_calibration_utilities import (
-    convert_cube_data_to_2d, ensure_dimension_is_the_zeroth_dimension,
-    rename_coordinate, check_predictor_of_mean_flag)
-from improver.utilities.cube_manipulation import concatenate_cubes
+    convert_cube_data_to_2d, rename_coordinate, check_predictor_of_mean_flag)
+from improver.utilities.cube_manipulation import (
+    concatenate_cubes, enforce_coordinate_ordering)
 
 
 class ContinuousRankedProbabilityScoreMinimisers(object):
@@ -161,7 +161,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         elif predictor_of_mean_flag.lower() in ["members"]:
             truth_data = truth.data.flatten()
             forecast_predictor = (
-                ensure_dimension_is_the_zeroth_dimension(
+                enforce_coordinate_ordering(
                     forecast_predictor, "realization"))
             forecast_predictor_data = convert_cube_data_to_2d(
                 forecast_predictor)
@@ -436,7 +436,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                 if self.statsmodels_found:
                     truth_data = truth.data.flatten()
                     forecast_predictor = (
-                        ensure_dimension_is_the_zeroth_dimension(
+                        enforce_coordinate_ordering(
                             forecast_predictor, "realization"))
                     forecast_data = np.array(
                         convert_cube_data_to_2d(
@@ -939,7 +939,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                         [[optimised_coeffs_at_date["a"]],
                          optimised_coeffs_at_date["beta"]**2])
                     forecast_predictor = (
-                        ensure_dimension_is_the_zeroth_dimension(
+                        enforce_coordinate_ordering(
                             forecast_predictor, "realization"))
                     forecast_predictor_flat = (
                         convert_cube_data_to_2d(

--- a/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
@@ -69,43 +69,6 @@ def convert_cube_data_to_2d(
     return np.array(forecast_data)
 
 
-def ensure_dimension_is_the_zeroth_dimension(cube, coord):
-    """
-    Function to ensure that the requested coordinate within the cube is
-    the first dimension within the cube.
-
-    If the requested dimension coordinate exists, the cube is transposed.
-    If the requested coordinate exists, but it is not a dimension coordinate
-    i.e. a scalar coordinate, then a new axis is created with the scalar
-    coordinate becoming a dimension coordinate.
-    If the coordinate is not present on the cube, then an error is raised.
-
-    Args:
-        cube (iris.cube.Cube):
-            Cube where the requirement for the required dimension to be the
-            first dimension will be enforced.
-        coord (string):
-            Name of the coordinate that is to be made the first dimension
-            coordinate in the cube.
-
-    """
-    if cube.coords(coord, dim_coords=True):
-        if cube.coord_dims(coord)[0] != 0:
-            coords = []
-            for acoord in cube.coords(dim_coords=True):
-                if acoord.name() not in [coord]:
-                    coords.append(cube.coord_dims(acoord)[0])
-            first_coord = cube.coord_dims(coord)[0]
-            cube.transpose([first_coord]+coords)
-    elif cube.coords(coord, dim_coords=False):
-        cube = iris.util.new_axis(cube, coord)
-    else:
-        msg = ("The coordinate {} is not a dimension coordinate "
-               "in the cube: {}".format(coord, cube))
-        raise ValueError(msg)
-    return cube
-
-
 def rename_coordinate(cubes, original_coord, renamed_coord):
     """
     Renames a coordinate to an alternative name for an

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -40,14 +40,15 @@ import iris
 from iris.exceptions import CoordinateNotFoundError
 
 from improver.ensemble_calibration.ensemble_calibration_utilities import (
-    convert_cube_data_to_2d, ensure_dimension_is_the_zeroth_dimension)
+    convert_cube_data_to_2d)
 from improver.ensemble_copula_coupling.ensemble_copula_coupling_utilities \
     import (concatenate_2d_array_with_2d_array_endpoints,
             create_cube_with_percentiles, choose_set_of_percentiles,
             get_bounds_of_distribution,
             insert_lower_and_upper_endpoint_to_1d_array,
             restore_non_probabilistic_dimensions)
-from improver.utilities.cube_manipulation import concatenate_cubes
+from improver.utilities.cube_manipulation import (
+    concatenate_cubes, enforce_coordinate_ordering)
 from improver.utilities.cube_checker import find_percentile_coordinate
 
 
@@ -189,7 +190,7 @@ class ResamplePercentiles(object):
         # Ensure that the percentile dimension is first, so that the
         # conversion to a 2d array produces data in the desired order.
         forecast_at_percentiles = (
-            ensure_dimension_is_the_zeroth_dimension(
+            enforce_coordinate_ordering(
                 forecast_at_percentiles, percentile_coord))
         forecast_at_reshaped_percentiles = convert_cube_data_to_2d(
             forecast_at_percentiles, coord=percentile_coord)
@@ -380,7 +381,7 @@ class GeneratePercentilesFromProbabilities(object):
         # Ensure that the percentile dimension is first, so that the
         # conversion to a 2d array produces data in the desired order.
         forecast_probabilities = (
-            ensure_dimension_is_the_zeroth_dimension(
+            enforce_coordinate_ordering(
                 forecast_probabilities, threshold_coord.name()))
         prob_slices = convert_cube_data_to_2d(
             forecast_probabilities, coord=threshold_coord.name())
@@ -573,10 +574,10 @@ class GeneratePercentilesFromMeanAndVariance(object):
 
         """
         calibrated_forecast_predictor = (
-            ensure_dimension_is_the_zeroth_dimension(
+            enforce_coordinate_ordering(
                 calibrated_forecast_predictor, "realization"))
         calibrated_forecast_variance = (
-            ensure_dimension_is_the_zeroth_dimension(
+            enforce_coordinate_ordering(
                 calibrated_forecast_variance, "realization"))
 
         calibrated_forecast_predictor_data = (
@@ -853,11 +854,10 @@ class EnsembleReordering(object):
             post_processed_forecast,
             coords_to_slice_over=[percentile_coord, "time"])
         post_processed_forecast_percentiles = (
-            ensure_dimension_is_the_zeroth_dimension(
-                post_processed_forecast_percentiles,
-                percentile_coord))
+            enforce_coordinate_ordering(
+                post_processed_forecast_percentiles, percentile_coord))
         raw_forecast_members = concatenate_cubes(raw_forecast)
-        raw_forecast_members = ensure_dimension_is_the_zeroth_dimension(
+        raw_forecast_members = enforce_coordinate_ordering(
             raw_forecast_members, "realization")
         raw_forecast_members = (
             self._recycle_raw_ensemble_members(
@@ -872,7 +872,6 @@ class EnsembleReordering(object):
                 post_processed_forecast_members))
 
         post_processed_forecast_members = (
-            ensure_dimension_is_the_zeroth_dimension(
-                post_processed_forecast_members,
-                "realization"))
+            enforce_coordinate_ordering(
+                post_processed_forecast_members, "realization"))
         return post_processed_forecast_members

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_utilities.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_utilities.py
@@ -288,8 +288,8 @@ def restore_non_probabilistic_dimensions(
         else:
             msg = ("The {} coordinate is a dimension coordinate but is not "
                    "the first dimension coordinate in the cube: {}.\n"
-                   "The ensure_dimension_is_the_first_dimension function "
-                   "may be useful. ".format(
+                   "The enforce_coordinate_ordering function may be "
+                   "useful. ".format(
                        input_probabilistic_dimension_name, original_cube))
             raise ValueError(msg)
     elif original_cube.coords(

--- a/lib/improver/generate_ancillaries/generate_ancillary.py
+++ b/lib/improver/generate_ancillaries/generate_ancillary.py
@@ -91,35 +91,6 @@ def _make_mask_cube(
     return mask_cube
 
 
-def find_standard_ancil(standard_ancil_glob, msg=None):
-    """
-    Reads standard ancillary or raises exception.
-
-    Args:
-        standard_ancil_glob (string):
-          Location of input ancillaries
-
-        msg (str):
-          Optional custom message.
-
-    Returns:
-        standard_ancil (cube):
-            Cube containing standard ancillary data.
-
-    Raises:
-        IOError: if input ancillary cannot be found in the directory provided.
-    """
-    standard_ancil_file = glob(standard_ancil_glob)
-    if len(standard_ancil_file) > 0:
-        standard_ancil = iris.load_cube(standard_ancil_file[0])
-    else:
-        if msg is None:
-            msg = ('Cannot find input ancillary. Tried directory: '
-                   '{}'.format(standard_ancil_glob))
-        raise IOError(msg)
-    return standard_ancil
-
-
 class CorrectLandSeaMask(object):
     """
     Round landsea mask to binary values

--- a/lib/improver/generate_ancillaries/generate_ancillary.py
+++ b/lib/improver/generate_ancillaries/generate_ancillary.py
@@ -30,8 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing ancillary generation utilities for Improver"""
 
-from glob import glob
-
 from cf_units import Unit
 import iris
 import numpy as np

--- a/lib/improver/spotdata/ancillaries.py
+++ b/lib/improver/spotdata/ancillaries.py
@@ -35,7 +35,7 @@ land masks.
 
 """
 
-from improver.spotdata.read_input import Load
+from improver.utilities.load import load_cube
 
 
 def get_ancillary_data(diagnostics, ancillary_path):
@@ -65,8 +65,9 @@ def get_ancillary_data(diagnostics, ancillary_path):
     ancillary_data = {}
 
     try:
-        orography = Load('single_file').process(
-            ancillary_path + '/highres_orog.nc', diagnostic='surface_altitude')
+        orography = load_cube(
+            ancillary_path + '/highres_orog.nc',
+            constraints='surface_altitude')
     except:
         raise IOError('Orography file not found.')
 
@@ -76,9 +77,9 @@ def get_ancillary_data(diagnostics, ancillary_path):
     if any([(diagnostics[key]['neighbour_finding']['land_constraint'])
             for key in diagnostics.keys()]):
         try:
-            land = Load('single_file').process(
+            land = load_cube(
                 ancillary_path + '/land_mask.nc',
-                diagnostic='land_binary_mask')
+                constraints='land_binary_mask')
         except:
             raise IOError('Land mask file not found.')
 

--- a/lib/improver/spotdata/read_input.py
+++ b/lib/improver/spotdata/read_input.py
@@ -36,75 +36,7 @@ For reading data processed by IMPROVER, and site specification input.
 """
 import os
 import iris
-from iris import load_cube, load
-
-
-class Load(object):
-
-    """Plugin for loading data."""
-
-    def __init__(self, method):
-        """
-        Simple function that currently takes a filename and loads a netCDF
-        file.
-
-        Args:
-            method (string):
-                A string representing the method of loading, be it a
-                'single_file' that is loaded as an iris.cube.Cube, or
-                'multi_file' that causes an iris.cube.CubeList to be returned
-                containing all the cubes.
-
-        """
-        self.method = method
-
-    def __repr__(self):
-        """Represent the configured plugin instance as a string."""
-        result = ('<Load: method: {}>')
-        return result.format(self.method)
-
-    def process(self, filepath, diagnostic=None):
-        """
-        Simple wrapper for using iris load on a supplied netCDF file.
-
-        Args:
-            filepath (string):
-                Path to the input data files.
-
-            diagnostic (string):
-                The name of the desired diagnostic to be loaded.
-
-        Returns:
-            iris.cube.Cube or iris.cube.CubeList:
-                An iris.cube.Cube or CubeList containing the data from the
-                netCDF file(s).
-
-        """
-        try:
-            function = getattr(self, self.method)
-        except:
-            raise AttributeError('Unknown method "{}" passed to {}.'.format(
-                self.method, self.__class__.__name__))
-
-        return function(filepath, diagnostic)
-
-    @staticmethod
-    def single_file(filepath, diagnostic=None):
-        """ Load and return a single iris.cube.Cube """
-        if diagnostic:
-            cube = load_cube(filepath, diagnostic)
-        else:
-            cube = load_cube(filepath)
-        return cube
-
-    @staticmethod
-    def multi_file(filepath, diagnostic=None):
-        """ Load multiple cubes and return a iris.cube.CubeList """
-        if diagnostic:
-            cubes = load(filepath, diagnostic)
-        else:
-            cubes = load(filepath)
-        return cubes
+from improver.utilities.load import load_cubelist
 
 
 def get_method_prerequisites(method, diagnostic_data_path):
@@ -177,7 +109,7 @@ def get_additional_diagnostics(diagnostic_name, diagnostic_data_path,
                       'as an additional diagnostic is not available '
                       'in {}.'.format(
                           diagnostic_name, diagnostic_data_path))
-    cubes = Load('multi_file').process(files_to_read, None)
+    cubes = load_cubelist(files_to_read)
 
     if time_extract is not None:
         with iris.FUTURE.context(cell_datetime_objects=True):

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -36,7 +36,6 @@ module.
 import unittest
 
 import iris
-from iris.cube import Cube
 from iris.tests import IrisTest
 import numpy as np
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -172,69 +172,6 @@ class Test_convert_cube_data_to_2d(IrisTest):
         self.assertArrayAlmostEqual(result, data)
 
 
-class Test_ensure_dimension_is_the_zeroth_dimension(IrisTest):
-
-    """
-    Test the ensure_dimension_is_the_zeroth_dimension
-    utility.
-    """
-
-    def setUp(self):
-        """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
-
-    def test_basic(self):
-        """Test that the function returns an iris.cube.Cube."""
-        result = (
-            ensure_dimension_is_the_zeroth_dimension(self.cube, "realization"))
-        self.assertIsInstance(result, Cube)
-
-    def test_if_probabilistic_dimension_is_first(self):
-        """
-        Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is the first dimension coordinate.
-        """
-        result = (
-            ensure_dimension_is_the_zeroth_dimension(self.cube, "realization"))
-        self.assertArrayAlmostEqual(result.data, self.cube.data)
-
-    def test_if_probabilistic_dimension_is_not_first(self):
-        """
-        Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a dimension coordinate but it is
-        not the first dimension coordinate,.
-        """
-        expected = self.cube.copy()
-        expected.transpose([0, 3, 2, 1])
-
-        cube = self.cube.copy()
-        cube.transpose([3, 2, 1, 0])
-        result = (
-            ensure_dimension_is_the_zeroth_dimension(cube, "realization"))
-        self.assertArrayAlmostEqual(result.data, expected.data)
-
-    def test_if_probabilistic_dimension_is_scalar(self):
-        """
-        Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a scalar coordinate.
-        """
-        cube = self.cube[0, :, :, :]
-        result = (
-            ensure_dimension_is_the_zeroth_dimension(cube, "realization"))
-        self.assertArrayAlmostEqual(result.data, [cube.data])
-
-    def test_if_probabilistic_dimension_not_available(self):
-        """
-        Test that the expected error message is raised when the required
-        probabilistic dimension is not available in the cube.
-        """
-        cube = self.cube[0, :, :, :]
-        cube.remove_coord("realization")
-        msg = "not a dimension coordinate"
-        with self.assertRaisesRegexp(ValueError, msg):
-            ensure_dimension_is_the_zeroth_dimension(cube, "realization")
-
-
 class Test_rename_coordinate(IrisTest):
 
     """Test the rename_coordinate utility."""

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -41,8 +41,8 @@ from iris.tests import IrisTest
 import numpy as np
 
 from improver.ensemble_calibration.ensemble_calibration_utilities import (
-    convert_cube_data_to_2d, ensure_dimension_is_the_zeroth_dimension,
-    rename_coordinate, _renamer, check_predictor_of_mean_flag)
+    convert_cube_data_to_2d, rename_coordinate, _renamer,
+    check_predictor_of_mean_flag)
 from improver.tests.ensemble_calibration.ensemble_calibration.\
     helper_functions import set_up_temperature_cube
 

--- a/lib/improver/tests/generate_ancillaries/test_generate_ancillary.py
+++ b/lib/improver/tests/generate_ancillaries/test_generate_ancillary.py
@@ -42,8 +42,7 @@ from iris import save
 import numpy as np
 from cf_units import Unit
 
-from improver.generate_ancillaries.generate_ancillary import (
-    _make_mask_cube, find_standard_ancil)
+from improver.generate_ancillaries.generate_ancillary import _make_mask_cube
 
 
 def _make_test_cube(long_name):
@@ -111,44 +110,6 @@ class Test__make_mask_cube(IrisTest):
                          np.mean([self.lower, self.upper]))
         self.assertEqual(result.coord('topographic_zone').units, Unit('m'))
 
-
-class Test_find_standard_ancil(IrisTest):
-    """Test function to find input for ancillary generation."""
-
-    def setUp(self):
-        """setting up test dir and test files"""
-        self.test_dir = './anciltest/'
-        self.stage = self.test_dir + 'stage.nc'
-        os.mkdir(self.test_dir)
-        save(_make_test_cube('stage test'), self.stage)
-
-    def tearDown(self):
-        """"remove test directories and files"""
-        if os.path.exists(self.test_dir):
-            files = glob(self.test_dir + '*')
-            for f in files:
-                os.remove(f)
-            os.rmdir(self.test_dir)
-
-    def test_findstage(self):
-        """test case where stage file is present and read"""
-        result = find_standard_ancil(self.stage)
-        self.assertIsInstance(result, Cube)
-
-    def test_findstage_fail(self):
-        """test the correct exception is raised when stage ancillaries
-           are not found"""
-        os.remove(self.stage)
-        with self.assertRaisesRegexp(IOError, 'Cannot find input ancillary'):
-            find_standard_ancil(self.stage)
-
-    def test_custom_msg_fail(self):
-        """test the correct exception is raised when the optional msg
-           argument is passed in and the file cannot be found"""
-        os.remove(self.stage)
-        msg = "That file doesn't exist"
-        with self.assertRaisesRegexp(IOError, msg):
-            find_standard_ancil(self.stage, msg)
 
 if __name__ == "__main__":
     unittest.main()

--- a/lib/improver/tests/generate_ancillaries/test_generate_ancillary.py
+++ b/lib/improver/tests/generate_ancillaries/test_generate_ancillary.py
@@ -31,14 +31,11 @@
 """Unit tests for the the stand alone functions in generate_ancillary.py"""
 
 import unittest
-from glob import glob
-import os
 from iris.cube import Cube
 from iris.tests import IrisTest
 from iris.coords import DimCoord
 from iris.coord_systems import GeogCS
 from iris.fileformats.pp import EARTH_RADIUS
-from iris import save
 import numpy as np
 from cf_units import Unit
 

--- a/lib/improver/tests/spotdata/spotdata/test_read_input.py
+++ b/lib/improver/tests/spotdata/spotdata/test_read_input.py
@@ -46,7 +46,6 @@ from iris.tests import IrisTest
 from iris.time import PartialDateTime
 from iris.exceptions import ConstraintMismatchError
 
-from improver.spotdata.read_input import Load as Plugin
 from improver.spotdata.read_input import get_method_prerequisites
 from improver.spotdata.read_input import get_additional_diagnostics
 
@@ -175,58 +174,6 @@ class Test_read_input(IrisTest):
         for a_file in self.made_files:
             Call(['rm', a_file])
         Call(['rmdir', self.data_directory])
-
-
-class Test_Load(Test_read_input):
-    """Test function used for loading data cubes."""
-
-    def test_single_file(self):
-        """Test loading of a single file as an iris.cube.Cube."""
-
-        expected = self.cube
-        result = Plugin('single_file').process(self.cube_file,
-                                               self.cube.name())
-        self.assertArrayEqual(expected.data, result.data)
-        for ex_coord, re_coord in zip(expected.dim_coords, result.dim_coords):
-            self.assertEqual(ex_coord, re_coord)
-
-    def test_multi_file(self):
-        """Test loading of multiple files as an iris.cube.CubeList."""
-
-        expected = CubeList([self.cube, self.cube2])
-        result = Plugin('multi_file').process(
-            [self.cube_file, self.cube_file2], 'air_temperature')
-
-        for ex, re in zip(expected, result):
-            self.assertEqual(ex.name(), re.name())
-            self.assertArrayEqual(ex.data, re.data)
-
-    def test_invalid_method(self):
-        """Test attempting to load data with an invalid method."""
-
-        method = 'not_a_valid_method'
-        msg = 'Unknown method ".*" passed to .*'
-        with self.assertRaisesRegexp(AttributeError, msg):
-            Plugin(method).process(self.cube_file, self.cube.name())
-
-    def test_single_file_invalid_diagnostic(self):
-        """Test attempt to load a diagnostic cube from a file within which it
-        cannot be found."""
-
-        diagnostic = 'not_a_valid_diagnostic'
-        msg = 'no cubes found'
-        with self.assertRaisesRegexp(ConstraintMismatchError, msg):
-            Plugin('single_file').process(self.cube_file, diagnostic)
-
-    def test_multi_file_invalid_diagnostic(self):
-        """Test attempt to load diagnostic cubes from files within which they
-        cannot be found."""
-
-        diagnostic = 'not_a_valid_diagnostic'
-        msg = 'no cubes found'
-        with self.assertRaisesRegexp(ConstraintMismatchError, msg):
-            Plugin('single_file').process([self.cube_file, self.cube_file2],
-                                          diagnostic)
 
 
 class Test_get_method_prerequisites(Test_read_input):

--- a/lib/improver/tests/spotdata/spotdata/test_read_input.py
+++ b/lib/improver/tests/spotdata/spotdata/test_read_input.py
@@ -44,7 +44,6 @@ from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 from iris.tests import IrisTest
 from iris.time import PartialDateTime
-from iris.exceptions import ConstraintMismatchError
 
 from improver.spotdata.read_input import get_method_prerequisites
 from improver.spotdata.read_input import get_additional_diagnostics

--- a/lib/improver/tests/utilities/test_cube_manipulation.py
+++ b/lib/improver/tests/utilities/test_cube_manipulation.py
@@ -58,7 +58,7 @@ from improver.utilities.cube_manipulation import (
     compare_coords,
     build_coordinate,
     add_renamed_cell_method,
-    sort_coord_in_cube)
+    sort_coord_in_cube, ensure_coordinate_ordering)
 
 from improver.tests.ensemble_calibration.ensemble_calibration.\
     helper_functions import (
@@ -1537,6 +1537,69 @@ class Test_sort_coord_in_cube(IrisTest):
             self.assertTrue(any(warning_msg in str(item)
                                 for item in warning_list))
             self.assertIsInstance(result, iris.cube.Cube)
+
+
+class Test_ensure_dimension_is_the_zeroth_dimension(IrisTest):
+
+    """
+    Test the ensure_dimension_is_the_zeroth_dimension
+    utility.
+    """
+
+    def setUp(self):
+        """Use temperature cube to test with."""
+        self.cube = set_up_temperature_cube()
+
+    def test_basic(self):
+        """Test that the function returns an iris.cube.Cube."""
+        result = (
+            ensure_dimension_is_the_zeroth_dimension(self.cube, "realization"))
+        self.assertIsInstance(result, Cube)
+
+    def test_if_probabilistic_dimension_is_first(self):
+        """
+        Test that a cube with the expected data contents is returned when
+        the probabilistic dimension is the first dimension coordinate.
+        """
+        result = (
+            ensure_dimension_is_the_zeroth_dimension(self.cube, "realization"))
+        self.assertArrayAlmostEqual(result.data, self.cube.data)
+
+    def test_if_probabilistic_dimension_is_not_first(self):
+        """
+        Test that a cube with the expected data contents is returned when
+        the probabilistic dimension is a dimension coordinate but it is
+        not the first dimension coordinate,.
+        """
+        expected = self.cube.copy()
+        expected.transpose([0, 3, 2, 1])
+
+        cube = self.cube.copy()
+        cube.transpose([3, 2, 1, 0])
+        result = (
+            ensure_dimension_is_the_zeroth_dimension(cube, "realization"))
+        self.assertArrayAlmostEqual(result.data, expected.data)
+
+    def test_if_probabilistic_dimension_is_scalar(self):
+        """
+        Test that a cube with the expected data contents is returned when
+        the probabilistic dimension is a scalar coordinate.
+        """
+        cube = self.cube[0, :, :, :]
+        result = (
+            ensure_dimension_is_the_zeroth_dimension(cube, "realization"))
+        self.assertArrayAlmostEqual(result.data, [cube.data])
+
+    def test_if_probabilistic_dimension_not_available(self):
+        """
+        Test that the expected error message is raised when the required
+        probabilistic dimension is not available in the cube.
+        """
+        cube = self.cube[0, :, :, :]
+        cube.remove_coord("realization")
+        msg = "not a dimension coordinate"
+        with self.assertRaisesRegexp(ValueError, msg):
+            ensure_dimension_is_the_zeroth_dimension(cube, "realization")
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/test_cube_manipulation.py
+++ b/lib/improver/tests/utilities/test_cube_manipulation.py
@@ -1672,13 +1672,24 @@ class Test_enforce_coordinate_ordering(IrisTest):
         self.assertEqual(result.coord_dims("realization")[0], 1)
         self.assertArrayAlmostEqual(result.data, expected.data)
 
-    def test_move_coordinate_to_start_with_scalar(self):
+    def test_force_promotion_of_scalar(self):
         """Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a scalar coordinate."""
+        the probabilistic dimension is a scalar coordinate, where the scalar
+        coordinate is promoted to a dimension coordinate."""
         cube = self.cube[0, :, :, :]
-        result = enforce_coordinate_ordering(cube, "realization")
+        result = enforce_coordinate_ordering(
+            cube, "realization", promote_scalar=True)
         self.assertEqual(result.coord_dims("realization")[0], 0)
         self.assertArrayAlmostEqual(result.data, [cube.data])
+
+    def test_do_not_promote_scalar(self):
+        """Test that a cube with the expected data contents is returned when
+        the probabilistic dimension is a scalar coordinate, where the scalar
+        coordinate is not promoted to a dimension coordinate."""
+        cube = self.cube[0, :, :, :]
+        result = enforce_coordinate_ordering(cube, "realization")
+        self.assertFalse(result.coord_dims("realization"))
+        self.assertArrayAlmostEqual(result.data, cube.data)
 
     def test_coordinate_raise_exception(self):
         """Test that the expected error message is raised when the required

--- a/lib/improver/tests/utilities/test_cube_manipulation.py
+++ b/lib/improver/tests/utilities/test_cube_manipulation.py
@@ -1623,7 +1623,7 @@ class Test_enforce_coordinate_ordering(IrisTest):
 
     def test_full_reordering(self):
         """Test that a cube with the expected data contents is returned when
-        the all the coordinates within the cube are reordered into the order
+        all the coordinates within the cube are reordered into the order
         specified by the names within the input list."""
         expected = self.cube.copy()
         expected.transpose([2, 0, 3, 1])
@@ -1638,8 +1638,8 @@ class Test_enforce_coordinate_ordering(IrisTest):
 
     def test_partial_names(self):
         """Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a dimension coordinate but it is
-        not the first dimension coordinate."""
+        the names provided are partial matches of the names of the coordinates
+        within the cube."""
         expected = self.cube.copy()
         expected.transpose([1, 0, 2, 3])
         cube = self.cube.copy()
@@ -1649,9 +1649,9 @@ class Test_enforce_coordinate_ordering(IrisTest):
         self.assertArrayAlmostEqual(result.data, expected.data)
 
     def test_partial_names_multiple_matches_exception(self):
-        """Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a dimension coordinate but it is
-        not the first dimension coordinate."""
+        """Test that the expected exception is raised when the names provided
+        are partial matches of the names of multiple coordinates within the
+        cube."""
         expected = self.cube.copy()
         expected.transpose([2, 3, 0, 1])
         cube = self.cube.copy()
@@ -1661,8 +1661,8 @@ class Test_enforce_coordinate_ordering(IrisTest):
 
     def test_include_extra_coordinates(self):
         """Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a dimension coordinate but it is
-        not the first dimension coordinate."""
+        extra coordinates are passed in for reordering but these coordinates
+        are not present within the cube."""
         expected = self.cube.copy()
         expected.transpose([1, 0, 2, 3])
         cube = self.cube.copy()
@@ -1674,8 +1674,8 @@ class Test_enforce_coordinate_ordering(IrisTest):
 
     def test_force_promotion_of_scalar(self):
         """Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a scalar coordinate, where the scalar
-        coordinate is promoted to a dimension coordinate."""
+        the probabilistic dimension is a scalar coordinate, which is promoted
+        to a dimension coordinate."""
         cube = self.cube[0, :, :, :]
         result = enforce_coordinate_ordering(
             cube, "realization", promote_scalar=True)
@@ -1684,8 +1684,8 @@ class Test_enforce_coordinate_ordering(IrisTest):
 
     def test_do_not_promote_scalar(self):
         """Test that a cube with the expected data contents is returned when
-        the probabilistic dimension is a scalar coordinate, where the scalar
-        coordinate is not promoted to a dimension coordinate."""
+        the probabilistic dimension is a scalar coordinate, which is not
+        promoted to a dimension coordinate."""
         cube = self.cube[0, :, :, :]
         result = enforce_coordinate_ordering(cube, "realization")
         self.assertFalse(result.coord_dims("realization"))

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -50,6 +50,7 @@ class Test_load_cube(IrisTest):
 
     """Test the load function."""
     def setUp(self):
+        """Set up variables for use in testing."""
         self.directory = mkdtemp()
         self.filepath = self.directory+"temp.nc"
         self.cube = set_up_temperature_cube()
@@ -186,7 +187,7 @@ class Test_load_cubelist(IrisTest):
         """Test that the loading works correctly, if a wildcarded filepath is
         provided."""
         filepath = self.directory+"*.nc"
-        result = load_cubelist(self.filepath)
+        result = load_cubelist(filepath)
         self.assertIsInstance(result, iris.cube.CubeList)
         self.assertArrayAlmostEqual(
             result[0].coord("realization").points, self.realization_points)

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -216,7 +216,7 @@ class Test_load_cubelist(IrisTest):
 
     def test_wildcard_files_with_constraint(self):
         """Test that the loading works correctly, if a wildcarded filepath is
-        provided and a constraint is provide that is only valid for a subset
+        provided and a constraint is provided that is only valid for a subset
         of the available files."""
         low_cloud_cube = self.cube.copy()
         low_cloud_cube.rename("low_type_cloud_area_fraction")

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -218,7 +218,6 @@ class Test_load_cubelist(IrisTest):
         """Test that the loading works correctly, if a wildcarded filepath is
         provided and a constraint is provide that is only valid for a subset
         of the available files."""
-        filepath = self.directory+"*.nc"
         low_cloud_cube = self.cube.copy()
         low_cloud_cube.rename("low_type_cloud_area_fraction")
         low_cloud_filepath = self.directory+"low_cloud.nc"

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -155,6 +155,7 @@ class Test_load_cubelist(IrisTest):
 
     """Test the load function."""
     def setUp(self):
+        """Set up variables for use in testing."""
         self.directory = mkdtemp()
         self.filepath = self.directory+"temp.nc"
         self.cube = set_up_temperature_cube()

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -214,6 +214,33 @@ class Test_load_cubelist(IrisTest):
             self.assertArrayAlmostEqual(
                 cube.coord("longitude").points, self.longitude_points)
 
+    def test_wildcard_files_with_constraint(self):
+        """Test that the loading works correctly, if a wildcarded filepath is
+        provided and a constraint is provide that is only valid for a subset
+        of the available files."""
+        filepath = self.directory+"*.nc"
+        low_cloud_cube = self.cube.copy()
+        low_cloud_cube.rename("low_type_cloud_area_fraction")
+        low_cloud_filepath = self.directory+"low_cloud.nc"
+        iris.save(low_cloud_cube, low_cloud_filepath)
+        medium_cloud_cube = self.cube.copy()
+        medium_cloud_cube.rename("medium_type_cloud_area_fraction")
+        medium_cloud_filepath = self.directory+"medium_cloud.nc"
+        iris.save(medium_cloud_cube, medium_cloud_filepath)
+        constr = iris.Constraint("low_type_cloud_area_fraction")
+        result = load_cubelist(
+            [low_cloud_filepath, medium_cloud_filepath], constraints=constr)
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertEqual(len(result), 1)
+        self.assertArrayAlmostEqual(
+            result[0].coord("realization").points, self.realization_points)
+        self.assertArrayAlmostEqual(
+            result[0].coord("time").points, self.time_points)
+        self.assertArrayAlmostEqual(
+            result[0].coord("latitude").points, self.latitude_points)
+        self.assertArrayAlmostEqual(
+            result[0].coord("longitude").points, self.longitude_points)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for loading functionality."""
+
+from subprocess import call as Call
+from tempfile import mkdtemp
+import unittest
+
+import iris
+from iris.tests import IrisTest
+import numpy as np
+
+from improver.utilities.load import load
+
+from improver.tests.ensemble_calibration.ensemble_calibration.\
+    helper_functions import set_up_temperature_cube
+
+iris.FUTURE.netcdf_no_unlimited = True
+
+
+class Test_load(IrisTest):
+
+    """Test the load function."""
+    def setUp(self):
+        self.directory = mkdtemp()
+        self.filepath = self.directory+"temp.nc"
+        self.cube = set_up_temperature_cube()
+        iris.save(self.cube, self.filepath)
+        self.realization_points = np.array([0, 1, 2])
+        self.time_points = np.array(402192.5)
+        self.latitude_points = np.array([-45., 0., 45.])
+        self.longitude_points = np.array([120., 150., 180.])
+
+    def tearDown(self):
+        """Remove temporary directories created for testing."""
+        Call(['rm', '-f', self.filepath])
+        Call(['rmdir', self.directory])
+
+    def test_filepath_only(self):
+        """Test that the loading works correctly, if only the filepath is
+        provided."""
+        result = load(self.filepath)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertArrayAlmostEqual(
+            result.coord("realization").points, self.realization_points)
+        self.assertArrayAlmostEqual(
+            result.coord("time").points, self.time_points)
+        self.assertArrayAlmostEqual(
+            result.coord("latitude").points, self.latitude_points)
+        self.assertArrayAlmostEqual(
+            result.coord("longitude").points, self.longitude_points)
+
+    def test_constraint(self):
+        """Test that the loading works correctly, if a constraint is
+        specified."""
+        realization_points = np.array([0])
+        constr = iris.Constraint(realization=0)
+        result = load(self.filepath, constraints=constr)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertArrayAlmostEqual(
+            result.coord("realization").points, realization_points)
+        self.assertArrayAlmostEqual(
+            result.coord("time").points, self.time_points)
+        self.assertArrayAlmostEqual(
+            result.coord("latitude").points, self.latitude_points)
+        self.assertArrayAlmostEqual(
+            result.coord("longitude").points, self.longitude_points)
+
+    def test_multiple_constraints(self):
+        """Test that the loading works correctly, if multiple constraints are
+        specified."""
+        realization_points = np.array([0])
+        latitude_points = np.array([0])
+        constr1 = iris.Constraint(realization=0)
+        constr2 = iris.Constraint(latitude=lambda cell: -0.1 < cell < 0.1)
+        constr = constr1 & constr2
+        result = load(self.filepath, constraints=constr)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertArrayAlmostEqual(
+            result.coord("realization").points, realization_points)
+        self.assertArrayAlmostEqual(
+            result.coord("time").points, self.time_points)
+        self.assertArrayAlmostEqual(
+            result.coord("latitude").points, latitude_points)
+        self.assertArrayAlmostEqual(
+            result.coord("longitude").points, self.longitude_points)
+
+    def test_ordering(self):
+        """Test that cube has been reordered, if it is originally in an
+        undesirable order."""
+        filepath = self.directory+"temp.nc"
+        cube = set_up_temperature_cube()
+        cube.transpose([3, 2, 1, 0])
+        iris.save(cube, filepath)
+        result = load(filepath)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertArrayAlmostEqual(
+            result.coord("realization").points, self.realization_points)
+        self.assertArrayAlmostEqual(
+            result.coord("time").points, self.time_points)
+        self.assertArrayAlmostEqual(
+            result.coord("latitude").points, self.latitude_points)
+        self.assertArrayAlmostEqual(
+            result.coord("longitude").points, self.longitude_points)
+        self.assertEqual(result.coord_dims("realization")[0], 0)
+        self.assertEqual(result.coord_dims("time")[0], 1)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -30,12 +30,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """ Provides support utilities for cube manipulation."""
 
-from collections import OrderedDict
+import operator
 import warnings
 import numpy as np
 
 import iris
 from iris.coords import AuxCoord, DimCoord
+from iris.exceptions import CoordinateNotFoundError
 
 
 def _associate_any_coordinate_with_master_coordinate(
@@ -689,8 +690,8 @@ def sort_coord_in_cube(cube, coord, order="ascending"):
 
 
 def ensure_coordinate_ordering(
-        cube, coord_definitions, anchor="start", desired_ordering=None,
-        raise_exception=True):
+        cube, coord_names, anchor="start", desired_ordering=None,
+        raise_exception=False):
     """
     Function to ensure that the requested coordinate within the cube is
     the first dimension within the cube.
@@ -705,7 +706,7 @@ def ensure_coordinate_ordering(
         cube (iris.cube.Cube):
             Cube where the requirement for the required dimension to be the
             first dimension will be enforced.
-        coord_definitions (list or dict):
+        coord_names (list or dict):
             List of the names of the coordinates to order.
         anchor (str):
             String to define where within the range of possible dimensions
@@ -716,9 +717,8 @@ def ensure_coordinate_ordering(
         raise_exception (bool):
 
     """
-    if isinstance(coord_definitions, list):
-        name_list = ["name"] * len(coord_definitions)
-        coord_definitions = OrderedDict(zip(coord_definitions, name_list))
+    if isinstance(coord_names, str):
+        coord_names = [coord_names]
 
     if anchor not in ["start", "end"]:
         msg = ("The value for the anchor must be either 'start' or 'end'."
@@ -726,51 +726,54 @@ def ensure_coordinate_ordering(
         raise ValueError(msg)
 
     #if desired_ordering:
-        #if len(coord_definitions) != len(desired_ordering):
+        #if len(coord_names) != len(desired_ordering):
             #msg = ("The number of coordinates: {} is not equal to the number of "
                    #"values provided for the ordering.: {} The number of "
                    #"coordinates must equal the number of values provided "
-                   #"for the ordering.".format(coord_definitions, desired_ordering))
+                   #"for the ordering.".format(coord_names, desired_ordering))
             #raise ValueError(msg)
 
-    coord_indices = np.array(range(len(coord_definitions.keys())))
+    coord_indices = np.array(range(len(coord_names)))
     if anchor == "end":
         coord_indices = sorted(len(cube.dim_coords) - coord_indices)
 
-    for coord_index, coord_identifier in zip(
-            coord_indices, coord_definitions.keys()):
+    coord_dict = dict(zip(coord_names, coord_indices))
+
+    # 
+    for coord_name in coord_dict.keys():
         # Deal with the coord_name being a partial match to the actual
         # coordinate name.
-        if coord_definitions[coord_identifier] == "name":
-            coord_name = [c for c in cube.coords if coord_name in c]
-            coord_definitions[coord_identifier] = coord_name
-        elif coord_definitions[coord_identifier] == "axis":
-            coord_name = cube.coords(axis=coord_identifier).name()
+        coord = [c for c in cube.coords() if coord_name in c.name()]
+        if len(coord) == 0:
+            if raise_exception:
+                msg = ("The requested coordinate {} is not a coordinate "
+                      "in the cube: {}".format(coord, cube))
+                raise CoordinateNotFoundError(msg)
+            else:
+                continue
+        else:
+            full_coord_name = coord[0].name()
+            coord_dict[full_coord_name] = coord_dict.pop(coord_name)
 
-        if cube.coords(coord_name, dim_coords=True):
-            if cube.coord_dims(coord_name)[0] != coord_index:
-                remaining_coords = []
-                for acoord in cube.coords(dim_coords=True):
-                    if acoord.name() not in [coords]:
-                        remaining_coords.append(cube.coord_dims(acoord)[0])
-            remaining_coords = list(set(remaining_coords))
-        elif cube.coords(coord, dim_coords=False):
-            cube = iris.util.new_axis(cube, coord)
-        elif raise_exception:
-            msg = ("The coordinate {} is not a dimension coordinate "
-                  "in the cube: {}".format(coord, cube))
-            raise ValueError(msg)
+        if cube.coords(full_coord_name, dim_coords=False):
+            cube = iris.util.new_axis(cube, full_coord_name)
+
+    remaining_coords = []
+    for acoord in cube.coords(dim_coords=True):
+          if acoord.name() not in coord_dict.keys():
+            remaining_coords.append(cube.coord_dims(acoord)[0])
+    remaining_coords = list(set(remaining_coords))
 
     coord_dims = []
-    for coord in enumerate(coords):
-        if cube.coords(coord, dim_coords=True):
-            coord_dims.append(cube.coord_dims(coord)[0])
+    for coord_name, _ in sorted(coord_dict.items(), key=operator.itemgetter(1)):
+        if cube.coords(coord_name, dim_coords=True):
+            coord_dims.append(cube.coord_dims(coord_name)[0])
 
     if anchor == "start":
         cube.transpose(coord_dims+remaining_coords)
     elif anchor == "end":
         cube.transpose(remaining_coords+coord_dims)
-
+    print "cube = ", cube
     #if desired_ordering:
         #if len(coords) == len(cube.dim_coords):
             #cube.transpose(desired_ordering)

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -690,7 +690,8 @@ def sort_coord_in_cube(cube, coord, order="ascending"):
 
 
 def enforce_coordinate_ordering(
-        cube, coord_names, anchor="start", raise_exception=False):
+        cube, coord_names, anchor="start", promote_scalar=False,
+        raise_exception=False):
     """
     Function to ensure that the requested coordinate within the cube are in
     the desired position.
@@ -711,6 +712,11 @@ def enforce_coordinate_ordering(
             String to define where within the range of possible dimensions
             the specified coordinates should be located. This could be either:
             "start" or "end".
+        promote_scalar (bool):
+            If True, any coordinates that are matched and are not dimension
+            coordinates are promoted to dimension coordinates.
+            If False, any coordinates that are matched and are not dimension
+            coordinates will not be considered in the reordering.
         raise_exception (bool):
             Option as to whether an exception should be raised, if the
             requested coordinate is not present.
@@ -723,9 +729,9 @@ def enforce_coordinate_ordering(
     Raises:
         ValueError: The anchor argument must have a value of either start or
             end.
-       CoordinateNotFoundError: The requested coordinate is not available on
-           the cube.
-       ValueError: Multiple coordinates match the partial name provided.
+        CoordinateNotFoundError: The requested coordinate is not available on
+            the cube.
+        ValueError: Multiple coordinates match the partial name provided.
 
     """
     if isinstance(coord_names, unicode):
@@ -776,7 +782,10 @@ def enforce_coordinate_ordering(
         # If the requested coordinate is not a dimension coordinate, make it
         # a dimension coordinate.
         if cube.coords(full_coord_name, dim_coords=False):
-            cube = iris.util.new_axis(cube, full_coord_name)
+            if promote_scalar:
+                cube = iris.util.new_axis(cube, full_coord_name)
+            else:
+                coord_dict.pop(full_coord_name, None)
 
     # Get the dimensions for the coordinates that have not been requested.
     remaining_coords = []

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -30,6 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for loading cubes."""
 
+from collections import OrderedDict
+
 import iris
 
 
@@ -53,6 +55,8 @@ def load(filepath, constraints=None):
     cube = enforce_coordinate_order(
         cube, ["realization", "percentile_over", "probability"])
     # Ensure the y and x dimension are last.
+    y_name = cube.coord(axis="y").name()
+    x_name = cube.coord(axis="x").name()
     cube = enforce_coordinate_order(
-        cube, {"y": "axis", "x": "axis"}, anchor="end")
+        cube, [y_name, x_name], anchor="end")
     return cube

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -30,6 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for loading cubes."""
 
+import glob
+
 import iris
 
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
@@ -37,8 +39,8 @@ from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 iris.FUTURE.netcdf_promote = True
 
 
-def load(filepath, constraints=None):
-    """Load the filepath provided using Iris.
+def load_cube(filepath, constraints=None):
+    """Load the filepath provided using Iris into a cube.
 
     Args:
         filepath (str):
@@ -52,7 +54,7 @@ def load(filepath, constraints=None):
             constraints provided.
     """
     cube = iris.load_cube(filepath, constraints)
-    # Ensure the probabilistic dimensions are first.
+    # Ensure the coordinates are ordered as required.
     cube = enforce_coordinate_ordering(
         cube, ["realization", "percentile_over", "probability"])
     # Ensure the y and x dimensions are the last dimensions within the cube.
@@ -61,3 +63,29 @@ def load(filepath, constraints=None):
     cube = enforce_coordinate_ordering(
         cube, [y_name, x_name], anchor="end")
     return cube
+
+
+def load_cubelist(filepath, constraints=None):
+    """Load the filepath(s) provided using Iris into a cubelist.
+
+    Args:
+        filepath (str or list):
+            Filepath(s) that will be loaded.
+        constraints (iris.Constraint or None):
+            Iris constraint to be applied when loading from the input filepath.
+
+    Returns:
+        cubelist (iris.cube.CubeList):
+            CubeList that has been created from the input filepath given the
+            constraints provided.
+    """
+    if isinstance(filepath, str):
+        filepaths = glob.glob(filepath)
+    else:
+        filepaths = filepath
+    # Ensure the coordinates are ordered as required.
+    cubelist = iris.cube.CubeList([])
+    for filepath in filepaths:
+        cube = load_cube(filepath, constraints=constraints)
+        cubelist.append(cube)
+    return cubelist

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -30,9 +30,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for loading cubes."""
 
-from collections import OrderedDict
-
 import iris
+
+from improver.utilities.cube_manipulation import enforce_coordinate_ordering
+
+iris.FUTURE.netcdf_promote = True
 
 
 def load(filepath, constraints=None):
@@ -50,13 +52,12 @@ def load(filepath, constraints=None):
             constraints provided.
     """
     cube = iris.load_cube(filepath, constraints)
-
     # Ensure the probabilistic dimensions are first.
-    cube = enforce_coordinate_order(
+    cube = enforce_coordinate_ordering(
         cube, ["realization", "percentile_over", "probability"])
-    # Ensure the y and x dimension are last.
+    # Ensure the y and x dimensions are the last dimensions within the cube.
     y_name = cube.coord(axis="y").name()
     x_name = cube.coord(axis="x").name()
-    cube = enforce_coordinate_order(
+    cube = enforce_coordinate_ordering(
         cube, [y_name, x_name], anchor="end")
     return cube

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -45,23 +45,26 @@ def load_cube(filepath, constraints=None):
     Args:
         filepath (str):
             Filepath that will be loaded.
-        constraints (iris.Constraint or None):
-            Iris constraint to be applied when loading from the input filepath.
+        constraints (iris.Constraint, str or None):
+            Constraint to be applied when loading from the input filepath.
+            This can be in the form of an iris.Constraint or could be a string
+            that is intended to match the name of the cube.
+            The default is None.
 
     Returns:
         cube (iris.cube.Cube):
             Cube that has been loaded from the input filepath given the
             constraints provided.
     """
-    cube = iris.load_cube(filepath, constraints)
-    # Ensure the coordinates are ordered as required.
+    cube = iris.load_cube(filepath, constraint=constraints)
+    # Ensure the probabilistic coordinates are the first coordinates within a
+    # cube and are in the specified order.
     cube = enforce_coordinate_ordering(
         cube, ["realization", "percentile_over", "probability"])
     # Ensure the y and x dimensions are the last dimensions within the cube.
     y_name = cube.coord(axis="y").name()
     x_name = cube.coord(axis="x").name()
-    cube = enforce_coordinate_ordering(
-        cube, [y_name, x_name], anchor="end")
+    cube = enforce_coordinate_ordering(cube, [y_name, x_name], anchor="end")
     return cube
 
 
@@ -71,19 +74,24 @@ def load_cubelist(filepath, constraints=None):
     Args:
         filepath (str or list):
             Filepath(s) that will be loaded.
-        constraints (iris.Constraint or None):
-            Iris constraint to be applied when loading from the input filepath.
+        constraints (iris.Constraint, str or None):
+            Constraint to be applied when loading from the input filepath.
+            This can be in the form of an iris.Constraint or could be a string
+            that is intended to match the name of the cube.
+            The default is None.
 
     Returns:
         cubelist (iris.cube.CubeList):
             CubeList that has been created from the input filepath given the
             constraints provided.
     """
+    # If the filepath is a string, then use glob, in case the str contains
+    # wildcards.
     if isinstance(filepath, str):
         filepaths = glob.glob(filepath)
     else:
         filepaths = filepath
-    # Ensure the coordinates are ordered as required.
+    # Constuct a cubelist using the load_cube function.
     cubelist = iris.cube.CubeList([])
     for filepath in filepaths:
         cube = load_cube(filepath, constraints=constraints)

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -33,6 +33,7 @@
 import glob
 
 import iris
+from iris.exceptions import ConstraintMismatchError
 
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 
@@ -91,9 +92,13 @@ def load_cubelist(filepath, constraints=None):
         filepaths = glob.glob(filepath)
     else:
         filepaths = filepath
+
     # Constuct a cubelist using the load_cube function.
     cubelist = iris.cube.CubeList([])
     for filepath in filepaths:
-        cube = load_cube(filepath, constraints=constraints)
+        try:
+            cube = load_cube(filepath, constraints=constraints)
+        except ConstraintMismatchError:
+            continue
         cubelist.append(cube)
     return cubelist

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module for loading cubes."""
+
+import iris
+
+
+def load(filepath, constraints=None):
+    """Load the filepath provided using Iris.
+
+    Args:
+        filepath (str):
+            Filepath that will be loaded.
+        constraints (iris.Constraint or None):
+            Iris constraint to be applied when loading from the input filepath.
+
+    Returns:
+        cube (iris.cube.Cube):
+            Cube that has been loaded from the input filepath given the
+            constraints provided.
+    """
+    cube = iris.load_cube(filepath, constraints)
+
+    # Ensure the probabilistic dimensions are first.
+    cube = enforce_coordinate_order(
+        cube, ["realization", "percentile_over", "probability"])
+    # Ensure the y and x dimension are last.
+    cube = enforce_coordinate_order(
+        cube, {"y": "axis", "x": "axis"}, anchor="end")
+    return cube


### PR DESCRIPTION
#31 

A large number of files has been changed in this PR, although for most of these files the changes are minor. In summary, this PR adds load_cube, load_cubelist and enforce_coordinate_ordering functions and associated unit tests and subsequently proliferates the usage of these functions through the code, as appropriate.

A summary of the edits on a file-by-file basis is below:
- **lib/improver/utilities/load.py**   - Add load_cube and load_cubelist function to wrap iris.load_cube.
- **lib/improver/utilities/cube_manipulation.py**   - Add enforce_coordinate_ordering function.
- **lib/improver/tests/utilities/test_load.py**   - Add tests for the load_cube and load_cubelist functions that have been   added.
- **lib/improver/tests/utilities/test_cube_manipulation.py**   - Add tests for enforce_coordinate_ordering function.
- **lib/improver/tests/spotdata/spotdata/test_read_input.py**   - Remove tests for Load plugin.
- **lib/improver/tests/generate_ancillaries/test_generate_ancillary.py**   - Remove tests on find_standard_ancil function.
- **.../tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py**   - Remove tests on ensure_dimension_is_the_zeroth_dimension coordinate.
- **lib/improver/spotdata/read_input.py**   - Remove Load plugin to avoid having multiple methods for loading cubes.
- **lib/improver/spotdata/ancillaries.py**   - Replace use of find_standard_ancil with functions from the load module.
- **lib/improver/generate_ancillaries/generate_ancillary.py**   - Remove find_standard_ancil function to avoid having multiple methods for   loading cubes.
- **lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_utilities.py**   - Replace ensure_dimension_is_the_zeroth_dimension function with   enforce_coordinate_ordering.
- **lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py**   - Use of the ensure_dimension_is_the_zeroth_dimension function has been   replaced by enforce_coordinate_ordering.
- **lib/improver/ensemble_calibration/ensemble_calibration_utilities.py**   - Removed ensure_dimension_is_the_zeroth_dimension function.
- **lib/improver/ensemble_calibration/ensemble_calibration.py**   - Use of the ensure_dimension_is_the_zeroth_dimension function has been   replaced by enforce_coordinate_ordering.
- For all CLIs, usage of iris.load or iris.load_cube has been replaced with usage   of the functions from the load module, either load_cube or load_cubelist.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
