### PR TITLE
Port IMPROVER to Python 3 (#558)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 
 language: python
 python:
-  - 2.7.12
+  - 3.6.5
 sudo: false
 
 git:

--- a/bin/improver-generate-landmask-ancillary
+++ b/bin/improver-generate-landmask-ancillary
@@ -63,7 +63,7 @@ def main():
         land_binary_mask = CorrectLandSeaMask().process(landmask)
         save_netcdf(land_binary_mask, args.output_filepath)
     else:
-        print 'File already exists here: ', args.output_filepath
+        print('File already exists here: ', args.output_filepath)
 
 
 if __name__ == "__main__":

--- a/bin/improver-generate-topography-bands-mask
+++ b/bin/improver-generate-topography-bands-mask
@@ -120,7 +120,7 @@ def main():
         result = result.concatenate_cube()
         save_netcdf(result, args.output_filepath)
     else:
-        print 'File already exists here: ', args.output_filepath
+        print('File already exists here: ', args.output_filepath)
 
 
 if __name__ == "__main__":

--- a/bin/improver-generate-topography-bands-weights
+++ b/bin/improver-generate-topography-bands-weights
@@ -126,7 +126,7 @@ def main():
             orography, thresholds_dict, landmask=landmask)
         save_netcdf(result, args.output_filepath)
     else:
-        print 'File already exists here: ', args.output_filepath
+        print('File already exists here: ', args.output_filepath)
 
 
 if __name__ == "__main__":

--- a/bin/improver-gradient
+++ b/bin/improver-gradient
@@ -67,7 +67,7 @@ def main():
         gradients = iris.cube.CubeList([gradients[0], gradients[1]])
         save_netcdf(gradients, args.output_filepath)
     else:
-        print args.output_filepath
+        print(args.output_filepath)
         msg = 'File already exists here: {}'.format(args.output_filepath)
         raise IOError(msg)
 

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -120,12 +120,12 @@ def main():
                 fuzzy_bounds.append(tuple(thresholds_from_file[key]))
         except ValueError as err:
             # Extend error message with hint for common JSON error.
-            raise type(err)(err.message + " in JSON file {}. \nHINT: Try "
+            raise type(err)(err + " in JSON file {}. \nHINT: Try "
                             "adding a zero after the decimal point.".format(
                                 args.threshold_config))
         except Exception as err:
             # Extend any errors with message about WHERE this occurred.
-            raise type(err)(err.message + " in JSON file {}".format(
+            raise type(err)(err + " in JSON file {}".format(
                 args.threshold_config))
     else:
         thresholds = args.threshold_values

--- a/bin/improver-wxcode
+++ b/bin/improver-wxcode
@@ -64,7 +64,7 @@ def interrogate_decision_tree():
     # How the data has been thresholded relative to these thresholds.
     relative = {}
 
-    for query in queries.itervalues():
+    for query in queries.values():
         diagnostics = expand_nested_lists(query, 'diagnostic_fields')
         for index, diagnostic in enumerate(diagnostics):
             if diagnostic not in requirements:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -364,7 +364,7 @@ napoleon_include_init_with_doc = True
 def run_apidoc(_):
     """Allow automatic running of sphinx-apidoc:
     Adapted from: https://github.com/rtfd/readthedocs.org/issues/1139"""
-    from sphinx.apidoc import main
+    from sphinx.ext.apidoc import main
 
     output_dir = os.path.dirname(os.path.abspath(__file__))
     exclude_dir = os.path.join(SOURCE_DIR, 'improver', 'tests')

--- a/lib/improver/argparser.py
+++ b/lib/improver/argparser.py
@@ -138,7 +138,7 @@ class ArgParser(ArgumentParser):
             specific_arguments = []
 
         # argspecs of the compulsory arguments (no switch here)
-        compulsory_arguments = ArgParser.COMPULSORY_ARGUMENTS.values()
+        compulsory_arguments = list(ArgParser.COMPULSORY_ARGUMENTS.values())
 
         # get argspecs of the central arguments from the list of keys passed in
         central_arguments = [ArgParser.CENTRALIZED_ARGUMENTS[arg_name] for

--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -416,7 +416,7 @@ class WeightedBlendAcrossWholeDimension(object):
         """Represent the configured plugin instance as a string."""
         description = ('<WeightedBlendAcrossWholeDimension:'
                        ' coord = {0:s}, weighting_mode = {1:s},'
-                       ' coord_adjust = {2:s}>')
+                       ' coord_adjust = {2}>')
         return description.format(self.coord, self.mode, self.coord_adjust)
 
     def process(self, cube, weights=None):
@@ -457,7 +457,7 @@ class WeightedBlendAcrossWholeDimension(object):
         if not isinstance(cube, iris.cube.Cube):
             msg = ('The first argument must be an instance of '
                    'iris.cube.Cube but is'
-                   ' {0:s}.'.format(type(cube)))
+                   ' {}.'.format(type(cube)))
             raise TypeError(msg)
 
         # Check that the points within the time coordinate are equal
@@ -503,9 +503,10 @@ class WeightedBlendAcrossWholeDimension(object):
                 msg = ('The weights array must match the shape '
                        'of the coordinate in the input cube; '
                        'weight shape is '
-                       '{0:s}'.format(np.array(weights).shape) +
+                       '{0:s}'.format(str(np.array(weights).shape)) +
                        ', cube shape is '
-                       '{0:s}'.format(cube.coord(self.coord).points.shape))
+                       '{0:s}'.format(
+                           str(cube.coord(self.coord).points.shape)))
                 raise ValueError(msg)
 
         # If coord to blend over is a scalar_coord warn

--- a/lib/improver/blending/weights.py
+++ b/lib/improver/blending/weights.py
@@ -349,7 +349,7 @@ class ChooseDefaultWeightsLinear(object):
         if not isinstance(cube, iris.cube.Cube):
             msg = ('The first argument must be an instance of '
                    'iris.cube.Cube but is'
-                   ' {0:s}'.format(type(cube)))
+                   ' {0:s}'.format(str(type(cube))))
             raise TypeError(msg)
 
         (num_of_weights,
@@ -443,7 +443,7 @@ class ChooseDefaultWeightsNonLinear(object):
         if not isinstance(cube, iris.cube.Cube):
             msg = ('The first argument must be an instance of '
                    'iris.cube.Cube but is'
-                   ' {0:s}'.format(type(cube)))
+                   ' {0:s}'.format(str(type(cube))))
             raise TypeError(msg)
 
         (num_of_weights,
@@ -550,7 +550,7 @@ class ChooseDefaultWeightsTriangular(object):
         if not isinstance(cube, iris.cube.Cube):
             msg = ('The first argument must be an instance of '
                    'iris.cube.Cube but is'
-                   ' {0:s}'.format(type(cube)))
+                   ' {0:s}'.format(str(type(cube))))
             raise TypeError(msg)
 
         cube_coord = cube.coord(coord_name)
@@ -568,6 +568,6 @@ class ChooseDefaultWeightsTriangular(object):
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
         msg = ("<ChooseDefaultTriangularWeights width={:4.1f},"
-               " parameters_units={:s}>")
+               " parameters_units={}>")
         desc = msg.format(self.width, self.parameters_units)
         return desc

--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -226,7 +226,7 @@ class CubeCombiner(object):
 
         # If cube has coord bounds that we want to expand
         if expanded_coord:
-            for coord, treatment in expanded_coord.iteritems():
+            for coord, treatment in expanded_coord.items():
                 result = self.expand_bounds(result,
                                             cube_list,
                                             coord=coord,

--- a/lib/improver/database.py
+++ b/lib/improver/database.py
@@ -152,8 +152,8 @@ class SpotDatabase(object):
                     self.map_primary_index(df)
 
                 if self.column_dims and self.column_maps:
-                    for dim, col in itertools.izip_longest(self.column_dims,
-                                                           self.column_maps):
+                    for dim, col in itertools.zip_longest(self.column_dims,
+                                                          self.column_maps):
                         self.insert_extra_mapped_column(df, cube_slice, dim,
                                                         col)
                 try:
@@ -211,7 +211,7 @@ class SpotDatabase(object):
 
         """
         coords = cube.coord(self.pivot_dim).points
-        col_names = map(self.pivot_map, coords)
+        col_names = list(map(self.pivot_map, coords))
         dataframe.insert(1, self.pivot_dim, col_names)
         dataframe = dataframe.pivot(columns=self.pivot_dim, values='values')
         return dataframe
@@ -227,7 +227,7 @@ class SpotDatabase(object):
         """
         for mapping, function in zip(self.primary_map,
                                      self.primary_func):
-            dataframe.insert(0, mapping, map(function, dataframe.index))
+            dataframe.insert(0, mapping, list(map(function, dataframe.index)))
         dataframe.set_index(self.primary_map, inplace=True)
 
     @staticmethod

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -359,7 +359,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                     "the individual ensemble members. "
                     "A default initial guess will be used without "
                     "estimating coefficients from a linear model.")
-                warnings.warn(msg)
+                warnings.warn(msg, ImportWarning)
         self.statsmodels_found = statsmodels_found
 
     def __str__(self):
@@ -900,7 +900,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                     excess_beta = (
                         optimised_coeffs_at_date[len(coeff_names):].tolist())
                     optimised_coeffs_at_date = (
-                        dict(zip(coeff_names, optimised_coeffs_at_date)))
+                        dict(list(zip(coeff_names, optimised_coeffs_at_date))))
                     optimised_coeffs_at_date["beta"] = np.array(
                         [optimised_coeffs_at_date["beta"]]+excess_beta)
                 else:

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -752,7 +752,7 @@ class EnsembleReordering(object):
                 realization_list.append(mpoints[index % len(mpoints)])
 
             # Assume that the ensemble members are ascending linearly.
-            new_member_numbers = realization_list[0] + range(plen)
+            new_member_numbers = realization_list[0] + list(range(plen))
 
             # Extract the members required in the realization_list from
             # the raw_forecast_members. Edit the member number as appropriate

--- a/lib/improver/percentile.py
+++ b/lib/improver/percentile.py
@@ -63,7 +63,7 @@ class PercentileConverter(object):
         """
         if not isinstance(collapse_coord, list):
             collapse_coord = [collapse_coord]
-        if not all([isinstance(test_coord, basestring)
+        if not all([isinstance(test_coord, str)
                     for test_coord in collapse_coord]):
             raise TypeError('collapse_coord is {!r}, which is not a string '
                             'as is expected.'.format(collapse_coord))

--- a/lib/improver/spotdata/common_functions.py
+++ b/lib/improver/spotdata/common_functions.py
@@ -174,7 +174,7 @@ def nearest_n_neighbours(i, j, no_neighbours, exclude_self=False):
                  for a in range(-delta_neighbours, delta_neighbours+1)
                  for b in range(-delta_neighbours, delta_neighbours+1)]
     if exclude_self is True:
-        n_indices.pop(no_neighbours/2)
+        n_indices.pop(no_neighbours//2)
     return np.array(
         [np.array(n_indices)[:, 0], np.array(n_indices)[:, 1]]
         ).astype(int).tolist()
@@ -216,8 +216,8 @@ def node_edge_check(node_list, cube):
             node_list[k, min_list] = node_list[k, min_list] + coord_max
             node_list[k, max_list] = node_list[k, max_list] - coord_max
         else:
-            node_list = np.delete(node_list,
-                                  np.hstack((min_list, max_list)), 1)
+            indices_for_removal = np.hstack((min_list, max_list)).astype(int)
+            node_list = np.delete(node_list, indices_for_removal, 1)
 
     return node_list.tolist()
 
@@ -264,7 +264,7 @@ def list_entry_from_index(list_in, index_in):
         list:
             The extracted value returned as a list.
     """
-    return list(zip(*list_in)[index_in])
+    return list(list(zip(*list_in))[index_in])
 
 
 def construct_neighbour_hash(neighbour_finding):

--- a/lib/improver/spotdata/extract_data.py
+++ b/lib/improver/spotdata/extract_data.py
@@ -247,8 +247,8 @@ class ExtractData(object):
         # Build the new auxiliary coordinates.
         crds = self._aux_coords_to_make()
         aux_crds = []
-        for key, kwargs in zip(crds.keys(), crds.itervalues()):
-            aux_data = np.array([entry[key] for entry in sites.itervalues()])
+        for key, kwargs in zip(crds.keys(), crds.values()):
+            aux_data = np.array([entry[key] for entry in sites.values()])
             crd = build_coordinate(aux_data, long_name=key, **kwargs)
             aux_crds.append(crd)
 
@@ -344,7 +344,7 @@ class ExtractData(object):
 
         data = np.empty(shape=(len(sites)), dtype=float)
 
-        for i_site, site in enumerate(sites.itervalues()):
+        for i_site, site in enumerate(sites.values()):
             i, j = neighbours['i'][i_site], neighbours['j'][i_site]
 
             altitude = site['altitude']

--- a/lib/improver/spotdata/extrema.py
+++ b/lib/improver/spotdata/extrema.py
@@ -203,7 +203,7 @@ def make_local_time_cube(cube):
 
     # Create ascending indices to help with filling new_data array.
     n_sites = cube.data.shape[1]
-    row_index = range(0, n_sites)
+    row_index = list(range(0, n_sites))
 
     # Loop through times in UTC and displace data in array so that each datum
     # sits at its local time.

--- a/lib/improver/spotdata/main.py
+++ b/lib/improver/spotdata/main.py
@@ -167,14 +167,14 @@ def run_spotdata(diagnostics, ancillary_data, sites, config_constants,
         # Process diagnostics on separate threads if multiprocessing is
         # selected. Determine number of diagnostics to establish
         # multiprocessing pool size.
-        n_diagnostic_threads = min(len(diagnostics.keys()), mp.cpu_count())
+        n_diagnostic_threads = (
+            min(len(diagnostics.keys())), mp.cpu_count())
 
         # Establish multiprocessing pool - each diagnostic processed on its
         # own thread.
         diagnostic_pool = mp.Pool(processes=n_diagnostic_threads)
 
-        diagnostic_keys = [
-            diagnostic_name for diagnostic_name in diagnostics.keys()]
+        diagnostic_keys = diagnostics.keys()
 
         result = (
             diagnostic_pool.map_async(

--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -182,7 +182,7 @@ class PointSelection(object):
         iname = cube.coord(axis='y').name()
         jname = cube.coord(axis='x').name()
 
-        for i_site, site in enumerate(sites.itervalues()):
+        for i_site, site in enumerate(sites.values()):
             latitude, longitude, altitude = (site['latitude'],
                                              site['longitude'],
                                              site['altitude'])
@@ -269,7 +269,7 @@ class PointSelection(object):
         else:
             neighbours = default_neighbours
 
-        for i_site, site in enumerate(sites.itervalues()):
+        for i_site, site in enumerate(sites.values()):
 
             altitude = site['altitude']
 

--- a/lib/improver/spotdata/site_data.py
+++ b/lib/improver/spotdata/site_data.py
@@ -177,7 +177,8 @@ class ImportSiteData(object):
         self.altitudes = np.full(n_sites, np.nan)
         self.wmo_site = np.full(n_sites, 0, dtype=int)
         for i_site, site in enumerate(site_data):
-            if 'altitude' in site.keys() and site['altitude'] is not None:
+            if ('altitude' in site.keys() and
+                    site['altitude'] is not None):
                 self.altitudes[i_site] = site['altitude']
             if 'wmo_id' in site.keys() and site['wmo_id'] is not None:
                 self.wmo_site[i_site] = site['wmo_id']

--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -102,7 +102,7 @@ class Test__init__(IrisTest):
         """Test that the __init__ raises the right error"""
         message = ("weighting_mode: no_mode is not recognised, "
                    "must be either weighted_maximum or weighted_mean")
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             TriangularWeightedBlendAcrossAdjacentPoints(
                 'time', 3.0, 'hours', 'no_mode')
 
@@ -187,7 +187,7 @@ class Test_correct_collapsed_coordinates(IrisTest):
         # r added in front of error message string to make this a raw string
         # and avoid 'anomalous backslash in string' codacy and travis errors.
         message = r"Require data with shape \(3,\), got \(2,\)\."
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             self.plugin.correct_collapsed_coordinates(orig_cube, new_cube,
                                                       ['forecast_period'])
 
@@ -196,7 +196,7 @@ class Test_correct_collapsed_coordinates(IrisTest):
            a coordinate that doesn't exist."""
         self.new_cube.remove_coord('forecast_period')
         message = "Expected to find exactly 1 .* coordinate, but found none."
-        with self.assertRaisesRegexp(CoordinateNotFoundError, message):
+        with self.assertRaisesRegex(CoordinateNotFoundError, message):
             self.plugin.correct_collapsed_coordinates(self.orig_cube,
                                                       self.new_cube,
                                                       ['forecast_period'])

--- a/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -75,7 +75,7 @@ class Test__init__(IrisTest):
         """Test that the __init__ raises an error when appropriate."""
         message = ("weighting_mode: not_a_method is not recognised, "
                    "must be either weighted_maximum or weighted_mean")
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             WeightedBlendAcrossWholeDimension('time', 'not_a_method')
 
 
@@ -166,7 +166,7 @@ class Test_process(IrisTest):
         coord = "notset"
         plugin = WeightedBlendAcrossWholeDimension(coord, 'weighted_mean')
         msg = ('Expected to find exactly 1 .* coordinate, but found none.')
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             plugin.process(self.cube)
 
     def test_fails_input_not_a_cube(self):
@@ -176,7 +176,7 @@ class Test_process(IrisTest):
         notacube = 0.0
         msg = ('The first argument must be an instance of ' +
                'iris.cube.Cube')
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             plugin.process(notacube)
 
     def test_fails_perc_coord_not_dim(self):
@@ -188,7 +188,7 @@ class Test_process(IrisTest):
                                         long_name="percentile_over_time"))
         msg = ('The percentile coord must be a dimension '
                'of the cube.')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(new_cube)
 
     def test_fails_only_one_percentile_value(self):
@@ -202,7 +202,7 @@ class Test_process(IrisTest):
                                         long_name="time"), 1)
         msg = ('Percentile coordinate does not have enough points'
                ' in order to blend. Must have at least 2 percentiles.')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(new_cube)
 
     def test_fails_weights_shape(self):
