### PR TITLE
Fix enforcing of probability coordinate within load_cube

### DIFF
--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -36,6 +36,7 @@ from subprocess import call as Call
 from tempfile import mkdtemp
 
 import iris
+from iris.coords import DimCoord
 from iris.tests import IrisTest
 import numpy as np
 
@@ -50,6 +51,34 @@ from improver.tests.utilities.test_cube_manipulation import (
 
 
 iris.FUTURE.netcdf_no_unlimited = True
+
+
+def create_sample_cube_with_additional_coordinate(
+        cube, coord_name, coord_points):
+    """
+    Function to duplicate a sample cube with an additional coordinate to
+    create a cubelist. The cubelist is merged to create a single cube.
+
+    Args:
+        cube (iris.cube.Cube):
+            Create a cube to be duplicated.
+        coord_name (str):
+            Long name of the coordinate that you would like to add.
+        coord_points (list):
+            Values for the coordinate.
+
+    Returns:
+        iris.cube.Cube:
+            Cube containing an additional dimension coordinate.
+
+    """
+    cubes = iris.cube.CubeList([])
+    for val in coord_points:
+        temp_cube = cube.copy()
+        temp_cube.add_aux_coord(
+            DimCoord(np.array([val]), long_name=coord_name))
+        cubes.append(temp_cube)
+    return cubes.merge_cube()
 
 
 class Test_load_cube(IrisTest):
@@ -71,11 +100,16 @@ class Test_load_cube(IrisTest):
         Call(['rm', '-f', self.filepath])
         Call(['rmdir', self.directory])
 
-    def test_filepath_only(self):
-        """Test that the loading works correctly, if only the filepath is
-        provided."""
+    def test_a_cube_is_loaded(self):
+        """Test that a cube is loaded when a valid filepath is provided."""
         result = load_cube(self.filepath)
         self.assertIsInstance(result, iris.cube.Cube)
+
+    def test_filepath_only(self):
+        """Test that the realization, time, latitude and longitude coordinates
+        have the expected values, when a cube is loaded from the specified
+        filepath."""
+        result = load_cube(self.filepath)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, self.realization_points)
         self.assertArrayAlmostEqual(
@@ -86,10 +120,10 @@ class Test_load_cube(IrisTest):
             result.coord("longitude").points, self.longitude_points)
 
     def test_filepath_as_list(self):
-        """Test that the loading works correctly, if only the filepath is
-        provided as a list."""
+        """Test that the realization, time, latitude and longitude coordinates
+        have the expected values, if a cube is loaded from an input filepath
+        specified in a list."""
         result = load_cube([self.filepath])
-        self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, self.realization_points)
         self.assertArrayAlmostEqual(
@@ -100,12 +134,12 @@ class Test_load_cube(IrisTest):
             result.coord("longitude").points, self.longitude_points)
 
     def test_constraint(self):
-        """Test that the loading works correctly, if a constraint is
-        specified."""
+        """Test that the realization, time, latitude and longitude coordinates
+        have the expected values, if constraint are specified
+        when loading a cube from a file."""
         realization_points = np.array([0])
         constr = iris.Constraint(realization=0)
         result = load_cube(self.filepath, constraints=constr)
-        self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, realization_points)
         self.assertArrayAlmostEqual(
@@ -116,15 +150,15 @@ class Test_load_cube(IrisTest):
             result.coord("longitude").points, self.longitude_points)
 
     def test_multiple_constraints(self):
-        """Test that the loading works correctly, if multiple constraints are
-        specified."""
+        """Test that the realization, time, latitude and longitude coordinates
+        have the expected values, if multiple constraints are specified
+        when loading a cube from a file."""
         realization_points = np.array([0])
         latitude_points = np.array([0])
         constr1 = iris.Constraint(realization=0)
         constr2 = iris.Constraint(latitude=lambda cell: -0.1 < cell < 0.1)
         constr = constr1 & constr2
         result = load_cube(self.filepath, constraints=constr)
