### PR TITLE
Changing an error to a warning in ensemble_copula_coupling and modify…

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -32,6 +32,7 @@
 This module defines the plugins required for Ensemble Copula Coupling.
 
 """
+import warnings
 import numpy as np
 from scipy.stats import norm
 
@@ -413,7 +414,7 @@ class GeneratePercentilesFromProbabilities(object):
                    "must be ascending i.e. in order to yield "
                    "a monotonically increasing CDF."
                    "The probabilities are {}".format(probabilities_for_cdf))
-            raise ValueError(msg)
+            warnings.warn(msg)
 
         # Convert percentiles into fractions.
         percentiles = [x/100.0 for x in percentiles]

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -344,7 +344,8 @@ class Test__probabilities_to_percentiles(IrisTest):
         warning_msg = "The probability values used to construct the"
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter("always")
-            plugin._probabilities_to_percentiles(cube, percentiles, bounds_pairing)
+            plugin._probabilities_to_percentiles(
+                cube, percentiles, bounds_pairing)
             self.assertTrue(any(warning_msg in str(item)
                                 for item in warning_list))
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -33,6 +33,7 @@ Unit tests for the
 `ensemble_copula_coupling.GeneratePercentilesFromProbabilities` class.
 
 """
+import warnings
 import numpy as np
 import unittest
 
@@ -323,7 +324,7 @@ class Test__probabilities_to_percentiles(IrisTest):
 
     def test_probabilities_not_monotonically_increasing(self):
         """
-        Test that the plugin raises a ValueError when the probabilities
+        Test that the plugin raises a Warning when the probabilities
         of the Cumulative Distribution Function are not monotonically
         increasing.
         """
@@ -340,10 +341,12 @@ class Test__probabilities_to_percentiles(IrisTest):
         percentiles = [10, 50, 90]
         bounds_pairing = (-40, 50)
         plugin = Plugin()
-        msg = "The probability values used to construct the"
-        with self.assertRaisesRegexp(ValueError, msg):
-            plugin._probabilities_to_percentiles(
-                cube, percentiles, bounds_pairing)
+        warning_msg = "The probability values used to construct the"
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            plugin._probabilities_to_percentiles(cube, percentiles, bounds_pairing)
+            self.assertTrue(any(warning_msg in str(item)
+                                for item in warning_list))
 
     def test_result_cube_has_no_air_temperature_threshold_coordinate(self):
         """


### PR DESCRIPTION
…ing the unit test

I have changed the ensemble_copula_coupling.py (probabilities to percentiles) so that it now generates a warning if the probabilities of the cumulative distribution function are not monotonically increasing. Before this change it raised an error. I have also changed the unit test to reflect this change.

Testing:
 - [X] Ran tests and they passed OK
 - [X] Modified existing test to reflect the small change