@@ -213,7 +213,7 @@ class Test_process(IrisTest):
         weights = [0.1, 0.2, 0.7]
         msg = ('The weights array must match the shape ' +
                'of the coordinate in the input cube')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, weights)
 
     @ManageWarnings(
@@ -225,7 +225,7 @@ class Test_process(IrisTest):
         plugin = WeightedBlendAcrossWholeDimension(coord, 'weighted_mean',
                                                    coord_adjust)
         result = plugin.process(self.cube)
-        self.assertAlmostEquals(result.coord(coord).points, [402193.5])
+        self.assertAlmostEqual(result.coord(coord).points, [402193.5])
 
     def test_forecast_reference_time_exception(self):
         """Test that a ValueError is raised if the coordinate to be blended
@@ -234,7 +234,7 @@ class Test_process(IrisTest):
         coord = "forecast_reference_time"
         plugin = WeightedBlendAcrossWholeDimension(coord, 'weighted_mean')
         msg = ('For blending using the forecast_reference_time')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube)
 
     @ManageWarnings(record=True)

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -54,16 +54,16 @@ class Test_linear_weights(IrisTest):
     def test_fails_y0val_set_wrong(self):
         """Test it fails if y0val not set properly """
         msg = ('y0val must be a float >= 0.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LinearWeights(y0val=-0.1).linear_weights(3)
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LinearWeights(y0val=2).linear_weights(3)
 
     def test_fails_ynval_and_slope_set(self):
         """Test it fails if y0val not set properly """
         msg = ('Relative end point weight or slope must be set'
                ' but not both.')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LinearWeights(ynval=3.0, slope=-1.0).linear_weights(3)
 
     def test_returns_correct_values_num_of_weights_one(self):
@@ -103,13 +103,13 @@ class Test_linear_weights(IrisTest):
     def test_returns_correct_values_y0val_is_0_ynval_is_0(self):
         """Test it raises an error when y0val=0 and ynval=0."""
         msg = "Sum of weights must be > 0.0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LinearWeights(y0val=0.0, slope=0.0).linear_weights(5)
 
     def test_returns_correct_values_y0val_is_0_slope_is_0(self):
         """Test it raises an error when y0val=0 and slope=0."""
         msg = "Sum of weights must be > 0.0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LinearWeights(y0val=0.0, slope=0.0).linear_weights(5)
 
 
@@ -132,7 +132,7 @@ class Test_process(IrisTest):
         """Test that the resulting weights add up to one. """
         plugin = LinearWeights()
         result = plugin.process(self.cube, self.coord_name, self.coord_vals)
-        self.assertAlmostEquals(result.sum(), 1.0)
+        self.assertAlmostEqual(result.sum(), 1.0)
 
     def test_fails_coord_not_in_cube(self):
         """Test it raises a Value Error if coord not in the cube. """
@@ -140,7 +140,7 @@ class Test_process(IrisTest):
         plugin = LinearWeights()
         msg = ('The coord for this plugin must be '
                'an existing coordinate in the input cube')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, coord)
 
     def test_fails_input_not_a_cube(self):
@@ -149,14 +149,14 @@ class Test_process(IrisTest):
         notacube = 0.0
         msg = ('The first argument must be an instance of '
                'iris.cube.Cube')
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             plugin.process(notacube, self.coord_name)
 
     def test_fails_y0val_lessthan_zero(self):
         """Test it raises a Value Error if y0val less than zero. """
         plugin = LinearWeights(y0val=-10.0)
         msg = ('y0val must be a float >= 0.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, self.coord_name, self.coord_vals)
 
     def test_fails_ynval_and_slope_set(self):
@@ -164,7 +164,7 @@ class Test_process(IrisTest):
         plugin = LinearWeights(y0val=10.0, slope=-5.0, ynval=5.0)
         msg = ('Relative end point weight or slope must be set'
                ' but not both.')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, self.coord_name, self.coord_vals)
 
     def test_fails_weights_negative(self):
@@ -173,7 +173,7 @@ class Test_process(IrisTest):
         cubenew = add_realizations(self.cube, 6)
         coord = cubenew.coord('realization')
         msg = 'Weights must be positive'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cubenew, coord)
 
     def test_works_scalar_coord(self):

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
@@ -53,9 +53,9 @@ class Test_nonlinear_weights(IrisTest):
     def test_fails_cval_set_wrong(self):
         """Test it fails if cval is not >0 and <=1 """
         msg = ('cval must be greater than 0.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             NonLinearWeights(-0.1).nonlinear_weights(3)
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             NonLinearWeights(1.85).nonlinear_weights(3)
 
     def test_returns_correct_values(self):
@@ -86,7 +86,7 @@ class Test_process(IrisTest):
         """Test that the resulting weights add up to one. """
         plugin = NonLinearWeights()
         result = plugin.process(self.cube, self.coord_name, self.coord_vals)
-        self.assertAlmostEquals(result.sum(), 1.0)
+        self.assertAlmostEqual(result.sum(), 1.0)
 
     def test_fails_coord_not_in_cube(self):
         """Test it raises a Value Error if coord not in the cube. """
@@ -94,7 +94,7 @@ class Test_process(IrisTest):
         plugin = NonLinearWeights()
         msg = ('The coord for this plugin must be '
                'an existing coordinate in the input cube')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, coord)
 
     def test_fails_input_not_a_cube(self):
@@ -103,7 +103,7 @@ class Test_process(IrisTest):
         notacube = 0.0
         msg = ('The first argument must be an instance of '
                'iris.cube.Cube')
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             plugin.process(notacube, self.coord_name)
 
     def test_fails_if_cval_not_valid(self):
@@ -114,10 +114,10 @@ class Test_process(IrisTest):
         plugin = NonLinearWeights(cval=-1.0)
         msg = ('cval must be greater than 0.0 and less '
                'than or equal to 1.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, self.coord_name, self.coord_vals)
         plugin2 = NonLinearWeights(cval=1.1)
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin2.process(self.cube, self.coord_name, self.coord_vals)
 
     def test_works_if_scalar_coord(self):

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsTriangular.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsTriangular.py
@@ -258,7 +258,7 @@ class Test_process(IrisTest):
         weights_instance = ChooseDefaultWeightsTriangular(width, units="m")
         midpoint = 3600
         message = r"Unable to convert from 'Unit\('m'\)' to 'Unit\('hours'\)'"
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             weights_instance.process(self.cube, self.coord_name, midpoint)
 
 

--- a/lib/improver/tests/blending/weights/test_WeightsUtilities.py
+++ b/lib/improver/tests/blending/weights/test_WeightsUtilities.py
@@ -117,20 +117,20 @@ class Test_normalise_weights(IrisTest):
         """Test that the resulting weights add up to one. """
         weights_in = np.array([1.0, 2.0, 3.0])
         result = WeightsUtilities.normalise_weights(weights_in)
-        self.assertAlmostEquals(result.sum(), 1.0)
+        self.assertAlmostEqual(result.sum(), 1.0)
 
     def test_fails_weight_less_than_zero(self):
         """Test it fails if weight less than zero. """
         weights_in = np.array([-1.0, 0.1])
         msg = ('Weights must be positive')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.normalise_weights(weights_in)
 
     def test_fails_sum_equals_zero(self):
         """Test it fails if sum of input weights is zero. """
         weights_in = np.array([0.0, 0.0, 0.0])
         msg = ('Sum of weights must be > 0.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.normalise_weights(weights_in)
 
     def test_returns_correct_values(self):
@@ -185,7 +185,7 @@ class Test_redistribute_weights(IrisTest):
         weights_in = np.array([3.0, 2.0, 1.0])
         missing_weights = np.ones(3)
         msg = ('Sum of weights must be 1.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.redistribute_weights(weights_in,
                                                   missing_weights)
 
@@ -194,7 +194,7 @@ class Test_redistribute_weights(IrisTest):
         weights_in = np.array([-0.1, 1.1])
         missing_weights = np.ones(2)
         msg = ('Weights should be positive or at least one > 0.0')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.redistribute_weights(weights_in,
                                                   missing_weights)
 
@@ -203,7 +203,7 @@ class Test_redistribute_weights(IrisTest):
         weights_in = np.array([0.7, 0.2, 0.1])
         missing_weights = np.ones(2)
         msg = ('Arrays weights and forecast_present not the same size')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.redistribute_weights(weights_in,
                                                   missing_weights)
 
@@ -242,7 +242,7 @@ class Test_redistribute_weights(IrisTest):
         weights_in = np.array([0.6, 0.3, 0.1])
         missing_weights = np.zeros(3)
         msg = 'None of the expected forecasts were found.'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.redistribute_weights(weights_in, missing_weights)
 
 
@@ -270,7 +270,7 @@ class Test_process_coord(IrisTest):
         """ Test process_cord fails if coord not in cube """
         msg = ('The coord for this plugin must be '
                'an existing coordinate in the input cube.')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.process_coord(self.cube, 'not_in_cube', '0')
 
     def test_no_points_set_in_coord(self):
@@ -280,7 +280,7 @@ class Test_process_coord(IrisTest):
         (result_num_of_weights,
          result_missing) = WeightsUtilities.process_coord(self.cube,
                                                           self.coordinate)
-        self.assertAlmostEquals(result_num_of_weights, expected_num)
+        self.assertAlmostEqual(result_num_of_weights, expected_num)
         self.assertArrayAlmostEqual(result_missing, expected_array)
 
     def test_fails_less_points_in_coord(self):
@@ -288,7 +288,7 @@ class Test_process_coord(IrisTest):
         exp_coord_vals = self.exp_coord_vals[0]
         msg = ('The cube coordinate has more points '
                'than requested coord, ')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.process_coord(self.cube, self.coordinate,
                                            exp_coord_vals)
 
@@ -297,7 +297,7 @@ class Test_process_coord(IrisTest):
         units = 'mm'
         exp_coord_vals = '402191.5, 402192.5, 402193.5'
         msg = ('Failed to convert coord units ')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WeightsUtilities.process_coord(
                 self.cube, self.coordinate, exp_coord_vals, units)
 
@@ -311,7 +311,7 @@ class Test_process_coord(IrisTest):
         (result_num_of_weights,
          result_missing) = WeightsUtilities.process_coord(
              self.cube, self.coordinate, exp_coord_vals)
-        self.assertAlmostEquals(result_num_of_weights, expected_num)
+        self.assertAlmostEqual(result_num_of_weights, expected_num)
         self.assertArrayAlmostEqual(result_missing, expected_array)
 
 

--- a/lib/improver/tests/convection/test_DiagnoseConvectivePrecipitation.py
+++ b/lib/improver/tests/convection/test_DiagnoseConvectivePrecipitation.py
@@ -227,7 +227,7 @@ class Test__calculate_convective_ratio(IrisTest):
             self.cube.copy(), self.cube.copy(), lower_threshold,
             higher_threshold)
         msg = "A value of infinity was found"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             DiagnoseConvectivePrecipitation(
                 self.lower_threshold, self.higher_threshold,
                 self.neighbourhood_method,
@@ -244,7 +244,7 @@ class Test__calculate_convective_ratio(IrisTest):
             higher_threshold)
         radii = 4000.0
         msg = "A value of greater than 1.0 was found"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             DiagnoseConvectivePrecipitation(
                 self.lower_threshold, self.higher_threshold,
                 self.neighbourhood_method, radii,

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -58,7 +58,7 @@ class Test__init__(IrisTest):
     def test_raise_error_wrong_operation(self):
         """Test __init__ raises a ValueError for invalid operation"""
         msg = 'Unknown operation '
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             CubeCombiner('%')
 
 
@@ -138,7 +138,7 @@ class Test_expand_bounds(IrisTest):
         """Test that if an error is raised if a coordinate with more than
         one point is given"""
         emsg = 'the expand bounds function should only be used on a'
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with self.assertRaisesRegex(ValueError, emsg):
             CubeCombiner.expand_bounds(self.cubelist[0],
                                        self.cubelist,
                                        'latitude',

--- a/lib/improver/tests/database/test_SpotDatabase.py
+++ b/lib/improver/tests/database/test_SpotDatabase.py
@@ -51,6 +51,10 @@ from improver.database import SpotDatabase
 from improver.utilities.warnings_handler import ManageWarnings
 
 
+IGNORED_MESSAGES = ["invalid escape sequence"]
+WARNING_TYPES = [DeprecationWarning]
+
+
 def set_up_spot_cube(point_data, validity_time=1487311200, forecast_period=0,
                      number_of_sites=3):
     """Set up a spot data cube at a given validity time and forecast period for
@@ -177,7 +181,7 @@ class Test_check_input_dimensions(IrisTest):
                    "coord_to_slice_over must only have one point in. "
                    "Dimension '1' has length '2' and is associated with the "
                    "'percentile' coordinate.")
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             self.plugin.check_input_dimensions(self.cubes[0])
 
     def test_no_exception_if_pivot_dim_set(self):
@@ -201,7 +205,7 @@ class Test_check_input_dimensions(IrisTest):
                   "coord_to_slice_over must only have one point in. "\
                   "Dimension '2' has length '3' and is associated with the "\
                   "'index' coordinate."
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             plugin.check_input_dimensions(cubes[0])
 
 
@@ -435,6 +439,8 @@ class Test_to_dataframe(IrisTest):
         columns = ["time", "values"]
         self.input_df = pd.DataFrame(data, columns=columns)
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_no_optional_args(self):
         """Test we create a datafram even when we have no optional
            arguements set"""
@@ -448,6 +454,8 @@ class Test_to_dataframe(IrisTest):
 
         assert_frame_equal(self.plugin.df, expected_df)
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_all_optional_args(self):
         """Test we create a datafram even when we have all optional
            arguements set"""
@@ -469,6 +477,8 @@ class Test_to_dataframe(IrisTest):
         plugin.to_dataframe(self.cubelist)
         assert_frame_equal(plugin.df, expected_df)
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_all_optional_args_multiple_input_cubes(self):
         """Test we create a dataframe even when we have no optional
            arguements set and multiple cubes"""
@@ -493,6 +503,8 @@ class Test_to_dataframe(IrisTest):
         assert_frame_equal(plugin.df, expected_df)
 
     @staticmethod
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_all_optional_args_multiple_sites():
         """Test we create a datafram even when we have all optional
            arguements set and multiple spots"""
@@ -528,6 +540,8 @@ class Test_determine_schema(IrisTest):
                                    "index")
         self.dataframe = self.plugin.to_dataframe(cubes)
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_full_schema(self):
         """Basic test using a basic dataframe as input"""
         schema = self.plugin.determine_schema("improver")
@@ -551,6 +565,8 @@ class Test_process(IrisTest):
         Call(['rm', '-f', self.data_directory + '/test.csv'])
         Call(['rmdir', self.data_directory])
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_save_as_csv(self):
         """Basic test using a basic dataframe as input"""
         self.plugin.process(self.cubes)
@@ -559,13 +575,15 @@ class Test_process(IrisTest):
         expected_string = ',values\n1487311200,280.0\n'
         self.assertEqual(resulting_string, expected_string)
 
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_unknown_output_type(self):
         """Test what happens if you give an unknown output type."""
         plugin = SpotDatabase("kitten", self.data_directory + "/test.csv",
                               "improver", "time", "index")
         message = ("Unrecognised output type. Current options are 'sqlite'"
                    " or 'csv', 'kitten' given.")
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             plugin.process(self.cubes)
 
 

