### PR TITLE
Add support for providing a verbose option for the unit tests

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -52,7 +52,10 @@ function improver_test_doc {
 
 function improver_test_unit {
     # Unit tests.
-    python -m unittest discover
+    if [[ -n $DEBUG_OPT ]]; then
+        VERBOSE_OPT='-v'
+    fi
+    python -m unittest discover ${VERBOSE_OPT:-}
     echo_ok "Unit tests"
 }
 


### PR DESCRIPTION
Related to #558 

Description: As part of #558, it was helpful to run the unit tests with the verbose option enabled, so that it was possible to know which unit test was generating the warnings that were being raised. This PR makes use of the existing ability to specify a `--debug` option, so that this option is passed to the call to `unittest discover` and verbose unit test output is enabled.

Testing:
 - [x] Ran tests and they passed OK

