### PR TITLE
Update to remove warnings when running the Iris 2 stack

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -50,8 +50,9 @@ from improver.utilities.warnings_handler import ManageWarnings
 
 IGNORED_MESSAGES = ["The pandas.core.datetools module is deprecated",
                     "numpy.dtype size changed",
-                    "Not importing directory .*sphinxcontrib'"]
-WARNING_TYPES = [FutureWarning, RuntimeWarning, ImportWarning]
+                    "Not importing directory .*sphinxcontrib'",
+                    "The statsmodels can not be imported"]
+WARNING_TYPES = [FutureWarning, RuntimeWarning, ImportWarning, ImportWarning]
 
 
 class ContinuousRankedProbabilityScoreMinimisers(object):
@@ -367,7 +368,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                     "the individual ensemble members. "
                     "A default initial guess will be used without "
                     "estimating coefficients from a linear model.")
-                warnings.warn(msg)
+                warnings.warn(msg, ImportWarning)
         self.statsmodels_found = statsmodels_found
 
     def __str__(self):

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -46,6 +46,12 @@ from improver.ensemble_calibration.ensemble_calibration_utilities import (
 from improver.utilities.cube_manipulation import (
     concatenate_cubes, enforce_coordinate_ordering)
 from improver.utilities.temporal import iris_time_to_datetime
+from improver.utilities.warnings_handler import ManageWarnings
+
+IGNORED_MESSAGES = ["The pandas.core.datetools module is deprecated",
+                    "numpy.dtype size changed",
+                    "Not importing directory .*sphinxcontrib'"]
+WARNING_TYPES = [FutureWarning, RuntimeWarning, ImportWarning]
 
 
 class ContinuousRankedProbabilityScoreMinimisers(object):
@@ -318,6 +324,8 @@ class EstimateCoefficientsForEnsembleCalibration(object):
     # ESTIMATE_COEFFICIENTS_FROM_LINEAR_MODEL_FLAG = False.
     ESTIMATE_COEFFICIENTS_FROM_LINEAR_MODEL_FLAG = True
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def __init__(self, distribution, desired_units,
                  predictor_of_mean_flag="mean"):
         """

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -102,7 +102,10 @@ class Test_process(IrisTest):
         ignored_messages=["The statsmodels can not be imported",
                           "Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in"
-                          " convergence"])
+                          " convergence",
+                          "\nThe final iteration resulted in a percentage "
+                          "change that is greater than the"
+                          " accepted threshold "])
     def test_basic_temperature_members(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -150,6 +153,8 @@ class Test_process(IrisTest):
     @ManageWarnings(
         ignored_messages=["The statsmodels can not be imported",
                           "Collapsing a non-contiguous coordinate.",
+                          "\nThe final iteration resulted in a percentage "
+                          "change that is greater than the accepted threshold",
                           "Minimisation did not result in"
                           " convergence"])
     def test_basic_wind_speed_members(self):
@@ -202,10 +207,17 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result[1][0].data, variance_data)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
+        ignored_messages=["\nThe final iteration resulted in a percentage "
+                          "change that is greater than the"
+                          " accepted threshold ",
+                          "The pandas.core.datetools module is deprecated",
+                          "numpy.dtype size changed",
+                          "Not importing directory .*sphinxcontrib'",
                           "Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in"
-                          " convergence"])
+                          " convergence"],
+        warning_types=[UserWarning, FutureWarning, RuntimeWarning,
+                       ImportWarning, UserWarning, UserWarning])
     def test_temperature_members_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -287,10 +299,17 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result[1][0].data, variance_data)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
+        ignored_messages=["\nThe final iteration resulted in a percentage "
+                          "change that is greater than the"
+                          " accepted threshold ",
+                          "The pandas.core.datetools module is deprecated",
+                          "numpy.dtype size changed",
+                          "Not importing directory .*sphinxcontrib'",
                           "Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in"
-                          " convergence"])
+                          " convergence"],
+        warning_types=[UserWarning, FutureWarning, RuntimeWarning,
+                       ImportWarning, UserWarning, UserWarning])
     def test_wind_speed_members_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -49,9 +49,8 @@ from improver.tests.ensemble_calibration.ensemble_calibration.\
                              _create_historic_forecasts, _create_truth)
 from improver.utilities.warnings_handler import ManageWarnings
 
-IGNORED_MESSAGES = ["Collapsing a non-contiguous coordinate.",
-                    "Not importing directory .*sphinxcontrib'"]
-WARNING_TYPES = [UserWarning, ImportWarning]
+IGNORED_MESSAGES = ["Collapsing a non-contiguous coordinate."]
+WARNING_TYPES = [UserWarning]
 
 
 class Test__init__(IrisTest):
@@ -467,8 +466,10 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Minimisation did not result in convergence",
-                          "Collapsing a non-contiguous coordinate.",
-                          "The statsmodels can not be imported"])
+                          "\nThe final iteration resulted in a percentage "
+                          "change that is greater than the"
+                          " accepted threshold ",
+                          "Collapsing a non-contiguous coordinate."])
     def test_coefficient_values_for_gaussian_distribution_members(self):
         """
         Ensure that the values generated within optimised_coeffs match the
@@ -511,8 +512,10 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Minimisation did not result in convergence",
-                          "Collapsing a non-contiguous coordinate.",
-                          "The statsmodels can not be imported"])
+                          "\nThe final iteration resulted in a percentage "
+                          "change that is greater than the"
+                          " accepted threshold ",
+                          "Collapsing a non-contiguous coordinate."])
     def test_coefficient_values_for_truncated_gaussian_distribution_mem(self):
         """
         Ensure that the values generated within optimised_coeffs match the


### PR DESCRIPTION
Edits related to the import of the statsmodels module that is causing warnings messages to be raised following the upgrade to the Iris 2 stack, which now includes statsmodels.

Issue: #478 , #551 

Testing:
 - [x] Ran tests and they passed OK