--- a/lib/improver/tests/database/test_VerificationDatabase.py
+++ b/lib/improver/tests/database/test_VerificationDatabase.py
@@ -97,7 +97,7 @@ class Test_to_dataframe(IrisTest):
                   "coord_to_slice_over must only have one point in. "\
                   "Dimension '1' has length '2' and is associated with the "\
                   "'percentile' coordinate."
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             plugin.to_dataframe(cubes)
 
     @staticmethod

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -470,7 +470,9 @@ class Test__apply_params(IrisTest):
             4.55819380e-06, -8.02401974e-09, 1.66667055e+00, 1.00000011e+00]
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_basic(self):
         """Test that the plugin returns a tuple."""
         optimised_coeffs = {}
@@ -492,7 +494,9 @@ class Test__apply_params(IrisTest):
         self.assertEqual(len(result), 3)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_two_dates(self):
         """
         Test that the plugin returns a tuple when two dates are present
@@ -530,7 +534,9 @@ class Test__apply_params(IrisTest):
         self.assertEqual(len(coefficients), 8)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_calibrated_predictor(self):
         """
         Test that the plugin returns values for the calibrated predictor (the
@@ -568,7 +574,9 @@ class Test__apply_params(IrisTest):
         self.assertArrayAlmostEqual(forecast_predictor[0].data, data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_calibrated_variance(self):
         """
         Test that the plugin returns values for the calibrated variance,
@@ -606,7 +614,9 @@ class Test__apply_params(IrisTest):
         self.assertArrayAlmostEqual(forecast_variance[0].data, data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_coefficients(self):
         """
         Test that the plugin returns values for the coefficients,
@@ -642,7 +652,9 @@ class Test__apply_params(IrisTest):
         self.assertArrayAlmostEqual(coefficients[0].data, data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_calibrated_predictor_members(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
@@ -683,7 +695,9 @@ class Test__apply_params(IrisTest):
         self.assertArrayAlmostEqual(forecast_predictor[0].data, data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_calibrated_variance_members(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
@@ -724,7 +738,9 @@ class Test__apply_params(IrisTest):
         self.assertArrayAlmostEqual(forecast_variance[0].data, data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_coefficients_members(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
@@ -762,7 +778,9 @@ class Test__apply_params(IrisTest):
         self.assertArrayAlmostEqual(coefficients[0].data, data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_too_many_coefficients(self):
         """
         Test that the plugin returns values for the coefficients,
@@ -793,14 +811,16 @@ class Test__apply_params(IrisTest):
         plugin = Plugin(self.cube, optimised_coeffs,
                         coeff_names)
         msg = "Number of coefficient names"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             dummy_result = plugin._apply_params(
                 predictor_cube, variance_cube, optimised_coeffs,
                 coeff_names, predictor_of_mean_flag)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Ensemble calibration not available"])
+                          "Ensemble calibration not available",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, UserWarning, DeprecationWarning])
     def test_missing_date(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
@@ -833,7 +853,9 @@ class Test__apply_params(IrisTest):
 
     @ManageWarnings(
         record=True,
-        ignored_messages=["Collapsing a non-contiguous coordinate."])
+        ignored_messages=["Collapsing a non-contiguous coordinate.",
+                          "invalid escape sequence"],
+        warning_types=[UserWarning, DeprecationWarning])
     def test_missing_date_catch_warning(self, warning_list=None):
         """
         Test that the plugin returns values for the calibrated forecasts,

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -366,7 +366,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
         plugin = Plugin()
         distribution = "foo"
         msg = "Distribution requested"
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             plugin.crps_minimiser_wrapper(
                 initial_guess, forecast_predictor, truth, forecast_variance,
                 predictor_of_mean_flag, distribution)
@@ -582,7 +582,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
         plugin = Plugin()
         distribution = "foo"
         msg = "Distribution requested"
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             plugin.crps_minimiser_wrapper(
                 initial_guess, forecast_predictor, truth, forecast_variance,
                 predictor_of_mean_flag, distribution)
@@ -610,7 +610,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
         plugin = Plugin()
         distribution = "foo"
         msg = "Distribution requested"
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             plugin.crps_minimiser_wrapper(
                 initial_guess, forecast_predictor, truth, forecast_variance,
                 predictor_of_mean_flag, distribution)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -47,8 +47,21 @@ from improver.tests.ensemble_calibration.ensemble_calibration.\
 from improver.utilities.warnings_handler import ManageWarnings
 
 IGNORED_MESSAGES = ["Collapsing a non-contiguous coordinate.",
-                    "Not importing directory .*sphinxcontrib'"]
-WARNING_TYPES = [UserWarning, ImportWarning]
+                    "Not importing directory .*sphinxcontrib'",
+                    "The pandas.core.datetools module is deprecated",
+                    "numpy.dtype size changed",
+                    "The statsmodels can not be imported",
+                    "invalid escape sequence",
+                    "can't resolve package from",
+                    "Collapsing a non-contiguous coordinate.",
+                    "Minimisation did not result in"
+                    " convergence",
+                    "\nThe final iteration resulted in a percentage "
+                    "change that is greater than the"
+                    " accepted threshold "]
+WARNING_TYPES = [UserWarning, ImportWarning, FutureWarning, RuntimeWarning,
+                 ImportWarning, DeprecationWarning, ImportWarning, UserWarning,
+                 UserWarning, UserWarning]
 
 
 class Test_process(IrisTest):
@@ -99,10 +112,7 @@ class Test_process(IrisTest):
         self.assertEqual(len(result), 2)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
-                          "Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in"
-                          " convergence"])
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_basic_temperature_members(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -124,12 +134,7 @@ class Test_process(IrisTest):
         self.assertEqual(len(result), 2)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
-                          "Collapsing a non-contiguous coordinate.",
-                          "\nThe final iteration resulted in a percentage "
-                          "change that is greater than the accepted threshold",
-                          "Minimisation did not result in"
-                          " convergence"])
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_basic_wind_speed(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -148,10 +153,7 @@ class Test_process(IrisTest):
         self.assertEqual(len(result), 2)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
-                          "Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in"
-                          " convergence"])
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_basic_wind_speed_members(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -202,10 +204,7 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result[1][0].data, variance_data)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
-                          "Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in"
-                          " convergence"])
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_temperature_members_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -255,10 +254,7 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result[1][0].data, variance_data)
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "\nThe final iteration resulted in a percentage "
-                          "change that is greater than "
-                          "the accepted threshold"])
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_wind_speed_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -287,10 +283,7 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result[1][0].data, variance_data)
 
     @ManageWarnings(
-        ignored_messages=["The statsmodels can not be imported",
-                          "Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in"
-                          " convergence"])
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_wind_speed_members_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList
@@ -367,7 +360,7 @@ class Test_process(IrisTest):
         desired_units = "degreesC"
         plugin = Plugin(calibration_method, distribution, desired_units)
         msg = "unknown"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(
                 self.current_temperature_forecast_cube,
                 self.historic_temperature_forecast_cube,

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -215,7 +215,7 @@ class Test_rename_coordinate(IrisTest):
         """
         fake_cube = "fake"
         msg = "A Cube or CubeList is not provided for renaming"
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             rename_coordinate(
                 fake_cube, "realization", "ensemble_member_id")
 
@@ -293,7 +293,7 @@ class Test_check_predictor_of_mean_flag(IrisTest):
         predictor_of_mean_flag = "foo"
 
         msg = "The requested value for the predictor_of_mean_flag"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             check_predictor_of_mean_flag(predictor_of_mean_flag)
 
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
@@ -254,7 +254,7 @@ class Test__mean_and_variance_to_percentiles(IrisTest):
         percentiles = [-10, 10]
         plugin = Plugin()
         msg = "NaNs are present within the result for the"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin._mean_and_variance_to_percentiles(
                 current_forecast_predictor, current_forecast_variance,
                 percentiles)

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -122,7 +122,7 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         bounds_pairing = (-40, 50)
         plugin = Plugin()
         msg = "The end points added to the threshold values for"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin._add_bounds_to_thresholds_and_probabilities(
                 threshold_points, probabilities_for_cdf, bounds_pairing)
 
@@ -161,7 +161,7 @@ class Test__probabilities_to_percentiles(IrisTest):
         bounds_pairing = (-40, 50)
         plugin = Plugin()
         msg = "Probabilities to percentiles only implemented for"
-        with self.assertRaisesRegexp(NotImplementedError, msg):
+        with self.assertRaisesRegex(NotImplementedError, msg):
             plugin._probabilities_to_percentiles(
                 cube, percentiles, bounds_pairing)
 
@@ -643,7 +643,7 @@ class Test_process(IrisTest):
         cube = self.current_temperature_forecast_cube
         plugin = Plugin()
         msg = "Cannot specify both no_of_percentiles and percentiles"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cube, no_of_percentiles=no_of_percentiles,
                            percentiles=percentiles)
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsMembers.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsMembers.py
@@ -114,7 +114,7 @@ class Test_process(IrisTest):
         cube.add_aux_coord(AuxCoord(0, 'realization'))
         plugin = Plugin()
         msg = r"Cannot rebadge percentile coordinate to realization.*"
-        with self.assertRaisesRegexp(InvalidCubeError, msg):
+        with self.assertRaisesRegex(InvalidCubeError, msg):
             plugin.process(cube)
 
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -105,9 +105,11 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         forecast_at_percentiles = cube.data.reshape(3, 9)
         bounds_pairing = (-40, 50)
         lower_array = np.full(
-            forecast_at_percentiles[:, 0].shape, bounds_pairing[0])
+            forecast_at_percentiles[:, 0].shape, bounds_pairing[0],
+            dtype=np.float32)
         upper_array = np.full(
-            forecast_at_percentiles[:, 0].shape, bounds_pairing[1])
+            forecast_at_percentiles[:, 0].shape, bounds_pairing[1],
+            dtype=np.float32)
         plugin = Plugin()
         result = plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
             percentiles, forecast_at_percentiles, bounds_pairing)
@@ -126,7 +128,7 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         bounds_pairing = (-40, 50)
         plugin = Plugin()
         msg = "The end points added to the forecast at percentiles"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
                 percentiles, forecast_at_percentiles, bounds_pairing)
 
@@ -140,7 +142,7 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         bounds_pairing = (-40, 50)
         plugin = Plugin()
         msg = "The percentiles must be in ascending order"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
                 percentiles, forecast_at_percentiles, bounds_pairing)
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ensemble_copula_coupling_utilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ensemble_copula_coupling_utilities.py
@@ -88,7 +88,7 @@ class Test_concatenate_2d_array_with_2d_array_endpoints(IrisTest):
         """
         input_array = np.array([-40, 200, 1000])
         msg = "all the input arrays must have same number of dimensions"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             concatenate_2d_array_with_2d_array_endpoints(
                 input_array, -100, 10000)
 
@@ -98,7 +98,7 @@ class Test_concatenate_2d_array_with_2d_array_endpoints(IrisTest):
         """
         input_array = np.array([[[-40, 200, 1000]]])
         msg = "all the input arrays must have same number of dimensions"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             concatenate_2d_array_with_2d_array_endpoints(
                 input_array, -100, 10000)
 
@@ -145,7 +145,7 @@ class Test_choose_set_of_percentiles(IrisTest):
         """
         no_of_percentiles = 3
         msg = "The unknown sampling option is not yet implemented"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             choose_set_of_percentiles(no_of_percentiles, sampling="unknown")
 
 
@@ -233,7 +233,7 @@ class Test_create_cube_with_percentiles(IrisTest):
              len(cube.coord("latitude").points),
              len(cube.coord("longitude").points)])
         msg = "could not convert string to float"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             create_cube_with_percentiles(percentiles, cube, cube_data)
 
     def test_percentile_points(self):
@@ -277,7 +277,7 @@ class Test_create_cube_with_percentiles(IrisTest):
         cube_data = self.cube_data + 2
         percentiles = [10, 50]
         msg = "Unequal lengths"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             create_cube_with_percentiles(
                 percentiles, cube, cube_data)
 
@@ -292,7 +292,7 @@ class Test_create_cube_with_percentiles(IrisTest):
         cube_data = self.cube_data + 2
         percentiles = [10, 50, 90]
         msg = "Unequal lengths"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             create_cube_with_percentiles(
                 percentiles, cube, cube_data)
 
@@ -377,7 +377,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         cube_name = "nonsense"
         cube_units = Unit("degreesC")
         msg = "The bounds_pairing_key"
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             get_bounds_of_distribution(cube_name, cube_units)
 
 
@@ -415,7 +415,7 @@ class Test_insert_lower_and_upper_endpoint_to_1d_array(IrisTest):
         """
         percentiles = np.array([[-40, 200, 1000], [-40, 200, 1000]])
         msg = "all the input arrays must have same number of dimensions"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             insert_lower_and_upper_endpoint_to_1d_array(
                 percentiles, -100, 10000)
 
@@ -470,7 +470,7 @@ class Test_restore_non_probabilistic_dimensions(IrisTest):
         cube.transpose([3, 2, 1, 0])
         plen = len(cube.coord("percentile_over_realization").points)
         msg = "coordinate is a dimension coordinate but is not"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             restore_non_probabilistic_dimensions(
                 cube.data, cube, "percentile_over_realization", plen)
 
@@ -551,7 +551,7 @@ class Test_restore_non_probabilistic_dimensions(IrisTest):
         cube = self.current_temperature_forecast_cube
         plen = len(cube.coord("percentile_over_realization").points)
         msg = "coordinate is not available"
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             restore_non_probabilistic_dimensions(
                 cube.data, cube, "nonsense", plen)
 

--- a/lib/improver/tests/generate_ancillaries/test_GenerateTopographicZoneWeights.py
+++ b/lib/improver/tests/generate_ancillaries/test_GenerateTopographicZoneWeights.py
@@ -324,7 +324,7 @@ class Test_process(IrisTest):
             orography_data, "altitude", "m", realizations=np.array([0]),
             y_dimension_length=2, x_dimension_length=2)
         msg = "The input orography cube should be two-dimensional"
-        with self.assertRaisesRegexp(InvalidCubeError, msg):
+        with self.assertRaisesRegex(InvalidCubeError, msg):
             self.plugin.process(orography, self.thresholds_dict, self.landmask)
 
     def test_data(self):

--- a/lib/improver/tests/generate_ancillaries/test_generate_ancillary.py
+++ b/lib/improver/tests/generate_ancillaries/test_generate_ancillary.py
@@ -79,9 +79,9 @@ class Test__make_mask_cube(IrisTest):
         """test checking that an exception is raised when the _make_mask_cube
         method is called with an incorrect number of bounds."""
         emsg = "should have only an upper and lower limit"
-        with self.assertRaisesRegexp(TypeError, emsg):
+        with self.assertRaisesRegex(TypeError, emsg):
             _make_mask_cube(self.mask, self.coords, [0], self.units)
-        with self.assertRaisesRegexp(TypeError, emsg):
+        with self.assertRaisesRegex(TypeError, emsg):
             _make_mask_cube(self.mask,
                             self.coords,
                             [0, 2, 4], self.units)
@@ -90,7 +90,7 @@ class Test__make_mask_cube(IrisTest):
         """test checking that an exception is raised when the _make_mask_cube
         method is called with only an upper bound."""
         emsg = "should have both an upper and lower limit"
-        with self.assertRaisesRegexp(TypeError, emsg):
+        with self.assertRaisesRegex(TypeError, emsg):
             _make_mask_cube(self.mask,  self.coords,
                             [None, self.upper], self.units)
 

--- a/lib/improver/tests/nbhood/circular_kernel/test_CircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_CircularNeighbourhood.py
@@ -52,7 +52,7 @@ class Test__init__(IrisTest):
         in for sum_or_fraction."""
         sum_or_fraction = "nonsense"
         msg = "option is invalid"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             CircularNeighbourhood(sum_or_fraction=sum_or_fraction)
 
 
@@ -345,7 +345,7 @@ class Test_run(IrisTest):
             zero_point_indices=((0, 0, 2, 2),), num_grid_points=5)[0, 0]
         msg = ("The use of a mask cube with a circular kernel is "
                "not yet implemented.")
-        with self.assertRaisesRegexp(NotImplementedError, msg):
+        with self.assertRaisesRegex(NotImplementedError, msg):
             CircularNeighbourhood().run(cube, self.RADIUS, mask_cube=cube)
 
 

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -406,7 +406,7 @@ class Test_run(IrisTest):
         cube = set_up_cube_lat_long()
         msg = "Invalid grid: projection_x/y coords required"
         radius = 6000.
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(cube, radius)
 
     def test_single_point_masked_to_null(self):
@@ -507,7 +507,7 @@ class Test_run(IrisTest):
         cube = self.cube
         radius = 0.
         msg = "Distance of {0}m gives zero cell extent".format(radius)
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(cube, radius)
 
     def test_point_pair(self):
