### PR TITLE
IMPRO-618: Grid to grid interpolation

### DIFF
--- a/bin/improver-regrid
+++ b/bin/improver-regrid
@@ -36,7 +36,7 @@ import iris
 from improver.argparser import ArgParser
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
-from improver.utilities.cube_metadata import delete_attributes
+from improver.utilities.cube_metadata import amend_metadata, delete_attributes
 
 
 def main():
@@ -105,7 +105,10 @@ def main():
             extrapolation_mode=args.extrapolation_mode)
 
     source_on_target = source_data.regrid(target_grid, regridder)
-    delete_attributes(source_on_target, ['mosg__grid', 'title'])
+    target_grid_attributes = {k: v for (k, v) in target_grid.attributes.items()
+                              if 'mosg__grid' in k}
+    amend_metadata(source_on_target, revised_attributes=target_grid_attributes)
+    delete_attributes(source_on_target, ['title'])
     save_netcdf(source_on_target, args.output_filepath)
 
 

--- a/bin/improver-regrid
+++ b/bin/improver-regrid
@@ -67,7 +67,7 @@ def main():
                               (['--extrapolation_mode'],
                                {'default': 'nanmask',
                                 'help': ('Mode to use for extrapolating data '
-                                         'in to regions beyond the limits of '
+                                         'into regions beyond the limits of '
                                          'the source_data domain. Modes are: '
                                          'extrapolate - The extrapolation '
                                          'points will take their value from '

--- a/bin/improver-regrid
+++ b/bin/improver-regrid
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to regrid a source grid to a target grid."""
+
+import iris
+
+from improver.argparser import ArgParser
+from improver.utilities.load import load_cube
+from improver.utilities.save import save_netcdf
+from improver.utilities.cube_metadata import delete_attributes
+
+
+def main():
+    """Regrid data from a source cube on to a target grid described by another
+       cube."""
+
+    cli_specific_arguments = [(['source_data_filepath'],
+                               {'metavar': 'SOURCE_DATA',
+                                'help': ('A cube of data that is to be '
+                                         'regridded onto the target_grid.')}),
+                              (['target_grid_filepath'],
+                               {'metavar': 'TARGET_GRID',
+                                'help': ('A cube containing the grid to which '
+                                         'the source_data is to be regridded.'
+                                         )}),
+                              (['output_filepath'],
+                               {'metavar': 'OUTPUT_FILE',
+                                'help': ('The output path for the processed '
+                                         'NetCDF')}),
+                              (['--nearest'],
+                               {'default': False,
+                                'action': 'store_true',
+                                'help': ('If True, regridding will be '
+                                         'performed using iris.analysis.'
+                                         'Nearest() instead of Linear(). '
+                                         'Use for less continuous fields, e.g.'
+                                         ' precipitation.')}),
+                              (['--extrapolation_mode'],
+                               {'default': 'nanmask',
+                                'help': ('Mode to use for extrapolating data '
+                                         'in to regions beyond the limits of '
+                                         'the source_data domain. Modes are: '
+                                         'extrapolate - The extrapolation '
+                                         'points will take their value from '
+                                         'the nearest source point. '
+                                         'nan - The extrapolation points will '
+                                         'be be set to NaN. error - A '
+                                         'ValueError exception will be raised,'
+                                         ' notifying an attempt to extrapolate'
+                                         '. mask  - The extrapolation points '
+                                         'will always be masked, even if the '
+                                         'source data is not a MaskedArray. '
+                                         'nanmask - If the source data is a '
+                                         'MaskedArray the extrapolation points'
+                                         ' will be masked. Otherwise they will'
+                                         ' be set to NaN. Defaults to nanmask.'
+                                         )}),
+                              ]
+
+    cli_definition = {'central_arguments': [],
+                      'specific_arguments': cli_specific_arguments,
+                      'description': ('Regrid data from source_data on to the '
+                                      'grid contained within target_grid using'
+                                      ' iris.analysis.Linear() or optionally '
+                                      'iris.analysis.Nearest()')}
+
+    args = ArgParser(**cli_definition).parse_args()
+
+    source_data = load_cube(args.source_data_filepath)
+    target_grid = load_cube(args.target_grid_filepath)
+
+    regridder = iris.analysis.Linear(
+        extrapolation_mode=args.extrapolation_mode)
+    if args.nearest:
+        regridder = iris.analysis.Nearest(
+            extrapolation_mode=args.extrapolation_mode)
+
+    source_on_target = source_data.regrid(target_grid, regridder)
+    delete_attributes(source_on_target, ['mosg__grid', 'title'])
+    save_netcdf(source_on_target, args.output_filepath)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -34,6 +34,7 @@ import unittest
 import numpy as np
 
 import iris
+from copy import copy
 from iris.tests import IrisTest
 from iris.cube import Cube
 from iris.coords import DimCoord
@@ -526,7 +527,7 @@ class Test_delete_attributes(IrisTest):
     def test_accepts_string(self):
         """Test that a single string passed as an argument works."""
         attributes_to_delete = 'title'
-        attributes = self.cube.attributes
+        attributes = copy(self.cube.attributes)
         attributes.pop(attributes_to_delete)
         delete_attributes(self.cube, attributes_to_delete)
 
@@ -536,7 +537,7 @@ class Test_delete_attributes(IrisTest):
         """Test that a list of complete attribute names removes the expected
         attributes."""
         attributes_to_delete = ['title', 'tithe', 'mosg_model']
-        attributes = self.cube.attributes
+        attributes = copy(self.cube.attributes)
         for item in attributes_to_delete:
             attributes.pop(item)
         delete_attributes(self.cube, attributes_to_delete)

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -234,10 +234,10 @@ def update_attribute(cube, attribute_name, changes, warnings_on=False):
 
 
 def amend_metadata(cube,
-                   new_diagnostic_name,
-                   data_type,
-                   revised_coords,
-                   revised_attributes,
+                   new_diagnostic_name=None,
+                   data_type=None,
+                   revised_coords=None,
+                   revised_attributes=None,
                    warnings_on=False):
     """Amend the metadata in the combined cube.
 
@@ -263,8 +263,10 @@ def amend_metadata(cube,
 
     """
     result = cube
-    result.data = result.data.astype(data_type)
-    result.rename(new_diagnostic_name)
+    if data_type:
+        result.data = result.data.astype(data_type)
+    if new_diagnostic_name:
+        result.rename(new_diagnostic_name)
 
     if revised_coords is not None:
         for key in revised_coords:

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -368,8 +368,4 @@ def delete_attributes(cube, patterns):
     grid_attributes = list(set(grid_attributes))
 
     for key in grid_attributes:
-        try:
-            cube.attributes.pop(key)
-        except KeyError:
-            msg = 'Key: {} not found in cube attributes.'.format(key)
-            warnings.warn(msg)
+        cube.attributes.pop(key)

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -343,3 +343,33 @@ def resolve_metadata_diff(cube1, cube2, warnings_on=False):
         msg = "Can not combine cubes, mismatching shapes"
         raise ValueError(msg)
     return result1, result2
+
+
+def delete_attributes(cube, patterns):
+    """
+    Delete attributes that are complete or partial matches to elements in the
+    list patterns.
+
+    Args:
+        cube (iris.cube.Cube):
+            The cube from which attributes are to be deleted.
+        patterns (list or tuple):
+            A list of strings that match or partially match the keys of
+            attributes to be deleted from the cube.
+    """
+
+    if not isinstance(patterns, (tuple, list)):
+        patterns = [patterns]
+
+    grid_attributes = []
+    for pattern in patterns:
+        grid_attributes.extend([k for k in cube.attributes if pattern in k])
+
+    grid_attributes = list(set(grid_attributes))
+
+    for key in grid_attributes:
+        try:
+            cube.attributes.pop(key)
+        except KeyError:
+            msg = 'Key: {} not found in cube attributes.'.format(key)
+            warnings.warn(msg)

--- a/tests/improver-regrid/00-null.bats
+++ b/tests/improver-regrid/00-null.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "regrid no arguments" {
+  run improver regrid
+  [[ "$status" -eq 2 ]]
+  read -d '' expected <<'__TEXT__' || true
+usage: improver-regrid [-h] [--nearest]
+                       [--extrapolation_mode EXTRAPOLATION_MODE]
+                       SOURCE_DATA TARGET_GRID OUTPUT_FILE
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-regrid/01-help.bats
+++ b/tests/improver-regrid/01-help.bats
@@ -53,10 +53,10 @@ optional arguments:
                         iris.analysis.Nearest() instead of Linear(). Use for
                         less continuous fields, e.g. precipitation.
   --extrapolation_mode EXTRAPOLATION_MODE
-                        Mode to use for extrapolating data in to regions
-                        beyond the limits of the source_data domain. Modes
-                        are: extrapolate - The extrapolation points will take
-                        their value from the nearest source point. nan - The
+                        Mode to use for extrapolating data into regions beyond
+                        the limits of the source_data domain. Modes are:
+                        extrapolate - The extrapolation points will take their
+                        value from the nearest source point. nan - The
                         extrapolation points will be be set to NaN. error - A
                         ValueError exception will be raised, notifying an
                         attempt to extrapolate. mask - The extrapolation

--- a/tests/improver-regrid/01-help.bats
+++ b/tests/improver-regrid/01-help.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "regrid -h" {
+  run improver regrid -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__HELP__' || true
+usage: improver-regrid [-h] [--nearest]
+                       [--extrapolation_mode EXTRAPOLATION_MODE]
+                       SOURCE_DATA TARGET_GRID OUTPUT_FILE
+
+Regrid data from source_data on to the grid contained within target_grid using
+iris.analysis.Linear() or optionally iris.analysis.Nearest()
+
+positional arguments:
+  SOURCE_DATA           A cube of data that is to be regridded onto the
+                        target_grid.
+  TARGET_GRID           A cube containing the grid to which the source_data is
+                        to be regridded.
+  OUTPUT_FILE           The output path for the processed NetCDF
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --nearest             If True, regridding will be performed using
+                        iris.analysis.Nearest() instead of Linear(). Use for
+                        less continuous fields, e.g. precipitation.
+  --extrapolation_mode EXTRAPOLATION_MODE
+                        Mode to use for extrapolating data in to regions
+                        beyond the limits of the source_data domain. Modes
+                        are: extrapolate - The extrapolation points will take
+                        their value from the nearest source point. nan - The
+                        extrapolation points will be be set to NaN. error - A
+                        ValueError exception will be raised, notifying an
+                        attempt to extrapolate. mask - The extrapolation
+                        points will always be masked, even if the source data
+                        is not a MaskedArray. nanmask - If the source data is
+                        a MaskedArray the extrapolation points will be masked.
+                        Otherwise they will be set to NaN. Defaults to
+                        nanmask.
+__HELP__
+  [[ "$output" == "$expected" ]]
+}

--- a/tests/improver-regrid/02-basic.bats
+++ b/tests/improver-regrid/02-basic.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "regrid" {
+  improver_check_skip_acceptance
+  KGO="regrid/basic/kgo.nc"
+
+  # Run cube regrid processing and check it passes.
+  run improver regrid \
+      "$IMPROVER_ACC_TEST_DIR/regrid/basic/global_cutout.nc" \
+      "$IMPROVER_ACC_TEST_DIR/regrid/basic/ukvx_grid.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-regrid/03-nearest.bats
+++ b/tests/improver-regrid/03-nearest.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "regrid" {
+  improver_check_skip_acceptance
+  KGO="regrid/nearest/kgo.nc"
+
+  # Run cube regrid processing and check it passes.
+  run improver regrid \
+      "$IMPROVER_ACC_TEST_DIR/regrid/basic/global_cutout.nc" \
+      "$IMPROVER_ACC_TEST_DIR/regrid/basic/ukvx_grid.nc" \
+      "$TEST_DIR/output.nc" --nearest
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-regrid/04-extrapolate.bats
+++ b/tests/improver-regrid/04-extrapolate.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "regrid" {
+  improver_check_skip_acceptance
+  KGO="regrid/extrapolate/kgo.nc"
+
+  # Run cube regrid processing and check it passes.
+  run improver regrid \
+      "$IMPROVER_ACC_TEST_DIR/regrid/basic/ukvx_grid.nc" \
+      "$IMPROVER_ACC_TEST_DIR/regrid/basic/global_cutout.nc" \
+      "$TEST_DIR/output.nc" --nearest --extrapolation_mode extrapolate
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
A wrapper to iris regrid functionality; initial use case if regridding radar data. Includes a new utility to use a pattern to delete attributes from a cube; this is used to delete StaGE derived grid descriptors which become incorrect once a grid is regridded.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)