### PR TITLE
Fix to the wind-gust diagnostic (IMPRO 361)

### DIFF
--- a/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -323,6 +323,16 @@ class Test_process(IrisTest):
         with self.assertRaisesRegexp(ValueError, msg):
             plugin.process(cube_wg, self.cube_ws)
 
+    def test_raises_error_points_mismatch_and_invalid_bounds(self):
+        """Test raises Value Error if points mismatch and bounds are invalid"""
+        cube_wg = self.cube_wg
+        cube_wg.coord('time').points = [402192.0, 402193.0]
+        cube_wg.coord('time').bounds = [[402191.5], [402193.5]]
+        plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
+        msg = ('Could not match time coordinate')
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.process(cube_wg, self.cube_ws)
+
     def test_no_raises_error_if_ws_point_in_bounds(self):
         """Test raises no Value Error if wind-speed point in bounds """
         cube_wg = self.cube_wg

--- a/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -158,7 +158,7 @@ class Test_update_metadata_after_max(IrisTest):
             self.cube = cube.collapsed(self.perc_coord, iris.analysis.MAX)
 
     def test_basic(self):
-        """Test that the function returns a Cube AAAA. """
+        """Test that the function returns a Cube. """
         plugin = WindGustDiagnostic(50.0, 95.0)
         result = plugin.update_metadata_after_max(self.cube,
                                                   self.perc_coord)

--- a/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -154,10 +154,11 @@ class Test_update_metadata_after_max(IrisTest):
         self.perc_coord = DimCoord(percentile_values,
                                    long_name="percentile_over_nbhood",
                                    units="%")
-        self.cube = cube.collapsed(self.perc_coord, iris.analysis.MAX)
+        with warnings.catch_warnings(record=True):
+            self.cube = cube.collapsed(self.perc_coord, iris.analysis.MAX)
 
     def test_basic(self):
-        """Test that the function returns a Cube. """
+        """Test that the function returns a Cube AAAA. """
         plugin = WindGustDiagnostic(50.0, 95.0)
         result = plugin.update_metadata_after_max(self.cube,
                                                   self.perc_coord)
@@ -290,6 +291,48 @@ class Test_process(IrisTest):
                'does not match coord of wind-speed data')
         with self.assertRaisesRegexp(ValueError, msg):
             plugin.process(cube_wg, self.cube_ws)
+
+    def test_raises_error_for_no_time_coord(self):
+        """Test raises Value Error if cubes have no time coordinate """
+        cube_wg = self.cube_wg[:, 0, ::]
+        cube_ws = self.cube_ws[:, 0, ::]
+        cube_wg.remove_coord('time')
+        cube_wg = iris.util.squeeze(cube_wg)
+        plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
+        msg = ('Could not match time coordinate')
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.process(cube_wg, cube_ws)
+
+    def test_raises_error_points_mismatch_and_no_bounds(self):
+        """Test raises Value Error if points mismatch and no bounds """
+        cube_wg = self.cube_wg
+        cube_wg.coord('time').points = [402192.5, 402194.5]
+        plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
+        msg = ('Could not match time coordinate')
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.process(cube_wg, self.cube_ws)
+
+    def test_raises_error_points_mismatch_and_bounds(self):
+        """Test raises Value Error if both points and bounds mismatch """
+        cube_wg = self.cube_wg
+        cube_wg.coord('time').points = [402192.0, 402193.0]
+        cube_wg.coord('time').bounds = [[402191.0, 402192.0],
+                                        [402192.0, 402193.0]]
+        plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
+        msg = ('Could not match time coordinate')
+        with self.assertRaisesRegexp(ValueError, msg):
+            plugin.process(cube_wg, self.cube_ws)
+
+    def test_no_raises_error_if_ws_point_in_bounds(self):
+        """Test raises no Value Error if wind-speed point in bounds """
+        cube_wg = self.cube_wg
+        cube_wg.coord('time').points = [402192.0, 402193.0]
+        cube_wg.coord('time').bounds = [[402191.5, 402192.5],
+                                        [402192.5, 402193.5]]
+
+        plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
+        result = plugin.process(cube_wg, self.cube_ws)
+        self.assertIsInstance(result, Cube)
 
     def test_returns_wind_gust_diagnostic(self):
         """Test that the plugin returns a Cube. """

