### PR TITLE
Fix to coordinate reordering in PercentileAggregator

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -535,11 +535,18 @@ class WeightedBlendAcrossWholeDimension(object):
                 if perc_coord and self.mode == "weighted_mean":
                     percentiles = np.array(perc_coord.points, dtype=float)
                     perc_dim, = cube_thres.coord_dims(perc_coord.name())
-                    # The Iris aggregate method moves the collapse coordinate
-                    # to index=-1, so we must adjust perc_dim if moving the
-                    # collapse coordinate moves the perc_dim as well.
+
+                    # The iris.analysis.Aggregator moves the coordinate being
+                    # collapsed to index=-1 in initialisation, before the
+                    # aggregation method is called. This reduces by 1 the index
+                    # of all coordinates with an initial index higher than the
+                    # collapsing coordinate. As we need to know the index of
+                    # the percentile coordinate at a later step, if it will be
+                    # changed by this process, we adjust our record (perc_dim)
+                    # here.
                     if cube_thres.coord_dims(self.coord)[0] < perc_dim:
                         perc_dim -= 1
+
                     # Set equal weights if none are provided
                     if weights is None:
                         num = len(cube_thres.coord(self.coord).points)

--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -213,7 +213,6 @@ class PercentileBlendingAggregator(object):
         # Firstly ensure axis coordinate and percentile coordinate
         # are indexed as the first and second values in the data array
         data = np.moveaxis(data, [perc_dim, axis], [1, 0])
-
         # Determine the rest of the shape
         shape = data.shape[2:]
         input_shape = [data.shape[0],
@@ -536,6 +535,11 @@ class WeightedBlendAcrossWholeDimension(object):
                 if perc_coord and self.mode == "weighted_mean":
                     percentiles = np.array(perc_coord.points, dtype=float)
                     perc_dim, = cube_thres.coord_dims(perc_coord.name())
+                    # The Iris aggregate method moves the collapse coordinate
+                    # to index=-1, so we must adjust perc_dim if moving the
+                    # collapse coordinate moves the perc_dim as well.
+                    if cube_thres.coord_dims(self.coord)[0] < perc_dim:
+                        perc_dim -= 1
                     # Set equal weights if none are provided
                     if weights is None:
                         num = len(cube_thres.coord(self.coord).points)
@@ -544,7 +548,6 @@ class WeightedBlendAcrossWholeDimension(object):
                     PERCENTILE_BLEND = (Aggregator(
                         'weighted_mean',
                         PercentileBlendingAggregator.aggregate))
-
                     cube_new = cube_thres.collapsed(self.coord,
                                                     PERCENTILE_BLEND,
                                                     arr_percent=percentiles,

--- a/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -322,6 +322,26 @@ class Test_process(IrisTest):
                                            (6, 2, 2))
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
+    def test_percentiles_different_coordinate_orders(self):
+        """Test the result of the percentile aggregation is the same
+        regardless of the coordinate order in the input cube. Most
+        importantly, the result should be the same regardless of on which
+        side of the collapsing coordinate the percentile coordinate falls."""
+        coord = "time"
+        plugin = WeightedBlendAcrossWholeDimension(coord, 'weighted_mean')
+        weights = None
+        percentile_leading = percentile_cube()
+        time_leading = percentile_cube()
+        time_leading.transpose([1, 0, 2, 3])
+        result_percentile_leading = plugin.process(percentile_leading, weights)
+        result_time_leading = plugin.process(time_leading, weights)
+        expected_result_array = np.reshape(BLENDED_PERCENTILE_DATA1,
+                                           (6, 2, 2))
+        self.assertArrayAlmostEqual(result_percentile_leading.data,
+                                    expected_result_array)
+        self.assertArrayAlmostEqual(result_time_leading.data,
+                                    expected_result_array)
+
     def test_weighted_max_weights_none(self):
         """Test it works for weighted max with weights set to None."""
         coord = "time"


### PR DESCRIPTION
The iris aggregate method always moves the dimension being collapsed to the -1 index position. This is hardcoded in iris. As the percentile aggregator stands it works out the percentile coordinate index (perc_dim) before this happens, and then uses it after it happens. As such the np.moveaxis that occurs in the top of our custom aggregate function within PercentileBlendingAggregator gets a bit confused and the data array ends up oddly shaped. This PR addresses this issue.

This is not picked up in the acceptance tests as the percentile coordinate precedes the coordinate being collapsed in the input data, thus moving the latter does not affect the index of the former. We could consider capturing this, but once it is fixed it is probably not necessary.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)