### PR TITLE
Fixed bug in unit tests for iris 2.0: wildcarded coordinate names in …

### DIFF
--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -192,7 +192,7 @@ class Test_correct_collapsed_coordinates(IrisTest):
         """Test that an exception is raised by Iris when we try to correct
            a coordinate that doesn't exist."""
         self.new_cube.remove_coord('forecast_period')
-        message = "Expected to find exactly 1  coordinate, but found none."
+        message = "Expected to find exactly 1 .* coordinate, but found none."
         with self.assertRaisesRegexp(CoordinateNotFoundError, message):
             self.plugin.correct_collapsed_coordinates(self.orig_cube,
                                                       self.new_cube,

--- a/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -165,7 +165,7 @@ class Test_process(IrisTest):
         """Test it raises CoordinateNotFoundError if coord not in the cube."""
         coord = "notset"
         plugin = WeightedBlendAcrossWholeDimension(coord, 'weighted_mean')
-        msg = ('Expected to find exactly 1  coordinate, but found none.')
+        msg = ('Expected to find exactly 1 .* coordinate, but found none.')
         with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
             plugin.process(self.cube)
 

--- a/lib/improver/tests/nbhood/use_nbhood/test_CollapseMaskedNeighbourhoodCoordinate.py
+++ b/lib/improver/tests/nbhood/use_nbhood/test_CollapseMaskedNeighbourhoodCoordinate.py
@@ -198,7 +198,7 @@ class Test_renormalize_weights(IrisTest):
         nbhooded_cube = self.weights_cube.copy()
         plugin = CollapseMaskedNeighbourhoodCoordinate("kitten",
                                                        self.weights_cube)
-        message = "Expected to find exactly 1  coordinate, but found none."
+        message = "Expected to find exactly 1 .* coordinate, but found none."
         with self.assertRaisesRegexp(CoordinateNotFoundError, message):
             plugin.renormalize_weights(nbhooded_cube)
 

--- a/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -169,7 +169,7 @@ class Test_update_metadata_after_max(IrisTest):
         """Test that the metadata is set as expected """
         plugin = WindGustDiagnostic(50.0, 80.0)
         result = plugin.update_metadata_after_max(self.cube, self.perc_coord)
-        msg = 'Expected to find exactly 1  coordinate, but found none.'
+        msg = 'Expected to find exactly 1 .* coordinate, but found none.'
         with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
             result.coord(self.perc_coord)
 


### PR DESCRIPTION
…regular expression error messages (for backward compatibility with iris 1.13).
#474 

Testing:
 - [ x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

