### PR TITLE
Impro 570 fix iris2 unittests2

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -871,9 +871,10 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                 forecast_predictor.coord("time").units.name,
                 forecast_predictor.coord("time").units.calendar)[0]
 
-            constr = iris.Constraint(time=date)
-            forecast_predictor_at_date = forecast_predictor.extract(constr)
-            forecast_var_at_date = forecast_var.extract(constr)
+            with iris.FUTURE.context(cell_datetime_objects=True):
+                constr = iris.Constraint(time=date)
+                forecast_predictor_at_date = forecast_predictor.extract(constr)
+                forecast_var_at_date = forecast_var.extract(constr)
 
             # If the coefficients are not available for the date, use the
             # raw ensemble forecast as the calibrated ensemble forecast.

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -871,10 +871,9 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                 forecast_predictor.coord("time").units.name,
                 forecast_predictor.coord("time").units.calendar)[0]
 
-            with iris.FUTURE.context(cell_datetime_objects=True):
-                constr = iris.Constraint(time=date)
-                forecast_predictor_at_date = forecast_predictor.extract(constr)
-                forecast_var_at_date = forecast_var.extract(constr)
+            constr = iris.Constraint(time=date)
+            forecast_predictor_at_date = forecast_predictor.extract(constr)
+            forecast_var_at_date = forecast_var.extract(constr)
 
             # If the coefficients are not available for the date, use the
             # raw ensemble forecast as the calibrated ensemble forecast.

--- a/lib/improver/spotdata/extrema.py
+++ b/lib/improver/spotdata/extrema.py
@@ -109,8 +109,7 @@ class ExtractExtrema(object):
         period_cubes = CubeList()
         for period_start, period_end in zip(starts, ends):
             extrema_constraint = datetime_constraint(period_start, period_end)
-            with iris.FUTURE.context(cell_datetime_objects=True):
-                cube_over_period = local_tz_cube.extract(extrema_constraint)
+            cube_over_period = local_tz_cube.extract(extrema_constraint)
             if cube_over_period is not None:
                 # Ensure time dimension of resulting cube reflects period.
                 mid_time = dt_to_utc_hours(period_start +

--- a/lib/improver/spotdata/read_input.py
+++ b/lib/improver/spotdata/read_input.py
@@ -112,8 +112,7 @@ def get_additional_diagnostics(diagnostic_name, diagnostic_data_path,
     cubes = load_cubelist(files_to_read)
 
     if time_extract is not None:
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cubes = cubes.extract(time_extract)
+        cubes = cubes.extract(time_extract)
         if not cubes:
             raise ValueError('No diagnostics match {}'.format(time_extract))
     return cubes

--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -183,7 +183,8 @@ class Test_correct_collapsed_coordinates(IrisTest):
                         standard_name="lwe_thickness_of_precipitation_amount")
         new_cube.add_dim_coord(DimCoord([0, 1, 2], "forecast_period",
                                         units="hours"), 0)
-        message = "New points shape must match existing points shape."
+
+        message = "Require data with shape"
         with self.assertRaisesRegexp(ValueError, message):
             self.plugin.correct_collapsed_coordinates(orig_cube, new_cube,
                                                       ['forecast_period'])

--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -184,7 +184,7 @@ class Test_correct_collapsed_coordinates(IrisTest):
         new_cube.add_dim_coord(DimCoord([0, 1, 2], "forecast_period",
                                         units="hours"), 0)
 
-        message = "Require data with shape"
+        message = "Require data with shape \(3,\), got \(2,\)\."
         with self.assertRaisesRegexp(ValueError, message):
             self.plugin.correct_collapsed_coordinates(orig_cube, new_cube,
                                                       ['forecast_period'])

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -159,14 +159,13 @@ class Test_setup(IrisTest):
             dim_coords_and_dims=[(time, 0), (latitude, 1), (longitude, 2)],
             units="hPa")
 
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            ad = {
-                'temperature_on_height_levels':
-                    temperature_on_height_levels.extract(time_extract),
-                'pressure_on_height_levels':
-                    pressure_on_height_levels.extract(time_extract),
-                'surface_pressure': surface_pressure.extract(time_extract)
-                }
+        ad = {
+            'temperature_on_height_levels':
+                temperature_on_height_levels.extract(time_extract),
+            'pressure_on_height_levels':
+                pressure_on_height_levels.extract(time_extract),
+            'surface_pressure': surface_pressure.extract(time_extract)
+            }
 
         sites = OrderedDict()
         sites.update(
@@ -205,8 +204,7 @@ class Test_setup(IrisTest):
     def return_type(self, method, ancillary_data, additional_data, **kwargs):
         """Test that the plugin returns an iris.cube.Cube."""
         plugin = Plugin(method)
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cube = self.cube.extract(self.time_extract)
+        cube = self.cube.extract(self.time_extract)
         result = plugin.process(cube, self.sites, self.neighbour_list,
                                 ancillary_data, additional_data, **kwargs)
 
@@ -216,8 +214,7 @@ class Test_setup(IrisTest):
                         expected, **kwargs):
         """Test that the plugin returns the correct value."""
         plugin = Plugin(method)
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cube = self.cube.extract(self.time_extract)
+        cube = self.cube.extract(self.time_extract)
         result = plugin.process(cube, self.sites, self.neighbour_list,
                                 ancillary_data, additional_data, **kwargs)
 
