### PR TITLE
Removed use of deprecated flavor argument within pandas

### DIFF
--- a/lib/improver/database.py
+++ b/lib/improver/database.py
@@ -292,7 +292,6 @@ class SpotDatabase(object):
         # Find the number of columns which were indexes to index primary keys
         n_keys = len(new_df.columns) - len(self.df.columns)
         schema = pd.io.sql.get_schema(new_df, table,
-                                      flavor='sqlite',
                                       keys=new_df.columns[:n_keys])
         return schema
 

--- a/lib/improver/tests/database/test_SpotDatabase.py
+++ b/lib/improver/tests/database/test_SpotDatabase.py
@@ -528,9 +528,6 @@ class Test_determine_schema(IrisTest):
                                    "index")
         self.dataframe = self.plugin.to_dataframe(cubes)
 
-    @ManageWarnings(
-        ignored_messages=["the 'flavor' parameter is deprecated"],
-        warning_types=[FutureWarning])
     def test_full_schema(self):
         """Basic test using a basic dataframe as input"""
         schema = self.plugin.determine_schema("improver")


### PR DESCRIPTION
Master is currently failing on Travis due to the latest version of pandas (0.23.0) removing the flavor argument for pandas.io.sql.get_schema: https://github.com/pandas-dev/pandas/commit/5a926a7d1d9041749c1cd8f73e4e5e3cc5a7f360#diff-b41f9fd042c423682f8e4c4d808dbe64. This argument is no longer needed as 'sqlite' was the only supported flavor anyway.

Testing:
 - [x] Ran tests and they passed OK