--- a/lib/improver/wind_gust_diagnostic.py
+++ b/lib/improver/wind_gust_diagnostic.py
@@ -35,7 +35,6 @@ import warnings
 import iris
 from iris import FUTURE
 
-from improver.utilities.cube_manipulation import merge_cubes
 from improver.utilities.cube_checker import find_percentile_coordinate
 from improver.cube_combiner import CubeCombiner
 
@@ -201,6 +200,20 @@ class WindGustDiagnostic(object):
                    'does not match coord of wind-speed data'
                    ' {0:s} {1:s}.'.format(perc_coord_gust.name(),
                                           perc_coord_ws.name()))
+            raise ValueError(msg)
+
+        # Check times are compatible.
+        msg = ('Could not match time coordinate')
+        try:
+            wg_time = req_cube_gust.coord('time')
+            ws_time = req_cube_ws.coord('time')
+            for i, point in enumerate(wg_time.points):
+                if point != ws_time.points[i]:
+                    if ws_time.points[i] < wg_time.bounds[i][0]:
+                        raise ValueError(msg)
+                    elif ws_time.points[i] > wg_time.bounds[i][1]:
+                        raise ValueError(msg)
+        except:
             raise ValueError(msg)
 
         # Add metadata to gust cube

--- a/lib/improver/wind_gust_diagnostic.py
+++ b/lib/improver/wind_gust_diagnostic.py
@@ -31,7 +31,7 @@
 """Module containing plugin for WindGustDiagnostic."""
 
 import warnings
-import numpy as np
+
 import iris
 from iris import FUTURE
 

--- a/lib/improver/wind_gust_diagnostic.py
+++ b/lib/improver/wind_gust_diagnostic.py
@@ -204,17 +204,26 @@ class WindGustDiagnostic(object):
 
         # Check times are compatible.
         msg = ('Could not match time coordinate')
-        try:
-            wg_time = req_cube_gust.coord('time')
-            ws_time = req_cube_ws.coord('time')
-            for i, point in enumerate(wg_time.points):
-                if point != ws_time.points[i]:
-                    if ws_time.points[i] < wg_time.bounds[i][0]:
-                        raise ValueError(msg)
-                    elif ws_time.points[i] > wg_time.bounds[i][1]:
-                        raise ValueError(msg)
-        except:
+        wg_time = req_cube_gust.coords('time')
+        ws_time = req_cube_ws.coords('time')
+        if len(wg_time) == 0 or len(ws_time) == 0:
             raise ValueError(msg)
+        wg_time = wg_time[0]
+        ws_time = ws_time[0]
+        for i, point in enumerate(wg_time.points):
+            if point != ws_time.points[i]:
+                if wg_time.bounds is None:
+                    raise ValueError(msg)
+                if len(wg_time.bounds) >= i:
+                    if len(wg_time.bounds[i]) == 2:
+                        if ws_time.points[i] < wg_time.bounds[i][0]:
+                            raise ValueError(msg)
+                        elif ws_time.points[i] > wg_time.bounds[i][1]:
+                            raise ValueError(msg)
+                    else:
+                        raise ValueError(msg)
+                else:
+                    raise ValueError(msg)
 
         # Add metadata to gust cube
         req_cube_gust = self.add_metadata(req_cube_gust)


### PR DESCRIPTION
The current wind_gust_diagnostic code will not cope with wind-gust data which is max over the hour. This data reports mid-point in period so the time is 1/2 past the hour and forecast period is ?.5. The data will not match up with the instantaneous wind-speed data and so can not be merged into the same cube as the code currently stands. This change makes use of the CubeCombiner code to resolve the issue with max wind-gust data.

Testing:
 - [X] Ran tests and they passed OK
New CLI data is required as the old version loses _FillValue when the cube is collapsed.