### PR TITLE
Impro426: use of local_keys to restrict netcdf global attributes

### DIFF
--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-extension-pkg-whitelist=numpy,scipy
+extension-pkg-whitelist=numpy,scipy,netCDF4
 
 [TYPECHECK]
 ignored-classes=data,list,tuple,WeightedAggregator,MaskedArray,PercentileAggregator

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -103,12 +103,9 @@ class Test_save_netcdf(IrisTest):
         """ Test cube dimension coordinates are preserved """
         save_netcdf(self.cube, self.filepath)
         cube = load_cube(self.filepath)
-        coord_names = []
-        (coord_names.append(coord.name())
-            for coord in cube.coords(dim_coords=True))
-        reference_names = []
-        (reference_names.append(coord.name())
-            for coord in self.cube.coords(dim_coords=True))
+        coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
+        reference_names = [coord.name()
+                           for coord in self.cube.coords(dim_coords=True)]
         self.assertItemsEqual(coord_names, reference_names)
 
     def test_cf_global_attributes(self):

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -84,6 +84,14 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
         self.assertTrue(os.path.exists(self.filepath))
 
+    def test_cube_list(self):
+        """ Test functionality for saving iris.cube.CubeList """
+        cube_list = ([self.cube, self.cube])
+        save_netcdf(cube_list, self.filepath)
+        read_cubes = iris.load(self.filepath)
+        self.assertTrue(isinstance(read_cubes, iris.cube.CubeList))
+        self.assertEqual(len(read_cubes), 2)
+
     def test_cube_data(self):
         """ Test valid cube can be read from saved file """
         save_netcdf(self.cube, self.filepath)

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -43,27 +43,22 @@ from iris.fileformats.cf import CFReader
 
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
+from improver.tests.ensemble_calibration.ensemble_calibration.\
+    helper_functions import set_up_cube
 
 
 def set_up_test_cube():
-    """Create a cube with metadata and values suitable for air temperature."""
-    data = (np.linspace(-45.0, 45.0, 9).reshape(1, 3, 3) + 273.15)
-    realization = DimCoord(1, "realization")
-    y_coord = DimCoord(np.linspace(-45.0, 45.0, 3),
-                       'latitude', units='degrees')
-    x_coord = DimCoord(np.linspace(120, 180, 3),
-                       'longitude', units='degrees')
-    attributes = {'Conventions': 'CF-1.5', 'source_realizations': 12}
-    cube = iris.cube.Cube(data, 'air_temperature', units='K',
-                          attributes=attributes,
-                          dim_coords_and_dims=[(realization, 0), (y_coord, 1),
-                                               (x_coord, 2)])
+    """ Set up a temperature cube with additional global attributes. """
+    data = (np.linspace(-45.0, 45.0, 9).reshape(1, 1, 3, 3) + 273.15)
+    cube = set_up_cube(data, 'air_temperature', 'K', realizations=([0]))
+    cube.attributes['Conventions'] = 'CF-1.5'
+    cube.attributes['source_realizations'] = np.arange(12)
     return cube
 
 
 class Test_save_netcdf(IrisTest):
 
-    """ Test function to save iris cubes as netcdf. """
+    """ Test function to save iris cubes as NetCDF files. """
 
     def setUp(self):
         """ Set up cube to write, read and check """
@@ -78,18 +73,18 @@ class Test_save_netcdf(IrisTest):
         call(['rm', '-f', self.filepath])
         call(['rmdir', self.directory])
 
-    def test_basic(self):
+    def test_basic_cube(self):
         """ Test saves file in required location """
         self.assertFalse(os.path.exists(self.filepath))
         save_netcdf(self.cube, self.filepath)
         self.assertTrue(os.path.exists(self.filepath))
 
-    def test_cube_list(self):
+    def test_basic_cube_list(self):
         """ Test functionality for saving iris.cube.CubeList """
         cube_list = ([self.cube, self.cube])
         save_netcdf(cube_list, self.filepath)
         read_cubes = iris.load(self.filepath)
-        self.assertTrue(isinstance(read_cubes, iris.cube.CubeList))
+        self.assertIsInstance(read_cubes, iris.cube.CubeList)
         self.assertEqual(len(read_cubes), 2)
 
     def test_cube_data(self):
@@ -109,18 +104,27 @@ class Test_save_netcdf(IrisTest):
         self.assertItemsEqual(coord_names, reference_names)
 
     def test_cf_global_attributes(self):