@@ -679,8 +679,8 @@ class Test_run(IrisTest):
         cube = self.cube
         radius = 50000.0
         msg = ("Distance of {}m exceeds max domain distance of "
-               "11313.708499m").format(radius)
-        with self.assertRaisesRegexp(ValueError, msg):
+               "11313.70849898476m").format(radius)
+        with self.assertRaisesRegex(ValueError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(cube, radius)
 
     def test_mask_cube(self):
@@ -692,7 +692,7 @@ class Test_run(IrisTest):
         radius = 4000.
         msg = ("The use of a mask cube with a circular kernel is "
                "not yet implemented.")
-        with self.assertRaisesRegexp(NotImplementedError, msg):
+        with self.assertRaisesRegex(NotImplementedError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(
                 cube, radius, mask_cube=cube)
 

--- a/lib/improver/tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/lib/improver/tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -125,7 +125,8 @@ def set_up_cube(zero_point_indices=((0, 0, 7, 7),), num_time_points=1,
 
     cube.add_dim_coord(
         DimCoord(
-            range(num_realization_points), standard_name='realization'), 0)
+            range(num_realization_points),
+            standard_name='realization'), 0)
     tunit = Unit("hours since 1970-01-01 00:00:00", "gregorian")
     time_points = [402192.5 + _ for _ in range(num_time_points)]
     cube.add_dim_coord(DimCoord(time_points,
@@ -272,7 +273,7 @@ class Test__init__(IrisTest):
         radii = [10000, 20000, 30000]
         lead_times = [2, 3]
         msg = "There is a mismatch in the number of radii"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             neighbourhood_method = CircularNeighbourhood()
             NBHood(neighbourhood_method, radii, lead_times=lead_times)
 
@@ -357,7 +358,7 @@ class Test__find_radii(IrisTest):
         result = plugin._find_radii(num_ens)
         expected_result = 3563.8181771801998
         self.assertIsInstance(result, float)
-        self.assertAlmostEquals(result, expected_result)
+        self.assertAlmostEqual(result, expected_result)
 
     def test_basic_array_cube_lead_times_an_array(self):
         """Test _find_radii returns an array with the correct values."""
@@ -420,14 +421,14 @@ class Test_process(IrisTest):
         neighbourhood_method = 'nonsense'
         radii = 10000
         msg = "is not valid as a neighbourhood_method"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             NBHood(neighbourhood_method, radii).process(self.cube)
 
     def test_single_point_nan(self):
         """Test behaviour for a single NaN grid cell."""
         self.cube.data[0][0][6][7] = np.NAN
         msg = "NaN detected in input cube data"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             neighbourhood_method = CircularNeighbourhood
             NBHood(neighbourhood_method, self.RADIUS).process(self.cube)
 
@@ -436,7 +437,7 @@ class Test_process(IrisTest):
         self.cube.attributes.update({'source_realizations': [0, 1, 2, 3]})
         msg = ('Realizations and attribute source_realizations should not'
                ' both be set')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             neighbourhood_method = CircularNeighbourhood()
             NBHood(neighbourhood_method, self.RADIUS).process(self.cube)
 

--- a/lib/improver/tests/nbhood/nbhood/test_GeneratePercentilesFromANeighbourhood.py
+++ b/lib/improver/tests/nbhood/nbhood/test_GeneratePercentilesFromANeighbourhood.py
@@ -66,7 +66,7 @@ class Test__init__(IrisTest):
         neighbourhood_method = 'nonsense'
         radii = 10000
         msg = 'The neighbourhood_method requested: '
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             NBHood(neighbourhood_method, radii)
 
 

--- a/lib/improver/tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/lib/improver/tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -62,7 +62,7 @@ class Test__init__(IrisTest):
         neighbourhood_method = 'nonsense'
         radii = 10000
         msg = 'The neighbourhood_method requested: '
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             NBHood(neighbourhood_method, radii)
 
 

--- a/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -114,7 +114,7 @@ class Test__init__(Test_RecursiveFilter):
         """Test when an alpha_x value > unity is given (invalid)."""
         alpha_x = 1.1
         msg = "Invalid alpha_x: must be > 0 and < 1: 1.1"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
                             iterations=None, edge_width=1)
 
@@ -122,7 +122,7 @@ class Test__init__(Test_RecursiveFilter):
         """Test when an alpha_x value <= zero is given (invalid)."""
         alpha_x = -0.5
         msg = "Invalid alpha_x: must be > 0 and < 1: -0.5"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
                             iterations=None, edge_width=1)
 
@@ -130,7 +130,7 @@ class Test__init__(Test_RecursiveFilter):
         """Test when an alpha_y value > unity is given (invalid)."""
         alpha_y = 1.1
         msg = "Invalid alpha_y: must be > 0 and < 1: 1.1"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
                             iterations=None, edge_width=1)
 
@@ -138,7 +138,7 @@ class Test__init__(Test_RecursiveFilter):
         """Test when an alpha_y value <= zero is given (invalid)."""
         alpha_y = -0.5
         msg = "Invalid alpha_y: must be > 0 and < 1: -0.5"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
                             iterations=None, edge_width=1)
 
@@ -146,7 +146,7 @@ class Test__init__(Test_RecursiveFilter):
         """Test when iterations value less than unity is given (invalid)."""
         iterations = 0
         msg = "Invalid number of iterations: must be >= 1: 0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(alpha_x=None, alpha_y=None,
                             iterations=iterations, edge_width=1)
 
@@ -183,7 +183,7 @@ class Test__set_alphas(Test_RecursiveFilter):
         """Test that an error is raised if the alphas_cube is of a different
         shape to the data cube."""
         msg = "Dimensions of alphas array do not match dimensions "
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter()._set_alphas(self.cube, None,
                                           self.alphas_cube_wrong_dims)
 
@@ -193,7 +193,7 @@ class Test__set_alphas(Test_RecursiveFilter):
         alpha = None
         alphas_cube = None
         msg = "A value for alpha must be set if alphas_cube is "
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter()._set_alphas(self.cube, alpha, alphas_cube)
 
     def test_alphas_cube_and_alpha_both_set(self):
@@ -201,7 +201,7 @@ class Test__set_alphas(Test_RecursiveFilter):
         alpha = 0.5
         alphas_cube = self.alphas_cube
         msg = "A cube of alpha values and a single float value for"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter()._set_alphas(self.cube, alpha, alphas_cube)
 
 

--- a/lib/improver/tests/nbhood/square_kernel/test_SquareNeighbourhood.py
+++ b/lib/improver/tests/nbhood/square_kernel/test_SquareNeighbourhood.py
@@ -54,7 +54,7 @@ class Test__init__(IrisTest):
         in for sum_or_fraction."""
         sum_or_fraction = "nonsense"
         msg = "option is invalid"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             SquareNeighbourhood(sum_or_fraction=sum_or_fraction)
 
 
@@ -160,7 +160,7 @@ class Test_pad_coord(IrisTest):
         width = 1
         method = "add"
         msg = "Non-uniform increments between grid points"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             SquareNeighbourhood.pad_coord(coord, width, method)
 
     def test_remove(self):
@@ -909,9 +909,16 @@ class Test_run(IrisTest):
                [1.0000, 1.000000, 0.714286, 0.571429, 0.25],
                [np.nan, 1.000000, 0.666667, 0.571429, 0.25],
                [np.nan, 1.000000, 0.750000, 0.750000, 0.50]]]])
+        expected_mask_array = np.array(
+            [[[[True, True, False, False, True],
+               [True, False, False, False, True],
+               [True, True, False, False, False],
+               [True, True, False, False, True],
+               [True, True, False, False, True]]]])
         cube.data = np.ma.masked_where(mask == 0, cube.data)
         result = SquareNeighbourhood().run(cube, self.RADIUS)
-        self.assertArrayAlmostEqual(result.data, expected_array)
+        self.assertArrayAlmostEqual(result.data.data, expected_array)
+        self.assertArrayAlmostEqual(result.data.mask, expected_mask_array)
 
     def test_masked_array_re_mask_false(self):
         """Test that the run method produces a cube with correct data when a

--- a/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for nbhood.ApplyNeighbourhoodProcessingWithAMask."""
 
-
+from collections import OrderedDict
 import unittest
 
 import iris
@@ -62,7 +62,7 @@ def add_dimensions_to_cube(cube, new_dims):
         cube (iris.cube.Cube):
             The iris cube with the additional dimensions added.
     """
-    for dim_name, dim_size in new_dims.iteritems():
+    for dim_name, dim_size in new_dims.items():
         cubes = iris.cube.CubeList()
         for i in range(dim_size):
             threshold_coord = DimCoord([i], long_name=dim_name)
@@ -202,8 +202,8 @@ class Test_process(IrisTest):
            input cube, apart from the additional topographic zone coordinate.
         """
         self.cube.remove_coord("realization")
-        cube = add_dimensions_to_cube(self.cube,
-                                      {"realization": 4, "threshold": 3})
+        cube = add_dimensions_to_cube(
+            self.cube, OrderedDict([("threshold", 3), ("realization", 4)]))
         coord_for_masking = "topographic_zone"
         radii = 2000
         result = ApplyNeighbourhoodProcessingWithAMask(

--- a/lib/improver/tests/nbhood/use_nbhood/test_CollapseMaskedNeighbourhoodCoordinate.py
+++ b/lib/improver/tests/nbhood/use_nbhood/test_CollapseMaskedNeighbourhoodCoordinate.py
@@ -135,7 +135,7 @@ class Test_renormalize_weights(IrisTest):
         nbhood_data[:] = np.nan
         nbhooded_cube = self.weights_cube.copy(nbhood_data)
         message = "Sum of weights must be > 0.0"
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             self.plugin.renormalize_weights(nbhooded_cube)
 
     def test_no_NaNs_in_nbhooded_cube_and_masked_weights(self):
@@ -199,7 +199,7 @@ class Test_renormalize_weights(IrisTest):
         plugin = CollapseMaskedNeighbourhoodCoordinate("kitten",
                                                        self.weights_cube)
         message = "Expected to find exactly 1 .* coordinate, but found none."
-        with self.assertRaisesRegexp(CoordinateNotFoundError, message):
+        with self.assertRaisesRegex(CoordinateNotFoundError, message):
             plugin.renormalize_weights(nbhooded_cube)
 
     def test_normalizing_along_another_axis_with_error(self):
@@ -210,7 +210,7 @@ class Test_renormalize_weights(IrisTest):
         plugin = CollapseMaskedNeighbourhoodCoordinate(
             "projection_x_coordinate", self.weights_cube)
         message = "Sum of weights must be > 0.0"
-        with self.assertRaisesRegexp(ValueError, message):
+        with self.assertRaisesRegex(ValueError, message):
             plugin.renormalize_weights(nbhooded_cube)
 
     def test_normalizing_along_another_axis(self):

--- a/lib/improver/tests/nbhood/vicinity/test_ProbabilityOfOccurrence.py
+++ b/lib/improver/tests/nbhood/vicinity/test_ProbabilityOfOccurrence.py
@@ -53,7 +53,7 @@ class Test__init__(IrisTest):
         distance = 2000
         radius = 2000
         msg = "Only a square neighbourhood is accepted"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             ProbabilityOfOccurrence(distance, "circular", radius)
 
 

--- a/lib/improver/tests/nowcasting/optical_flow/test_AdvectField.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_AdvectField.py
@@ -80,7 +80,7 @@ class Test__init__(IrisTest):
         vel_y = set_up_xy_velocity_cube("advection_velocity_y",
                                         coord_points_y=2*np.arange(4))
         msg = "Velocity cubes on unmatched grids"
-        with self.assertRaisesRegexp(InvalidCubeError, msg):
+        with self.assertRaisesRegex(InvalidCubeError, msg):
             _ = AdvectField(vel_x, vel_y)
 
 
@@ -270,7 +270,7 @@ class Test_process(IrisTest):
         cube.add_aux_coord(self.time_coord)
 
         msg = "Input data grid does not match advection velocities"
-        with self.assertRaisesRegexp(InvalidCubeError, msg):
+        with self.assertRaisesRegex(InvalidCubeError, msg):
             self.plugin.process(cube, self.timestep)
 
     def test_validity_time(self):

--- a/lib/improver/tests/percentile/test_PercentileConverter.py
+++ b/lib/improver/tests/percentile/test_PercentileConverter.py
@@ -59,7 +59,7 @@ class Test_process(IrisTest):
               3 3 3 3
 
         """
-        data = [[range(0, 11, 1)]*11]*3
+        data = [[list(range(0, 11, 1))]*11]*3
         data = np.array(data).astype('float32')
         data.resize(3, 1, 11, 11)
 
@@ -154,7 +154,7 @@ class Test_process(IrisTest):
         collapse_coord = 'not_a_coordinate'
         plugin = PercentileConverter(collapse_coord)
         msg = "Coordinate "
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             plugin.process(self.cube)
 
     def test_invalid_collapse_coord_type(self):
@@ -164,7 +164,7 @@ class Test_process(IrisTest):
         """
         collapse_coord = self.cube
         msg = "collapse_coord is "
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             PercentileConverter(collapse_coord)
 
 

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperature.py
@@ -284,7 +284,7 @@ class Test_process(Test_WetBulbTemperature):
         temperature.coord('height').rename('pressure')
 
         msg = 'WetBulbTemperature: Cubes have differing'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             WetBulbTemperature().process(
                 temperature, relative_humidity, pressure)
 

--- a/lib/improver/tests/spotdata/spotdata/test_WriteOutput.py
+++ b/lib/improver/tests/spotdata/spotdata/test_WriteOutput.py
@@ -86,16 +86,8 @@ class Test_write_output(IrisTest):
 
         method = 'unknown_file_type'
         msg = 'Unknown method ".*" passed to WriteOutput.'
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with self.assertRaisesRegex(AttributeError, msg):
             Plugin(method, self.data_directory).process(self.cube)
-
-    def test_invalid_output_path(self):
-        """Test attempt to write to unwritable location."""
-
-        method = 'as_netcdf'
-        msg = 'Permission denied'
-        with self.assertRaisesRegexp(IOError, msg):
-            Plugin(method, '/').process(self.cube)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/spotdata/spotdata/test_ancillaries.py
+++ b/lib/improver/tests/spotdata/spotdata/test_ancillaries.py
@@ -114,7 +114,7 @@ class Test_get_ancillary_data(IrisTest):
 
         diagnostics = {}
         result = Plugin(diagnostics, self.directory)
-        self.assertIn('orography', result.keys())
+        self.assertIn('orography', result)
         self.assertIsInstance(result['orography'], Cube)
         self.assertArrayEqual(result['orography'].data, self.orography.data)
 
@@ -123,7 +123,7 @@ class Test_get_ancillary_data(IrisTest):
         land constraint condition."""
 
         result = Plugin(self.diagnostics, self.directory)
-        self.assertIn('land_mask', result.keys())
+        self.assertIn('land_mask', result)
         self.assertIsInstance(result['land_mask'], Cube)
         self.assertArrayEqual(result['land_mask'].data, self.land.data)
 
@@ -134,7 +134,7 @@ class Test_get_ancillary_data(IrisTest):
         Call(['rm', self.orography_path])
         diagnostics = {}
         msg = 'Orography file not found.'
-        with self.assertRaisesRegexp(IOError, msg):
+        with self.assertRaisesRegex(IOError, msg):
             Plugin(diagnostics, self.directory)
 
     def test_missing_land_mask(self):
@@ -143,7 +143,7 @@ class Test_get_ancillary_data(IrisTest):
 
         Call(['rm', self.land_path])
         msg = 'Land mask file not found.'
-        with self.assertRaisesRegexp(IOError, msg):
+        with self.assertRaisesRegex(IOError, msg):
             Plugin(self.diagnostics, self.directory)
 
 

--- a/lib/improver/tests/spotdata/spotdata/test_common_functions.py
+++ b/lib/improver/tests/spotdata/spotdata/test_common_functions.py
@@ -87,7 +87,7 @@ class Test_common_functions(IrisTest):
             units=cf_units.Unit('seconds since 1970-01-01 00:00:00',
                                 calendar='gregorian'))
         long_time_coord = DimCoord(
-            range(1487311200, 1487397600, 3600),
+            list(range(1487311200, 1487397600, 3600)),
             standard_name='time',
             units=cf_units.Unit('seconds since 1970-01-01 00:00:00',
                                 calendar='gregorian'))
@@ -159,7 +159,7 @@ class Test_conditional_list_extract(Test_common_functions):
 
         """
         plugin = ConditionalListExtract('less_than')
-        expected = [sorted(range(0, 4)*12), range(0, 12)*4]
+        expected = [sorted(list(range(0, 4))*12), list(range(0, 12))*4]
         result = plugin.process(self.data, self.data_indices, 2)
         self.assertArrayEqual(expected, result)
 
@@ -170,7 +170,7 @@ class Test_conditional_list_extract(Test_common_functions):
 
         """
         plugin = ConditionalListExtract('greater_than')
