### PR TITLE
Fix the gradient CLI to pass a CubeList to save_netcdf

### DIFF
--- a/bin/improver-gradient
+++ b/bin/improver-gradient
@@ -31,9 +31,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to calculate gradient of input field in x and y direction."""
 
-from improver.argparser import ArgParser
 import os
 
+import iris
+
+from improver.argparser import ArgParser
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
@@ -62,6 +64,7 @@ def main():
     if not os.path.exists(args.output_filepath) or args.force:
         input_field = load_cube(args.input_filepath)
         gradients = DifferenceBetweenAdjacentGridSquares().process(input_field)
+        gradients = iris.cube.CubeList([gradients[0], gradients[1]])
         save_netcdf(gradients, args.output_filepath)
     else:
         print args.output_filepath


### PR DESCRIPTION
Addresses #538 , #439 

Description:
Edit to force the gradient CLI to convert a tuple to a cubelist, as save_netcdf expects to be handling cubelists.

Testing:
 - [x] Ran tests and they passed OK
