### PR TITLE
snow falling level: no lazy load for speed

### DIFF
--- a/bin/improver-snow-falling-level
+++ b/bin/improver-snow-falling-level
@@ -78,10 +78,10 @@ def main():
                               "derived value."))
     args = parser.parse_args()
 
-    temperature = load_cube(args.temperature)
-    relative_humidity = load_cube(args.relative_humidity)
-    pressure = load_cube(args.pressure)
-    orog = load_cube(args.orography)
+    temperature = load_cube(args.temperature, no_lazy_load=True)
+    relative_humidity = load_cube(args.relative_humidity, no_lazy_load=True)
+    pressure = load_cube(args.pressure, no_lazy_load=True)
+    orog = load_cube(args.orography, no_lazy_load=True)
 
     result = FallingSnowLevel(
         precision=args.precision,

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -150,6 +150,26 @@ class Test_load_cube(IrisTest):
         self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
         self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 3)
 
+    def test_no_lazy_load(self):
+        """Test that the loading works correctly with lazy load bypassing."""
+        result = load_cube(self.filepath, no_lazy_load=True)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertFalse(result.has_lazy_data())
+        self.assertArrayAlmostEqual(
+            result.coord("realization").points, self.realization_points)
+        self.assertArrayAlmostEqual(
+            result.coord("time").points, self.time_points)
+        self.assertArrayAlmostEqual(
+            result.coord("latitude").points, self.latitude_points)
+        self.assertArrayAlmostEqual(
+            result.coord("longitude").points, self.longitude_points)
+
+    def test_lazy_load(self):
+        """Test that the loading works correctly with lazy loading."""
+        result = load_cube(self.filepath)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertTrue(result.has_lazy_data())
+
 
 class Test_load_cubelist(IrisTest):
 
@@ -239,6 +259,30 @@ class Test_load_cubelist(IrisTest):
             result[0].coord("latitude").points, self.latitude_points)
         self.assertArrayAlmostEqual(
             result[0].coord("longitude").points, self.longitude_points)
+
+    def test_no_lazy_load(self):
+        """Test that the loading works correctly with lazy load bypassing."""
+        result = load_cubelist([self.filepath, self.filepath],
+                               no_lazy_load=True)
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertArrayEqual([False, False],
+                              [_.has_lazy_data() for _ in result])
+        for cube in result:
+            self.assertArrayAlmostEqual(
+                cube.coord("realization").points, self.realization_points)
+            self.assertArrayAlmostEqual(
+                cube.coord("time").points, self.time_points)
+            self.assertArrayAlmostEqual(
+                cube.coord("latitude").points, self.latitude_points)
+            self.assertArrayAlmostEqual(
+                cube.coord("longitude").points, self.longitude_points)
+
+    def test_lazy_load(self):
+        """Test that the loading works correctly with lazy loading."""
+        result = load_cubelist([self.filepath, self.filepath])
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertArrayEqual([True, True],
+                              [_.has_lazy_data() for _ in result])
 
 
 if __name__ == '__main__':

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -40,7 +40,7 @@ from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 iris.FUTURE.netcdf_promote = True
 
 
-def load_cube(filepath, constraints=None):
+def load_cube(filepath, constraints=None, no_lazy_load=False):
     """Load the filepath provided using Iris into a cube.
 
     Args:
@@ -51,6 +51,10 @@ def load_cube(filepath, constraints=None):
             This can be in the form of an iris.Constraint or could be a string
             that is intended to match the name of the cube.
             The default is None.
+        no_lazy_load (bool)
+            If True, bypass cube deferred (lazy) loading and load the whole
+            cube into memory. This can increase performance at the cost of
+            memory. If False (default) then lazy load.
 
     Returns:
         cube (iris.cube.Cube):
@@ -66,10 +70,13 @@ def load_cube(filepath, constraints=None):
     y_name = cube.coord(axis="y").name()
     x_name = cube.coord(axis="x").name()
     cube = enforce_coordinate_ordering(cube, [y_name, x_name], anchor="end")
+    if no_lazy_load:
+        # Force the cube's data into memory by touching the .data attribute.
+        cube.data
     return cube
 
 
-def load_cubelist(filepath, constraints=None):
+def load_cubelist(filepath, constraints=None, no_lazy_load=False):
     """Load the filepath(s) provided using Iris into a cubelist.
 
     Args:
@@ -80,6 +87,10 @@ def load_cubelist(filepath, constraints=None):
             This can be in the form of an iris.Constraint or could be a string
             that is intended to match the name of the cube.
             The default is None.
+        no_lazy_load (bool)
+            If True, bypass cube deferred (lazy) loading and load the whole
+            cube into memory. This can increase performance at the cost of
+            memory. If False (default) then lazy load.
 
     Returns:
         cubelist (iris.cube.CubeList):
@@ -100,5 +111,8 @@ def load_cubelist(filepath, constraints=None):
             cube = load_cube(filepath, constraints=constraints)
         except ConstraintMismatchError:
             continue
+        if no_lazy_load:
+            # Force the cube's data into memory by touching the .data.
+            cube.data
         cubelist.append(cube)
     return cubelist


### PR DESCRIPTION
Snow falling level can take over an hour to run for a single lead time with input NetCDF with realization, height, x, y sizes of roughly 12, 30, 1000, 1000.

Profiling shows this is mainly (3000 seconds) due to inefficiencies in accessing the cube data,
with the rest being mainly numpy griddata interpolation.

We've seen this kind of problem before, so I think it would be good to have a generic solution.

This modifies our load wrapper to allow the option of disabling of Iris 1's lazy loading, at a cost in memory. Individual calls to the CLI are now ~4 times faster, although we can only run around half as many as once given the memory increase - so an increase of x2 from a suite point of view.

It looks like porting to Iris 2 (rc1) is non-trivial - there are now some interesting unit test failures in some areas that deal with masked array processing - otherwise we could have just done that instead.

Relates to #330.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
