### PR TITLE
Hardcode netcdf4 version, so that netcdftime is still included

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ install:
   - conda install -c conda-forge iris=2.0
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge mock filelock numpy=1.13.3 pycodestyle pylint pandas python-stratify sphinx=1.7.0
+  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint pandas python-stratify sphinx=1.7.0
+  - conda list
 
 script:
   - python -c "import iris"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ install:
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint pandas python-stratify sphinx=1.7.0
+
+  # List the name and version of all the dependencies within the conda environment.
   - conda list
 
 script:


### PR DESCRIPTION
Hardcode netcdf4 version, as netcdf4 version 1.4.0 currently breaks Iris, as the netcdf4 module no longer contains netcdftime, which has been factored out into a separate package.

Testing:
 - [x] Ran tests and they passed OK

