### PR TITLE
IMPRO-436: Changes to CLIs for use in importing ancillaries

### DIFF
--- a/bin/improver-extract
+++ b/bin/improver-extract
@@ -63,13 +63,18 @@ def main():
                         'units are not ideal (eg for float equality). If '
                         'used, this list must match the CONSTRAINTS list in '
                         'order and length (with null values set to None).')
+    parser.add_argument('--ignore-failure', action='store_true', default=False,
+                        help='Option to ignore constraint match failure and '
+                        'return the input cube.')
     args = parser.parse_args()
 
     cube = load_cube(args.input_file)
 
     output_cube = extract_subcube(cube, args.constraints, args.units)
 
-    if output_cube is None:
+    if output_cube is None and args.ignore_failure:
+        save_netcdf(cube, args.output_file)
+    elif output_cube is None:
         msg = ("Constraint(s) could not be matched in input cube")
         raise ValueError(msg)
     else:

--- a/bin/improver-generate-topography-bands-mask
+++ b/bin/improver-generate-topography-bands-mask
@@ -97,6 +97,8 @@ def main():
 
     if not os.path.exists(args.output_filepath) or args.force:
         orography = load_cube(args.input_filepath_standard_orography)
+        orography = next(orography.slices([orography.coord(axis='y'),
+                                           orography.coord(axis='x')]))
 
         landmask = None
         if args.input_filepath_landmask:
@@ -109,6 +111,10 @@ def main():
                        'improver-generate-landmask-ancillary first.').format(
                            err, args.input_filepath_landmask)
                 raise IOError(msg)
+
+            landmask = next(landmask.slices([landmask.coord(axis='y'),
+                                             landmask.coord(axis='x')]))
+
         result = GenerateOrographyBandAncils().process(
             orography, thresholds_dict, landmask=landmask)
         result = result.concatenate_cube()

--- a/bin/improver-generate-topography-bands-weights
+++ b/bin/improver-generate-topography-bands-weights
@@ -104,6 +104,8 @@ def main():
 
     if not os.path.exists(args.output_filepath) or args.force:
         orography = load_cube(args.input_filepath_standard_orography)
+        orography = next(orography.slices([orography.coord(axis='y'),
+                                           orography.coord(axis='x')]))
 
         landmask = None
         if args.input_filepath_landmask:
@@ -116,6 +118,10 @@ def main():
                        'improver-generate-landmask-ancillary first.').format(
                            err, args.input_filepath_landmask)
                 raise IOError(msg)
+
+            landmask = next(landmask.slices([landmask.coord(axis='y'),
+                                             landmask.coord(axis='x')]))
+
         result = GenerateTopographicZoneWeights().process(
             orography, thresholds_dict, landmask=landmask)
         save_netcdf(result, args.output_filepath)

--- a/tests/improver-extract/01-help.bats
+++ b/tests/improver-extract/01-help.bats
@@ -33,7 +33,7 @@
   run improver extract -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-usage: improver-extract [-h] [--units UNITS [UNITS ...]]
+usage: improver-extract [-h] [--units UNITS [UNITS ...]] [--ignore-failure]
                         INPUT_FILE OUTPUT_FILE CONSTRAINTS [CONSTRAINTS ...]
 
 Extracts subset of data from a single input file, subject to equality-based
@@ -60,6 +60,8 @@ optional arguments:
                         not ideal (eg for float equality). If used, this list
                         must match the CONSTRAINTS list in order and length
                         (with null values set to None).
+  --ignore-failure      Option to ignore constraint match failure and return
+                        the input cube.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-extract/09-ignore-failure.bats
+++ b/tests/improver-extract/09-ignore-failure.bats
@@ -29,12 +29,22 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-@test "extract no arguments" {
-  run improver extract
-  [[ "$status" -eq 2 ]]
-  read -d '' expected <<'__TEXT__' || true
-usage: improver-extract [-h] [--units UNITS [UNITS ...]] [--ignore-failure]
-                        INPUT_FILE OUTPUT_FILE CONSTRAINTS [CONSTRAINTS ...]
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "extract ignore failure" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+
+  # Run cube extraction processing and check it passes.
+  run improver extract \
+      "$IMPROVER_ACC_TEST_DIR/extract/basic/input.nc" \
+      "$TEST_DIR/output.nc" \
+      percentile=10 --ignore-failure
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/extract/basic/input.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
 }

--- a/tests/improver-generate-topography-bands-mask/06-multi-realization.bats
+++ b/tests/improver-generate-topography-bands-mask/06-multi-realization.bats
@@ -29,12 +29,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-@test "extract no arguments" {
-  run improver extract
-  [[ "$status" -eq 2 ]]
-  read -d '' expected <<'__TEXT__' || true
-usage: improver-extract [-h] [--units UNITS [UNITS ...]] [--ignore-failure]
-                        INPUT_FILE OUTPUT_FILE CONSTRAINTS [CONSTRAINTS ...]
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "generate-topography-bands-mask multi-realization input" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+  test_path=$IMPROVER_ACC_TEST_DIR/generate-topography-bands-mask/multi_realization/
+
+  # Run topography band mask generation and check it passes.
+  run improver generate-topography-bands-mask \
+      "$test_path/input_orog.nc" \
+      "$TEST_DIR/output.nc" \
+      --input_filepath_landmask "$test_path/input_land.nc"
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$test_path/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
 }

--- a/tests/improver-generate-topography-bands-weights/06-multi-realization.bats
+++ b/tests/improver-generate-topography-bands-weights/06-multi-realization.bats
@@ -29,12 +29,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-@test "extract no arguments" {
-  run improver extract
-  [[ "$status" -eq 2 ]]
-  read -d '' expected <<'__TEXT__' || true
-usage: improver-extract [-h] [--units UNITS [UNITS ...]] [--ignore-failure]
-                        INPUT_FILE OUTPUT_FILE CONSTRAINTS [CONSTRAINTS ...]
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "generate-topography-bands-weights multi-realization input" {
+  TEST_DIR=$(mktemp -d)
+  improver_check_skip_acceptance
+  test_path=$IMPROVER_ACC_TEST_DIR/generate-topography-bands-weights/multi_realization/
+
+  # Run topography band weights generation and check it passes.
+  run improver generate-topography-bands-weights \
+      "$test_path/input_orog.nc" \
+      "$TEST_DIR/output.nc" \
+      --input_filepath_landmask "$test_path/input_land.nc"
+  [[ "$status" -eq 0 ]]
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$test_path/kgo.nc"
+  rm "$TEST_DIR/output.nc"
+  rmdir "$TEST_DIR"
 }


### PR DESCRIPTION
Adds ignore failure option to cube extract to return input if constraints are not matched; useful for e.g. applying realization extraction to a cube of unknown origin which could be determinitistc. Also modified topographic band generation CLIs to work on an x-y slice in case there are leading dimensions of time/realization etc.

Added bats tests to relevant CLIs.

Reference issue if exists
IMPRO-436

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)