### PR TITLE
Acceptance test tweak

### DIFF
--- a/tests/improver-probabilities-to-realizations/02-basic.bats
+++ b/tests/improver-probabilities-to-realizations/02-basic.bats
@@ -36,7 +36,7 @@
   improver_check_skip_acceptance
 
   run improver probabilities-to-realizations  \
-      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/basic/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-probabilities-to-realizations/03-12_realizations.bats
+++ b/tests/improver-probabilities-to-realizations/03-12_realizations.bats
@@ -36,7 +36,7 @@
   improver_check_skip_acceptance
 
   run improver probabilities-to-realizations --no-of-realizations=12 \
-      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/basic/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 


### PR DESCRIPTION
Simply moving the input.nc file down into the /basic directory to keep the structure consistent with other tests.
