### PR TITLE
Changed bats tests to use cmp -b rather than cmp -bl

### DIFF
--- a/tests/improver-nbhood/05-mask-square.bats
+++ b/tests/improver-nbhood/05-mask-square.bats
@@ -41,8 +41,8 @@
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 
-  # Run cmp -bl to compare the output and kgo.
-  cmp -bl "$TEST_DIR/output.nc" \
+  # Run cmp -b to compare the output and kgo.
+  cmp -b "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/nbhood/mask/kgo_masked.nc"
   [[ "$status" -eq 0 ]]
   rm "$TEST_DIR/output.nc"

--- a/tests/improver-nbhood/07-external-mask-square.bats
+++ b/tests/improver-nbhood/07-external-mask-square.bats
@@ -42,8 +42,8 @@
       --input_mask_filepath "$IMPROVER_ACC_TEST_DIR/nbhood/mask/mask.nc"
   [[ "$status" -eq 0 ]]
 
-  # Run cmp -bl to compare the output and kgo.
-  cmp -bl "$TEST_DIR/output.nc" \
+  # Run cmp -b to compare the output and kgo.
+  cmp -b "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/nbhood/mask/kgo_external_masked.nc"
   [[ "$status" -eq 0 ]]
   rm "$TEST_DIR/output.nc"

--- a/tests/improver-nbhood/08-re_mask_external-mask-square.bats
+++ b/tests/improver-nbhood/08-re_mask_external-mask-square.bats
@@ -43,9 +43,9 @@
       --input_mask_filepath "$IMPROVER_ACC_TEST_DIR/nbhood/mask/mask.nc" --re_mask
   [[ "$status" -eq 0 ]]
 
-  # Run cmp -bl to compare the output and kgo.
-  cmp -bl "$TEST_DIR/output.nc" \
-      "$IMPROVER_ACC_TEST_DIR/nbhood/mask/kgo_re_mask.nc"
+  # Run cmp -b to compare the output and kgo.
+  cmp -b "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/nbhood/mask/kgo_external_masked.nc"
   [[ "$status" -eq 0 ]]
   rm "$TEST_DIR/output.nc"
   rmdir "$TEST_DIR"


### PR DESCRIPTION
Avoids printing loads of extra stuff when things go wrong.

Details of bug noted on IMPRO-452.

Testing:
 - [ ] Ran tests and they passed OK
