### PR TITLE
IMPRO-569 attempt to fix codacy and travis build errors due to recent unittest changes

### DIFF
--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -184,7 +184,9 @@ class Test_correct_collapsed_coordinates(IrisTest):
         new_cube.add_dim_coord(DimCoord([0, 1, 2], "forecast_period",
                                         units="hours"), 0)
 
-        message = "Require data with shape \(3,\), got \(2,\)\."
+        # r added in front of error message string to make this a raw string
+        # and avoid 'anomalous backslash in string' codacy and travis errors.
+        message = r"Require data with shape \(3,\), got \(2,\)\."
         with self.assertRaisesRegexp(ValueError, message):
             self.plugin.correct_collapsed_coordinates(orig_cube, new_cube,
                                                       ['forecast_period'])


### PR DESCRIPTION
GH issue #478

Add r in front of error message string to make this a raw string and see if this avoids the 'anomalous backslash in string' codacy and travis errors.

Reference issue if exists

Testing:
 - [X] Ran specified tests and they passed OK
