### PR TITLE
Sphinx changes and docstring fixes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -95,7 +95,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = []
+exclude_patterns = ['modules.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -169,7 +169,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,10 +9,18 @@ Welcome to IMPROVER's documentation!
 IMPROVER is a library of algorithms for meteorological post-processing and verification.
 Please see the :doc:`improver` for API documentation.
 
-
 Indices and tables
 ==================
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+
+Packages and Modules
+====================
+
+.. toctree::
+   :maxdepth: 4
+
+   improver

--- a/lib/improver/utilities/ancillary_creation.py
+++ b/lib/improver/utilities/ancillary_creation.py
@@ -132,12 +132,12 @@ class OrographicAlphas(object):
         rename.
 
         Args:
-        alphas_cube (iris.cube.Cube):
-            A cube of alphas with "gradient" metadata
+            alphas_cube (iris.cube.Cube):
+                A cube of alphas with "gradient" metadata
 
         Returns:
-        alphas_cube (iris.cube.Cube):
-            A cube of alphas with adjusted metadata
+            alphas_cube (iris.cube.Cube):
+                A cube of alphas with adjusted metadata
         """
         alphas_cube.rename('alphas')
         for coord in alphas_cube.coords(dim_coords=False):

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -91,6 +91,7 @@ def parse_constraint_list(constraints, units=None):
         constraints (list):
             List of string constraints with keys and values split by "=":
             e.g: ["kw1=val1", "kw2 = val2", "kw3=val3"].
+
     Kwargs:
         units (list):
             List of units (as strings) corresponding to each coordinate in the
@@ -98,11 +99,13 @@ def parse_constraint_list(constraints, units=None):
             may only be associated with coordinate constraints.
 
     Returns:
-        constraints (iris.Constraint or
-                     iris._constraints.ConstraintCombination):
-            A combination of all the constraints that were supplied.
-        units_dict (dictionary or None):
-            A dictionary of unit keys and values
+        (tuple): tuple containing
+            **constraints** (iris.Constraint or \
+            iris._constraints.ConstraintCombination):
+                A combination of all the constraints that were supplied.
+
+            **units_dict** (dictionary or None):
+                A dictionary of unit keys and values
     """
 
     if units is None:
@@ -148,18 +151,20 @@ def apply_extraction(cube, constraint, units=None):
     """
     Using a set of constraints, extract a subcube from the provided cube if it
     is available.
+
     Args:
         cube (iris.cube.Cube):
             The cube from which a subcube is to be extracted.
-        constraint (iris.Constraint or
-                    iris.ConstraintCombination):
+        constraint (iris.Constraint or iris.ConstraintCombination):
             The constraint or ConstraintCombination that will be used to
             extract a subcube from the input cube.
+
     Kwargs:
         units (dictionary):
-            A dictionary of units for the constraints.  Supplied if any
+            A dictionary of units for the constraints. Supplied if any
             coordinate constraints are provided in different units from those
             of the input cube (eg precip in mm/h for cube threshold in m/s).
+
     Returns:
         output_cube (iris.cube.Cube):
             A single cube matching the input constraints, or None if no subcube


### PR DESCRIPTION
Fixes to warnings raised by recently committed code that did not adhere to sphinx formatting requirements. Additionally, modified sphinx config to remove remaining warnings/errors that have always been raised. I have also added a modules/subpackages section to the front page of the docs.

Testing:
 - [x] Ran tests and they passed OK