-        expected = [sorted(range(8, 12)*12), range(0, 12)*4]
+        expected = [sorted(list(range(8, 12))*12), list(range(0, 12))*4]
         result = plugin.process(self.data, self.data_indices, 2)
         self.assertArrayEqual(expected, result)
 
@@ -181,7 +181,7 @@ class Test_conditional_list_extract(Test_common_functions):
 
         """
         plugin = ConditionalListExtract('equal_to')
-        expected = [sorted(range(4, 8)*12), range(0, 12)*4]
+        expected = [sorted(list(range(4, 8))*12), list(range(0, 12))*4]
         result = plugin.process(self.data, self.data_indices, 2)
         self.assertArrayEqual(expected, result)
 
@@ -192,7 +192,8 @@ class Test_conditional_list_extract(Test_common_functions):
 
         """
         plugin = ConditionalListExtract('not_equal_to')
-        expected = [sorted((range(0, 4) + range(8, 12))*12), range(0, 12)*8]
+        expected = [sorted((list(range(0, 4)) + list(range(8, 12)))*12),
+                    list(range(0, 12))*8]
         result = plugin.process(self.data, self.data_indices, 2)
         self.assertArrayEqual(expected, result)
 
@@ -200,7 +201,7 @@ class Test_conditional_list_extract(Test_common_functions):
         """Test that the plugin copes with an unknown method."""
         plugin = ConditionalListExtract('not_to')
         msg = 'Unknown method'
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with self.assertRaisesRegex(AttributeError, msg):
             plugin.process(self.data, self.data_indices, 2)
 
 
@@ -230,7 +231,7 @@ class Test_nearest_n_neighbours(Test_common_functions):
         """Test function rejects invalid numbers of neighbours."""
         plugin = nearest_n_neighbours
         msg = 'Invalid nearest'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin(10, 10, 7)
 
 
@@ -397,7 +398,7 @@ class Test_index_of_minimum_difference(Test_common_functions):
         """Test function when finding the index in a subset of the list."""
         plugin = index_of_minimum_difference
         test_list = [-10, 10, -1.5, 1.5, -0.6, 0.4]
-        subset = range(0, 5)
+        subset = list(range(0, 5))
         expected = 4  # index of value -0.6 as 0.4 is not in the sublist.
         result = plugin(test_list, subset_list=subset)
         self.assertEqual(expected, result)
@@ -437,7 +438,7 @@ class Test_list_entry_from_index(Test_common_functions):
     def test_ND_list(self):
         """Test in a ND list, where here N=10."""
         plugin = list_entry_from_index
-        test_list = [range(0, 5)]*10
+        test_list = [list(range(0, 5))]*10
         index = 3
         expected = [3]*10
         result = plugin(test_list, index)

--- a/lib/improver/tests/spotdata/spotdata/test_extract_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extract_data.py
@@ -218,7 +218,7 @@ class Test_setup(IrisTest):
         result = plugin.process(cube, self.sites, self.neighbour_list,
                                 ancillary_data, additional_data, **kwargs)
 
-        self.assertAlmostEqual(result.data, expected)
+        self.assertArrayAlmostEqual(result.data, expected)
 
     def different_projection(self, method, ancillary_data, additional_data,
                              expected, **kwargs):
@@ -271,7 +271,7 @@ class Test_setup(IrisTest):
                                 ancillary_data, additional_data, **kwargs)
 
         self.assertEqual(cube.coord_system(), trg_crs_iris)
-        self.assertAlmostEqual(result.data, expected)
+        self.assertArrayAlmostEqual(result.data, expected)
         self.assertEqual(result.coord(axis='y').name(), 'latitude')
         self.assertEqual(result.coord(axis='x').name(), 'longitude')
         self.assertAlmostEqual(result.coord(axis='y').points, 4.74)
@@ -306,7 +306,7 @@ class Test_ExtractData(Test_setup):
         plugin = Plugin('quantum_interpolation')
         msg = 'Unknown method'
         cube = self.cube.extract(self.time_extract)
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with self.assertRaisesRegex(AttributeError, msg):
             plugin.process(cube, self.sites, self.neighbour_list, {}, None,
                            **self.kwargs)
 
@@ -330,7 +330,7 @@ class Test_make_cube(Test_setup):
         data = np.array([123])
         self.cube.remove_coord('forecast_reference_time')
         msg = 'No forecast reference time found on source cube.'
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             plugin(self.cube, data, self.sites)
 
     def test_aux_coord_and_metadata(self):

--- a/lib/improver/tests/spotdata/spotdata/test_extrema.py
+++ b/lib/improver/tests/spotdata/spotdata/test_extrema.py
@@ -54,7 +54,7 @@ class Test_extrema(IrisTest):
     def setUp(self):
         """Set up the initial conditions for tests."""
 
-        times = range(414048, 414097, 1)  # Hours since 00Z-01-01-1970
+        times = list(range(414048, 414097, 1))  # Hours since 00Z-01-01-1970
         n_times, n_data = len(times), 27
         indices = DimCoord(np.arange(n_data), long_name='index',
                            units='1')
@@ -66,13 +66,13 @@ class Test_extrema(IrisTest):
         forecast_ref_time.rename('forecast_reference_time')
 
         # UTC offset arranged to sequence -12 --> 14.
-        utc_offsets = range(-12, 15) * int(n_data/24)
+        utc_offsets = list(range(-12, 15)) * int(n_data/24)
         utc_offset = AuxCoord(utc_offsets, long_name='utc_offset',
                               units='hours')
         # Data arranged to ascend 0 --> n_data, so each site shows a constant
         # temperature over time; this will need to be modified to check
         # analysis collapse method.