-        self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, realization_points)
         self.assertArrayAlmostEqual(
@@ -141,15 +175,6 @@ class Test_load_cube(IrisTest):
         cube.transpose([3, 2, 1, 0])
         iris.save(cube, self.filepath)
         result = load_cube(self.filepath)
-        self.assertIsInstance(result, iris.cube.Cube)
-        self.assertArrayAlmostEqual(
-            result.coord("realization").points, self.realization_points)
-        self.assertArrayAlmostEqual(
-            result.coord("time").points, self.time_points)
-        self.assertArrayAlmostEqual(
-            result.coord("latitude").points, self.latitude_points)
-        self.assertArrayAlmostEqual(
-            result.coord("longitude").points, self.longitude_points)
         self.assertEqual(result.coord_dims("realization")[0], 0)
         self.assertEqual(result.coord_dims("time")[0], 1)
         self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
@@ -159,62 +184,58 @@ class Test_load_cube(IrisTest):
         """Test that the cube has been reordered, if it is originally in an
         undesirable order and the cube contains a "percentile_over"
         coordinate."""
-        directory = mkdtemp()
-        filepath = os.path.join(directory, "temp.nc")
         cube = set_up_percentile_temperature_cube()
-        percentile_points = np.array([10, 50, 90])
         cube.transpose([3, 2, 1, 0])
-        iris.save(cube, filepath)
-        result = load_cube(filepath)
-        self.assertIsInstance(result, iris.cube.Cube)
-        self.assertArrayAlmostEqual(
-            result.coord("percentile_over_realization").points,
-            percentile_points)
-        self.assertArrayAlmostEqual(
-            result.coord("time").points, self.time_points)
-        self.assertArrayAlmostEqual(
-            result.coord("latitude").points, self.latitude_points)
-        self.assertArrayAlmostEqual(
-            result.coord("longitude").points, self.longitude_points)
+        iris.save(cube, self.filepath)
+        result = load_cube(self.filepath)
+        self.assertEqual(
+            result.coord_dims("percentile_over_realization")[0], 0)
+        self.assertEqual(result.coord_dims("time")[0], 1)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 3)
 
     def test_ordering_for_threshold_coordinate(self):
         """Test that the cube has been reordered, if it is originally in an
         undesirable order and the cube contains a "threshold" coordinate."""
-        directory = mkdtemp()
-        filepath = os.path.join(directory, "temp.nc")
         cube = set_up_probability_above_threshold_temperature_cube()
-        threshold_points = np.array([8, 10, 12])
         cube.transpose([3, 2, 1, 0])
-        iris.save(cube, filepath)
-        result = load_cube(filepath)
-        self.assertIsInstance(result, iris.cube.Cube)
-        self.assertArrayAlmostEqual(
-            result.coord("threshold").points, threshold_points)
-        self.assertArrayAlmostEqual(
-            result.coord("time").points, self.time_points)
-        self.assertArrayAlmostEqual(
-            result.coord("latitude").points, self.latitude_points)
-        self.assertArrayAlmostEqual(
-            result.coord("longitude").points, self.longitude_points)
+        iris.save(cube, self.filepath)
+        result = load_cube(self.filepath)
+        self.assertEqual(result.coord_dims("threshold")[0], 0)
+        self.assertEqual(result.coord_dims("time")[0], 1)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 3)
+
+    def test_ordering_for_realization_threshold_percentile_over_coordinate(
+            self):
+        """Test that the cube has been reordered, if it is originally in an
+        undesirable order and the cube contains a "threshold" coordinate,
+        a "realization" coordinate and a "percentile_over" coordinate."""
+        cube = set_up_probability_above_threshold_temperature_cube()
+        cube = create_sample_cube_with_additional_coordinate(
+            cube, "realization", [0, 1, 2])
+        cube = create_sample_cube_with_additional_coordinate(
+            cube, "percentile_over_neighbourhood", [10, 50, 90])
+        cube.transpose([5, 4, 3, 2, 1, 0])
+        iris.save(cube, self.filepath)
+        result = load_cube(self.filepath)
+        self.assertEqual(result.coord_dims("realization")[0], 0)
+        self.assertEqual(
+            result.coord_dims("percentile_over_neighbourhood")[0], 1)
+        self.assertEqual(result.coord_dims("threshold")[0], 2)
+        self.assertEqual(result.coord_dims("time")[0], 3)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 4)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 5)
 
     def test_no_lazy_load(self):
-        """Test that the loading works correctly with lazy load bypassing."""
+        """Test that the cube returned upon loading does not contain
+        lazy data."""
         result = load_cube(self.filepath, no_lazy_load=True)
-        self.assertIsInstance(result, iris.cube.Cube)
         self.assertFalse(result.has_lazy_data())
-        self.assertArrayAlmostEqual(
-            result.coord("realization").points, self.realization_points)
-        self.assertArrayAlmostEqual(
-            result.coord("time").points, self.time_points)
-        self.assertArrayAlmostEqual(
-            result.coord("latitude").points, self.latitude_points)
-        self.assertArrayAlmostEqual(
-            result.coord("longitude").points, self.longitude_points)
 
     def test_lazy_load(self):
         """Test that the loading works correctly with lazy loading."""
         result = load_cube(self.filepath)