@@ -268,8 +265,7 @@ class Test_setup(IrisTest):
         self.neighbour_list['j'] = 11
 
         plugin = Plugin(method)
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cube = cube.extract(self.time_extract)
+        cube = cube.extract(self.time_extract)
 
         result = plugin.process(cube, self.sites, self.neighbour_list,
                                 ancillary_data, additional_data, **kwargs)
@@ -309,8 +305,7 @@ class Test_ExtractData(Test_setup):
 
         plugin = Plugin('quantum_interpolation')
         msg = 'Unknown method'
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cube = self.cube.extract(self.time_extract)
+        cube = self.cube.extract(self.time_extract)
         with self.assertRaisesRegexp(AttributeError, msg):
             plugin.process(cube, self.sites, self.neighbour_list, {}, None,
                            **self.kwargs)
@@ -475,8 +470,7 @@ class Test_model_level_temperature_lapse_rate(Test_setup):
         t_data.resize((3, 20, 20))
 
         self.ad['temperature_on_height_levels'].data = t_data
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cube = self.cube.extract(self.time_extract)
+        cube = self.cube.extract(self.time_extract)
         cube.data = cube.data*0.0
 
         self.sites['100']['altitude'] = -90.

--- a/lib/improver/tests/spotdata/spotdata/test_read_input.py
+++ b/lib/improver/tests/spotdata/spotdata/test_read_input.py
@@ -108,14 +108,13 @@ class Test_read_input(IrisTest):
         surface_pressure.rename('surface_pressure')
 
         # Build reference copy of additional_data dictionary.
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            additional_data = {
-                'temperature_on_height_levels': CubeList(
-                    [temperature_on_height_levels]),
-                'pressure_on_height_levels': CubeList([
-                    pressure_on_height_levels]),
-                'surface_pressure': CubeList([surface_pressure])
-                }
+        additional_data = {
+            'temperature_on_height_levels': CubeList(
+                [temperature_on_height_levels]),
+            'pressure_on_height_levels': CubeList([
+                pressure_on_height_levels]),
+            'surface_pressure': CubeList([surface_pressure])
+            }
 
         self.data_directory = mkdtemp()
 

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -247,8 +247,7 @@ class Test_datetime_constraint(Test_common_functions):
         time_limit = datetime.datetime(2017, 2, 17, 18, 0)
         expected_times = range(1487311200, 1487354400, 3600)
         dt_constraint = plugin(time_start, time_max=time_limit)
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            result = self.long_cube.extract(dt_constraint)
+        result = self.long_cube.extract(dt_constraint)
         self.assertEqual(result.shape, (12, 12, 12))
         self.assertArrayEqual(result.coord('time').points,
                               expected_times)
@@ -263,16 +262,14 @@ class Test_datetime_constraint(Test_common_functions):
         """Test use of constraint at a time valid within the cube."""
         plugin = datetime_constraint
         dt_constraint = plugin(datetime.datetime(2017, 2, 17, 6, 0))
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            result = self.cube.extract(dt_constraint)
+        result = self.cube.extract(dt_constraint)
         self.assertIsInstance(result, Cube)
 
     def test_invalid_constraint(self):
         """Test use of constraint at a time invalid within the cube."""
         plugin = datetime_constraint
         dt_constraint = plugin(datetime.datetime(2017, 2, 17, 18, 0))
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            result = self.cube.extract(dt_constraint)
+        result = self.cube.extract(dt_constraint)
         self.assertNotIsInstance(result, Cube)
 
 

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -155,11 +155,10 @@ def forecast_period_coord(
         except ValueError as err:
             msg = "For forecast_reference_time: {}".format(err)
             raise ValueError(msg)
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            time_points = np.array(
-                [c.point for c in t_coord.cells()])
-            forecast_reference_time_points = np.array(
-                [c.point for c in fr_coord.cells()])
+        time_points = np.array(
+            [c.point for c in t_coord.cells()])
+        forecast_reference_time_points = np.array(
+            [c.point for c in fr_coord.cells()])
         required_lead_times = (
             time_points - forecast_reference_time_points)
         # Convert the timedeltas to a total in seconds.
@@ -279,8 +278,7 @@ def extract_cube_at_time(cubes, time, time_extract):
 
     """
     try:
-        with iris.FUTURE.context(cell_datetime_objects=True):
-            cube_in, = cubes.extract(time_extract)
+        cube_in, = cubes.extract(time_extract)
         return cube_in
     except ValueError:
         msg = ('Forecast time {} not found within data cubes.'.format(


### PR DESCRIPTION
GitHub Issue #477
Testing:

- [x] Ran **specified** tests and they passed OK

Following unittests now run:
* test_wrong_size_coords (tests.blending)
* test_invalid_extraction_time (tests.spotdata)
* test_invalid_time (tests.utilities)
* test_negative_forecast_periods_warning (tests.utilities)

Note that these changes are not backward compatible with Iris 1.13.0 due to the removal of `iris.FUTURE.context(cell_datetime_objects=True)` statements and unit test regex matching to changed Iris2 error messages.