-        data = np.array([range(n_data)*n_times])
+        data = np.array([list(range(n_data))*n_times])
         data.resize(n_times, n_data)
 
         cube = Cube(data,
@@ -119,7 +119,7 @@ class Test_ExtractExtrema(Test_extrema):
         Input data spans 48 hours, this will spread to three days with timezone
         adjustments."""
 
-        n_periods = 72/24
+        n_periods = 72//24
         mid_start = mktime(dt(2017, 3, 26, 12).utctimetuple())/3600.
         lower_bound = mktime(dt(2017, 3, 26, 00).utctimetuple())/3600.
         upper_bound = mktime(dt(2017, 3, 27, 00).utctimetuple())/3600.
@@ -155,7 +155,9 @@ class Test_ExtractExtrema(Test_extrema):
         Input data spans 48 hours, this will spread to three days with timezone
         adjustments."""
 
-        n_periods = 72/9 - 1  # -1 as no data falls in the first 9 hour period.
+        # -1 as no data falls in the first 9 hour period.
+        n_periods = 72//9 - 1
+
         mid_start = mktime(dt(2017, 3, 26, 13, 30).utctimetuple())/3600.
         lower_bound = mktime(dt(2017, 3, 26, 9).utctimetuple())/3600.
         upper_bound = mktime(dt(2017, 3, 26, 18).utctimetuple())/3600.
@@ -191,7 +193,7 @@ class Test_ExtractExtrema(Test_extrema):
 
         # Expected data array.
         expected = np.full(self.n_data, np.nan)
-        expected[0:12] = range(12)
+        expected[0:12] = list(range(12))
         expected = np.ma.masked_invalid(expected)
 
         result = Plugin(24, start_hour=0).process(self.cube)
@@ -275,7 +277,7 @@ class Test_get_datetime_limits(Test_extrema):
         """Check an error is raised if a non-integer hour is provided."""
 
         msg = "integer argument expected, got float"
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             get_datetime_limits(self.time_coord, start_hour=6.2)
 
 
@@ -307,8 +309,8 @@ class Test_make_local_time_cube(Test_extrema):
         # to a filled array of valid values. (Far western site initially only
         # one valid, before reaching local times for which all sites have valid
         # data).
-        for i in range(n_times/2 + 12):
-            values = range(min(n_data, i+1))
+        for i in range(n_times//2 + 12):
+            values = list(range(min(n_data, i+1)))
             expected = np.full(n_data, np.nan)
             expected[0:i+1] = values
             expected = np.ma.masked_invalid(expected)
@@ -318,8 +320,8 @@ class Test_make_local_time_cube(Test_extrema):
         # to ever more masked values, finishing with a single valid data point.
         # (All sites have valid data at initial local time, but by the end of
         # the sequence only far eastern sites still have valid data).
-        for ii, i in enumerate(range(n_times/2 + 12, n_times)):
-            base = range(0, 27)
+        for ii, i in enumerate(range(n_times//2 + 12, n_times)):
+            base = list(range(0, 27))
             values = base[ii+1:]
             expected = np.full(n_data, np.nan)
             expected[ii+1:] = values

--- a/lib/improver/tests/spotdata/spotdata/test_neighbour_finding.py
+++ b/lib/improver/tests/spotdata/spotdata/test_neighbour_finding.py
@@ -123,7 +123,7 @@ class Test_miscellaneous(Test_PointSelection):
         """
         plugin = Plugin('smallest distance')
         msg = 'Unknown method'
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with self.assertRaisesRegex(AttributeError, msg):
             plugin.process(self.cube, self.sites, self.ancillary_data)
 
     def test_variable_no_neighbours(self):
@@ -154,7 +154,7 @@ class Test_miscellaneous(Test_PointSelection):
                         vertical_bias=None,
                         land_constraint=False)
         msg = 'Invalid nearest no'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube, self.sites, self.ancillary_data,
                            no_neighbours=20)
 

--- a/lib/improver/tests/spotdata/spotdata/test_read_input.py
+++ b/lib/improver/tests/spotdata/spotdata/test_read_input.py
@@ -193,7 +193,7 @@ class Test_get_method_prerequisites(Test_read_input):
         result = get_method_prerequisites(method, self.data_directory)
 
         self.assertArrayEqual(expected.keys(), result.keys())
-        for diagnostic in expected.keys():
+        for diagnostic in expected:
             self.assertArrayEqual(expected[diagnostic][0].data,
                                   result[diagnostic][0].data)
 
@@ -225,7 +225,7 @@ class Test_get_additional_diagnostics(Test_read_input):
 
         diagnostic_name = 'temperature_on_height_levels'
         msg = 'The relevant data files for'
-        with self.assertRaisesRegexp(IOError, msg):
+        with self.assertRaisesRegex(IOError, msg):
             get_additional_diagnostics(diagnostic_name, 'not_a_valid_path')
 
     def test_available_data_files_with_time_extraction(self):
@@ -248,7 +248,7 @@ class Test_get_additional_diagnostics(Test_read_input):
         diagnostic_name = 'temperature_on_height_levels'
         msg = 'No diagnostics match .*'
         time_extract = Constraint(time=PartialDateTime(2018, 1, 1, 0))
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             get_additional_diagnostics(diagnostic_name, self.data_directory,
                                        time_extract=time_extract)
 

--- a/lib/improver/tests/spotdata/spotdata/test_site_data.py
+++ b/lib/improver/tests/spotdata/spotdata/test_site_data.py
@@ -135,7 +135,7 @@ class Test_from_file(Test_ImportSiteData):
         self.save_json(self.site_data)
 
         msg = 'longitude and latitude must be defined'
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             Plugin(self.method).process(self.site_path)
 
     def test_no_longitude(self):
@@ -149,7 +149,7 @@ class Test_from_file(Test_ImportSiteData):
         self.save_json(self.site_data)
 
         msg = 'longitude and latitude must be defined'
-        with self.assertRaisesRegexp(KeyError, msg):
+        with self.assertRaisesRegex(KeyError, msg):
             Plugin(self.method).process(self.site_path)
 
     def test_unequal_lat_lon(self):
@@ -161,7 +161,7 @@ class Test_from_file(Test_ImportSiteData):
         self.site_data[0].pop('longitude')
         self.save_json(self.site_data)
         msg = 'Unequal no. of latitudes (.*) and longitudes'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Plugin(self.method).process(self.site_path)
 
     def test_only_lat_lon(self):

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -454,7 +454,7 @@ class Test_process(IrisTest):
         msg = "NaN detected in input cube data"
         plugin = Threshold(
             2.0, fuzzy_factor=self.fuzzy_factor, below_thresh_ok=True)
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.cube)
 
     def test_threshold_zero_with_fuzzy_factor(self):
@@ -462,35 +462,35 @@ class Test_process(IrisTest):
         fuzzy factor (invalid)."""
         fuzzy_factor = 0.6
         msg = "Invalid threshold with fuzzy factor"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Threshold(0.0, fuzzy_factor=fuzzy_factor)
 
     def test_threshold_fuzzy_factor_minus_1(self):
         """Test when a fuzzy factor of minus 1 is given (invalid)."""
         fuzzy_factor = -1.0
         msg = "Invalid fuzzy_factor: must be >0 and <1: -1.0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Threshold(0.6, fuzzy_factor=fuzzy_factor)
 
     def test_threshold_fuzzy_factor_0(self):
         """Test when a fuzzy factor of zero is given (invalid)."""
         fuzzy_factor = 0.0
         msg = "Invalid fuzzy_factor: must be >0 and <1: 0.0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Threshold(0.6, fuzzy_factor=fuzzy_factor)
 
     def test_threshold_fuzzy_factor_1(self):
         """Test when a fuzzy factor of unity is given (invalid)."""
         fuzzy_factor = 1.0
         msg = "Invalid fuzzy_factor: must be >0 and <1: 1.0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Threshold(0.6, fuzzy_factor=fuzzy_factor)
 
     def test_threshold_fuzzy_factor_2(self):
         """Test when a fuzzy factor of 2 is given (invalid)."""
         fuzzy_factor = 2.0
         msg = "Invalid fuzzy_factor: must be >0 and <1: 2.0"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Threshold(0.6, fuzzy_factor=fuzzy_factor)
 
     def test_fuzzy_factor_and_fuzzy_bounds(self):
@@ -499,7 +499,7 @@ class Test_process(IrisTest):
         fuzzy_bounds = (0.4, 0.8)
         msg = ("Invalid combination of keywords. Cannot specify "
                "fuzzy_factor and fuzzy_bounds together")
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Threshold(0.6, fuzzy_factor=fuzzy_factor,
                       fuzzy_bounds=fuzzy_bounds)
 
@@ -510,7 +510,7 @@ class Test_process(IrisTest):
         # Regexp matches .* with any string.
         msg = ("Invalid bounds for one threshold: .*. "
                "Expected 2 floats.")
-        with self.assertRaisesRegexp(AssertionError, msg):
+        with self.assertRaisesRegex(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)
 
@@ -521,7 +521,7 @@ class Test_process(IrisTest):
         # Regexp matches .* with any string.
         msg = ("Invalid bounds for one threshold: .*. "
                "Expected 2 floats.")
-        with self.assertRaisesRegexp(AssertionError, msg):
+        with self.assertRaisesRegex(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)
 
@@ -533,7 +533,7 @@ class Test_process(IrisTest):
         msg = ("Threshold must be within bounds: "
                r"\!\( {} <= {} <= {} \)".format(
                    fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
-        with self.assertRaisesRegexp(AssertionError, msg):
+        with self.assertRaisesRegex(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)
 
@@ -545,7 +545,7 @@ class Test_process(IrisTest):
         msg = ("Threshold must be within bounds: "
                r"\!\( {} <= {} <= {} \)".format(
                    fuzzy_bounds[0], threshold, fuzzy_bounds[1]))
-        with self.assertRaisesRegexp(AssertionError, msg):
+        with self.assertRaisesRegex(AssertionError, msg):
             Threshold(threshold,
                       fuzzy_bounds=fuzzy_bounds)
 

--- a/lib/improver/tests/utilities/solar/test_solar.py
+++ b/lib/improver/tests/utilities/solar/test_solar.py
@@ -57,7 +57,7 @@ class Test_calc_solar_declination(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         day_of_year = -1
         msg = 'Day of the year must be between 0 and 365'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_declination(day_of_year)
 
 
@@ -90,7 +90,7 @@ class Test_calc_solar_hour_angle(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         longitudes = np.array([0.0, 10.0, -10.0, 181.0, -179.0])
         msg = 'Longitudes must be between -180.0 and 180.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_hour_angle(longitudes, self.day_of_year,
                                   self.utc_hour)
 
@@ -98,7 +98,7 @@ class Test_calc_solar_hour_angle(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         day_of_year = 367
         msg = 'Day of the year must be between 0 and 365'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_hour_angle(self.longitudes, day_of_year,
                                   self.utc_hour)
 
@@ -106,7 +106,7 @@ class Test_calc_solar_hour_angle(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         utc_hour = -10.0
         msg = 'Hour must be between 0 and 24.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_hour_angle(self.longitudes, self.day_of_year, utc_hour)
 
 
@@ -141,7 +141,7 @@ class Test_calc_solar_elevation(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         longitudes = np.array([-205.0, 0.0, 5.0])
         msg = 'Longitudes must be between -180.0 and 180.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_elevation(self.latitudes, longitudes,
                                  self.day_of_year, self.utc_hour)
 
@@ -149,7 +149,7 @@ class Test_calc_solar_elevation(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         latitudes = np.array([-150.0, 50.0, 50.0])
         msg = 'Latitudes must be between -90.0 and 90.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_elevation(latitudes, self.longitudes,
                                  self.day_of_year, self.utc_hour)
 
@@ -157,7 +157,7 @@ class Test_calc_solar_elevation(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         day_of_year = 367
         msg = 'Day of the year must be between 0 and 365'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_elevation(self.latitudes, self.longitudes,
                                  day_of_year, self.utc_hour)
 
@@ -165,7 +165,7 @@ class Test_calc_solar_elevation(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         utc_hour = -10.0
         msg = 'Hour must be between 0 and 24.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             calc_solar_elevation(self.latitudes, self.longitudes,
                                  self.day_of_year, utc_hour)
 
@@ -209,7 +209,7 @@ class Test_daynight_terminator(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         longitudes = np.array([-205.0, 0.0, 5.0])
         msg = 'Longitudes must be between -180.0 and 180.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             daynight_terminator(longitudes,
                                 self.day_of_year, self.utc_hour)
 
@@ -217,7 +217,7 @@ class Test_daynight_terminator(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         day_of_year = 367
         msg = 'Day of the year must be between 0 and 365'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             daynight_terminator(self.longitudes,
                                 day_of_year, self.utc_hour)
 
@@ -225,7 +225,7 @@ class Test_daynight_terminator(IrisTest):
         """Test an exception is raised if latitudes out of range"""
         utc_hour = -10.0
         msg = 'Hour must be between 0 and 24.0'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             daynight_terminator(self.longitudes,
                                 self.day_of_year, utc_hour)
 

--- a/lib/improver/tests/utilities/test_ProbabilitiesFromPercentiles2D.py
+++ b/lib/improver/tests/utilities/test_ProbabilitiesFromPercentiles2D.py
@@ -51,7 +51,7 @@ def set_up_percentiles_cube():
     """ Set up 3D cube with percentiles of height """
 
     test_data = np.full((5, 4, 4), -1, dtype=float)
-    for i in xrange(5):
+    for i in range(5):
         test_data[i].fill(100*i + 200)
 
     percentiles = DimCoord(np.linspace(0, 100, 5), long_name="percentiles",
@@ -131,7 +131,7 @@ class Test__init__(IrisTest):
         percentiles_cube = set_up_percentiles_cube()
         percentiles_cube = percentiles_cube[0]
         msg = "Percentile coordinate has only one value. Interpolation"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             ProbabilitiesFromPercentiles2D(percentiles_cube)
 
 
@@ -306,7 +306,7 @@ class Test_process(IrisTest):
         the units of cubes that have incompatible units."""
         self.orography_cube.units = 'K'
         msg = "Unable to convert from"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             self.plugin_instance.process(self.orography_cube)
 
     def test_preservation_of_dimensions(self):

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -66,7 +66,7 @@ class Test_check_for_x_and_y_axes(IrisTest):
             break
         sliced_cube.remove_coord("projection_y_coordinate")
         msg = "The cube does not contain the expected"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             check_for_x_and_y_axes(sliced_cube)
 
     def test_no_x_coordinate(self):
@@ -77,7 +77,7 @@ class Test_check_for_x_and_y_axes(IrisTest):
             break
         sliced_cube.remove_coord("projection_x_coordinate")
         msg = "The cube does not contain the expected"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             check_for_x_and_y_axes(sliced_cube)
 
 
@@ -142,7 +142,7 @@ class Test_check_cube_coordinates(IrisTest):
         new_cube = cube[0].copy()
         cube = iris.util.squeeze(cube)
         msg = 'is not within the permitted exceptions'
-        with self.assertRaisesRegexp(iris.exceptions.InvalidCubeError, msg):
+        with self.assertRaisesRegex(iris.exceptions.InvalidCubeError, msg):
             check_cube_coordinates(
                 cube, new_cube)
 
@@ -155,7 +155,7 @@ class Test_check_cube_coordinates(IrisTest):
         cube = iris.util.squeeze(cube)
         exception_coordinates = ["height"]
         msg = 'is not within the permitted exceptions'
-        with self.assertRaisesRegexp(iris.exceptions.InvalidCubeError, msg):
+        with self.assertRaisesRegex(iris.exceptions.InvalidCubeError, msg):
             check_cube_coordinates(
                 cube, new_cube, exception_coordinates=exception_coordinates)
 
@@ -167,8 +167,8 @@ class Test_check_cube_coordinates(IrisTest):
         new_cube = iris.util.squeeze(cube)
         new_cube.remove_coord('realization')
         msg = 'The number of dimension coordinates within the new cube'
-        with self.assertRaisesRegexp(iris.exceptions.CoordinateNotFoundError,
-                                     msg):
+        with self.assertRaisesRegex(iris.exceptions.CoordinateNotFoundError,
+                                    msg):
             check_cube_coordinates(cube, new_cube)
 
 
@@ -248,8 +248,8 @@ class Test_find_percentile_coordinate(IrisTest):
         """Test it raises a Type Error if cube is not a cube."""
         msg = ('Expecting data to be an instance of '
                'iris.cube.Cube but is'
-               ' {0:s}.'.format(type(self.wg_perc)))
-        with self.assertRaisesRegexp(TypeError, msg):
+               ' {}.'.format(type(self.wg_perc)))
+        with self.assertRaisesRegex(TypeError, msg):
             find_percentile_coordinate(self.wg_perc)
 
     def test_fails_if_no_perc_coord(self):
@@ -257,7 +257,7 @@ class Test_find_percentile_coordinate(IrisTest):
         msg = ('No percentile coord found on')
         cube = self.cube_wg
         cube.remove_coord("percentile_over_dummy")
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             find_percentile_coordinate(cube)
 
     def test_fails_if_too_many_perc_coord(self):
@@ -269,7 +269,7 @@ class Test_find_percentile_coordinate(IrisTest):
                                  long_name='percentile_over_realization',
                                  units='no_unit'))
         cube.add_aux_coord(new_perc_coord)
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             find_percentile_coordinate(cube)
 
 

--- a/lib/improver/tests/utilities/test_cube_constraints.py
+++ b/lib/improver/tests/utilities/test_cube_constraints.py
@@ -55,7 +55,7 @@ class Test_create_sorted_lambda_constraint(IrisTest):
         values = [0.03, 0.1]
         result = create_sorted_lambda_constraint(coord_name, values)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(result._coord_values.keys(), ["threshold"])
+        self.assertEqual(list(result._coord_values.keys()), ["threshold"])
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 
@@ -66,7 +66,7 @@ class Test_create_sorted_lambda_constraint(IrisTest):
         values = [0.1, 0.03]
         result = create_sorted_lambda_constraint(coord_name, values)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(result._coord_values.keys(), ["threshold"])
+        self.assertEqual(list(result._coord_values.keys()), ["threshold"])
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -86,7 +86,7 @@ class Test_create_range_constraint(IrisTest):
         values = "[0.03:0.1]"
         result = create_range_constraint(coord_name, values)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(result._coord_values.keys(), ["threshold"])
+        self.assertEqual(list(result._coord_values.keys()), ["threshold"])
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 
@@ -97,7 +97,7 @@ class Test_create_range_constraint(IrisTest):
         values = "0.03:0.1"
         result = create_range_constraint(coord_name, values)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(result._coord_values.keys(), ["threshold"])
+        self.assertEqual(list(result._coord_values.keys()), ["threshold"])
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 
@@ -130,8 +130,8 @@ class Test_parse_constraint_list(IrisTest):
         """ Test simple key-value splitting with no units """
         result, udict = parse_constraint_list(self.constraints)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(
-            result._coord_values.keys(), ["threshold", "percentile"])
+        self.assertCountEqual(
+            list(result._coord_values.keys()), ["threshold", "percentile"])
         cdict = result._coord_values
         self.assertEqual(cdict["percentile"], 10)
         self.assertEqual(cdict["threshold"], 0.1)
@@ -155,7 +155,7 @@ class Test_parse_constraint_list(IrisTest):
         """ Test for ValueError if units list does not match constraints """
         units = ["mm h-1"]
         msg = "units list must match constraints"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             parse_constraint_list(self.constraints, units=units)
 
     def test_list_constraint(self):
@@ -171,7 +171,7 @@ class Test_parse_constraint_list(IrisTest):
         result, _ = parse_constraint_list(constraints)
         self.assertIsInstance(result, iris._constraints.ConstraintCombination)
         cdict = result.rhs._coord_values
-        self.assertEqual(cdict.keys(), ["threshold"])
+        self.assertEqual(list(cdict.keys()), ["threshold"])
         precip_cube = set_up_precip_probability_cube()
         precip_cube.coord("threshold").convert_units("mm h-1")
         result_cube = precip_cube.extract(result)

--- a/lib/improver/tests/utilities/test_cube_manipulation.py
+++ b/lib/improver/tests/utilities/test_cube_manipulation.py
@@ -243,7 +243,7 @@ class Test__associate_any_coordinate_with_master_coordinate(IrisTest):
             DimCoord([0], "forecast_period", units="hours"))
 
         msg = "The master coordinate for associating other coordinates"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             _associate_any_coordinate_with_master_coordinate(
                 cube1, master_coord="time",
                 coordinates=["forecast_reference_time", "forecast_period"])
@@ -424,7 +424,7 @@ class Test_concatenate_cubes(IrisTest):
         """
         cubes = iris.cube.CubeList([self.cube, self.cube])
         msg = "An unexpected problem prevented concatenation."
-        with self.assertRaisesRegexp(ConcatenateError, msg):
+        with self.assertRaisesRegex(ConcatenateError, msg):
             concatenate_cubes(cubes)
 
     def test_cubelist_type_and_data(self):
@@ -490,7 +490,7 @@ class Test_concatenate_cubes(IrisTest):
 
         cubelist = iris.cube.CubeList([cube2, cube3])
         msg = "failed to concatenate into a single cube"
-        with self.assertRaisesRegexp(ConcatenateError, msg):
+        with self.assertRaisesRegex(ConcatenateError, msg):
             concatenate_cubes(cubelist, coords_to_slice_over=["time"])
 
     def test_cubelist_slice_over_time_only(self):
@@ -625,7 +625,7 @@ class Test_merge_cubes(IrisTest):
         """Test that merging identical cubes fails."""
         cubes = iris.cube.CubeList([self.cube, self.cube])
         msg = "failed to merge into a single cube"
-        with self.assertRaisesRegexp(DuplicateDataError, msg):
+        with self.assertRaisesRegex(DuplicateDataError, msg):
             merge_cubes(cubes)
 
     def test_lagged_ukv(self):
@@ -704,10 +704,10 @@ class Test_equalise_cubes(IrisTest):
                                     np.array([1000]))
         self.assertEqual(result[1].coord("model").points[0],
                          'Operational Mogreps UK Model Forecast')
-        self.assertNotIn("title", result[0].attributes.keys())
-        self.assertNotIn("title", result[1].attributes.keys())
-        self.assertAlmostEquals(result[0].attributes["grid_id"],
-                                result[1].attributes["grid_id"])
+        self.assertNotIn("title", result[0].attributes)
+        self.assertNotIn("title", result[1].attributes)
+        self.assertAlmostEqual(result[0].attributes["grid_id"],
+                               result[1].attributes["grid_id"])
         self.assertEqual(result[0].attributes["grid_id"],
                          'ukx_standard_v1')
         self.assertNotIn("history", result[0].attributes.keys())
@@ -736,8 +736,8 @@ class Test_equalise_cubes(IrisTest):
         cubelist = iris.cube.CubeList([self.cube_ukv, self.cube])
         result = equalise_cubes(cubelist)
         self.assertEqual(len(result), 4)
-        self.assertAlmostEquals(result[3].coord('model_realization').points,
-                                1002.0)
+        self.assertAlmostEqual(result[3].coord('model_realization').points,
+                               1002.0)
 
 
 class Test__equalise_cube_attributes(IrisTest):
@@ -949,7 +949,7 @@ class Test__equalise_cube_coords(IrisTest):
         cube2.remove_coord("threshold")
         cubes = iris.cube.CubeList([cube1, cube2])
         msg = "threshold coordinates must match to merge"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             _equalise_cube_coords(cubes)
 
     def test_model_id_without_realization(self):
@@ -987,7 +987,7 @@ class Test__equalise_cube_coords(IrisTest):
         cube2.remove_coord("realization")
         cubes = iris.cube.CubeList([cube1, cube2])
         msg = "Model_id has more than one point"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             _equalise_cube_coords(cubes)
 
     def test_model_id_with_realization_in_cube(self):
@@ -1100,7 +1100,7 @@ class Test_compare_attributes(IrisTest):
         cubelist = iris.cube.CubeList([cube1, cube2])
         result = compare_attributes(cubelist)
         self.assertIsInstance(result, list)
-        self.assertAlmostEquals(result, [{}, {}])
+        self.assertAlmostEqual(result, [{}, {}])
 
     @ManageWarnings(record=True)
     def test_warning(self, warning_list=None):
@@ -1112,7 +1112,7 @@ class Test_compare_attributes(IrisTest):
         warning_msg = "Only a single cube so no differences will be found "
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
-        self.assertAlmostEquals(result, [])
+        self.assertAlmostEqual(result, [])
 
     def test_history_attribute(self):
         """Test that the utility returns diff when history do not match"""
@@ -1134,14 +1134,14 @@ class Test_compare_attributes(IrisTest):
         cubelist = iris.cube.CubeList([cube_no_attributes,
                                        self.cube, self.cube_ukv])
         result = compare_attributes(cubelist)
-        self.assertAlmostEquals(result,
-                                [{},
-                                 {'grid_id': 'enukx_standard_v1',
-                                  'title':
-                                  'Operational Mogreps UK Model Forecast'},
-                                 {'grid_id': 'ukvx_standard_v1',
-                                  'title':
-                                  'Operational UKV Model Forecast'}])
+        self.assertAlmostEqual(result,
+                               [{},
+                                {'grid_id': 'enukx_standard_v1',
+                                 'title':
+                                 'Operational Mogreps UK Model Forecast'},
+                                {'grid_id': 'ukvx_standard_v1',
+                                 'title':
+                                 'Operational UKV Model Forecast'}])
 
 
 class Test_compare_coords(IrisTest):
@@ -1169,7 +1169,7 @@ class Test_compare_coords(IrisTest):
         warning_msg = "Only a single cube so no differences will be found "
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
-        self.assertAlmostEquals(result, [])
+        self.assertAlmostEqual(result, [])
 
     def test_first_cube_has_extra_dimension_coordinates(self):
         """Test for comparing coordinate between cubes, where the first
@@ -1366,7 +1366,7 @@ class Test_add_renamed_cell_method(IrisTest):
         self.cube.cell_methods = ()
         message = ('Input Cell_method is not an instance of '
                    'iris.coord.CellMethod')
-        with self.assertRaisesRegexp(TypeError, message):
+        with self.assertRaisesRegex(TypeError, message):
             add_renamed_cell_method(self.cube, 'not_a_cell_method',
                                     'weighted_mean')
 
@@ -1664,7 +1664,7 @@ class Test_enforce_coordinate_ordering(IrisTest):
         expected.transpose([2, 3, 0, 1])
         cube = self.cube.copy()
         msg = "More than 1 coordinate"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             enforce_coordinate_ordering(cube, ["l", "e"])
 
     def test_include_extra_coordinates(self):
@@ -1705,7 +1705,7 @@ class Test_enforce_coordinate_ordering(IrisTest):
         cube = self.cube[0, :, :, :]
         cube.remove_coord("realization")
         msg = "The requested coordinate"
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             enforce_coordinate_ordering(
                 cube, "realization", raise_exception=True)
 

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -106,7 +106,7 @@ class Test_add_coord(IrisTest):
         cube = iris.util.squeeze(cube)
         changes = {'bounds': [0.1, 2.0], 'units': 'mm'}
         msg = 'Trying to add new coord but no points defined'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             add_coord(cube, coord_name, changes)
 
     def test_fails_points_greater_than_1(self):
@@ -117,7 +117,7 @@ class Test_add_coord(IrisTest):
         cube = iris.util.squeeze(cube)
         changes = {'points': [0.1, 2.0]}
         msg = 'Can not add a coordinate of length > 1'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             add_coord(cube, coord_name, changes)
 
     @ManageWarnings(record=True)
@@ -167,7 +167,7 @@ class Test_update_coord(IrisTest):
         cube = create_cube_with_threshold()
         changes = 'delete'
         msg = "Can only remove a coordinate of length 1"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             update_coord(cube, 'time', changes)
 
     @ManageWarnings(record=True)
@@ -188,7 +188,7 @@ class Test_update_coord(IrisTest):
         cube = create_cube_with_threshold()
         changes = {'points': [2.0, 3.0]}
         msg = "Mismatch in points in existing coord and updated metadata"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             update_coord(cube, 'threshold', changes)
 
     def test_coords_update_fail_bounds(self):
@@ -196,7 +196,7 @@ class Test_update_coord(IrisTest):
         cube = create_cube_with_threshold(threshold_values=[2.0, 3.0])
         changes = {'bounds': [0.1, 2.0]}
         msg = "The shape of the bounds array should be"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             update_coord(cube, 'threshold', changes)
 
     def test_coords_update_bounds_succeed(self):
@@ -214,7 +214,7 @@ class Test_update_coord(IrisTest):
         cube.coord('threshold').guess_bounds()
         changes = {'bounds': [[0.1, 2.0], [2.0, 3.0], [3.0, 4.0]]}
         msg = "Mismatch in bounds in existing coord and updated metadata"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             update_coord(cube, 'threshold', changes)
 
     @ManageWarnings(record=True)
@@ -419,7 +419,7 @@ class Test_resolve_metadata_diff(IrisTest):
         cube1 = create_cube_with_threshold()
         cube2 = create_cube_with_threshold(threshold_values=[1.0, 2.0])
         msg = "Can not combine cubes, mismatching shapes"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             resolve_metadata_diff(cube1, cube2)
 
     def test_mismatching_coords_1d_coord_pos0_on_cube1(self):

--- a/lib/improver/tests/utilities/test_mathematical_operations.py
+++ b/lib/improver/tests/utilities/test_mathematical_operations.py
@@ -74,7 +74,7 @@ class Test__init__(IrisTest):
         coord_name = "height"
         direction = "sideways"
         msg = "The specified direction of integration"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Integration(coord_name, direction_of_integration=direction)
 
 
@@ -485,7 +485,7 @@ class Test_perform_integration(IrisTest):
         start_point = 25.
         direction = "positive"
         msg = "No integration could be performed for"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             Integration(
                 coord_name, start_point=start_point,
                 direction_of_integration=direction

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -62,13 +62,13 @@ class Test_rescale(IrisTest):
     def test_zero_range_input(self):
         """Test that the method returns the expected error"""
         msg = "Cannot rescale a zero input range"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             rescale(self.cube.data, data_range=[0, 0])
 
     def test_zero_range_output(self):
         """Test that the method returns the expected error"""
         msg = "Cannot rescale a zero output range"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             rescale(self.cube.data, scale_range=[4, 4])
 
     def test_rescaling_inrange(self):

--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -120,7 +120,7 @@ class Test_save_netcdf(IrisTest):
         coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
         reference_names = [coord.name()
                            for coord in self.cube.coords(dim_coords=True)]
-        self.assertItemsEqual(coord_names, reference_names)
+        self.assertCountEqual(coord_names, reference_names)
 
     def test_cf_global_attributes(self):
         """ Test that a NetCDF file saved from one cube only contains the

--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -88,7 +88,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
         """Test behaviour for a single grid cell on lat long grid."""
         cube = set_up_cube_lat_long()
         msg = "Invalid grid: projection_x/y coords required"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             convert_distance_into_number_of_grid_cells(
                 cube, self.DISTANCE, self.MAX_DISTANCE_IN_GRID_CELLS)
 
@@ -96,7 +96,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
         """Test behaviour with a non-zero point with negative range."""
         distance = -1.0 * self.DISTANCE
         msg = "distance of -6100.0m gives a negative cell extent"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             convert_distance_into_number_of_grid_cells(
                 self.cube, distance, self.MAX_DISTANCE_IN_GRID_CELLS)
 
@@ -104,7 +104,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
         """Test behaviour with a non-zero point with zero range."""
         distance = 5
         msg = "Distance of 5m gives zero cell extent"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             convert_distance_into_number_of_grid_cells(
                 self.cube, distance, self.MAX_DISTANCE_IN_GRID_CELLS)
 
@@ -113,7 +113,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
         distance = 40000.0
         max_distance_in_grid_cells = 10
         msg = "distance of 40000.0m exceeds maximum grid cell extent"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             convert_distance_into_number_of_grid_cells(
                 self.cube, distance, max_distance_in_grid_cells)
 
@@ -122,7 +122,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
            corner-to-corner distance of the domain."""
         distance = 42500.0
         msg = "Distance of 42500.0m exceeds max domain distance of "
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             convert_distance_into_number_of_grid_cells(
                 self.cube, distance, self.MAX_DISTANCE_IN_GRID_CELLS)
 
@@ -142,7 +142,7 @@ class Test_check_if_grid_is_equal_area(IrisTest):
         projection_x_coordinate or projection_y_coordinate."""
         cube = set_up_cube_lat_long()
         msg = "Invalid grid"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             check_if_grid_is_equal_area(cube)
 
     def test_allow_negative_stride(self):
@@ -158,14 +158,14 @@ class Test_check_if_grid_is_equal_area(IrisTest):
         """Test that the cube has equal intervals along the x or y axis."""
         cube = set_up_cube()
         msg = "Intervals between points along the "
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             check_if_grid_is_equal_area(cube)
 
     def non_equal_area_grid(self):
         """Test that the cubes have an equal areas grid."""
         cube = set_up_cube()
         msg = "The size of the intervals along the x and y axis"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             check_if_grid_is_equal_area(cube)
 
 

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -210,7 +210,7 @@ class Test_forecast_period_coord(IrisTest):
         """
         cube = set_up_cube()
         msg = "The forecast period coordinate is not available"
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             forecast_period_coord(cube)
 
 
@@ -245,7 +245,7 @@ class Test_datetime_constraint(Test_common_functions):
         plugin = datetime_constraint
         time_start = datetime.datetime(2017, 2, 17, 6, 0)
         time_limit = datetime.datetime(2017, 2, 17, 18, 0)
-        expected_times = range(1487311200, 1487354400, 3600)
+        expected_times = list(range(1487311200, 1487354400, 3600))
         dt_constraint = plugin(time_start, time_max=time_limit)
         result = self.long_cube.extract(dt_constraint)
         self.assertEqual(result.shape, (12, 12, 12))
@@ -411,7 +411,7 @@ class Test_get_forecast_times(IrisTest):
 
         forecast_date = '17MARCH2017'
         msg = 'Date .* is in unexpected format'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             get_forecast_times(144, forecast_date=forecast_date,
                                forecast_time=6)
 

--- a/lib/improver/tests/utilities/test_warnings_handler.py
+++ b/lib/improver/tests/utilities/test_warnings_handler.py
@@ -60,7 +60,7 @@ class Test__init__(IrisTest):
     def test_ignored_messages_not_list(self):
         """Test Raises type error if ignored_messages is not a list."""
         msg = "Expecting list of strings for ignored_messages"
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             ManageWarnings(ignored_messages="Wrong")
 
     def test_ignored_messages(self):
@@ -88,7 +88,7 @@ class Test__init__(IrisTest):
         messages = ["Testing", "Testing2"]
         warning_types = [UserWarning]
         msg = "Length of warning_types"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             ManageWarnings(ignored_messages=messages,
                            warning_types=warning_types)
 

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -150,7 +150,7 @@ class Test_complex_to_deg(IrisTest):
         # Input is complex for 0 and 360 deg - both should return 0.0.
         input_data = np.array([1+0j, 1-0j])
         result = WindDirection().complex_to_deg(input_data)
-        self.failUnless((result == 0.0).all())
+        self.assertTrue((result == 0.0).all())
 
     def test_converts_array(self):
         """Tests that array of complex values are converted to degrees."""
@@ -272,7 +272,7 @@ class Test_process(IrisTest):
         """Test code raises a Type Error if input cube is not a cube."""
         input_data = 50.0
         msg = ('Wind direction input is not a cube, but'
-               ' {0:s}'.format(type(input_data)))
+               ' {0}'.format(type(input_data)))
         with self.assertRaisesRegexp(TypeError, msg):
             WindDirection().process(input_data)
 

--- a/lib/improver/tests/wind_downscaling/test_FrictionVelocity.py
+++ b/lib/improver/tests/wind_downscaling/test_FrictionVelocity.py
@@ -117,7 +117,7 @@ class Test_process(IrisTest):
         """Test when if different size arrays have been input"""
         u_href = np.full([3, 3], 10, dtype=float)
         msg = 'Different size input arrays u_href, h_ref, z_0, mask'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             FrictionVelocity(u_href, self.h_ref,
                              self.z_0, self.mask).process()
 

--- a/lib/improver/tests/wind_downscaling/test_RoughnessCorrection.py
+++ b/lib/improver/tests/wind_downscaling/test_RoughnessCorrection.py
@@ -443,7 +443,7 @@ class Test1D(IrisTest):
             AoS=0.2, Sigma=20.0, z_0=RMDI, pporog=250., modelorog=230.,
             heightlevels=self.hls)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data >
+        self.assertTrue((land_hc_rc.data >
                          landpointtests_hc_rc.w_cube.data).all())
 
     def test_section0h(self):
@@ -459,7 +459,7 @@ class Test1D(IrisTest):
             AoS=0.2, Sigma=20.0, z_0=0.2, pporog=RMDI, modelorog=230.,
             heightlevels=self.hls)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data <=
+        self.assertTrue((land_hc_rc.data <=
                          landpointtests_hc_rc.w_cube.data).all() and
                         land_hc_rc.data[0] == 0)
 
@@ -477,7 +477,7 @@ class Test1D(IrisTest):
             heightlevels=self.hls
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data <=
+        self.assertTrue((land_hc_rc.data <=
                          landpointtests_hc_rc.w_cube.data).all() and
                         land_hc_rc.data[0] == 0)
 
@@ -494,7 +494,7 @@ class Test1D(IrisTest):
             AoS=0.2, Sigma=20.0, z_0=0.2, pporog=250., modelorog=RMDI,
             heightlevels=self.hls)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data <=
+        self.assertTrue((land_hc_rc.data <=
                          landpointtests_hc_rc.w_cube.data).all() and
                         land_hc_rc.data[0] == 0)
 
@@ -580,7 +580,7 @@ class Test1D(IrisTest):
         landpointtests_hc = TestSinglePoint(
             z_0=None, pporog=250., modelorog=230.)
         land_hc_rc = landpointtests_hc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data >=
+        self.assertTrue((land_hc_rc.data >=
                          landpointtests_hc.w_cube.data).all() and
                         (land_hc_rc.data >
                          landpointtests_hc.w_cube.data).any())
@@ -596,7 +596,7 @@ class Test1D(IrisTest):
         landpointtests_rc = TestSinglePoint(
             z_0=0.2, pporog=250., modelorog=250.)
         land_hc_rc = landpointtests_rc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data <=
+        self.assertTrue((land_hc_rc.data <=
                          landpointtests_rc.w_cube.data).all() and
                         (land_hc_rc.data <
                          landpointtests_rc.w_cube.data).any() and
@@ -616,7 +616,7 @@ class Test1D(IrisTest):
         landpointtests_hc_rc = TestSinglePoint(
             z_0=0.2, pporog=230., modelorog=250.)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
-        self.failUnless((land_hc_rc.data <=
+        self.assertTrue((land_hc_rc.data <=
                          landpointtests_hc_rc.w_cube.data).all() and
                         (land_hc_rc.data <
                          landpointtests_hc_rc.w_cube.data).any() and
@@ -681,7 +681,7 @@ class Test2D(IrisTest):
         land_hc_rc = multip_hc_rc.run_hc_rc(uin, dtime=1, height=heights)
         hidx = land_hc_rc.shape.index(hlvs)
         for field in land_hc_rc.slices_over(hidx):
-            self.failUnless((field.data == field.data[0, 0]).all())
+            self.assertTrue((field.data == field.data[0, 0]).all())
 
     def test_section2b(self):
         """Test a mix of sea and land points over multiple timesteps.
@@ -712,11 +712,11 @@ class Test2D(IrisTest):
         landp2new = land_hc_rc.data.take(1, axis=xidxnew)
         landp2old = multip_hc_rc.w_cube.data.take(1, axis=xidxold)
         # Check on p2.
-        self.failUnless((landp2new <= landp2old).all() and
+        self.assertTrue((landp2new <= landp2old).all() and
                         (landp2new < landp2old).any())
         landp3new = land_hc_rc.data.take(2, axis=xidxnew)
         # Check on p3.
-        self.failUnless((landp2new <= landp3new).all() and
+        self.assertTrue((landp2new <= landp3new).all() and
                         (landp2new < landp3new).any())
 
     def test_section2c(self):
@@ -733,7 +733,7 @@ class Test2D(IrisTest):
             modelorog=[0, 250, 230]
         )
         msg = "wind input is not a cube, but <class 'iris.cube.CubeList'>"
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             _ = multip_hc_rc.run_hc_rc([uin, uin], dtime=2, height=heights,
                                        aslist=True)
 
@@ -761,7 +761,7 @@ class Test2D(IrisTest):
                                          landpointtests_rc.z0_cube.data]),
             height=0, name=None, unit="m")
         msg = "ancillary grids are not consistent"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             _ = landpointtests_rc.run_hc_rc(self.uin)
 
     def test_section3b(self):
@@ -778,7 +778,7 @@ class Test2D(IrisTest):
                                          landpointtests_rc.moro_cube.data]),
             height=0, name=None, unit="m")
         msg = "ancillary grids are not consistent"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             _ = landpointtests_rc.run_hc_rc(self.uin)
 
     def test_section3c(self):
@@ -792,7 +792,7 @@ class Test2D(IrisTest):
         landpointtests_rc.z0_cube.units = Unit('s')
         msg = ("z0 ancil has unexpected unit: should be {} "
                "is {}")
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, msg.format(Unit('m'),
                                    landpointtests_rc.z0_cube.units)):
             _ = landpointtests_rc.run_hc_rc(self.uin)

--- a/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -170,7 +170,7 @@ class Test_update_metadata_after_max(IrisTest):
         plugin = WindGustDiagnostic(50.0, 80.0)
         result = plugin.update_metadata_after_max(self.cube, self.perc_coord)
         msg = 'Expected to find exactly 1 .* coordinate, but found none.'
-        with self.assertRaisesRegexp(CoordinateNotFoundError, msg):
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             result.coord(self.perc_coord)
 
 
@@ -203,8 +203,8 @@ class Test_extract_percentile_data(IrisTest):
         plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
         msg = ('Expecting wind_speed_of_gust data to be an instance of '
                'iris.cube.Cube but is'
-               ' {0:s}.'.format(type(self.wg_perc)))
-        with self.assertRaisesRegexp(TypeError, msg):
+               ' {0}.'.format(type(self.wg_perc)))
+        with self.assertRaisesRegex(TypeError, msg):
             plugin.extract_percentile_data(self.wg_perc,
                                            self.wg_perc,
                                            "wind_speed_of_gust")
@@ -229,7 +229,7 @@ class Test_extract_percentile_data(IrisTest):
         """Test it raises a Value Error if req_perc not in cube."""
         plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
         msg = ('Could not find required percentile')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.extract_percentile_data(self.cube_wg,
                                            20.0,
                                            "wind_speed_of_gust")
@@ -289,7 +289,7 @@ class Test_process(IrisTest):
                                               perc_name='percentile_dummy'))
         msg = ('Percentile coord of wind-gust data'
                'does not match coord of wind-speed data')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cube_wg, self.cube_ws)
 
     def test_raises_error_for_no_time_coord(self):
@@ -300,7 +300,7 @@ class Test_process(IrisTest):
         cube_wg = iris.util.squeeze(cube_wg)
         plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
         msg = ('Could not match time coordinate')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cube_wg, cube_ws)
 
     def test_raises_error_points_mismatch_and_no_bounds(self):