-        """
-        Test that the saved NetCDF file only contains the expected global
-        attributes.
+        """ Test that a NetCDF file saved from one cube only contains the
+        expected global attributes.
 
         NOTE Loading the file as an iris.cube.Cube does not distinguish global
         from local attributes, and therefore cannot test for the correct
         behaviour here.
         """
         save_netcdf(self.cube, self.filepath)
-        cube_keys = CFReader(self.filepath).cf_group.global_attributes.keys()
+        global_keys = CFReader(self.filepath).cf_group.global_attributes.keys()
         self.assertTrue(all(key in self.global_keys_ref
-                            for key in cube_keys))
+                            for key in global_keys))
+
+    def test_cf_shared_attributes_list(self):
+        """ Test that a NetCDF file saved from a list of cubes that share
+        non-global attributes does not promote these attributes to global.
+        """
+        cube_list = ([self.cube, self.cube])
+        save_netcdf(cube_list, self.filepath)
+        global_keys = CFReader(self.filepath).cf_group.global_attributes.keys()
+        self.assertTrue(all(key in self.global_keys_ref
+                            for key in global_keys))
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -31,7 +31,6 @@
 """Unit tests for saving functionality."""
 
 import os
-import copy
 import unittest
 import numpy as np
 from subprocess import call

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -91,7 +91,7 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
         cube = load_cube(self.filepath)
         self.assertTrue(isinstance(cube, iris.cube.Cube))
-        self.assertTrue(np.array_equal(cube.data, self.cube.data))
+        self.assertArrayEqual(cube.data, self.cube.data)
 
     def test_cube_dimensions(self):
         """ Test cube dimension coordinates are preserved """
@@ -125,9 +125,9 @@ class Test_save_netcdf(IrisTest):
         cf_data_dict = dict(Dataset(self.filepath, mode='r').variables)
         self.assertTrue('source_realizations' in
                         cf_data_dict['air_temperature'].ncattrs())
-        self.assertTrue(np.array_equal(
+        self.assertArrayEqual(
             cf_data_dict['air_temperature'].getncattr('source_realizations'),
-            np.arange(12)))
+            np.arange(12))
 
     def test_cf_shared_attributes_list(self):
         """ Test that a NetCDF file saved from a list of cubes that share

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -120,6 +120,8 @@ class Test_save_netcdf(IrisTest):
         attributes
         """
         save_netcdf(self.cube, self.filepath)
+        # cast explicitly to dictionary, as pylint does not recognise
+        # OrderedDict as subscriptable
         cf_data_dict = dict(Dataset(self.filepath, mode='r').variables)
         self.assertTrue('source_realizations' in
                         cf_data_dict['air_temperature'].ncattrs())

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -31,6 +31,7 @@
 """Unit tests for saving functionality."""
 
 import os
+import copy
 import unittest
 import numpy as np
 from subprocess import call
@@ -39,6 +40,7 @@ from tempfile import mkdtemp
 import iris
 from iris.tests import IrisTest
 from iris.fileformats.cf import CFReader
+from iris.fileformats.cf import CFDataVariable
 
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -114,6 +116,28 @@ class Test_save_netcdf(IrisTest):
         global_keys = CFReader(self.filepath).cf_group.global_attributes.keys()
         self.assertTrue(all(key in self.global_keys_ref
                             for key in global_keys))
+
+
+    def test_cf_data_attributes(self):
+        """ Test that forbidden global metadata are saved as data variable
+        attributes
+
+        TODO get this working.  Need to be able to inspect the data variable!
+        """
+        save_netcdf(self.cube, self.filepath)
+
+        cf_group = copy.deepcopy(CFReader(self.filepath).cf_group)
+        print cf_group.values()
+
+        #group = CFReader(self.filepath).cf_group
+
+        #print group.items()
+
+        #data_variable = CFDataVariable(group.data_variables.keys()[0],
+        #                               group.data_variables)
+
+        #print data_variable
+
 
     def test_cf_shared_attributes_list(self):
         """ Test that a NetCDF file saved from a list of cubes that share

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -54,7 +54,7 @@ def set_up_test_cube():
     x_coord = DimCoord(np.linspace(120, 180, 3),
                        'longitude', units='degrees')
 
