### PR TITLE
Fix for IMPRO-564 where ECDF bounds were not defined for max daytime…

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -66,5 +66,9 @@ BOUNDS_FOR_ECDF = {
     "thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.2), "m"),
     "lwe_snowfall_rate": Bounds((0, 0.00001), "m s-1"),
     "lwe_snowfall_rate_in_vicinity": Bounds((0, 0.00001), "m s-1"),
-    "visibility_in_air": Bounds((0, 100000), "m")
+    "visibility_in_air": Bounds((0, 100000), "m"),
+    "temperature_at_screen_level_nighttime_min": (  
+        Bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
+    "temperature_at_screen_level_daytime_max": (
+        Bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin"))
 }

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -67,7 +67,7 @@ BOUNDS_FOR_ECDF = {
     "lwe_snowfall_rate": Bounds((0, 0.00001), "m s-1"),
     "lwe_snowfall_rate_in_vicinity": Bounds((0, 0.00001), "m s-1"),
     "visibility_in_air": Bounds((0, 100000), "m"),
-    "temperature_at_screen_level_nighttime_min": (  
+    "temperature_at_screen_level_nighttime_min": (
         Bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
     "temperature_at_screen_level_daytime_max": (
         Bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin"))


### PR DESCRIPTION
… and min nighttime temperatures

Required to get the percentile_extract step to work in the suite after making the changes in the processing order for max daytime and min nighttime temperatures as part of [IMPRO-564](https://exxconfigmgmt:6391/browse/IMPRO-564).

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
