### PR TITLE
Coordinate precision preservation in conform_metadata

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -105,6 +105,9 @@ def conform_metadata(
                 new_cycletime = cycletime_to_number(
                     cycletime, time_unit=cycletime_units,
                     calendar=cycletime_calendar)
+                # Preserve the data type to avoid converting ints to floats.
+                fr_type = cube.coord("forecast_reference_time").dtype
+                new_cycletime = np.round(new_cycletime).astype(fr_type)
             cube.coord("forecast_reference_time").points = new_cycletime
             cube.coord("forecast_reference_time").bounds = None
 

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -149,6 +149,7 @@ def forecast_period_coord(
         time_units = cube.coord("time").units
         t_coord = cube.coord("time")
         fr_coord = cube.coord("forecast_reference_time")
+        fr_type = fr_coord.dtype
         try:
             fr_coord.convert_units(time_units)
         except ValueError as err:
@@ -163,7 +164,7 @@ def forecast_period_coord(
             time_points - forecast_reference_time_points)
         # Convert the timedeltas to a total in seconds.
         required_lead_times = np.array(
-            [x.total_seconds() for x in required_lead_times])
+            [x.total_seconds() for x in required_lead_times]).astype(fr_type)
         coord_type = iris.coords.AuxCoord
         if cube.coords("forecast_period"):
             if isinstance(


### PR DESCRIPTION
Added statements to preserve input precision when calculating new forecast reference times and forecast periods using the conform metadata utility and associated utilities in temporal.py.

New acceptance test data due to type change; location available from me.

Testing:
 - [x] Ran tests and they passed OK