-    attributes = {'Conventions' : 'CF-1.5', 'source_realizations' : 12 }
+    attributes = {'Conventions': 'CF-1.5', 'source_realizations': 12}
     cube = iris.cube.Cube(data, 'air_temperature', units='K',
                           attributes=attributes,
                           dim_coords_and_dims=[(realization, 0), (y_coord, 1),

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -120,10 +120,12 @@ class Test_save_netcdf(IrisTest):
         attributes
         """
         save_netcdf(self.cube, self.filepath)
-        temp = Dataset(self.filepath, mode='r').variables['air_temperature']
-        self.assertTrue('source_realizations' in temp.ncattrs())
-        self.assertTrue(np.array_equal(temp.getncattr('source_realizations'),
-                                       np.arange(12)))
+        cf_data_dict = dict(Dataset(self.filepath, mode='r').variables)
+        self.assertTrue('source_realizations' in
+                        cf_data_dict['air_temperature'].ncattrs())
+        self.assertTrue(np.array_equal(
+            cf_data_dict['air_temperature'].getncattr('source_realizations'),
+            np.arange(12)))
 
     def test_cf_shared_attributes_list(self):
         """ Test that a NetCDF file saved from a list of cubes that share

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -104,11 +104,11 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
         cube = load_cube(self.filepath)
         coord_names = []
-        [coord_names.append(coord.name())
-            for coord in cube.coords(dim_coords=True)]
+        (coord_names.append(coord.name())
+            for coord in cube.coords(dim_coords=True))
         reference_names = []
-        [reference_names.append(coord.name())
-            for coord in self.cube.coords(dim_coords=True)]
+        (reference_names.append(coord.name())
+            for coord in self.cube.coords(dim_coords=True))
         self.assertItemsEqual(coord_names, reference_names)
 
     def test_cf_global_attributes(self):

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -104,7 +104,7 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
         cube = load_cube(self.filepath)
         coord_names = []
-        [coord_names.append(coord.name()) 
+        [coord_names.append(coord.name())
             for coord in cube.coords(dim_coords=True)]
         reference_names = []
         [reference_names.append(coord.name())

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -53,7 +53,6 @@ def set_up_test_cube():
                        'latitude', units='degrees')
     x_coord = DimCoord(np.linspace(120, 180, 3),
                        'longitude', units='degrees')
-
     attributes = {'Conventions': 'CF-1.5', 'source_realizations': 12}
     cube = iris.cube.Cube(data, 'air_temperature', units='K',
                           attributes=attributes,
@@ -91,8 +90,18 @@ class Test_save_netcdf(IrisTest):
         cube = load_cube(self.filepath)
         self.assertTrue(isinstance(cube, iris.cube.Cube))
         self.assertTrue(np.array_equal(cube.data, self.cube.data))
-        self.assertEqual(len(cube.coords(dim_coords=True)),
-                         len(self.cube.coords(dim_coords=True)))
+
+    def test_cube_dimensions(self):
+        """ Test cube dimension coordinates are preserved """
+        save_netcdf(self.cube, self.filepath)
+        cube = load_cube(self.filepath)
+        coord_names = []
+        [coord_names.append(coord.name()) 
+            for coord in cube.coords(dim_coords=True)]
+        reference_names = []
+        [reference_names.append(coord.name())
+            for coord in self.cube.coords(dim_coords=True)]
+        self.assertItemsEqual(coord_names, reference_names)
 
     def test_cf_global_attributes(self):
         """

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -37,7 +37,6 @@ from subprocess import call
 from tempfile import mkdtemp
 
 import iris
-from iris.coords import DimCoord
 from iris.tests import IrisTest
 from iris.fileformats.cf import CFReader
 

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -122,6 +122,7 @@ class Test_save_netcdf(IrisTest):
         cube_list = ([self.cube, self.cube])
         save_netcdf(cube_list, self.filepath)
         global_keys = CFReader(self.filepath).cf_group.global_attributes.keys()
+        self.assertEqual(len(global_keys), 1)
         self.assertTrue(all(key in self.global_keys_ref
                             for key in global_keys))
 

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -40,20 +40,24 @@ def save_netcdf(cube, filename):
     """Save the input cube as a NetCDF file.
 
     Uses the functionality provided by iris.fileformats.netcdf.save with
-    local_keys to record shared attributes as data attributes rather than
+    local_keys to record non-global attributes as data attributes rather than
     global attributes.
-
-    NOTE current wrapper is a placeholder replicating the existing iris.save
-    functionality.
 
     Args:
         cube (iris.cube.Cube):
-            Input cube
+            Input cube, which must conform to CF metadata standards
         filename (str):
             Filename to save input cube
     """
 
-    local_keys = None
-    # TODO perform appropriate cube manipulation here to obtain local_keys
+    # TODO check grid / coordinate metadata to avoid loss of dim_coord names?
+
+    global_keys = ['title', 'um_version', 'grid_id', 'source', 'Conventions',
+                   'institution', 'history']
+
+    local_keys = []
+    for key in cube.attributes.keys():
+        if key not in global_keys:
+            local_keys.append(key)
 
     iris.fileformats.netcdf.save(cube, filename, local_keys=local_keys)

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -45,13 +45,10 @@ def save_netcdf(cube, filename):
 
     Args:
         cube (iris.cube.Cube):
-            Input cube, which must conform to CF metadata standards
+            Input cube
         filename (str):
             Filename to save input cube
     """
-
-    # TODO check grid / coordinate metadata to avoid loss of dim_coord names?
-
     global_keys = ['title', 'um_version', 'grid_id', 'source', 'Conventions',
                    'institution', 'history']
 

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -37,14 +37,14 @@ iris.FUTURE.netcdf_no_unlimited = True
 
 
 def save_netcdf(cube, filename):
-    """Save the input cube as a NetCDF file.
+    """Save the input Cube or CubeList as a NetCDF file.
 
     Uses the functionality provided by iris.fileformats.netcdf.save with
     local_keys to record non-global attributes as data attributes rather than
     global attributes.
 
     Args:
-        cube (iris.cube.Cube):
+        cube (iris.cube.Cube or iris.cube.CubeList):
             Input cube
         filename (str):
             Filename to save input cube
@@ -53,8 +53,15 @@ def save_netcdf(cube, filename):
                    'institution', 'history']
 
     local_keys = []
-    for key in cube.attributes.keys():
-        if key not in global_keys:
-            local_keys.append(key)
+
+    if isinstance(cube, iris.cube.Cube):
+        for key in cube.attributes.keys():
+            if key not in global_keys:
+                local_keys.append(key)
+    else:
+        for subcube in cube:
+            for key in subcube.attributes.keys():
+                if key not in global_keys and key not in local_keys:
+                    local_keys.append(key)
 
     iris.fileformats.netcdf.save(cube, filename, local_keys=local_keys)

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -54,9 +54,8 @@ def save_netcdf(cubelist, filename):
 
     global_keys = ['title', 'um_version', 'grid_id', 'source', 'Conventions',
                    'institution', 'history']
-    local_keys = []
-    [local_keys.append(key) for cube in cubelist
-        for key in cube.attributes.keys()
-        if key not in global_keys and key not in local_keys]
+    local_keys = {key for cube in cubelist
+                  for key in cube.attributes.keys()
+                  if key not in global_keys}
 
     iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys)

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -36,7 +36,7 @@ iris.FUTURE.netcdf_promote = True
 iris.FUTURE.netcdf_no_unlimited = True
 
 
-def save_netcdf(cube, filename):
+def save_netcdf(cubelist, filename):
     """Save the input Cube or CubeList as a NetCDF file.
 
     Uses the functionality provided by iris.fileformats.netcdf.save with
@@ -44,24 +44,19 @@ def save_netcdf(cube, filename):
     global attributes.
 
     Args:
-        cube (iris.cube.Cube or iris.cube.CubeList):
-            Input cube
+        cubelist (iris.cube.Cube or iris.cube.CubeList):
+            Cube or list of cubes to be saved
         filename (str):
-            Filename to save input cube
+            Filename to save input cube(s)
     """
+    if isinstance(cubelist, iris.cube.Cube):
+        cubelist = [cubelist]
+
     global_keys = ['title', 'um_version', 'grid_id', 'source', 'Conventions',
                    'institution', 'history']
-
     local_keys = []
+    [local_keys.append(key) for cube in cubelist
+        for key in cube.attributes.keys()
+        if key not in global_keys and key not in local_keys]
 
-    if isinstance(cube, iris.cube.Cube):
-        for key in cube.attributes.keys():
-            if key not in global_keys:
-                local_keys.append(key)
-    else:
-        for subcube in cube:
-            for key in subcube.attributes.keys():
-                if key not in global_keys and key not in local_keys:
-                    local_keys.append(key)
-
-    iris.fileformats.netcdf.save(cube, filename, local_keys=local_keys)
+    iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys)


### PR DESCRIPTION
Generic save wrapper to save dataset-specific attributes as non-global attributes in netcdf files.
Substantial amount of CLI test output needs updating for this change.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

Related issue #393