### PR TITLE
Edit improver-combine so that wildcard expansion occurs within shell

### DIFF
--- a/bin/improver-combine
+++ b/bin/improver-combine
@@ -36,7 +36,6 @@ from improver.argparser import ArgParser
 import iris
 import json
 import warnings
-from glob import glob
 
 from improver.cube_combiner import CubeCombiner
 from improver.utilities.load import load_cube
@@ -84,11 +83,7 @@ def main():
     # Load the cubes
     cubes = iris.cube.CubeList([])
     new_cube_name = args.new_name
-    input_filenames = []
-    for filename_globlist in args.input_filenames:
-        for filename in glob(filename_globlist):
-            input_filenames.append(filename)
-    for filename in input_filenames:
+    for filename in args.input_filenames:
         new_cube = load_cube(filename)
         cubes.append(new_cube)
         if new_cube_name is None:

--- a/tests/improver-combine/02-basic.bats
+++ b/tests/improver-combine/02-basic.bats
@@ -41,7 +41,7 @@
       --new-name='total_cloud_cover_excluding_high_cloud' \
       "$IMPROVER_ACC_TEST_DIR/combine/basic/low_cloud.nc" \
       "$IMPROVER_ACC_TEST_DIR/combine/basic/medium_cloud.nc" \
-       "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo.

--- a/tests/improver-combine/03-metadata.bats
+++ b/tests/improver-combine/03-metadata.bats
@@ -41,7 +41,7 @@
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/metadata/prob_precip.json" \
       "$IMPROVER_ACC_TEST_DIR/combine/metadata/precip_prob_0p1.nc" \
       "$IMPROVER_ACC_TEST_DIR/combine/metadata/precip_prob_1p0.nc" \
-       "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo.

--- a/tests/improver-combine/04-min-temp.bats
+++ b/tests/improver-combine/04-min-temp.bats
@@ -39,7 +39,7 @@
   run improver combine \
       --operation='min' \
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/bounds/time_bound.json" \
-      "$IMPROVER_ACC_TEST_DIR/combine/bounds/*H-temperature_at_screen_level_min.nc" \
+      $IMPROVER_ACC_TEST_DIR/combine/bounds/*H-temperature_at_screen_level_min.nc \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-combine/05-max-temp.bats
+++ b/tests/improver-combine/05-max-temp.bats
@@ -39,7 +39,7 @@
   run improver combine \
       --operation='max' \
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/bounds/time_bound.json" \
-      "$IMPROVER_ACC_TEST_DIR/combine/bounds/*H-temperature_at_screen_level_max.nc" \
+      $IMPROVER_ACC_TEST_DIR/combine/bounds/*H-temperature_at_screen_level_max.nc \
        "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-combine/05-max-temp.bats
+++ b/tests/improver-combine/05-max-temp.bats
@@ -40,7 +40,7 @@
       --operation='max' \
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/bounds/time_bound.json" \
       $IMPROVER_ACC_TEST_DIR/combine/bounds/*H-temperature_at_screen_level_max.nc \
-       "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo.

--- a/tests/improver-combine/06-accumulations.bats
+++ b/tests/improver-combine/06-accumulations.bats
@@ -38,7 +38,7 @@
   # Run cube-combiner processing and check it passes.
   run improver combine \
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/accum/time_bound.json" \
-      "$IMPROVER_ACC_TEST_DIR/combine/accum/*H-rainfall_accumulation.nc" \
+      $IMPROVER_ACC_TEST_DIR/combine/accum/*H-rainfall_accumulation.nc \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-combine/07-mean-temp.bats
+++ b/tests/improver-combine/07-mean-temp.bats
@@ -39,7 +39,7 @@
   run improver combine \
       --operation='mean' \
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/bounds/time_bound.json" \
-      "$IMPROVER_ACC_TEST_DIR/combine/bounds/20180101T0?00Z-PT000?H-temperature_at_screen_level.nc" \
+      $IMPROVER_ACC_TEST_DIR/combine/bounds/20180101T0?00Z-PT000?H-temperature_at_screen_level.nc \
        "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-combine/07-mean-temp.bats
+++ b/tests/improver-combine/07-mean-temp.bats
@@ -40,7 +40,7 @@
       --operation='mean' \
       --metadata_jsonfile="$IMPROVER_ACC_TEST_DIR/combine/bounds/time_bound.json" \
       $IMPROVER_ACC_TEST_DIR/combine/bounds/20180101T0?00Z-PT000?H-temperature_at_screen_level.nc \
-       "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo.


### PR DESCRIPTION
Removal of globbing from improver-combine by allowing wildcard expansion on command line.

Reference issue: #409 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