@@ -309,7 +309,7 @@ class Test_process(IrisTest):
         cube_wg.coord('time').points = [402192.5, 402194.5]
         plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
         msg = ('Could not match time coordinate')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cube_wg, self.cube_ws)
 
     def test_raises_error_points_mismatch_and_bounds(self):
@@ -320,7 +320,7 @@ class Test_process(IrisTest):
                                         [402192.0, 402193.0]]
         plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
         msg = ('Could not match time coordinate')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cube_wg, self.cube_ws)
 
     def test_raises_error_points_mismatch_and_invalid_bounds(self):
@@ -330,7 +330,7 @@ class Test_process(IrisTest):
         cube_wg.coord('time').bounds = [[402191.5], [402193.5]]
         plugin = WindGustDiagnostic(self.wg_perc, self.ws_perc)
         msg = ('Could not match time coordinate')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.process(cube_wg, self.cube_ws)
 
     def test_no_raises_error_if_ws_point_in_bounds(self):

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -166,7 +166,7 @@ class Test_check_input_cubes(IrisTest):
         plugin = WeatherSymbols()
         cubes = self.cubes.pop()
         msg = 'Weather Symbols input cubes are missing'
-        with self.assertRaisesRegexp(IOError, msg):
+        with self.assertRaisesRegex(IOError, msg):
             plugin.check_input_cubes(cubes)
 
     def test_raises_error_missing_threshold(self):
