### PR TITLE
Retire make_stat_coordinate_first

### DIFF
--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -45,7 +45,8 @@ from improver.spotdata.common_functions import (nearest_n_neighbours,
                                                 node_edge_check)
 from improver.constants import (R_DRY_AIR,
                                 CP_DRY_AIR)
-from improver.utilities.cube_manipulation import build_coordinate
+from improver.utilities.cube_manipulation import (
+    build_coordinate, enforce_coordinate_ordering)
 
 
 class ExtractData(object):
@@ -182,49 +183,6 @@ class ExtractData(object):
                 'utc_offset': {'units': 'hours', 'data_type': float,
                                'coord_type': AuxCoord}}
 
-    @staticmethod
-    def make_stat_coordinate_first(cube):
-        """
-        Reorder cube dimension coordinates to ensure the statistical
-        coordinate is first.
-
-        Args:
-            cube (iris.cube.Cube):
-                The cube to be reordered.
-
-        Returns:
-            cube (iris.cube.Cube):
-                Cube with the statistical coordinate moved to be first.
-
-        Raises:
-            Warning if more than one statistical dimension is found. Then
-            promotes the first found to become the leading dimension.
-
-        """
-        stat_coordinates = ['realization', 'percentile_over']
-        cube_dimension_order = {
-            coord.name(): cube.coord_dims(coord.name())[0]
-            for coord in cube.dim_coords}
-
-        stat_coord = []
-        for crd in stat_coordinates:
-            stat_coord += [coord for coord in cube_dimension_order.keys()
-                           if crd in coord]
-        if len(stat_coord) >= 1:
-            if len(stat_coord) > 1:
-                msg = ('More than one statistical coordinate found. Promoting '
-                       'the first found, {}, to the leading dimension.'.format(
-                           stat_coord))
-                warnings.warn(msg)
-
-            stat_index = cube_dimension_order[stat_coord[0]]
-            new_order = range(len(cube_dimension_order))
-            new_order.pop(stat_index)
-            new_order.insert(0, stat_index)
-            cube.transpose(new_order)
-
-        return cube
-
     def make_cube(self, cube, data, sites):
         """
         Construct and return a cube containing the data extracted from the
@@ -320,8 +278,9 @@ class ExtractData(object):
         # to a standard name if possible.
         result_cube.rename(cube.name())
 
-        # Promote any statistical coordinates to be first.
-        result_cube = self.make_stat_coordinate_first(result_cube)
+        # Promote any statistical coordinate to be first.
+        result_cube = enforce_coordinate_ordering(
+            result_cube, ["realization", "percentile_over", "threshold"])
         return result_cube
 
     def use_nearest(self, cube, sites, neighbours):

--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -278,9 +278,8 @@ class ExtractData(object):
         # to a standard name if possible.
         result_cube.rename(cube.name())
 
-        # Promote any statistical coordinate to be first.
         result_cube = enforce_coordinate_ordering(
-            result_cube, ["realization", "percentile_over", "threshold"])
+            result_cube, ["realization", "percentile_over"])
         return result_cube
 
     def use_nearest(self, cube, sites, neighbours):

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -317,65 +317,6 @@ class Test_ExtractData(Test_setup):
                            **self.kwargs)
 
 
-class Test_make_stat_coordinate_first(Test_setup):
-    """Test the function to reorder a cube to ensure the statistical coordinate
-    is the first dimension."""
-
-    def test_cube_reorder_realization(self):
-        """Test reordering a cube with a realization coordinate to make it come
-        first."""
-
-        plugin = Plugin().make_stat_coordinate_first
-        cube = set_up_cube(
-            zero_point_indices=(
-                (0, 0, 2, 2), (1, 0, 3, 3), (0, 1, 0, 0), (1, 1, 2, 1)),
-            num_time_points=2, num_grid_points=5, num_realization_points=2)
-        incorrect_cube = cube.copy()
-        incorrect_cube.transpose([1, 2, 0, 3])
-        result = plugin(incorrect_cube)
-        self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
-        self.assertEqual(cube.coords(), result.coords())
-
-    def test_cube_reorder_percentile(self):
-        """Test reordering a cube with a percentile coordinate to make it come
-        first."""
-
-        plugin = Plugin().make_stat_coordinate_first
-        cube = set_up_cube(
-            zero_point_indices=(
-                (0, 0, 2, 2), (1, 0, 3, 3), (0, 1, 0, 0), (1, 1, 2, 1)),
-            num_time_points=2, num_grid_points=5, num_realization_points=2)
-        cube.coords()[0].rename('percentile_over_time')
-        incorrect_cube = cube.copy()
-        incorrect_cube.transpose([1, 2, 0, 3])
-        result = plugin(incorrect_cube)
-        self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
-        self.assertEqual(cube.coords(), result.coords())
-
-    def test_cube_reorder_percentile_and_realization(self):
-        """Test reordering a cube with a percentile and a realization
-        coordinate. Should produce a warning and promote the first statistical
-        coordinate that is found."""
-
-        plugin = Plugin().make_stat_coordinate_first
-        cube = set_up_cube(
-            zero_point_indices=(
-                (0, 0, 2, 2), (1, 0, 3, 3), (0, 1, 0, 0), (1, 1, 2, 1)),
-            num_time_points=2, num_grid_points=5, num_realization_points=2)
-        realization = cube.coords()[0][0].copy()
-        cube.coords()[0].rename('percentile_over_time')
-        cube.add_aux_coord(realization)
-        cube = iris.util.new_axis(cube, 'realization')
-        incorrect_cube = cube.copy()
-        incorrect_cube.transpose([2, 1, 0, 3, 4])
-        with warnings.catch_warnings(record=True) as w_messages:
-            result = plugin(incorrect_cube)
-            assert len(w_messages) == 1
-            assert issubclass(w_messages[0].category, UserWarning)
-            assert "More than one statistical" in str(w_messages[0])
-        self.assertEqual(cube.coords()[0].name(), result.coords()[0].name())
-
-
 class Test_make_cube(Test_setup):
     """Test the creation of spotdata cubes."""
 

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -207,6 +207,6 @@ class BasicThreshold(object):
         cube.units = Unit(1)
 
         cube = enforce_coordinate_ordering(
-            cube, ["realization", "percentile_over", "threshold"])
+            cube, ["realization", "percentile_over"])
 
         return cube

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -34,7 +34,7 @@
 import numpy as np
 import iris
 from cf_units import Unit
-from improver.spotdata.extract_data import ExtractData
+from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 from improver.utilities.rescale import rescale
 
 
@@ -206,6 +206,7 @@ class BasicThreshold(object):
         cube.rename("probability_of_{}".format(cube.name()))
         cube.units = Unit(1)
 
-        cube = ExtractData.make_stat_coordinate_first(cube)
+        cube = enforce_coordinate_ordering(
+            cube, ["realization", "percentile_over", "threshold"])
 
         return cube


### PR DESCRIPTION
Refactoring to remove make_stat_coordinate_first function, in favour of more generic enforce_coordinate_ordering function.

Issues: #384 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

