### PR TITLE
415 Generate percentiles from a neighbourhood for a single percentile

### DIFF
--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -232,7 +232,10 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
                 DEFAULT_PERCENTILES.
 
         """
-        self.percentiles = tuple(percentiles)
+        try:
+            self.percentiles = tuple(percentiles)
+        except TypeError:
+            self.percentiles = tuple([percentiles])
 
     def __repr__(self):
         """Represent the configured class instance as a string."""

--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -472,6 +472,8 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
                 pct, long_name=pct_coord_name, units='%'))
             pctcubelist.append(pctcube)
         result = pctcubelist.merge_cube()
+        # If percentile coord is not already a dimension, promote it.
+        # This is required when self.percentiles is length 1.
         if result.coord_dims(pct_coord_name) == ():
             result = iris.util.new_axis(result, scalar_coord=pct_coord_name)
         return result

--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -465,9 +465,13 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
                 Each slice along this coordinate is identical.
         """
         pctcubelist = iris.cube.CubeList()
+        pct_coord_name = "percentiles_over_neighbourhood"
         for pct in self.percentiles:
             pctcube = cube.copy()
             pctcube.add_aux_coord(iris.coords.DimCoord(
-                pct, long_name="percentiles_over_neighbourhood", units='%'))
+                pct, long_name=pct_coord_name, units='%'))
             pctcubelist.append(pctcube)
-        return pctcubelist.merge_cube()
+        result = pctcubelist.merge_cube()
+        if result.coord_dims(pct_coord_name) == ():
+            result = iris.util.new_axis(result, scalar_coord=pct_coord_name)
+        return result

--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -227,7 +227,7 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
         Initialise class.
 
         Keyword Args:
-            percentiles (list):
+            percentiles (list or float):
                 Percentile values at which to calculate; if not provided uses
                 DEFAULT_PERCENTILES.
 

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -109,8 +109,8 @@ class Test_make_percentile_cube(IrisTest):
             zero_point_indices=((0, 0, 2, 2),), num_time_points=1,
             num_grid_points=5)
         result = (
-            GeneratePercentilesFromACircularNeighbourhood(50.
-            ).make_percentile_cube(cube))
+            GeneratePercentilesFromACircularNeighbourhood(
+                50.).make_percentile_cube(cube))
         self.assertEqual(
             result.coord_dims("percentiles_over_neighbourhood")[0], 0)
 

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -65,8 +65,7 @@ class Test_make_percentile_cube(IrisTest):
        GeneratePercentilesFromACircularNeighbourhood."""
 
     def test_basic(self):
-        """Test that the plugin returns an iris.cube.Cube and that percentile
-        coord is added."""
+        """Test that the plugin returns an iris.cube.Cube."""
         cube = set_up_cube(
             zero_point_indices=((0, 0, 2, 2),), num_time_points=1,
             num_grid_points=5)
@@ -74,6 +73,15 @@ class Test_make_percentile_cube(IrisTest):
             GeneratePercentilesFromACircularNeighbourhood(
             ).make_percentile_cube(cube))
         self.assertIsInstance(result, Cube)
+
+    def test_coord_present(self):
+        """Test that the percentile coord is added."""
+        cube = set_up_cube(
+            zero_point_indices=((0, 0, 2, 2),), num_time_points=1,
+            num_grid_points=5)
+        result = (
+            GeneratePercentilesFromACircularNeighbourhood(
+            ).make_percentile_cube(cube))
         self.assertIsInstance(result.coord(
             'percentiles_over_neighbourhood'), iris.coords.Coord)
         self.assertArrayEqual(result.coord(
@@ -81,6 +89,30 @@ class Test_make_percentile_cube(IrisTest):
         self.assertArrayEqual(result[0].data, cube.data)
         self.assertDictEqual(
             cube.metadata._asdict(), result.metadata._asdict())
+
+    def test_coord_is_dim_vector(self):
+        """Test that the percentile coord is added as the zeroth dimension when
+        multiple percentiles are used."""
+        cube = set_up_cube(
+            zero_point_indices=((0, 0, 2, 2),), num_time_points=1,
+            num_grid_points=5)
+        result = (
+            GeneratePercentilesFromACircularNeighbourhood(
+            ).make_percentile_cube(cube))
+        self.assertEqual(
+            result.coord_dims("percentiles_over_neighbourhood")[0], 0)
+
+    def test_coord_is_dim_scalar(self):
+        """Test that the percentile coord is added as the zeroth dimension when
+        a single percentile is used."""
+        cube = set_up_cube(
+            zero_point_indices=((0, 0, 2, 2),), num_time_points=1,
+            num_grid_points=5)
+        result = (
+            GeneratePercentilesFromACircularNeighbourhood(50.
+            ).make_percentile_cube(cube))
+        self.assertEqual(
+            result.coord_dims("percentiles_over_neighbourhood")[0], 0)
 
 
 class Test_pad_and_unpad_cube(IrisTest):


### PR DESCRIPTION
Reference issue: #415 

As an IMPROVER developer I want to be able to generate percentiles from a neighbourhood for a single percentile so that I can, for example, generate a wind gust diagnostic successfully, where I want to focus on processing a single percentile.

Currently, it is the case that when using the generate percentiles from a neighbourhood code with a single percentile value there is a shape mismatch due to the promotion/demotion of what effectively becomes a scalar coordinate within pad_and_unpad_cube function. This needs to be fixed, so that the wind_gust_diagnostic processing chain can complete properly.

This PR fixes the bug.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