@@ -175,7 +175,7 @@ class Test_check_input_cubes(IrisTest):
         cubes = self.cubes
         cubes[0] = cubes[0][0]
         msg = 'Weather Symbols input cubes are missing'
-        with self.assertRaisesRegexp(IOError, msg):
+        with self.assertRaisesRegex(IOError, msg):
             plugin.check_input_cubes(cubes)
 
     def test_incorrect_units(self):
@@ -185,7 +185,7 @@ class Test_check_input_cubes(IrisTest):
 
         msg = "Unable to convert from"
         self.cubes[0].coord('threshold').units = Unit('mm kg-1')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             plugin.check_input_cubes(self.cubes)
 
 
@@ -197,7 +197,7 @@ class Test_invert_condition(IrisTest):
         """Test that the invert_condition method returns a tuple of strings."""
         plugin = WeatherSymbols()
         tree = plugin.queries
-        result = plugin.invert_condition(tree[tree.keys()[0]])
+        result = plugin.invert_condition(tree[list(tree.keys())[0]])
         self.assertIsInstance(result, tuple)
         self.assertEqual(len(result), 2)
         self.assertIsInstance(result[0], str)
@@ -434,7 +434,7 @@ class Test_create_symbol_cube(IrisTest):
         self.cube = set_up_probability_above_threshold_cube(data,
                                                             'air_temperature',
                                                             'K')
-        self.wxcode = np.array(WX_DICT.keys())
+        self.wxcode = np.array(list(WX_DICT.keys()))
         self.wxmeaning = " ".join(WX_DICT.values())
 
     def test_basic(self):
@@ -455,7 +455,7 @@ class Test_process(IrisTest):
     def setUp(self):
         """ Set up wxcubes for testing. """
         self.cubes = set_up_wxcubes()
-        self.wxcode = np.array(WX_DICT.keys())
+        self.wxcode = np.array(list(WX_DICT.keys()))
         self.wxmeaning = " ".join(WX_DICT.values())
 
     def test_basic(self):

--- a/lib/improver/tests/wxcode/wxcode/test_wxcode_utilities.py
+++ b/lib/improver/tests/wxcode/wxcode/test_wxcode_utilities.py
@@ -99,7 +99,7 @@ class Test_add_wxcode_metadata(IrisTest):
                          2, 0, 1, 29, 30, 1, 5, 6, 6]).reshape(2, 1, 3, 3)
         self.cube = set_up_cube(data, 'air_temperature', 'K',
                                 realizations=np.array([0, 1]))
-        self.wxcode = np.array(WX_DICT.keys())
+        self.wxcode = np.array(list(WX_DICT.keys()))
         self.wxmeaning = " ".join(WX_DICT.values())
         self.data_directory = mkdtemp()
         self.nc_file = self.data_directory + '/wxcode.nc'
@@ -153,13 +153,13 @@ class Test_expand_nested_lists(IrisTest):
         """Testexpand_nested_lists returns a expanded list if given a list."""
         result = expand_nested_lists(self.dictionary, 'list')
         for val in result:
-            self.assertEquals(val, 'a')
+            self.assertEqual(val, 'a')
 
     def test_list_of_lists(self):
         """Returns a expanded list if given a list of lists."""
         result = expand_nested_lists(self.dictionary, 'list_of_lists')
         for val in result:
-            self.assertEquals(val, 'a')
+            self.assertEqual(val, 'a')
 
 
 if __name__ == '__main__':

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -188,7 +188,7 @@ def find_percentile_coordinate(cube):
     if not isinstance(cube, iris.cube.Cube):
         msg = ('Expecting data to be an instance of '
                'iris.cube.Cube but is'
-               ' {0:s}.'.format(type(cube)))
+               ' {0}.'.format(type(cube)))
         raise TypeError(msg)
     standard_name = cube.name()
     perc_coord = None

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -765,12 +765,12 @@ def enforce_coordinate_ordering(
     # Determine coordinate indices for use in creating a dictionary.
     # These indices are either relative to the start or end of the available
     # dimension coordinates.
-    coord_indices = np.array(range(len(coord_names)))
+    coord_indices = np.array(list(range(len(coord_names))))
     if anchor == "end":
         coord_indices = sorted(len(cube.dim_coords) - coord_indices)
-    coord_dict = dict(zip(coord_names, coord_indices))
+    coord_dict = dict(list(zip(coord_names, coord_indices)))
 
-    for coord_name in coord_dict.keys():
+    for coord_name in list(coord_dict.keys()):
         # Deal with the coord_name being a partial match to the actual
         # coordinate name.
         if cube.coords(coord_name):
@@ -822,7 +822,7 @@ def enforce_coordinate_ordering(
     # getting the keys from the dictionary that have been sorted by the values.
     coord_dims = []
     for coord_name, _ in sorted(
-            coord_dict.items(), key=operator.itemgetter(1)):
+            list(coord_dict.items()), key=operator.itemgetter(1)):
         if cube.coords(coord_name, dim_coords=True):
             coord_dims.append(cube.coord_dims(coord_name)[0])
 

--- a/lib/improver/utilities/mathematical_operations.py
+++ b/lib/improver/utilities/mathematical_operations.py
@@ -165,11 +165,11 @@ class Integration(object):
         if self.direction_of_integration == "positive":
             integrated_cube = upper_bounds_cube.copy()
             integrated_cube.coord(self.coord_name_to_integrate).bounds = (
-                zip(lower_bounds, upper_bounds))
+                list(zip(lower_bounds, upper_bounds)))
         elif self.direction_of_integration == "negative":
             integrated_cube = lower_bounds_cube.copy()
             integrated_cube.coord(self.coord_name_to_integrate).bounds = (
-                zip(lower_bounds, upper_bounds))
+                list(zip(lower_bounds, upper_bounds)))
 
         integrated_cube.data = np.zeros(lower_bounds_cube.shape)
         return upper_bounds_cube, lower_bounds_cube, integrated_cube
@@ -207,10 +207,10 @@ class Integration(object):
 
         """
         # Create a zip for looping over.
-        levels_tuple = zip(
+        levels_tuple = list(zip(
             upper_bounds_cube.slices_over(self.coord_name_to_integrate),
             lower_bounds_cube.slices_over(self.coord_name_to_integrate),
-            integrated_cube.slices_over(self.coord_name_to_integrate))
+            integrated_cube.slices_over(self.coord_name_to_integrate)))
 
         # Perform the integration
         stride_sum = 0

--- a/lib/improver/utilities/warnings_handler.py
+++ b/lib/improver/utilities/warnings_handler.py
@@ -89,7 +89,7 @@ class ManageWarnings(object):
         Clears the hidden __warningregistry__ attribute from
         all imported modules.
         """
-        for mod in sys.modules.values():
+        for mod in list(sys.modules.values()):
             if hasattr(mod, '__warningregistry__'):
                 mod.__warningregistry__.clear()
 

--- a/lib/improver/wind_downscaling.py
+++ b/lib/improver/wind_downscaling.py
@@ -112,7 +112,8 @@ class FrictionVelocity(object):
         """
         ustar = np.full(self.u_href.shape, RMDI, dtype=np.float32)
         numerator = self.u_href[self.mask]
-        denominator = np.log(self.h_ref[self.mask] / self.z_0[self.mask])
+        with np.errstate(invalid='ignore'):
+            denominator = np.log(self.h_ref[self.mask] / self.z_0[self.mask])
         ustar[self.mask] = VONKARMAN * (numerator / denominator)
         return ustar
 
@@ -711,12 +712,12 @@ class RoughnessCorrection(object):
         try:
             xname = cube.coord(axis="x").name()
         except CoordinateNotFoundError as exc:
-            print("'{0}' while xname setting. Args: {1}.".format(exc.message,
+            print("'{0}' while xname setting. Args: {1}.".format(exc,
                                                                  exc.args))
         try:
             yname = cube.coord(axis="y").name()
         except CoordinateNotFoundError as exc:
-            print("'{0}' while yname setting. Args: {1}.".format(exc.message,
+            print("'{0}' while yname setting. Args: {1}.".format(exc,
                                                                  exc.args))
         if clist.intersection(self.zcoordnames):
             zname = list(clist.intersection(self.zcoordnames))[0]

--- a/lib/improver/wind_gust_diagnostic.py
+++ b/lib/improver/wind_gust_diagnostic.py
@@ -148,7 +148,7 @@ class WindGustDiagnostic(object):
         if not isinstance(cube, iris.cube.Cube):
             msg = ('Expecting {0:s} data to be an instance of '
                    'iris.cube.Cube but is'
-                   ' {1:s}.'.format(standard_name, type(cube)))
+                   ' {1}.'.format(standard_name, type(cube)))
             raise TypeError(msg)
         perc_coord = find_percentile_coordinate(cube)
         if cube.standard_name != standard_name:

--- a/lib/improver/wxcode/weather_symbols.py
+++ b/lib/improver/wxcode/weather_symbols.py
@@ -79,7 +79,7 @@ class WeatherSymbols(object):
                 The error includes details of which fields are missing.
         """
         missing_data = []
-        for query in self.queries.itervalues():
+        for query in self.queries.values():
             diagnostics = expand_nested_lists(query, 'diagnostic_fields')
             thresholds = expand_nested_lists(query, 'diagnostic_thresholds')
             conditions = expand_nested_lists(query, 'diagnostic_conditions')
@@ -398,8 +398,8 @@ class WeatherSymbols(object):
 
         # Search through tree for all leaves (weather code end points)
         defined_symbols = []
-        for item in self.queries.itervalues():
-            for value in item.itervalues():
+        for item in self.queries.values():
+            for value in item.values():
                 if isinstance(value, int):
                     defined_symbols.append(value)
 

--- a/lib/improver/wxcode/wxcode_utilities.py
+++ b/lib/improver/wxcode/wxcode_utilities.py
@@ -81,7 +81,7 @@ def add_wxcode_metadata(cube):
     cube.standard_name = None
     cube.var_name = None
     cube.units = "1"
-    wx_keys = np.array(WX_DICT.keys())
+    wx_keys = np.array(list(WX_DICT.keys()))
     cube.attributes.update({'weather_code': wx_keys})
     wxstring = " ".join(WX_DICT.values())
     cube.attributes.update({'weather_code_meaning': wxstring})

--- a/tests/improver-blend-adjacent-points/00-null.bats
+++ b/tests/improver-blend-adjacent-points/00-null.bats
@@ -38,7 +38,6 @@ usage: improver-blend-adjacent-points [-h] [--parameter_unit UNIT_STRING]
                                       COORDINATE_TO_BLEND_OVER
                                       WEIGHTED_BLEND_MODE TRIANGLE_WIDTH
                                       INPUT_FILE OUTPUT_FILE
-improver-blend-adjacent-points: error: too few arguments
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-ecc/00-null.bats
+++ b/tests/improver-ecc/00-null.bats
@@ -40,7 +40,6 @@ usage: improver-ecc [-h] [--no_of_percentiles NUMBER_OF_PERCENTILES]
                     [--random_ordering] [--random_seed RANDOM_SEED]
                     [--member_numbers MEMBER_NUMBERS]
                     INPUT_FILE OUTPUT_FILE
-improver-ecc: error: too few arguments
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-ensemble-calibration/00_null.bats
+++ b/tests/improver-ensemble-calibration/00_null.bats
@@ -1,4 +1,33 @@
 #!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 @test "ensemble-calibration no arguments" {
   run improver ensemble-calibration

--- a/tests/improver-generate-topography-bands-mask/04-missing_landmask.bats
+++ b/tests/improver-generate-topography-bands-mask/04-missing_landmask.bats
@@ -43,7 +43,7 @@
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-IOError: Loading land mask has been unsuccessful: One or more of the files specified did not exist
+OSError: Loading land mask has been unsuccessful: One or more of the files specified did not exist
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 

--- a/tests/improver-generate-topography-bands-weights/04-missing_landmask.bats
+++ b/tests/improver-generate-topography-bands-weights/04-missing_landmask.bats
@@ -43,7 +43,7 @@
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-IOError: Loading land mask has been unsuccessful: One or more of the files specified did not exist
+OSError: Loading land mask has been unsuccessful: One or more of the files specified did not exist
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 

--- a/tests/improver-probabilities-to-realizations/00-null.bats
+++ b/tests/improver-probabilities-to-realizations/00-null.bats
@@ -36,7 +36,6 @@
 usage: improver-probabilities-to-realizations [-h]
                                               [--no-of-realizations NUMBER_OF_REALIZATIONS]
                                               INPUT_FILE OUTPUT_FILE
-improver-probabilities-to-realizations: error: too few arguments
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-spotdb/00-null.bats
+++ b/tests/improver-spotdb/00-null.bats
@@ -36,7 +36,6 @@ expected="usage: improver-spotdb [-h] [--table_name OUTPUT_TABLE_NAME]
                        [--experiment_id EXPERIMENT_ID]
                        [--max_forecast_leadtime MAX_LEADTIME]
                        (--sqlite | --csv)
-                       INPUT_FILES OUTPUT_FILE
-improver-spotdb: error: too few arguments"
+                       INPUT_FILES OUTPUT_FILE"
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-weighted-blending/00-null.bats
+++ b/tests/improver-weighted-blending/00-null.bats
@@ -47,7 +47,6 @@ usage: improver-weighted-blending [-h] [--coord_exp_val COORD_EXPECTED_VALUES]
                                   COORDINATE_TO_AVERAGE_OVER
                                   WEIGHTED_BLEND_MODE INPUT_FILES
                                   [INPUT_FILES ...] OUTPUT_FILE
-improver-weighted-blending: error: too few arguments
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-wxcode/01-help.bats
+++ b/tests/improver-wxcode/01-help.bats
@@ -41,13 +41,13 @@ Calculate gridded weather symbol codes.
 This plugin requires a specific set of input diagnostics, where data
 may be in any units to which the thresholds given below can
 be converted:
- - probability_of_lwe_snowfall_rate; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_rainfall_rate_in_vicinity; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
  - probability_of_rainfall_rate; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate_in_vicinity; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
  - probability_of_cloud_area_fraction; thresholds: above 0.1875 (1), above 0.8125 (1)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl; thresholds: above 0.85 (1)
  - probability_of_visibility_in_air; thresholds: below 1000.0 (m), below 5000.0 (m)
+ - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl; thresholds: above 0.85 (1)
+ - probability_of_rainfall_rate_in_vicinity; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_in_vicinity; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
 
 positional arguments:
   INPUT_FILES  Paths to files containing the required input diagnostics.


### PR DESCRIPTION
* Modifications to upgrade IMPROVER to Python 3. Pycodestyle and pylint -E pass. Unit tests pass, although a few tests still generate warnings, which needs further investigation. CLI tests need further work, as all the known good output will change, as a result of an upgrade to the hdf5 version that is recorded within each netcdf file.

* Edits to ignore relevant warnings arising when importing statsmodels. Argparse unclosed file warning is now ignored, however, an unclosed socket warning will sometimes remains.

* Update python version used in Travis.

* Further minor edits for warnings. There is still one DeprecationWarning that seems to arise based on the interaction between the ensemble calibration and the spot database tests.

* Reconfigure the managing of warnings for ensemble calibration, so the the ManageWarnings utility is only used within the unit tests.

* Make unit test output verbose.

* As a result of some interaction between the warnings within test_ApplyCoefficientsForEnsembleCalibration.py and test_SpotDatabase.py, I've ignored Deprecation Warnings, which I think are coming from pandas that are causing Deprecation Warnings to be raised locally.

* Edits to ensure warnings raised in test_EstimateCoefficientsForEnsembleCalibration.py are trapped and other causes of errors are resolved.

* Print statement to try to debug Travis error.

* Modify warnings that are managed by test_statsmodels_members.

* Remove verbosity from unit test output.

* Sphinx documentation fix, as sphinx.apidoc has moved to sphinx.ext.apidoc. It seems like Sphinx should support the use of sphinx.apidoc, rather than sphinx.ext.apidoc, however, it seems like something about this interface doesn't seem to be working.

* Remove unused import of ManageWarnings.

* Include an explicit closing of the file that is opened within the setUpClass.

* Removal of unnecessary lists added by the 2to3 tool.

* Further edits to remove unnecessary conversion of variables to a list and removal of the use of the warnings handler within test_ArgParser.py.

* Edits to remove enforcing of string formatting.

* Update to the type of error raised in CLI tests for a missing land mask.

* Re-added usage of keys() when iterating over the keys within a dictionary, as this syntax is more explicit.

* Further edits to explicitly access the keys on a dictionary, where appropriate.

* Removed extra blank line.

Addresses #GitHubissuenum

Description

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

