### PR TITLE
Code coverage reporting for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ install:
   - conda install -c conda-forge iris=2.0
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint pandas python-stratify sphinx=1.7.0
+  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint pandas python-stratify sphinx=1.7.0 coverage
+  - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.
   - conda list

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -52,7 +52,16 @@ function improver_test_doc {
 
 function improver_test_unit {
     # Unit tests.
-    python -m unittest discover
+    if type -f coverage 1>/dev/null 2>&1; then
+        coverage run -m unittest discover
+        coverage xml
+        if [[ -n "${CODACY_PROJECT_TOKEN:-}" ]]; then
+            # Report coverage to Codacy if possible.
+            python-codacy-coverage -r coverage.xml
+        fi
+    else
+        python -m unittest discover
+    fi
     echo_ok "Unit tests"
 }
 


### PR DESCRIPTION
This is aimed at #580.

This should add code coverage results to Codacy, at least for master (so we can view current and past coverage info). Incoming PRs from non-metoppv forks are hit by https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions and won't work with this.

Follows https://support.codacy.com/hc/en-us/articles/207279819-Coverage and https://github.com/codacy/python-codacy-coverage#setup.

I've added the token to our Travis setup, suitably securely: https://travis-ci.org/metoppv/improver/builds/386636363#L422

and the coverage uploads OK:
https://travis-ci.org/metoppv/improver/builds/386636363#L1987