### PR TITLE
Fix load unit tests to clean up all temporary files

### DIFF
--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -77,7 +77,8 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
 
 
 def load_cubelist(filepath, constraints=None, no_lazy_load=False):
-    """Load the filepath(s) provided using Iris into a cubelist.
+    """Load the filepath(s) provided using Iris into a cubelist.  Loads
+    exactly one data cube per file.
 
     Args:
         filepath (str or list):


### PR DESCRIPTION
Some unit tests were not defining temporary file paths correctly, leading to files persisting in temporary directories.  This change is to fix the issue with test_load.py.  The full unit test suite was also run to check that no other tests caused this problem.

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)
