### PR TITLE
Add contributing guidance and CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# IMPROVER: How to Contribute
+
+
+## Raising Bug Reports or Feature Requests
+
+Please raise issues to capture bugs or feature requests - or feel free
+to contact us directly and discuss things if you have our contact details.
+
+
+## Contributing Code or Reviewing
+
+We really appreciate code or review contributions!
+
+Code contributions are made by raising pull requests against the master
+branch of https://github.com/metoppv/improver/. If you are a new contributor,
+your pull request must include adding your details to the list of contributors
+under the [Code Contributors](#code-contributors) part of this page.
+
+Reviewers of the pull requests must check this has been done before the pull
+request is merged into master.
+
+We have a checklist for making sure code is ready to merge in:
+
+https://github.com/metoppv/improver/wiki/Definition-of-Done
+
+and guidance for going through the review process:
+
+https://github.com/metoppv/improver/wiki/Guidance-for-Reviewing-Code
+
+
+## Code Contributors
+
+The following people have contributed to this code under the terms of
+the Contributor Licence Agreement and Certificate of Origin detailed
+below:
+
+* Paul Abernethy (Met Office, UK)
+* Benjamin Ayliffe (Met Office, UK)
+* Mark Baker (Met Office, UK)
+* Laurence Beard (Met Office, UK)
+* Gavin Evans (Met Office, UK)
+* Ben Fitzpatrick (Met Office, UK)
+* Martina Friedrich (Met Office, UK, pre-GitHub)
+* Aaron Hopkinson (Met Office, UK)
+* Kathryn Howard (Met Office, UK)
+* Simon Jackson (Met Office, UK)
+* Caroline Jones (Met Office, UK)
+* Stephen Moseley (Met Office, UK)
+* Meabh NicGuidhir (Met Office, UK)
+* Tim Pillinger (Met Office, UK)
+* Fiona Rust (Met Office, UK)
+* Caroline Sandford (Met Office, UK)
+* Tomasz Trzeciak (Met Office, UK)
+
+(All contributors on GitHub are identifiable with email addresses in the
+version control logs or otherwise.)
+
+
+## Contributor Licence Agreement and Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it, either on my behalf or on behalf of my
+    employer, under the terms and conditions as described by this file;
+    or
+
+(b) The contribution is based upon previous work that, to the best of
+    my knowledge, is covered under an appropriate licence and I have
+    the right or permission from the copyright owner under that licence
+    to submit that work with modifications, whether created in whole or
+    in part by me, under the terms and conditions as described by
+    this file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a) or (b) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including my
+    name and email address) is maintained for the full term of the copyright
+    and may be redistributed consistent with this project or the licence(s)
+    involved.
+
+(e) I, or my employer, grant to the UK Met Office and all recipients of
+    this software a perpetual, worldwide, non-exclusive, no-charge,
+    royalty-free, irrevocable copyright licence to reproduce, modify,
+    prepare derivative works of, publicly display, publicly perform,
+    sub-licence, and distribute this contribution and such modifications
+    and derivative works consistent with this project or the licence(s)
+    involved or other appropriate open source licence(s) specified by
+    the project and approved by the
+    [Open Source Initiative (OSI)](http://www.opensource.org/).
+
+(f) If I become aware of anything that would make any of the above
+    inaccurate, in any way, I will let the UK Met Office know as soon as
+    I become aware.
+
+(The IMPROVER Contributor Licence Agreement and Certificate of Origin is
+derived almost entirely from the Rose version
+(https://github.com/metomi/rose/), which was inspired by the Certificate of
+Origin used by Enyo and the Linux Kernel.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ below:
 * Fiona Rust (Met Office, UK)
 * Caroline Sandford (Met Office, UK)
 * Tomasz Trzeciak (Met Office, UK)
+* Mark Worsfold (Met Office, UK)
 
 (All contributors on GitHub are identifiable with email addresses in the
 version control logs or otherwise.)


### PR DESCRIPTION
This adds contributing guidance and a contributor licence agreement (CLA). This allows external contributors to contribute code under our open-source licence.

It adds all contributors who have made non-merge commits to master as of this date.
Future and upcoming new contributors must add their names to the file as part of their first pull request.


