### PR TITLE
Fix iris.fileformats.grib Travis warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 1.13 and all dependencies.
-  - conda install -c conda-forge iris_grib
+  - conda install -c conda-forge iris-grib
   - conda install -c conda-forge iris=1.13
 
   # Install our own extra dependencies (+ filelock for Iris test).

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 1.13 and all dependencies.
-  - conda install -c conda-forge iris-grib
   - conda install -c conda-forge iris=1.13
+  - conda install -c conda-forge iris-grib
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge mock filelock numpy=1.13.3 pep8 pylint pandas python-stratify sphinx=1.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 1.13 and all dependencies.
+  - conda install -c conda-forge iris_grib
   - conda install -c conda-forge iris=1.13
 
   # Install our own extra dependencies (+ filelock for Iris test).

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
   # Download Iris 1.13 and all dependencies.
   - conda install -c conda-forge iris=1.13
   - conda install -c conda-forge iris-grib=0.10.1
-  - python -c "import iris_grib"
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge mock filelock numpy=1.13.3 pep8 pylint pandas python-stratify sphinx=1.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ install:
 
   # Download Iris 1.13 and all dependencies.
   - conda install -c conda-forge iris=1.13
-  - python -c "import iris_grib"
-  - conda install -c conda-forge iris-grib
+  - conda install -c conda-forge iris-grib=0.10.1
   - python -c "import iris_grib"
 
   # Install our own extra dependencies (+ filelock for Iris test).

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ install:
 
   # Download Iris 1.13 and all dependencies.
   - conda install -c conda-forge iris=1.13
+  - python -c "import iris_grib"
   - conda install -c conda-forge iris-grib
+  - python -c "import iris_grib"
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge mock filelock numpy=1.13.3 pep8 pylint pandas python-stratify sphinx=1.7.0


### PR DESCRIPTION
Attempt to avoid iris.fileformats.grib deprecation warning, which breaks current CLI tests.
