### PR TITLE
Sphinx 1.7.1 Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,8 @@ install:
   # Download Iris 1.13 and all dependencies.
   - conda install -c conda-forge iris=1.13
 
-  # Force numpy to remain at version 1.13.3
-  - conda install -c conda-forge numpy=1.13.3
-
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge mock filelock pep8 pylint sphinx pandas python-stratify
+  - conda install -c conda-forge mock filelock numpy=1.13.3 pep8 pylint pandas python-stratify sphinx=1.7.0
 
 script:
   - python -c "import iris"


### PR DESCRIPTION
Set sphinx version to remain at 1.7.0 (it changed to 1.7.1 over the weekend and seems buggy) and consolidate numpy install statement into single conda line (which seems to remove the seg fault issue we have been seeing).