-        self.assertIsInstance(result, iris.cube.Cube)
         self.assertTrue(result.has_lazy_data())
 
 
@@ -242,11 +263,15 @@ class Test_load_cubelist(IrisTest):
         Call(['rm', '-f', self.med_cloud_filepath])
         Call(['rmdir', self.directory])
 
+    def test_a_cubelist_is_loaded(self):
+        """Test that a cubelist is loaded when a valid filepath is provided."""
+        result = load_cubelist(self.filepath)
+        self.assertIsInstance(result, iris.cube.CubeList)
+
     def test_single_file(self):
         """Test that the loading works correctly, if only the filepath is
         provided."""
         result = load_cubelist(self.filepath)
-        self.assertIsInstance(result, iris.cube.CubeList)
         self.assertArrayAlmostEqual(
             result[0].coord("realization").points, self.realization_points)
         self.assertArrayAlmostEqual(
@@ -261,7 +286,6 @@ class Test_load_cubelist(IrisTest):
         provided."""
         filepath = os.path.join(self.directory, "*.nc")
         result = load_cubelist(filepath)
-        self.assertIsInstance(result, iris.cube.CubeList)
         self.assertArrayAlmostEqual(
             result[0].coord("realization").points, self.realization_points)
         self.assertArrayAlmostEqual(
@@ -275,7 +299,6 @@ class Test_load_cubelist(IrisTest):
         """Test that the loading works correctly, if a path to multiple files
         is provided."""
         result = load_cubelist([self.filepath, self.filepath])
-        self.assertIsInstance(result, iris.cube.CubeList)
         for cube in result:
             self.assertArrayAlmostEqual(
                 cube.coord("realization").points, self.realization_points)
@@ -299,7 +322,6 @@ class Test_load_cubelist(IrisTest):
         constr = iris.Constraint("low_type_cloud_area_fraction")
         result = load_cubelist([self.low_cloud_filepath,
                                 self.med_cloud_filepath], constraints=constr)
-        self.assertIsInstance(result, iris.cube.CubeList)
         self.assertEqual(len(result), 1)
         self.assertArrayAlmostEqual(
             result[0].coord("realization").points, self.realization_points)
@@ -311,10 +333,10 @@ class Test_load_cubelist(IrisTest):
             result[0].coord("longitude").points, self.longitude_points)
 
     def test_no_lazy_load(self):
-        """Test that the loading works correctly with lazy load bypassing."""
+        """Test that the cubelist returned upon loading does not contain
+        lazy data."""
         result = load_cubelist([self.filepath, self.filepath],
                                no_lazy_load=True)
-        self.assertIsInstance(result, iris.cube.CubeList)
         self.assertArrayEqual([False, False],
                               [_.has_lazy_data() for _ in result])
         for cube in result:
@@ -328,9 +350,9 @@ class Test_load_cubelist(IrisTest):
                 cube.coord("longitude").points, self.longitude_points)
 
     def test_lazy_load(self):
-        """Test that the loading works correctly with lazy loading."""
+        """Test that the cubelist returned upon loading does contain
+        lazy data."""
         result = load_cubelist([self.filepath, self.filepath])
-        self.assertIsInstance(result, iris.cube.CubeList)
         self.assertArrayEqual([True, True],
                               [_.has_lazy_data() for _ in result])
 

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -185,8 +185,8 @@ class Test_load_cube(IrisTest):
         cube = set_up_probability_above_threshold_temperature_cube()
         threshold_points = np.array([8, 10, 12])
         cube.transpose([3, 2, 1, 0])
-        iris.save(cube, self.filepath)
-        result = load_cube(self.filepath)
+        iris.save(cube, filepath)
+        result = load_cube(filepath)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(
             result.coord("threshold").points, threshold_points)

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -65,7 +65,7 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
     # Ensure the probabilistic coordinates are the first coordinates within a
     # cube and are in the specified order.
     cube = enforce_coordinate_ordering(
-        cube, ["realization", "percentile_over", "probability"])
+        cube, ["realization", "percentile_over", "threshold"])
     # Ensure the y and x dimensions are the last dimensions within the cube.
     y_name = cube.coord(axis="y").name()
     x_name = cube.coord(axis="x").name()


### PR DESCRIPTION
Correction to rename coordinate to be reordered to threshold, rather than probability. Two unit tests have been added to test the reordering of a percentile_over coordinate and a threshold coordinate.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

