### PR TITLE
IMPRO-505: ensure output is float32 not double

### DIFF
--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -146,6 +146,32 @@ class Test_process(IrisTest):
         result = plugin.process(self.cube)
         self.assertIsInstance(result, Cube)
 
+    def test_data_precision_preservation(self):
+        """Test that the plugin returns an iris.cube.Cube of the same float
+        precision as the input cube."""
+        threshold = 0.1
+        plugin = Threshold(threshold, fuzzy_factor=self.fuzzy_factor)
+        f64cube = self.cube.copy(data=self.cube.data.astype(np.float64))
+        f32cube = self.cube.copy(data=self.cube.data.astype(np.float32))
+        f64result = plugin.process(f64cube)
+        f32result = plugin.process(f32cube)
+        self.assertEqual(f64cube.dtype, f64result.dtype)
+        self.assertEqual(f32cube.dtype, f32result.dtype)
+
+    def test_data_type_change_for_ints(self):
+        """Test that the plugin returns an iris.cube.Cube of float32 type
+        if the input cube is of int type. This allows fuzzy bounds to be used
+        which return fractional values."""
+        fuzzy_factor = 5./6.
+        threshold = 12
+        self.cube.data = np.arange(25).reshape(1, 5, 5)
+        plugin = Threshold(threshold, fuzzy_factor=fuzzy_factor)
+        result = plugin.process(self.cube)
+        expected = np.round(np.arange(0, 1, 1./25.)).reshape(1, 1, 5, 5)
+        expected[0, 0, 2, 1:4] = [0.25, 0.5, 0.75]
+        self.assertEqual(result.dtype, 'float32')
+        self.assertArrayEqual(result.data, expected)
+
     def test_metadata_changes(self):
         """Test the metadata altering functionality"""
         # Copy the cube as the cube.data is used as the basis for comparison.

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -163,6 +163,12 @@ class BasicThreshold(object):
             ValueError: if a np.nan value is detected within the input cube.
 
         """
+        # Record input cube data type to ensure consistent output, though
+        # integer data must become float to enable fuzzy thresholding.
+        input_cube_dtype = input_cube.dtype
+        if input_cube.dtype.kind == 'i':
+            input_cube_dtype = np.float32
+
         thresholded_cubes = iris.cube.CubeList()
         if np.isnan(input_cube.data).any():
             raise ValueError("Error: NaN detected in input cube data")
@@ -183,7 +189,7 @@ class BasicThreshold(object):
                             scale_range=(0.5, 1.),
                             clip=True),
                 )
-            truth_value = truth_value.astype(np.float64)
+            truth_value = truth_value.astype(input_cube_dtype)
             if self.below_thresh_ok:
                 truth_value = 1. - truth_value
             cube.data = truth_value
@@ -196,7 +202,6 @@ class BasicThreshold(object):
             thresholded_cubes.append(cube)
 
         cube, = thresholded_cubes.concatenate()
-
         # TODO: Correct when formal cf-standards exists
         # Force the metadata to temporary conventions
         if self.below_thresh_ok:


### PR DESCRIPTION
Changes to ensure float precision is preserved within the thresholding app. Additionally, ensures integer inputs become float32 output cubes to allow for fuzzy thresholding.

Unit tests added to check conservation/conversion. Requires updated KGO, though no new tests were added.

IMPRO-505 / #434 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
