### PR TITLE
Impro-672 use realizations rather than members

### DIFF
--- a/bin/improver-ecc
+++ b/bin/improver-ecc
@@ -35,7 +35,7 @@
 import numpy as np
 
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
-    RebadgePercentilesAsMembers, ResamplePercentiles, EnsembleReordering)
+    RebadgePercentilesAsRealizations, ResamplePercentiles, EnsembleReordering)
 from improver.argparser import ArgParser
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -59,7 +59,7 @@ def main():
                         metavar='NUMBER_OF_PERCENTILES',
                         help='The number of percentiles to be generated. '
                              'This is also equal to the number of ensemble '
-                             'members that will be generated.')
+                             'realizations that will be generated.')
     parser.add_argument('--sampling_method', default='quantile',
                         const='quantile', nargs='?',
                         choices=['quantile', 'random'],
@@ -74,20 +74,21 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
 
     group.add_argument('--reordering', default=False, action='store_true',
-                       help='The option used to create ensemble members '
+                       help='The option used to create ensemble realizations '
                        'from percentiles by reordering the input '
                        'percentiles based on the order of the '
                        'raw ensemble forecast.')
     group.add_argument('--rebadging', default=False, action='store_true',
-                       help='The option used to create ensemble members '
+                       help='The option used to create ensemble realizations '
                        'from percentiles by rebadging the input '
                        'percentiles.')
 
-    # If reordering, can do so either based on original members, or randomly.
+    # If reordering, can do so either based on original realizations,
+    # or randomly.
     reordering = parser.add_argument_group(
         'Reordering options', 'Options for reordering the input percentiles '
         'using the raw ensemble forecast as required to create ensemble '
-        'members.')
+        'realizations.')
     reordering.add_argument('--raw_forecast_filepath',
                             metavar='RAW_FORECAST_FILE',
                             help='A path to an raw forecast NetCDF file to be '
@@ -110,11 +111,12 @@ def main():
 
     rebadging = parser.add_argument_group(
         'Rebadging options', 'Options for rebadging the input percentiles '
-        'as ensemble members.')
-    rebadging.add_argument('--member_numbers', default=None,
-                           metavar='MEMBER_NUMBERS',
-                           help='A list of ensemble member numbers to use '
-                           'when rebadging the percentiles into members.')
+        'as ensemble s.')
+    rebadging.add_argument('--realization_numbers', default=None,
+                           metavar='REALIZATION_NUMBERS',
+                           help='A list of ensemble realization numbers to '
+                                'use when rebadging the percentiles '
+                                'into realizations.')
 
     args = parser.parse_args()
 
@@ -124,8 +126,8 @@ def main():
     # Note: Shouldn't need to check that both/none are set, since they are
     # defined as mandatory, but mutually exclusive, options.
     if args.reordering:
-        if np.any([args.member_numbers]):
-            parser.wrong_args_error('member_numbers', 'reordering')
+        if np.any([args.realization_numbers]):
+            parser.wrong_args_error('realization_numbers', 'reordering')
     if args.rebadging:
         if np.any([args.raw_forecast_filepath, args.random_ordering]):
             parser.wrong_args_error(
@@ -146,8 +148,8 @@ def main():
             result_cube, raw_forecast, random_ordering=args.random_ordering,
             random_seed=args.random_seed)
     elif args.rebadging:
-        result_cube = RebadgePercentilesAsMembers().process(
-            result_cube, ensemble_member_numbers=args.member_numbers)
+        result_cube = RebadgePercentilesAsRealizations().process(
+            result_cube, ensemble_realization_numbers=args.realization_numbers)
 
     save_netcdf(result_cube, args.output_filepath)
 

--- a/bin/improver-ecc
+++ b/bin/improver-ecc
@@ -111,7 +111,7 @@ def main():
 
     rebadging = parser.add_argument_group(
         'Rebadging options', 'Options for rebadging the input percentiles '
-        'as ensemble s.')
+        'as ensemble realizations.')
     rebadging.add_argument('--realization_numbers', default=None,
                            metavar='REALIZATION_NUMBERS',
                            help='A list of ensemble realization numbers to '

--- a/bin/improver-ensemble-calibration
+++ b/bin/improver-ensemble-calibration
@@ -51,12 +51,12 @@ def main():
 
        The mean and variance calculated by this plugin are passed to
        GeneratePercentilesFromMeanAndVariance and EnsembleReordering plugins
-       to regenerate members.
+       to regenerate realizations.
     """
     parser = ArgParser(
         description='Apply the requested ensemble calibration method using '
         'historical forecast and "truth" data. Then apply ensemble '
-        'copula coupling to regenerate ensemble members from output.')
+        'copula coupling to regenerate ensemble realizations from output.')
     # Arguments for EnsembleCalibration
     parser.add_argument('calibration_method',
                         metavar='ENSEMBLE_CALIBRATION_METHOD',
@@ -91,22 +91,22 @@ def main():
                         help='The output path for the processed NetCDF')
     # Optional arguments.
     parser.add_argument('--predictor_of_mean', metavar='CALIBRATE_MEAN_FLAG',
-                        choices=['mean', 'members'], default='mean',
+                        choices=['mean', 'realizations'], default='mean',
                         help='String to specify the input to calculate the '
                              'calibrated mean. Currently the ensemble mean '
-                             '("mean") and the ensemble members ("members") '
-                             'are supported as the predictors. Default: '
-                             '"mean".')
+                             '("mean") and the ensemble realizations '
+                             '("realizations") are supported as the '
+                             'predictors. Default: "mean".')
     parser.add_argument('--save_mean_variance', metavar='MEAN_VARIANCE_FILE',
                         default=False,
                         help='Option to save output mean and variance from '
                              'EnsembleCalibration plugin. If used, a path '
                              'to save the output to must be provided.')
-    parser.add_argument('--num_members', metavar='NUMBER_OF_MEMBERS',
+    parser.add_argument('--num_realizations', metavar='NUMBER_OF_REALIZATIONS',
                         default=None,
                         help='Optional argument to specify the number of '
-                             'ensemble members to produce. Default will be '
-                             'the number in the raw input file.')
+                             'ensemble realizations to produce. Default will '
+                             'be the number in the raw input file.')
     parser.add_argument('--random_ordering', default=False,
                         action='store_true',
                         help='Option to reorder the post-processed forecasts '
@@ -128,9 +128,11 @@ def main():
     current_forecast = load_cube(args.input_filepath)
     historic_forecast = load_cube(args.historic_filepath)
     truth = load_cube(args.truth_filepath)
-    # Default number of ensemble members is the number in the raw forecast.
-    if not args.num_members:
-        args.num_members = len(current_forecast.coord('realization').points)
+    # Default number of ensemble realizations is the number in
+    # the raw forecast.
+    if not args.num_realizations:
+        args.num_realizations = len(
+            current_forecast.coord('realization').points)
 
     # Ensemble-Calibration to calculate the mean and variance.
     forecast_predictor_and_variance = EnsembleCalibration(
@@ -143,9 +145,9 @@ def main():
         mean_variance = iris.cube.CubeList(mean_variance)
         save_netcdf(mean_variance, args.save_mean_variance)
 
-    # Ensemble-Copula-Coupling to generate members from mean and variance.
+    # Ensemble-Copula-Coupling to generate realizations from mean and variance.
     percentiles = GeneratePercentilesFromMeanAndVariance().process(
-        forecast_predictor_and_variance, args.num_members)
+        forecast_predictor_and_variance, args.num_realizations)
     result = EnsembleReordering().process(percentiles, current_forecast,
                                           random_ordering=args.random_ordering,
                                           random_seed=args.random_seed)

--- a/bin/improver-nbhood
+++ b/bin/improver-nbhood
@@ -82,10 +82,10 @@ def main():
                         default=1.0,
                         help='The factor with which to adjust the '
                         'neighbourhood size for more than one '
-                        'ensemble member. If ens_factor = 1.0 this '
-                        'essentially conserves ensemble members if '
+                        'ensemble realization. If ens_factor = 1.0 this '
+                        'essentially conserves ensemble realizations if '
                         'every grid square is considered to be the '
-                        'equivalent of an ensemble member. '
+                        'equivalent of an ensemble realization. '
                         'Optional, defaults to 1.0.')
     parser.add_argument('--weighted_mode', action='store_true', default=False,
                         help='For neighbourhood processing using a circular '

--- a/bin/improver-nbhood-iterate-with-mask
+++ b/bin/improver-nbhood-iterate-with-mask
@@ -94,10 +94,10 @@ def main():
                         default=1.0,
                         help='The factor with which to adjust the '
                         'neighbourhood size for more than one '
-                        'ensemble member. If ens_factor = 1.0 this '
-                        'essentially conserves ensemble members if '
+                        'ensemble realization. If ens_factor = 1.0 this '
+                        'essentially conserves ensemble realizations if '
                         'every grid square is considered to be the '
-                        'equivalent of an ensemble member.'
+                        'equivalent of an ensemble realization.'
                         'Optional, defaults to 1.0.')
     parser.add_argument('--sum_or_fraction', default="fraction",
                         choices=["sum", "fraction"],

--- a/bin/improver-nbhood-land-and-sea
+++ b/bin/improver-nbhood-land-and-sea
@@ -102,10 +102,10 @@ def main():
                         default=1.0,
                         help='The factor with which to adjust the '
                         'neighbourhood size for more than one '
-                        'ensemble member. If ens_factor = 1.0 this '
-                        'essentially conserves ensemble members if '
+                        'ensemble realization. If ens_factor = 1.0 this '
+                        'essentially conserves ensemble realizationss if '
                         'every grid square is considered to be the '
-                        'equivalent of an ensemble member.'
+                        'equivalent of an ensemble realization.'
                         'Optional, defaults to 1.0.')
     parser.add_argument('--sum_or_fraction', default="fraction",
                         choices=["sum", "fraction"],

--- a/bin/improver-nbhood-land-and-sea
+++ b/bin/improver-nbhood-land-and-sea
@@ -103,7 +103,7 @@ def main():
                         help='The factor with which to adjust the '
                         'neighbourhood size for more than one '
                         'ensemble realization. If ens_factor = 1.0 this '
-                        'essentially conserves ensemble realizationss if '
+                        'essentially conserves ensemble realizations if '
                         'every grid square is considered to be the '
                         'equivalent of an ensemble realization.'
                         'Optional, defaults to 1.0.')

--- a/bin/improver-nbhood-land-and-sea
+++ b/bin/improver-nbhood-land-and-sea
@@ -97,7 +97,6 @@ def main():
                        'should be used. For example: 10000,12000,14000 1,2,3 '
                        'where a lead time of 1 hour uses a radius of 10000m, '
                        'a lead time of 2 hours uses a radius of 12000m, etc.')
-
     parser.add_argument('--ens_factor', metavar='ENS_FACTOR', type=float,
                         default=1.0,
                         help='The factor with which to adjust the '
@@ -105,7 +104,7 @@ def main():
                         'ensemble realization. If ens_factor = 1.0 this '
                         'essentially conserves ensemble realizations if '
                         'every grid square is considered to be the '
-                        'equivalent of an ensemble realization.'
+                        'equivalent of an ensemble realization. '
                         'Optional, defaults to 1.0.')
     parser.add_argument('--sum_or_fraction', default="fraction",
                         choices=["sum", "fraction"],

--- a/bin/improver-nbhood-vicinity
+++ b/bin/improver-nbhood-vicinity
@@ -84,10 +84,10 @@ def main():
                         default=1.0,
                         help='The factor with which to adjust the '
                         'neighbourhood size for more than one '
-                        'ensemble member. If ens_factor = 1.0 this '
-                        'essentially conserves ensemble members if '
+                        'ensemble realization. If ens_factor = 1.0 this '
+                        'essentially conserves ensemble realizations if '
                         'every grid square is considered to be the '
-                        'equivalent of an ensemble member.'
+                        'equivalent of an ensemble realization.'
                         'Optional, defaults to 1.0.')
     parser.add_argument('--weighted_mode', action='store_true', default=False,
                         help='For neighbourhood processing using a circular '

--- a/bin/improver-nbhood-vicinity
+++ b/bin/improver-nbhood-vicinity
@@ -87,7 +87,7 @@ def main():
                         'ensemble realization. If ens_factor = 1.0 this '
                         'essentially conserves ensemble realizations if '
                         'every grid square is considered to be the '
-                        'equivalent of an ensemble realization.'
+                        'equivalent of an ensemble realization. '
                         'Optional, defaults to 1.0.')
     parser.add_argument('--weighted_mode', action='store_true', default=False,
                         help='For neighbourhood processing using a circular '

--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -50,7 +50,7 @@ def main():
     parser = ArgParser(
         description="Calculate percentiled data over a given coordinate by "
         "collapsing that coordinate. Typically used to convert realization "
-        "(member) data into percentiled data, but may calculate over any "
+        "data into percentiled data, but may calculate over any "
         "dimension coordinate. Alternatively, calling this CLI with a dataset"
         " containing probabilities will convert those to percentiles using "
         "the ensemble copula coupling plugin. If no particular percentiles "

--- a/bin/improver-probabilities-to-realizations
+++ b/bin/improver-probabilities-to-realizations
@@ -33,7 +33,7 @@
 
 from improver.argparser import ArgParser
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
-    GeneratePercentilesFromProbabilities, RebadgePercentilesAsMembers)
+    GeneratePercentilesFromProbabilities, RebadgePercentilesAsRealizations)
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
@@ -64,7 +64,7 @@ def main():
 
     cube = GeneratePercentilesFromProbabilities().process(
             cube, no_of_percentiles=args.no_of_realizations)
-    cube = RebadgePercentilesAsMembers().process(cube)
+    cube = RebadgePercentilesAsRealizations().process(cube)
 
     save_netcdf(cube, args.output_filepath)
 

--- a/bin/improver-wind-direction
+++ b/bin/improver-wind-direction
@@ -29,7 +29,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Script to calculate mean wind direction from ensemble members."""
+"""Script to calculate mean wind direction from ensemble realizations."""
 
 from improver.argparser import ArgParser
 
@@ -40,11 +40,12 @@ from improver.utilities.save import save_netcdf
 
 def main():
     """Load in arguments to calculate mean wind direction from ensemble
-       members."""
+       realizations."""
 
     cli_definition = {'central_arguments': ('input_file', 'output_file'),
                       'description': ('Run wind direction to calculate mean'
-                                      ' wind direction from ensemble members')}
+                                      ' wind direction from '
+                                      'ensemble realizations')}
 
     args = ArgParser(**cli_definition).parse_args()
 

--- a/lib/improver/convection.py
+++ b/lib/improver/convection.py
@@ -84,10 +84,10 @@ class DiagnoseConvectivePrecipitation(object):
                 If False, use a circle with constant weighting.
             ens_factor (float):
                 The factor with which to adjust the neighbourhood size
-                for more than one ensemble member.
+                for more than one ensemble realization.
                 If ens_factor = 1.0 this essentially conserves ensemble
-                members if every grid square is considered to be the
-                equivalent of an ensemble member.
+                realizations if every grid square is considered to be the
+                equivalent of an ensemble realization.
                 Optional, defaults to 1.0
             use_adjacent_grid_square_differences (boolean):
                 If True, use the differences between adjacent grid squares

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -577,9 +577,9 @@ class EstimateCoefficientsForEnsembleCalibration(object):
             return optimised_coeffs, coeff_names
 
         rename_coordinate(
-            current_forecast_cubes, "ensemble_member_id", "realization")
+            current_forecast_cubes, "ensemble_realization_id", "realization")
         rename_coordinate(
-            historic_forecast_cubes, "ensemble_member_id", "realization")
+            historic_forecast_cubes, "ensemble_realization_id", "realization")
 
         current_forecast_cubes = concatenate_cubes(
             current_forecast_cubes)
@@ -808,7 +808,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
         check_predictor_of_mean_flag(self.predictor_of_mean_flag)
 
         rename_coordinate(
-            self.current_forecast, "ensemble_member_id", "realization")
+            self.current_forecast, "ensemble_realization_id", "realization")
 
         current_forecast_cubes = concatenate_cubes(
             self.current_forecast)

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -97,15 +97,15 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 Order of coefficients is [c, d, a, b].
             forecast_predictor (iris.cube.Cube):
                 Cube containing the fields to be used as the predictor,
-                either the ensemble mean or the ensemble members.
+                either the ensemble mean or the ensemble realizations.
             truth (iris.cube.Cube):
                 Cube containing the field, which will be used as truth.
             forecast_var (iris.cube.Cube):
                 Cube containg the field containing the ensemble variance.
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
             distribution (String):
                 String used to access the appropriate minimisation function
                 within self.minimisation_dict.
@@ -159,7 +159,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
             forecast_predictor_data = forecast_predictor.data.flatten()
             truth_data = truth.data.flatten()
             forecast_var_data = forecast_var.data.flatten()
-        elif predictor_of_mean_flag.lower() in ["members"]:
+        elif predictor_of_mean_flag.lower() in ["realizations"]:
             truth_data = truth.data.flatten()
             forecast_predictor = (
                 enforce_coordinate_ordering(
@@ -207,7 +207,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 Order of coefficients is [c, d, a, b].
             forecast_predictor : Numpy array
                 Data to be used as the predictor,
-                either the ensemble mean or the ensemble members.
+                either the ensemble mean or the ensemble realizations.
             truth : Numpy array
                 Data to be used as truth.
             forecast_var : Numpy array
@@ -216,8 +216,8 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 Square root of Pi
             predictor_of_mean_flag : String
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
 
         Returns:
             result (Float):
@@ -226,7 +226,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         """
         if predictor_of_mean_flag.lower() in ["mean"]:
             beta = initial_guess[2:]
-        elif predictor_of_mean_flag.lower() in ["members"]:
+        elif predictor_of_mean_flag.lower() in ["realizations"]:
             beta = np.array([initial_guess[2]]+(initial_guess[3:]**2).tolist())
 
         new_col = np.ones(truth.shape)
@@ -263,7 +263,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 Order of coefficients is [c, d, a, b].
             forecast_predictor (Numpy array):
                 Data to be used as the predictor,
-                either the ensemble mean or the ensemble members.
+                either the ensemble mean or the ensemble realizations.
             truth (Numpy array):
                 Data to be used as truth.
             forecast_var (Numpy array):
@@ -272,8 +272,8 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 Square root of Pi
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
 
         Returns:
             result (Float):
@@ -282,7 +282,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         """
         if predictor_of_mean_flag.lower() in ["mean"]:
             beta = initial_guess[2:]
-        elif predictor_of_mean_flag.lower() in ["members"]:
+        elif predictor_of_mean_flag.lower() in ["realizations"]:
             beta = np.array([initial_guess[2]]+(initial_guess[3:]**2).tolist())
 
         new_col = np.ones(truth.shape)
@@ -335,8 +335,8 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                 converted as required.
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
 
         """
         self.distribution = distribution
@@ -352,11 +352,11 @@ class EstimateCoefficientsForEnsembleCalibration(object):
             self.sm = sm
         except ImportError:
             statsmodels_found = False
-            if predictor_of_mean_flag.lower() in ["members"]:
+            if predictor_of_mean_flag.lower() in ["realizations"]:
                 msg = (
                     "The statsmodels can not be imported. "
                     "Will not be able to calculate an initial guess from "
-                    "the individual ensemble members. "
+                    "the individual ensemble realizations. "
                     "A default initial guess will be used without "
                     "estimating coefficients from a linear model.")
                 warnings.warn(msg, ImportWarning)
@@ -374,7 +374,8 @@ class EstimateCoefficientsForEnsembleCalibration(object):
 
     def compute_initial_guess(
             self, truth, forecast_predictor, predictor_of_mean_flag,
-            estimate_coefficients_from_linear_model_flag, no_of_members=None):
+            estimate_coefficients_from_linear_model_flag,
+            no_of_realizations=None):
         """
         Function to compute initial guess of the a and beta components of the
         EMOS coefficients by linear regression of the forecast predictor
@@ -390,17 +391,17 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                 Cube containing the field, which will be used as truth.
             forecast_predictor (Iris cube):
                 Cube containing the fields to be used as the predictor,
-                either the ensemble mean or the ensemble members.
+                either the ensemble mean or the ensemble realizations.
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
             estimate_coefficients_from_linear_model_flag (Logical):
                 Flag whether coefficients should be estimated from
                 the linear regression, or static estimates should be used.
-            no_of_members (Int):
-                Number of members, if ensemble members are to be used as
-                predictors. Default is None.
+            no_of_realizations (Int):
+                Number of realizations, if ensemble realizations are to be
+                used as predictors. Default is None.
 
         Returns:
             initial_guess (List):
@@ -412,9 +413,10 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         if (predictor_of_mean_flag.lower() in ["mean"] and
                 not estimate_coefficients_from_linear_model_flag):
             initial_guess = [1, 1, 0, 1]
-        elif (predictor_of_mean_flag.lower() in ["members"] and
+        elif (predictor_of_mean_flag.lower() in ["realizations"] and
               not estimate_coefficients_from_linear_model_flag):
-            initial_guess = [1, 1, 0] + np.repeat(1, no_of_members).tolist()
+            initial_guess = [1, 1, 0] + np.repeat(
+                1, no_of_realizations).tolist()
         elif estimate_coefficients_from_linear_model_flag:
             if predictor_of_mean_flag.lower() in ["mean"]:
                 # Find all values that are not NaN.
@@ -433,7 +435,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                                 combined_not_nan],
                             truth.data.flatten()[combined_not_nan]))
                 initial_guess = [1, 1, intercept, gradient]
-            elif predictor_of_mean_flag.lower() in ["members"]:
+            elif predictor_of_mean_flag.lower() in ["realizations"]:
                 if self.statsmodels_found:
                     truth_data = truth.data.flatten()
                     forecast_predictor = (
@@ -457,7 +459,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                     initial_guess = [1, 1, intercept]+gradient.tolist()
                 else:
                     initial_guess = (
-                        [1, 1, 0] + np.repeat(1, no_of_members).tolist())
+                        [1, 1, 0] + np.repeat(1, no_of_realizations).tolist())
         return initial_guess
 
     def estimate_coefficients_for_ngr(
@@ -619,11 +621,11 @@ class EstimateCoefficientsForEnsembleCalibration(object):
             truth_cube.convert_units(self.desired_units)
 
             if self.predictor_of_mean_flag.lower() in ["mean"]:
-                no_of_members = None
+                no_of_realizations = None
                 forecast_predictor = historic_forecast_cube.collapsed(
                     "realization", iris.analysis.MEAN)
-            elif self.predictor_of_mean_flag.lower() in ["members"]:
-                no_of_members = len(
+            elif self.predictor_of_mean_flag.lower() in ["realizations"]:
+                no_of_realizations = len(
                     historic_forecast_cube.coord("realization").points)
                 forecast_predictor = historic_forecast_cube
 
@@ -638,7 +640,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                     truth_cube, forecast_predictor,
                     self.predictor_of_mean_flag,
                     self.ESTIMATE_COEFFICIENTS_FROM_LINEAR_MODEL_FLAG,
-                    no_of_members=no_of_members)
+                    no_of_realizations=no_of_realizations)
 
             if np.any(np.isnan(initial_guess)):
                 nan_in_initial_guess = True
@@ -682,8 +684,8 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                 The name of each coefficient.
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
 
         """
         self.current_forecast = current_forecast
@@ -793,10 +795,10 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
             (tuple) : tuple containing:
                 **calibrated_forecast_predictor** (CubeList):
                     CubeList containing both the calibrated version of the
-                    ensemble predictor, either the ensemble mean/members.
+                    ensemble predictor, either the ensemble mean/realizations.
                 **calibrated_forecast_variance** (CubeList):
                     CubeList containing both the calibrated version of the
-                    ensemble variance, either the ensemble mean/members.
+                    ensemble variance, either the ensemble mean/realizations.
                 **calibrated_forecast_coefficients** (CubeList):
                     CubeList containing both the coefficients for calibrating
                     the ensemble.
@@ -814,7 +816,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
         if self.predictor_of_mean_flag.lower() in ["mean"]:
             forecast_predictors = current_forecast_cubes.collapsed(
                 "realization", iris.analysis.MEAN)
-        elif self.predictor_of_mean_flag.lower() in ["members"]:
+        elif self.predictor_of_mean_flag.lower() in ["realizations"]:
             forecast_predictors = current_forecast_cubes
 
         forecast_vars = current_forecast_cubes.collapsed(
@@ -837,7 +839,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
         Args:
             forecast_predictors (Iris cube):
                 Cube containing the forecast predictor e.g. ensemble mean
-                or ensemble members.
+                or ensemble realizations.
             forecast_vars (Iris cube.):
                 Cube containing the forecast variance e.g. ensemble variance.
             optimised_coeffs (List):
@@ -846,8 +848,8 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                 Coefficient names.
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
 
         Returns:
             (tuple) : tuple containing:
@@ -930,7 +932,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                     predicted_mean = np.dot(all_data, beta)
                     calibrated_forecast_predictor_at_date = (
                         forecast_predictor_at_date)
-                elif predictor_of_mean_flag.lower() in ["members"]:
+                elif predictor_of_mean_flag.lower() in ["realizations"]:
                     # Calculate predicted mean = a + b*X, where X is the
                     # raw ensemble mean. In this case, b = beta^2.
                     beta = np.concatenate(
@@ -948,7 +950,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                     all_data = (
                         np.column_stack((new_col, forecast_predictor_flat)))
                     predicted_mean = np.dot(all_data, beta)
-                    # Calculate mean of ensemble members, as only the
+                    # Calculate mean of ensemble realizations, as only the
                     # calibrated ensemble mean will be returned.
                     calibrated_forecast_predictor_at_date = (
                         forecast_predictor_at_date.collapsed(
@@ -1022,8 +1024,8 @@ class EnsembleCalibration(object):
                 converted as required.
             predictor_of_mean_flag (String):
                 String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble members
-                ("members") are supported as the predictors.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
         """
         self.calibration_method = calibration_method
         self.distribution = distribution

--- a/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
@@ -124,13 +124,13 @@ def check_predictor_of_mean_flag(predictor_of_mean_flag):
     Args:
         predictor_of_mean_flag (string):
             String to specify the input to calculate the calibrated mean.
-            Currently the ensemble mean ("mean") and the ensemble members
-            ("members") are supported as the predictors.
+            Currently the ensemble mean ("mean") and the ensemble realizations
+            ("realizations") are supported as the predictors.
 
     """
-    if predictor_of_mean_flag.lower() not in ["mean", "members"]:
+    if predictor_of_mean_flag.lower() not in ["mean", "realizations"]:
         msg = ("The requested value for the predictor_of_mean_flag {}"
                "is not an accepted value."
-               "Accepted values are 'mean' or 'members'").format(
+               "Accepted values are 'mean' or 'realizations'").format(
                    predictor_of_mean_flag.lower())
         raise ValueError(msg)

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -715,7 +715,7 @@ class EnsembleReordering(object):
         realizations are recycled. This assumes that the identity of the
         ensemble realizations within the raw ensemble forecast is random, such
         that the raw ensemble realizations are exchangeable. If fewer
-        percentiles  are requested than ensemble realizations, then only the
+        percentiles are requested than ensemble realizations, then only the
         first n ensemble realizations are used.
 
         Args:

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -752,18 +752,20 @@ class EnsembleReordering(object):
                 realization_list.append(mpoints[index % len(mpoints)])
 
             # Assume that the ensemble realizations are ascending linearly.
-            new_member_numbers = realization_list[0] + list(range(plen))
+            new_realization_numbers = realization_list[0] + list(range(plen))
 
             # Extract the realizations required in the realization_list from
             # the raw_forecast_realizations. Edit the member number as
             # appropriate and append to a cubelist containing rebadged
             # raw ensemble realizations.
             for realization, index in zip(
-                    realization_list, new_member_numbers):
+                    realization_list, new_realization_numbers):
                 constr = iris.Constraint(realization=realization)
-                raw_forecast_member = raw_forecast_realizations.extract(constr)
-                raw_forecast_member.coord("realization").points = index
-                raw_forecast_realizations_extended.append(raw_forecast_member)
+                raw_forecast_realization = raw_forecast_realizations.extract(
+                    constr)
+                raw_forecast_realization.coord("realization").points = index
+                raw_forecast_realizations_extended.append(
+                    raw_forecast_realization)
             raw_forecast_realizations = (
                 concatenate_cubes(raw_forecast_realizations_extended))
         return raw_forecast_realizations

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -53,7 +53,7 @@ from improver.utilities.cube_manipulation import (
 from improver.utilities.cube_checker import find_percentile_coordinate
 
 
-class RebadgePercentilesAsMembers(object):
+class RebadgePercentilesAsRealizations(object):
     """
     Class to rebadge percentiles as ensemble realizations.
     This will allow the quantisation to percentiles to be completed, without
@@ -67,11 +67,11 @@ class RebadgePercentilesAsMembers(object):
         pass
 
     @staticmethod
-    def process(cube, ensemble_member_numbers=None):
+    def process(cube, ensemble_realization_numbers=None):
         """
-        Rebadge percentiles as ensemble members. The ensemble member numbering
-        will depend upon the number of percentiles in the input cube i.e.
-        0, 1, 2, 3, ..., n-1, if there are n percentiles.
+        Rebadge percentiles as ensemble realizations. The ensemble
+        member numbering will depend upon the number of percentiles in
+        the input cube i.e. 0, 1, 2, 3, ..., n-1, if there are n percentiles.
 
         Args:
             cube (Iris.cube.Cube):
@@ -85,13 +85,13 @@ class RebadgePercentilesAsMembers(object):
         percentile_coord = (
             find_percentile_coordinate(cube).name())
 
-        if ensemble_member_numbers is None:
-            ensemble_member_numbers = (
+        if ensemble_realization_numbers is None:
+            ensemble_realization_numbers = (
                 np.arange(
                     len(cube.coord(percentile_coord).points)))
 
         cube.coord(percentile_coord).points = (
-            ensemble_member_numbers)
+            ensemble_realization_numbers)
 
         # we can't rebadge if the realization coordinate already exists:
         try:
@@ -690,7 +690,7 @@ class GeneratePercentilesFromMeanAndVariance(object):
 class EnsembleReordering(object):
     """
     Plugin for applying the reordering step of Ensemble Copula Coupling,
-    in order to generate ensemble members with multivariate structure
+    in order to generate ensemble realizations with multivariate structure
     from percentiles. The percentiles are assumed to be in ascending order.
 
     Reference:
@@ -705,83 +705,83 @@ class EnsembleReordering(object):
         pass
 
     @staticmethod
-    def _recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+    def _recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             percentile_coord):
         """
         Function to determine whether there is a mismatch between the number
-        of percentiles and the number of raw forecast members. If more
-        percentiles are requested than ensemble members, then the ensemble
-        members are recycled. This assumes that the identity of the ensemble
-        members within the raw ensemble forecast is random, such that the
-        raw ensemble members are exchangeable. If fewer percentiles are
-        requested than ensemble members, then only the first n ensemble
-        members are used.
+        of percentiles and the number of raw forecast realizations. If more
+        percentiles are requested than ensemble realizations, then the ensemble
+        realizations are recycled. This assumes that the identity of the
+        ensemble realizations within the raw ensemble forecast is random, such
+        that the raw ensemble realizations are exchangeable. If fewer
+        percentiles  are requested than ensemble members, then only the
+        first n ensemble realizations are used.
 
         Args:
             post_processed_forecast_percentiles  (iris.cube.Cube):
                 Cube for post-processed percentiles.
                 The percentiles are assumed
                 to be in ascending order.
-            raw_forecast_members (iris.cube.Cube):
+            raw_forecast_realizations (iris.cube.Cube):
                 Cube containing the raw (not post-processed) forecasts.
             percentile_coord (String):
                 Name of required percentile coordinate.
 
         Returns:
-            raw_forecast_members (iris cube.Cube):
+            raw_forecast_realizations (iris cube.Cube):
                 Cube for the raw ensemble forecast, where the raw ensemble
-                members have either been recycled or constrained,
+                realizations have either been recycled or constrained,
                 depending upon the number of percentiles present
                 in the post-processed forecast cube.
         """
         plen = len(
             post_processed_forecast_percentiles.coord(
                 percentile_coord).points)
-        mlen = len(raw_forecast_members.coord("realization").points)
+        mlen = len(raw_forecast_realizations.coord("realization").points)
         if plen == mlen:
             pass
         else:
-            raw_forecast_members_extended = iris.cube.CubeList()
+            raw_forecast_realizations_extended = iris.cube.CubeList()
             realization_list = []
-            mpoints = raw_forecast_members.coord("realization").points
+            mpoints = raw_forecast_realizations.coord("realization").points
             # Loop over the number of percentiles and finding the
             # corresponding ensemble member number. The ensemble member
             # numbers are recycled e.g. 1, 2, 3, 1, 2, 3, etc.
             for index in range(plen):
                 realization_list.append(mpoints[index % len(mpoints)])
 
-            # Assume that the ensemble members are ascending linearly.
+            # Assume that the ensemble realizations are ascending linearly.
             new_member_numbers = realization_list[0] + list(range(plen))
 
-            # Extract the members required in the realization_list from
-            # the raw_forecast_members. Edit the member number as appropriate
-            # and append to a cubelist containing rebadged raw ensemble
-            # members.
+            # Extract the realizations required in the realization_list from
+            # the raw_forecast_realizations. Edit the member number as
+            # appropriate and append to a cubelist containing rebadged
+            # raw ensemble realizations.
             for realization, index in zip(
                     realization_list, new_member_numbers):
                 constr = iris.Constraint(realization=realization)
-                raw_forecast_member = raw_forecast_members.extract(constr)
+                raw_forecast_member = raw_forecast_realizations.extract(constr)
                 raw_forecast_member.coord("realization").points = index
-                raw_forecast_members_extended.append(raw_forecast_member)
-            raw_forecast_members = (
-                concatenate_cubes(raw_forecast_members_extended))
-        return raw_forecast_members
+                raw_forecast_realizations_extended.append(raw_forecast_member)
+            raw_forecast_realizations = (
+                concatenate_cubes(raw_forecast_realizations_extended))
+        return raw_forecast_realizations
 
     @staticmethod
     def rank_ecc(
-            post_processed_forecast_percentiles, raw_forecast_members,
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             random_ordering=False, random_seed=None):
         """
         Function to apply Ensemble Copula Coupling. This ranks the
-        post-processed forecast members based on a ranking determined from
-        the raw forecast members.
+        post-processed forecast realizations based on a ranking determined from
+        the raw forecast realizations.
 
         Args:
             post_processed_forecast_percentiles (cube):
                 Cube for post-processed percentiles. The percentiles are
                 assumed to be in ascending order.
-            raw_forecast_members (cube):
+            raw_forecast_realizations (cube):
                 Cube containing the raw (not post-processed) forecasts.
                 The probabilistic dimension is assumed to be the zeroth
                 dimension.
@@ -797,14 +797,14 @@ class EnsembleReordering(object):
 
         Returns:
             iris.cube.Cube:
-                Cube for post-processed members where at a particular grid
+                Cube for post-processed realizations where at a particular grid
                 point, the ranking of the values within the ensemble matches
                 the ranking from the raw ensemble.
 
         """
         results = iris.cube.CubeList([])
         for rawfc, calfc in zip(
-                raw_forecast_members.slices_over("time"),
+                raw_forecast_realizations.slices_over("time"),
                 post_processed_forecast_percentiles.slices_over("time")):
             if random_seed is not None:
                 random_seed = int(random_seed)
@@ -839,7 +839,7 @@ class EnsembleReordering(object):
         Args:
             post_processed_forecast (Iris Cube or CubeList):
                 The cube or cubelist containing the post-processed
-                forecast members.
+                forecast realizations.
             raw_forecast (Iris Cube or CubeList):
                 The cube or cubelist containing the raw (not post-processed)
                 forecast.
@@ -854,8 +854,8 @@ class EnsembleReordering(object):
                 values generated are not reproducible.
 
         Returns:
-            post-processed_forecast_members (cube):
-                Cube containing the new ensemble members where all points
+            post-processed_forecast_realizations (cube):
+                Cube containing the new ensemble realizations where all points
                 within the dataset have been reordered in comparison to the
                 input percentiles.
         """
@@ -872,22 +872,22 @@ class EnsembleReordering(object):
         post_processed_forecast_percentiles = (
             enforce_coordinate_ordering(
                 post_processed_forecast_percentiles, percentile_coord))
-        raw_forecast_members = concatenate_cubes(raw_forecast)
-        raw_forecast_members = enforce_coordinate_ordering(
-            raw_forecast_members, "realization")
-        raw_forecast_members = (
-            self._recycle_raw_ensemble_members(
-                post_processed_forecast_percentiles, raw_forecast_members,
+        raw_forecast_realizations = concatenate_cubes(raw_forecast)
+        raw_forecast_realizations = enforce_coordinate_ordering(
+            raw_forecast_realizations, "realization")
+        raw_forecast_realizations = (
+            self._recycle_raw_ensemble_realizations(
+                post_processed_forecast_percentiles, raw_forecast_realizations,
                 percentile_coord))
-        post_processed_forecast_members = self.rank_ecc(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        post_processed_forecast_realizations = self.rank_ecc(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             random_ordering=random_ordering,
             random_seed=random_seed)
-        post_processed_forecast_members = (
-            RebadgePercentilesAsMembers.process(
-                post_processed_forecast_members))
+        post_processed_forecast_realizations = (
+            RebadgePercentilesAsRealizations.process(
+                post_processed_forecast_realizations))
 
-        post_processed_forecast_members = (
+        post_processed_forecast_realizations = (
             enforce_coordinate_ordering(
-                post_processed_forecast_members, "realization"))
-        return post_processed_forecast_members
+                post_processed_forecast_realizations, "realization"))
+        return post_processed_forecast_realizations

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -70,13 +70,13 @@ class RebadgePercentilesAsRealizations(object):
     def process(cube, ensemble_realization_numbers=None):
         """
         Rebadge percentiles as ensemble realizations. The ensemble
-        member numbering will depend upon the number of percentiles in
+        realization numbering will depend upon the number of percentiles in
         the input cube i.e. 0, 1, 2, 3, ..., n-1, if there are n percentiles.
 
         Args:
             cube (Iris.cube.Cube):
             Cube containing a percentile coordinate, which will be rebadged as
-            ensemble member.
+            ensemble realization.
 
         Raises:
             InvalidCubeError:
@@ -715,7 +715,7 @@ class EnsembleReordering(object):
         realizations are recycled. This assumes that the identity of the
         ensemble realizations within the raw ensemble forecast is random, such
         that the raw ensemble realizations are exchangeable. If fewer
-        percentiles  are requested than ensemble members, then only the
+        percentiles  are requested than ensemble realizations, then only the
         first n ensemble realizations are used.
 
         Args:
@@ -746,8 +746,8 @@ class EnsembleReordering(object):
             realization_list = []
             mpoints = raw_forecast_realizations.coord("realization").points
             # Loop over the number of percentiles and finding the
-            # corresponding ensemble member number. The ensemble member
-            # numbers are recycled e.g. 1, 2, 3, 1, 2, 3, etc.
+            # corresponding ensemble realization number. The ensemble
+            # realization numbers are recycled e.g. 1, 2, 3, 1, 2, 3, etc.
             for index in range(plen):
                 realization_list.append(mpoints[index % len(mpoints)])
 
@@ -755,7 +755,7 @@ class EnsembleReordering(object):
             new_realization_numbers = realization_list[0] + list(range(plen))
 
             # Extract the realizations required in the realization_list from
-            # the raw_forecast_realizations. Edit the member number as
+            # the raw_forecast_realizations. Edit the realization number as
             # appropriate and append to a cubelist containing rebadged
             # raw ensemble realizations.
             for realization, index in zip(

--- a/lib/improver/nbhood/nbhood.py
+++ b/lib/improver/nbhood/nbhood.py
@@ -84,10 +84,10 @@ class BaseNeighbourhoodProcessing(object):
                 in hours.
             ens_factor (float):
                 The factor with which to adjust the neighbourhood size
-                for more than one ensemble member.
+                for more than one ensemble realization.
                 If ens_factor = 1.0 this essentially conserves ensemble
                 realizations if every grid square is considered to be the
-                equivalent of an ensemble member.
+                equivalent of an ensemble realization.
                 Optional, defaults to 1.0
         """
         self.neighbourhood_method = neighbourhood_method
@@ -293,10 +293,10 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
                 in hours.
             ens_factor (float):
                 The factor with which to adjust the neighbourhood size
-                for more than one ensemble member.
+                for more than one ensemble realization.
                 If ens_factor = 1.0 this essentially conserves ensemble
                 realizations if every grid square is considered to be the
-                equivalent of an ensemble member.
+                equivalent of an ensemble realization.
                 Optional, defaults to 1.0
             percentiles (list):
                 Percentile values at which to calculate; if not provided uses
@@ -348,10 +348,10 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
                 in hours.
             ens_factor (float):
                 The factor with which to adjust the neighbourhood size
-                for more than one ensemble member.
+                for more than one ensemble realization.
                 If ens_factor = 1.0 this essentially conserves ensemble
                 realizations if every grid square is considered to be the
-                equivalent of an ensemble member.
+                equivalent of an ensemble realization.
                 Optional, defaults to 1.0
             weighted_mode (boolean):
                 If True, use a circle for neighbourhood kernel with

--- a/lib/improver/nbhood/nbhood.py
+++ b/lib/improver/nbhood/nbhood.py
@@ -86,7 +86,7 @@ class BaseNeighbourhoodProcessing(object):
                 The factor with which to adjust the neighbourhood size
                 for more than one ensemble member.
                 If ens_factor = 1.0 this essentially conserves ensemble
-                members if every grid square is considered to be the
+                realizations if every grid square is considered to be the
                 equivalent of an ensemble member.
                 Optional, defaults to 1.0
         """
@@ -111,7 +111,7 @@ class BaseNeighbourhoodProcessing(object):
 
         Args:
             num_ens (float):
-                Number of realizations or ensemble members.
+                Number of realizations or ensemble realizations.
             width (float):
                 radius or width appropriate for a single forecast in m.
 
@@ -128,16 +128,17 @@ class BaseNeighbourhoodProcessing(object):
         return new_width
 
     def _find_radii(self, num_ens, cube_lead_times=None):
-        """Revise radius or radii for found lead times and ensemble members
+        """Revise radius or radii for found lead times and ensemble
+        realizations
 
         If cube_lead_times is None just adjust for ensemble
-        members if necessary.
+        realizations if necessary.
         Otherwise interpolate to find radius at each cube
-        lead time and adjust for ensemble members if necessary.
+        lead time and adjust for ensemble realizations if necessary.
 
         Args:
             num_ens (float):
-                Number of ensemble members or realizations.
+                Number of ensemble realizations.
 
         Keyword Args:
             cube_lead_times (np.array):
@@ -294,7 +295,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
                 The factor with which to adjust the neighbourhood size
                 for more than one ensemble member.
                 If ens_factor = 1.0 this essentially conserves ensemble
-                members if every grid square is considered to be the
+                realizations if every grid square is considered to be the
                 equivalent of an ensemble member.
                 Optional, defaults to 1.0
             percentiles (list):
@@ -349,7 +350,7 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
                 The factor with which to adjust the neighbourhood size
                 for more than one ensemble member.
                 If ens_factor = 1.0 this essentially conserves ensemble
-                members if every grid square is considered to be the
+                realizations if every grid square is considered to be the
                 equivalent of an ensemble member.
                 Optional, defaults to 1.0
             weighted_mode (boolean):

--- a/lib/improver/nbhood/use_nbhood.py
+++ b/lib/improver/nbhood/use_nbhood.py
@@ -111,7 +111,7 @@ class ApplyNeighbourhoodProcessingWithAMask(object):
                 The factor with which to adjust the neighbourhood size
                 for more than one ensemble member.
                 If ens_factor = 1.0 this essentially conserves ensemble
-                members if every grid square is considered to be the
+                realizations if every grid square is considered to be the
                 equivalent of an ensemble member.
                 Optional, defaults to 1.0
             weighted_mode (boolean):

--- a/lib/improver/nbhood/use_nbhood.py
+++ b/lib/improver/nbhood/use_nbhood.py
@@ -109,10 +109,10 @@ class ApplyNeighbourhoodProcessingWithAMask(object):
                 in hours.
             ens_factor (float):
                 The factor with which to adjust the neighbourhood size
-                for more than one ensemble member.
+                for more than one ensemble realization.
                 If ens_factor = 1.0 this essentially conserves ensemble
                 realizations if every grid square is considered to be the
-                equivalent of an ensemble member.
+                equivalent of an ensemble realization.
                 Optional, defaults to 1.0
             weighted_mode (boolean):
                 If True, use a circle for neighbourhood kernel with

--- a/lib/improver/nbhood/vicinity.py
+++ b/lib/improver/nbhood/vicinity.py
@@ -72,7 +72,7 @@ class ProbabilityOfOccurrence(object):
                 The factor with which to adjust the neighbourhood size
                 for more than one ensemble member.
                 If ens_factor = 1.0 this essentially conserves ensemble
-                members if every grid square is considered to be the
+                realizations if every grid square is considered to be the
                 equivalent of an ensemble member.
                 Optional, defaults to 1.0
             weighted_mode (boolean):
@@ -135,7 +135,7 @@ class ProbabilityOfOccurrence(object):
         cube = OccurrenceWithinVicinity(self.distance).process(cube)
         try:
             if cube.coord_dims('realization'):
-                ens_members = cube.coord('realization').points
+                ens_realizations = cube.coord('realization').points
                 # BUG in iris: collapsed returns a masked cube regardless of
                 # input status.  If input is not masked, output mask does not
                 # match data.  Fix is to re-cast output to an unmasked array.
@@ -144,7 +144,7 @@ class ProbabilityOfOccurrence(object):
                 if not cube_is_masked:
                     cube.data = np.array(cube.data)
                 cube.remove_coord('realization')
-                cube.attributes['source_realizations'] = ens_members
+                cube.attributes['source_realizations'] = ens_realizations
         except iris.exceptions.CoordinateNotFoundError:
             pass
 

--- a/lib/improver/nbhood/vicinity.py
+++ b/lib/improver/nbhood/vicinity.py
@@ -70,10 +70,10 @@ class ProbabilityOfOccurrence(object):
                 in hours.
             ens_factor (float):
                 The factor with which to adjust the neighbourhood size
-                for more than one ensemble member.
+                for more than one ensemble realization.
                 If ens_factor = 1.0 this essentially conserves ensemble
                 realizations if every grid square is considered to be the
-                equivalent of an ensemble member.
+                equivalent of an ensemble realization.
                 Optional, defaults to 1.0
             weighted_mode (boolean):
                 If True, use a circle for neighbourhood kernel with

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -356,10 +356,10 @@ class Test_apply_params_entry(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_basic_members(self):
+    def test_basic_realizations(self):
         """
         Test that the plugin returns a tuple when using the ensemble
-        members as the predictor of the mean.
+        realizations as the predictor of the mean.
         """
         cube = self.current_temperature_forecast_cube
         optimised_coeffs = {}
@@ -368,7 +368,8 @@ class Test_apply_params_entry(IrisTest):
             4.55819380e-06, -8.02401974e-09, 1.66667055e+00, 1.00000011e+00,
             1.00000011e+00, 1.00000011e+00])
         plugin = Plugin(cube, optimised_coeffs,
-                        self.coeff_names, predictor_of_mean_flag="members")
+                        self.coeff_names,
+                        predictor_of_mean_flag="realizations")
         result = plugin.apply_params_entry()
         self.assertIsInstance(result, tuple)
         self.assertEqual(len(result), 3)
@@ -431,10 +432,10 @@ class Test_apply_params_entry(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_output_coefficients_members(self):
+    def test_output_coefficients_realizations(self):
         """
         Test that the plugin returns a tuple containing cubes with the
-        expected coefficient names when using ensemble members as the
+        expected coefficient names when using ensemble realizations as the
         predictor of the mean.
         """
         cube = self.current_temperature_forecast_cube
@@ -444,7 +445,8 @@ class Test_apply_params_entry(IrisTest):
             4.55819380e-06, -8.02401974e-09, 1.66667055e+00, 1.00000011e+00,
             1.00000011e+00, 1.00000011e+00])
         plugin = Plugin(cube, optimised_coeffs,
-                        self.coeff_names, predictor_of_mean_flag="members")
+                        self.coeff_names,
+                        predictor_of_mean_flag="realizations")
         _, _, coefficients = plugin.apply_params_entry()
         for result, coeff_name, coeff in zip(
                 coefficients, self.coeff_names, optimised_coeffs[the_date]):
@@ -655,11 +657,11 @@ class Test__apply_params(IrisTest):
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "invalid escape sequence"],
         warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_predictor_members(self):
+    def test_calibrated_predictor_realizations(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
-        which match the expected values when the individual ensemble members
-        are used as the predictor.
+        which match the expected values when the individual ensemble
+        realizations are used as the predictor.
         """
         data = np.array([[239.904135, 251.65926, 263.414385],
                          [275.16951, 286.924635, 298.67976],
@@ -685,7 +687,7 @@ class Test__apply_params(IrisTest):
         predictor_cube = cube.copy()
         variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin(self.cube, optimised_coeffs,
                         self.coeff_names)
@@ -698,11 +700,11 @@ class Test__apply_params(IrisTest):
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "invalid escape sequence"],
         warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_variance_members(self):
+    def test_calibrated_variance_realizations(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
-        which match the expected values when the individual ensemble members
-        are used as the predictor.
+        which match the expected values when the individual ensemble
+        realizations are used as the predictor.
         """
         data = np.array([[34.333333, 34.333333, 34.333333],
                          [34.333333, 34.333333, 34.333333],
@@ -728,7 +730,7 @@ class Test__apply_params(IrisTest):
         predictor_cube = cube.copy()
         variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin(self.cube, optimised_coeffs,
                         self.coeff_names)
@@ -741,11 +743,11 @@ class Test__apply_params(IrisTest):
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "invalid escape sequence"],
         warning_types=[UserWarning, DeprecationWarning])
-    def test_coefficients_members(self):
+    def test_coefficients_realizations(self):
         """
         Test that the plugin returns values for the calibrated forecasts,
-        which match the expected values when the individual ensemble members
-        are used as the predictor.
+        which match the expected values when the individual ensemble
+        realizations are used as the predictor.
         """
         data = np.array([5.0])
         cube = self.current_temperature_forecast_cube
@@ -768,7 +770,7 @@ class Test__apply_params(IrisTest):
         predictor_cube = cube.copy()
         variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin(self.cube, optimised_coeffs,
                         self.coeff_names)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -53,8 +53,8 @@ class Test_normal_crps_minimiser(IrisTest):
 
     """
     Test minimising the CRPS for a normal distribution.
-    Either the ensemble mean or the individual ensemble members are used as
-    the predictors.
+    Either the ensemble mean or the individual ensemble realizations are
+    used as the predictors.
     """
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -93,10 +93,10 @@ class Test_normal_crps_minimiser(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_basic_members_predictor(self):
+    def test_basic_realizations_predictor(self):
         """
-        Test that the plugin returns a numpy float array with ensemble members
-        as predictor.
+        Test that the plugin returns a numpy float array with ensemble
+        realizations as predictor.
         """
         initial_guess = [5, 1, 0, 1, 1, 1]
         initial_guess = np.array(initial_guess, dtype=np.float32)
@@ -116,7 +116,7 @@ class Test_normal_crps_minimiser(IrisTest):
 
         sqrt_pi = np.sqrt(np.pi).astype(np.float32)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         result = plugin.normal_crps_minimiser(
@@ -168,8 +168,8 @@ class Test_truncated_normal_crps_minimiser(IrisTest):
 
     """
     Test minimising the crps for a truncated normal distribution.
-    Either the ensemble mean or the individual ensemble members are used as
-    the predictors.
+    Either the ensemble mean or the individual ensemble realizations are used
+    as the predictors.
     """
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -208,10 +208,10 @@ class Test_truncated_normal_crps_minimiser(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_basic_members_predictor(self):
+    def test_basic_realizations_predictor(self):
         """
         Test that the plugin returns a numpy array.
-        The ensemble members are the predictor.
+        The ensemble realizations are the predictor.
         """
         initial_guess = [5, 1, 0, 1, 1, 1]
         initial_guess = np.array(initial_guess, dtype=np.float32)
@@ -231,7 +231,7 @@ class Test_truncated_normal_crps_minimiser(IrisTest):
 
         sqrt_pi = np.sqrt(np.pi).astype(np.float32)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         result = plugin.truncated_normal_crps_minimiser(
@@ -283,8 +283,8 @@ class Test_crps_minimiser_wrapper(IrisTest):
 
     """
     Test minimising the CRPS for a normal distribution.
-    Either the ensemble mean or the individual ensemble members are used as
-    the predictors.
+    Either the ensemble mean or the individual ensemble realizations are used
+    as the predictors.
     """
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
@@ -317,10 +317,10 @@ class Test_crps_minimiser_wrapper(IrisTest):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in convergence"])
-    def test_basic_normal_members_predictor(self):
+    def test_basic_normal_realizations_predictor(self):
         """
         Test that the plugin returns a numpy array.
-        The ensemble members are the predictor.
+        The ensemble realizations are the predictor.
         """
         initial_guess = [5, 1, 0, 1, 1, 1]
         initial_guess = np.array(initial_guess, dtype=np.float32)
@@ -331,7 +331,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
             "realization", iris.analysis.VARIANCE)
         truth = cube.collapsed("realization", iris.analysis.MAX)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         distribution = "gaussian"
@@ -406,12 +406,12 @@ class Test_crps_minimiser_wrapper(IrisTest):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in convergence"])
-    def test_normal_members_predictor_max_iterations(self):
+    def test_normal_realizations_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
-        equal to specific values, when the ensemble members are the predictor
-        assuming a truncated normal distribution and the value specified
-        for the MAX_ITERATIONS is overriden. The coefficients are
+        equal to specific values, when the ensemble realizations are the
+        predictor assuming a truncated normal distribution and the value
+        specified for the MAX_ITERATIONS is overriden. The coefficients are
         calculated by minimising the CRPS and using a set default value for
         the initial guess.
         """
@@ -424,7 +424,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
             "realization", iris.analysis.VARIANCE)
         truth = cube.collapsed("realization", iris.analysis.MAX)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         plugin.MAX_ITERATIONS = 400
@@ -536,7 +536,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in convergence"])
-    def test_basic_truncated_normal_members_predictor(self):
+    def test_basic_truncated_normal_realizations_predictor(self):
         """Test that the plugin returns a numpy array."""
         initial_guess = [5, 1, 0, 1, 1, 1]
         initial_guess = np.array(initial_guess, dtype=np.float32)
@@ -547,7 +547,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
             "realization", iris.analysis.VARIANCE)
         truth = cube.collapsed("realization", iris.analysis.MAX)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         distribution = "truncated gaussian"
@@ -589,11 +589,11 @@ class Test_crps_minimiser_wrapper(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_truncated_normal_members_predictor_keyerror(self):
+    def test_truncated_normal_realizations_predictor_keyerror(self):
         """
         Test that the minimisation has resulted in a successful convergence,
         and that the object returned is an OptimizeResult object, when the
-        ensemble members are the predictor.
+        ensemble realizations are the predictor.
         """
         initial_guess = [
             -8.70808509e-06, 7.23255721e-06, 2.66662740e+00, 1.00000012e+00]
@@ -605,7 +605,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
             "realization", iris.analysis.VARIANCE)
         truth = cube.collapsed("realization", iris.analysis.MAX)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         distribution = "foo"
@@ -650,12 +650,12 @@ class Test_crps_minimiser_wrapper(IrisTest):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in convergence"])
-    def test_truncated_normal_members_predictor_max_iterations(self):
+    def test_truncated_normal_realizations_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
-        equal to specific values, when the ensemble members are the predictor
-        assuming a truncated normal distribution and the value specified
-        for the MAX_ITERATIONS is overriden. The coefficients are
+        equal to specific values, when the ensemble realizations are the
+        predictor assuming a truncated normal distribution and the value
+        specified for the MAX_ITERATIONS is overriden. The coefficients are
         calculated by minimising the CRPS and using a set default value for
         the initial guess.
         """
@@ -668,7 +668,7 @@ class Test_crps_minimiser_wrapper(IrisTest):
             "realization", iris.analysis.VARIANCE)
         truth = cube.collapsed("realization", iris.analysis.MAX)
 
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
         plugin.MAX_ITERATIONS = 400

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -113,16 +113,16 @@ class Test_process(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_basic_temperature_members(self):
+    def test_basic_temperature_realizations(self):
         """
         Test that the plugin returns an iris.cube.CubeList
         with the desired length.
-        The ensemble members is the predictor.
+        The ensemble realizations is the predictor.
         """
         calibration_method = "ensemble model output statistics"
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
         plugin = Plugin(
             calibration_method, distribution, desired_units,
             predictor_of_mean_flag=predictor_of_mean_flag)
@@ -154,16 +154,16 @@ class Test_process(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_basic_wind_speed_members(self):
+    def test_basic_wind_speed_realizations(self):
         """
         Test that the plugin returns an iris.cube.CubeList
         with the desired length.
-        The ensemble members is the predictor.
+        The ensemble realizations is the predictor.
         """
         calibration_method = "ensemble model output_statistics"
         distribution = "truncated gaussian"
         desired_units = "m s^-1"
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
         plugin = Plugin(
             calibration_method, distribution, desired_units,
             predictor_of_mean_flag=predictor_of_mean_flag)
@@ -205,13 +205,13 @@ class Test_process(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_temperature_members_data_check(self):
+    def test_temperature_realizations_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList
         of temperature cubes with the expected data, where the plugin
         returns a cubelist of, firstly, the predictor and, secondly the
         variance.
-        The ensemble members is the predictor.
+        The ensemble realizations is the predictor.
         """
         import imp
         try:
@@ -242,7 +242,7 @@ class Test_process(IrisTest):
         calibration_method = "ensemble model output_statistics"
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
         plugin = Plugin(
             calibration_method, distribution, desired_units,
             predictor_of_mean_flag=predictor_of_mean_flag)
@@ -284,13 +284,13 @@ class Test_process(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_wind_speed_members_data_check(self):
+    def test_wind_speed_realizations_data_check(self):
         """
         Test that the plugin returns an iris.cube.CubeList
         of wind_speed cubes with the expected data, where the plugin
         returns a cubelist of, firstly, the predictor and, secondly the
         variance.
-        The ensemble members is the predictor.
+        The ensemble realizations is the predictor.
         """
         import imp
         try:
@@ -321,7 +321,7 @@ class Test_process(IrisTest):
         calibration_method = "ensemble model output_statistics"
         distribution = "truncated gaussian"
         desired_units = "m s^-1"
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
         plugin = Plugin(
             calibration_method, distribution, desired_units,
             predictor_of_mean_flag=predictor_of_mean_flag)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -105,7 +105,7 @@ class Test__init__(IrisTest):
         distribution = "gaussian"
         desired_units = "degreesC"
         predictor_of_mean_flag = "mean"
-        no_of_members = 3
+        no_of_realizations = 3
         estimate_coefficients_from_linear_model_flag = True
 
         if not statsmodels_found:
@@ -130,10 +130,11 @@ class Test__init__(IrisTest):
         warning_types=[UserWarning, ImportWarning, FutureWarning,
                        RuntimeWarning, DeprecationWarning, ImportWarning,
                        UserWarning, UserWarning, UserWarning])
-    def test_statsmodels_members(self, warning_list=None):
+    def test_statsmodels_realizations(self, warning_list=None):
         """
         Test that the plugin raises the desired warning if the statsmodels
-        module is not found for when the predictor is the ensemble members.
+        module is not found for when the predictor is the ensemble
+        realizations.
         """
         import imp
         try:
@@ -156,8 +157,8 @@ class Test__init__(IrisTest):
         truth = cube.collapsed("realization", iris.analysis.MAX)
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
-        no_of_members = 3
+        predictor_of_mean_flag = "realizations"
+        no_of_realizations = 3
         estimate_coefficients_from_linear_model_flag = True
 
         if not statsmodels_found:
@@ -204,11 +205,11 @@ class Test_compute_initial_guess(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_basic_members_predictor(self):
+    def test_basic_realizations_predictor(self):
         """
         Test that the plugin returns a list containing the initial guess
-        for the calibration coefficients, when the individual ensemble members
-        are used as predictors.
+        for the calibration coefficients, when the individual ensemble
+        realizations are used as predictors.
         """
         cube = self.cube
 
@@ -216,15 +217,15 @@ class Test_compute_initial_guess(IrisTest):
         truth = cube.collapsed("realization", iris.analysis.MAX)
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
-        no_of_members = 3
+        predictor_of_mean_flag = "realizations"
+        no_of_realizations = 3
         estimate_coefficients_from_linear_model_flag = False
 
         plugin = Plugin(distribution, desired_units)
         result = plugin.compute_initial_guess(
             truth, current_forecast_predictor, predictor_of_mean_flag,
             estimate_coefficients_from_linear_model_flag,
-            no_of_members=no_of_members)
+            no_of_realizations=no_of_realizations)
         self.assertIsInstance(result, list)
 
     @ManageWarnings(
@@ -256,12 +257,13 @@ class Test_compute_initial_guess(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_basic_members_predictor_value_check(self):
+    def test_basic_realizations_predictor_value_check(self):
         """
         Test that the plugin returns the expected values for the initial guess
-        for the calibration coefficients, when the individual ensemble members
-        are used as predictors. As coefficients are not estimated using a
-        linear model, the default values for the initial guess are used.
+        for the calibration coefficients, when the individual ensemble
+        realizations are used as predictors. As coefficients are not estimated
+        using a linear model, the default values for the initial guess
+        are used.
         """
         data = [1, 1, 0, 1, 1, 1]
         cube = self.cube
@@ -271,15 +273,15 @@ class Test_compute_initial_guess(IrisTest):
         truth = cube.collapsed("realization", iris.analysis.MAX)
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
-        no_of_members = 3
+        predictor_of_mean_flag = "realizations"
+        no_of_realizations = 3
         estimate_coefficients_from_linear_model_flag = False
 
         plugin = Plugin(distribution, desired_units)
         result = plugin.compute_initial_guess(
             truth, current_forecast_predictor, predictor_of_mean_flag,
             estimate_coefficients_from_linear_model_flag,
-            no_of_members=no_of_members)
+            no_of_realizations=no_of_realizations)
         self.assertArrayAlmostEqual(result, data)
 
     @ManageWarnings(
@@ -311,7 +313,7 @@ class Test_compute_initial_guess(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_members_predictor_estimate_coefficients(self):
+    def test_realizations_predictor_estimate_coefficients(self):
         """
         Test that the plugin returns the expected values for the initial guess
         for the calibration coefficients, when the ensemble mean is used
@@ -336,15 +338,15 @@ class Test_compute_initial_guess(IrisTest):
         truth = cube.collapsed("realization", iris.analysis.MAX)
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
-        no_of_members = 3
+        predictor_of_mean_flag = "realizations"
+        no_of_realizations = 3
         estimate_coefficients_from_linear_model_flag = True
 
         plugin = Plugin(distribution, desired_units)
         result = plugin.compute_initial_guess(
             truth, current_forecast_predictor, predictor_of_mean_flag,
             estimate_coefficients_from_linear_model_flag,
-            no_of_members=no_of_members)
+            no_of_realizations=no_of_realizations)
         self.assertArrayAlmostEqual(result, data)
 
     @ManageWarnings(
@@ -493,7 +495,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_coefficient_values_for_gaussian_distribution_members(self):
+    def test_coefficient_values_for_gaussian_distribution_realizations(self):
         """
         Ensure that the values generated within optimised_coeffs match the
         expected values, and the coefficient names also match
@@ -521,7 +523,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
         distribution = "gaussian"
         desired_units = "degreesC"
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin(distribution, desired_units,
                         predictor_of_mean_flag=predictor_of_mean_flag)
@@ -563,7 +565,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
         distribution = "truncated gaussian"
         desired_units = "m s^-1"
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         plugin = Plugin(distribution, desired_units,
                         predictor_of_mean_flag=predictor_of_mean_flag)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -537,7 +537,8 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_coefficient_values_for_truncated_gaussian_distribution_mem(self):
+    def test_coefficient_values_truncated_gaussian_distribution_realization(
+            self):
         """
         Ensure that the values generated within optimised_coeffs match the
         expected values, and the coefficient names also match

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -182,31 +182,31 @@ class Test_rename_coordinate(IrisTest):
     def test_basic_cube(self):
         """Test that the utility returns an iris.cube.Cube."""
         rename_coordinate(
-            self.cube, "realization", "ensemble_member_id")
+            self.cube, "realization", "ensemble_realization_id")
         self.assertIsInstance(self.cube, iris.cube.Cube)
 
     def test_basic_cubelist(self):
         """
         Test that the utility returns an iris.cube.CubeList and that
-        the cubes in the cubelist have an ensemble_member_id coordinate.
+        the cubes in the cubelist have an ensemble_realization_id coordinate.
         """
         cube1 = self.cube.copy()
         cube2 = self.cube.copy()
         cubes = iris.cube.CubeList([cube1, cube2])
         rename_coordinate(
-            cubes, "realization", "ensemble_member_id")
+            cubes, "realization", "ensemble_realization_id")
         self.assertIsInstance(cubes, iris.cube.CubeList)
         for cube in cubes:
-            self.assertTrue(cube.coord("ensemble_member_id"))
+            self.assertTrue(cube.coord("ensemble_realization_id"))
 
     def test_check_coordinate_name(self):
         """
         Test that the utility returns an iris.cube.Cube with an
-        ensemble_member_id coordinate.
+        ensemble_realization_id coordinate.
         """
         rename_coordinate(
-            self.cube, "realization", "ensemble_member_id")
-        self.assertTrue(self.cube.coord("ensemble_member_id"))
+            self.cube, "realization", "ensemble_realization_id")
+        self.assertTrue(self.cube.coord("ensemble_realization_id"))
 
     def test_check_type_error(self):
         """
@@ -217,7 +217,7 @@ class Test_rename_coordinate(IrisTest):
         msg = "A Cube or CubeList is not provided for renaming"
         with self.assertRaisesRegex(TypeError, msg):
             rename_coordinate(
-                fake_cube, "realization", "ensemble_member_id")
+                fake_cube, "realization", "ensemble_realization_id")
 
 
 class Test__renamer(IrisTest):
@@ -231,11 +231,11 @@ class Test__renamer(IrisTest):
     def test_check_coordinate_name(self):
         """
         Test that the utility returns an iris.cube.Cube with an
-        ensemble_member_id coordinate following renaming.
+        ensemble_realization_id coordinate following renaming.
         """
         _renamer(
-            self.cube, "realization", "ensemble_member_id")
-        self.assertTrue(self.cube.coord("ensemble_member_id"))
+            self.cube, "realization", "ensemble_realization_id")
+        self.assertTrue(self.cube.coord("ensemble_realization_id"))
 
     def test_absent_original_coord(self):
         """
@@ -244,8 +244,8 @@ class Test__renamer(IrisTest):
         the cube.
         """
         _renamer(
-            self.cube, "fake", "ensemble_member_id")
-        self.assertFalse(self.cube.coords("ensemble_member_id"))
+            self.cube, "fake", "ensemble_realization_id")
+        self.assertFalse(self.cube.coords("ensemble_realization_id"))
 
 
 class Test_check_predictor_of_mean_flag(IrisTest):
@@ -269,12 +269,12 @@ class Test_check_predictor_of_mean_flag(IrisTest):
                    "Message is {}").format(err)
             self.fail(msg)
 
-    def test_members(self):
+    def test_realizations(self):
         """
         Test that the utility does not fail when the predictor_of_mean_flag
-        is "members".
+        is "realizations".
         """
-        predictor_of_mean_flag = "members"
+        predictor_of_mean_flag = "realizations"
 
         try:
             check_predictor_of_mean_flag(predictor_of_mean_flag)

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -48,10 +48,10 @@ from improver.tests.ensemble_calibration.ensemble_calibration. \
 from improver.utilities.warnings_handler import ManageWarnings
 
 
-class Test__recycle_raw_ensemble_members(IrisTest):
+class Test__recycle_raw_ensemble_realizations(IrisTest):
 
     """
-    Test the _recycle_raw_ensemble_members
+    Test the _recycle_raw_ensemble_realizations
     method in the EnsembleReordering plugin.
     """
 
@@ -76,16 +76,16 @@ class Test__recycle_raw_ensemble_members(IrisTest):
     def test_realization_for_equal(self):
         """
         Test to check the behaviour whether the number of percentiles equals
-        the number of members. For when the length of the percentiles equals
-        the length of the members, check that the points of the realization
-        coordinate is as expected.
+        the number of realizations. For when the length of the percentiles
+        equals the length of the realizations, check that the points of the
+        realization coordinate is as expected.
         """
         data = [0, 1, 2]
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
+        raw_forecast_realizations = self.realization_cube
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(
@@ -94,18 +94,18 @@ class Test__recycle_raw_ensemble_members(IrisTest):
     def test_realization_for_greater_than(self):
         """
         Test to check the behaviour whether the number of percentiles is
-        greater than the number of members. For when the length of the
-        percentiles is greater than the length of the members, check that the
-        points of the realization coordinate is as expected.
+        greater than the number of realizations. For when the length of the
+        percentiles is greater than the length of the realizations,
+        check that the points of the realization coordinate is as expected.
         """
         data = [12, 13, 14]
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
-        raw_forecast_members = raw_forecast_members[:2, :, :, :]
-        raw_forecast_members.coord("realization").points = [12, 13]
+        raw_forecast_realizations = self.realization_cube
+        raw_forecast_realizations = raw_forecast_realizations[:2, :, :, :]
+        raw_forecast_realizations.coord("realization").points = [12, 13]
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(
@@ -114,18 +114,18 @@ class Test__recycle_raw_ensemble_members(IrisTest):
     def test_realization_for_less_than(self):
         """
         Test to check the behaviour whether the number of percentiles is
-        less than the number of members. For when the length of the
-        percentiles is less than the length of the members, check that the
-        points of the realization coordinate is as expected.
+        less than the number of realizations. For when the length of the
+        percentiles is less than the length of the realizations, check that
+        the points of the realization coordinate is as expected.
         """
         data = [0, 1]
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
+        raw_forecast_realizations = self.realization_cube
         post_processed_forecast_percentiles = (
             post_processed_forecast_percentiles[:2, :, :, :])
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(
@@ -134,9 +134,9 @@ class Test__recycle_raw_ensemble_members(IrisTest):
     def test_realization_for_equal_check_data(self):
         """
         Test to check the behaviour whether the number of percentiles equals
-        the number of members. For when the length of the percentiles equals
-        the length of the members, check that the points of the realization
-        coordinate is as expected.
+        the number of realizations. For when the length of the percentiles
+        equals the length of the realizations, check that the points of the
+        realization coordinate is as expected.
         """
         data = [0, 1, 2]
         data = np.array([[[[4., 4.625, 5.25],
@@ -150,19 +150,19 @@ class Test__recycle_raw_ensemble_members(IrisTest):
                            [11.75, 12.375, 13.]]]])
 
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
+        raw_forecast_realizations = self.realization_cube
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertArrayAlmostEqual(data, result.data)
 
     def test_realization_for_greater_than_check_data(self):
         """
         Test to check the behaviour whether the number of percentiles is
-        greater than the number of members. For when the length of the
-        percentiles is greater than the length of the members, check that the
-        points of the realization coordinate is as expected.
+        greater than the number of realizations. For when the length of the
+        percentiles is greater than the length of the realizations, check
+        that the points of the realization coordinate is as expected.
         """
         data = np.array([[[[4., 4.625, 5.25],
                            [5.875, 6.5, 7.125],
@@ -174,22 +174,22 @@ class Test__recycle_raw_ensemble_members(IrisTest):
                            [5.875, 6.5, 7.125],
                            [7.75, 8.375, 9.]]]])
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
-        # Slice number of raw forecast members, so that there are fewer
-        # members than percentiles.
-        raw_forecast_members = raw_forecast_members[:2, :, :, :]
+        raw_forecast_realizations = self.realization_cube
+        # Slice number of raw forecast realizations, so that there are fewer
+        # realizations than percentiles.
+        raw_forecast_realizations = raw_forecast_realizations[:2, :, :, :]
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertArrayAlmostEqual(data, result.data)
 
     def test_realization_for_less_than_check_data(self):
         """
         Test to check the behaviour whether the number of percentiles is
-        less than the number of members. For when the length of the
-        percentiles is less than the length of the members, check that the
-        points of the realization coordinate is as expected.
+        less than the number of realizations. For when the length of the
+        percentiles is less than the length of the realizations, check that
+        the points of the realization coordinate is as expected.
         """
         data = np.array([[[[4., 4.625, 5.25],
                            [5.875, 6.5, 7.125],
@@ -198,21 +198,21 @@ class Test__recycle_raw_ensemble_members(IrisTest):
                            [7.875, 8.5, 9.125],
                            [9.75, 10.375, 11.]]]])
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
+        raw_forecast_realizations = self.realization_cube
         post_processed_forecast_percentiles = (
             post_processed_forecast_percentiles[:2, :, :, :])
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertArrayAlmostEqual(data, result.data)
 
-    def test_realization_for_greater_than_check_data_lots_of_members(self):
+    def test_realization_for_greater_than_check_data_many_realizations(self):
         """
         Test to check the behaviour whether the number of percentiles is
-        greater than the number of members. For when the length of the
-        percentiles is greater than the length of the members, check that the
-        points of the realization coordinate is as expected.
+        greater than the number of realizations. For when the length of the
+        percentiles is greater than the length of the realizations, check
+        that the points of the realization coordinate is as expected.
         """
         data = np.tile(np.linspace(5, 10, 9), 9).reshape(9, 1, 3, 3)
         data[0] -= 1
@@ -256,11 +256,11 @@ class Test__recycle_raw_ensemble_members(IrisTest):
                                [5.875, 6.5, 7.125],
                                [7.75, 8.375, 9.]]]])
         post_processed_forecast_percentiles = self.percentile_cube
-        raw_forecast_members = self.realization_cube
-        raw_forecast_members = raw_forecast_members[:2, :, :, :]
+        raw_forecast_realizations = self.realization_cube
+        raw_forecast_realizations = raw_forecast_realizations[:2, :, :, :]
         plu = Plugin()
-        result = plu._recycle_raw_ensemble_members(
-            post_processed_forecast_percentiles, raw_forecast_members,
+        result = plu._recycle_raw_ensemble_realizations(
+            post_processed_forecast_percentiles, raw_forecast_realizations,
             self.perc_coord)
         self.assertArrayAlmostEqual(expected, result.data)
 
@@ -428,7 +428,7 @@ class Test_rank_ecc(IrisTest):
         """
         Test that the plugin returns the correct cube data for a
         3d input cube, when there are tied values witin the
-        raw ensemble members. As there are two possible options for the
+        raw ensemble realizations. As there are two possible options for the
         result data, as the tie is decided randomly, both possible result
         data options are checked.
         """
@@ -474,7 +474,7 @@ class Test_rank_ecc(IrisTest):
         """
         Test that the plugin returns the correct cube data for a
         3d input cube, when there are tied values witin the
-        raw ensemble members. The random seed is specified to ensure that
+        raw ensemble realizations. The random seed is specified to ensure that
         only one option, out of the two possible options will be returned.
         """
         raw_data = np.array(
@@ -668,16 +668,16 @@ class Test_process(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Only a single cube so no differences"])
-    def test_2d_cube_recycling_raw_ensemble_members(self):
+    def test_2d_cube_recycling_raw_ensemble_realizations(self):
         """
         Test that the plugin returns the correct cube data for a
-        2d input cube, if the number of raw ensemble members is fewer
+        2d input cube, if the number of raw ensemble realizations is fewer
         than the number of percentiles required, and therefore, raw
-        ensemble member recycling is required.
+        ensemble realization recycling is required.
 
-        Case where two raw ensemble members are exactly the same,
-        after the raw ensemble members have been recycled.
-        The number of raw ensemble members are recycled in order to match
+        Case where two raw ensemble realizations are exactly the same,
+        after the raw ensemble realizations have been recycled.
+        The number of raw ensemble realizations are recycled in order to match
         the number of percentiles.
 
         After recycling the raw _data will be
@@ -686,21 +686,22 @@ class Test_process(IrisTest):
                              [1]])
 
         If there's a tie, the re-ordering randomly allocates the ordering
-        for the data from the raw ensemble members, which is why there are
-        two possible options for the resulting post-processed ensemble members.
+        for the data from the raw ensemble realizations, which is why there are
+        two possible options for the resulting post-processed ensemble
+        realizations.
 
-        Raw ensemble members
+        Raw ensemble realizations
         1,  2
         Post-processed percentiles
         1,  2,  3
-        After recycling raw ensemble members
+        After recycling raw ensemble realizations
         1,  2,  1
-        As the second ensemble member(with a data value of 2), is the highest
-        value, the highest value from the post-processed percentiles will
-        be the second ensemble member data value within the post-processed
-        members. The data values of 1 and 2 from the post-processed
-        percentiles will then be split between the first and third
-        post-processed ensemble members.
+        As the second ensemble realization(with a data value of 2), is the
+        highest value, the highest value from the post-processed percentiles
+        will be the second ensemble realization data value within the
+        post-processed realizations. The data values of 1 and 2 from the
+        post-processed percentiles will then be split between the first
+        and third post-processed ensemble members.
 
         """
         raw_data = np.array([[1],

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -701,7 +701,7 @@ class Test_process(IrisTest):
         will be the second ensemble realization data value within the
         post-processed realizations. The data values of 1 and 2 from the
         post-processed percentiles will then be split between the first
-        and third post-processed ensemble members.
+        and third post-processed ensemble realizations.
 
         """
         raw_data = np.array([[1],

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -555,7 +555,7 @@ class Test_process(IrisTest):
     def test_check_data_specifying_single_percentile(self):
         """
         Test that the plugin returns an Iris.cube.Cube with the expected
-        data values for a specific percentile passes in as a single member
+        data values for a specific percentile passes in as a single realization
         list.
         """
         data = np.array([[[[21.5, 8.75, 11.],

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsMembers.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsMembers.py
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """
 Unit tests for the
-`ensemble_copula_coupling.RebadgePercentilesAsMembers` class.
+`ensemble_copula_coupling.RebadgePercentilesAsRealizations` class.
 
 """
 import unittest
@@ -42,7 +42,7 @@ from iris.exceptions import InvalidCubeError
 import numpy as np
 
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
-    RebadgePercentilesAsMembers as Plugin)
+    RebadgePercentilesAsRealizations as Plugin)
 from improver.tests.ensemble_calibration.ensemble_calibration. \
     helper_functions import (set_up_temperature_cube,
                              add_forecast_reference_time_and_forecast_period)
@@ -50,7 +50,8 @@ from improver.tests.ensemble_calibration.ensemble_calibration. \
 
 class Test_process(IrisTest):
 
-    """Test the process method of the RebadgePercentilesAsMembers plugin."""
+    """Test the process method of the
+    RebadgePercentilesAsRealizations plugin."""
 
     def setUp(self):
         """Set up temperature cube for testing."""
@@ -72,21 +73,21 @@ class Test_process(IrisTest):
         self.assertIsInstance(result, Cube)
         self.assertIsInstance(result.coord("realization"), DimCoord)
 
-    def test_specify_member_numbers(self):
-        """Use the ensemble_member_numbers optional argument to specify
-        particular values for the ensemble member numbers."""
+    def test_specify_realization_numbers(self):
+        """Use the ensemble_realization_numbers optional argument to specify
+        particular values for the ensemble realization numbers."""
         cube = self.current_temperature_cube
         plen = len(cube.coord("percentile_over_realization").points)
-        ensemble_member_numbers = np.arange(plen)+12
+        ensemble_realization_numbers = np.arange(plen)+12
         plugin = Plugin()
-        result = plugin.process(cube, ensemble_member_numbers)
+        result = plugin.process(cube, ensemble_realization_numbers)
         self.assertEqual(len(result.coord("realization").points), plen)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, np.array([12, 13, 14]))
 
-    def test_number_of_members(self):
+    def test_number_of_realizations(self):
         """Check the values for the realization coordinate generated without
-        specifying the ensemble_member_numbers argument."""
+        specifying the ensemble_realization_numbers argument."""
         cube = self.current_temperature_cube
         plen = len(cube.coord("percentile_over_realization").points)
         plugin = Plugin()

--- a/lib/improver/tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/lib/improver/tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -497,9 +497,10 @@ class Test_process(IrisTest):
 
     def test_source_realizations(self):
         """Test when the array has source_realization attribute."""
-        member_list = [0, 1, 2, 3]
+        realization_list = [0, 1, 2, 3]
         cube = (
-            set_up_cube_with_no_realizations(source_realizations=member_list))
+            set_up_cube_with_no_realizations(
+                source_realizations=realization_list))
         radii = 14400
         ens_factor = 0.8
         neighbourhood_method = CircularNeighbourhood()

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -184,7 +184,8 @@ class Test_calc_confidence_measure(IrisTest):
         """First element has two angles directly opposite (90 & 270 degs).
         Therefore the calculated mean angle of 180 degs is basically
         meaningless. This code calculates a confidence measure based on how
-        far the individual ensemble members are away from the mean point."""
+        far the individual ensemble realizationss are away from
+        the mean point."""
 
         expected_out = np.array([[0.0, 0.95638061],
                                  [0.91284426, 0.91284426]])

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -38,7 +38,7 @@ from improver.utilities.cube_manipulation import enforce_float32_precision
 
 
 class WindDirection(object):
-    """Plugin to calculate average wind direction from ensemble members.
+    """Plugin to calculate average wind direction from ensemble realizations.
 
     Science background:
     Taking an average wind direction is tricky since an average of two wind
@@ -65,11 +65,11 @@ class WindDirection(object):
 
     In the rare case that a meaningless complex average is calculated, the
     code rejects the calculated complex average and simply uses the wind
-    direction taken from the first ensemble member.
+    direction taken from the first ensemble realization.
 
     The steps are:
 
-    1) Take data from all ensemble members.
+    1) Take data from all ensemble realizations.
     2) Convert the wind direction angles to complex numbers.
     3) Find complex average and their radius values.
     4) Convert the complex average back into degrees.
@@ -192,13 +192,13 @@ class WindDirection(object):
 
         1) From wind_dir_deg_mean - create a new set of complex values.
            Therefore they will have the same angle but r is fixed as r=1.
-        2) Find the distance between the mean point and all the ensemble member
-           wind direction complex values.
+        2) Find the distance between the mean point and all the ensemble
+           realization wind direction complex values.
         3) Find the average distance between the mean point and the wind
            direction values. Large average distance == low confidence.
         4) A confidence value that is between 1 for confident (small spread in
-           ensemble members) and 0 for no-confidence. Set to 0 if r value is
-           below threshold as any r value is regarded as meaningless.
+           ensemble realizations) and 0 for no-confidence. Set to 0 if r value
+           is below threshold as any r value is regarded as meaningless.
 
         Args:
             wind_dir_complex (np.ndarray):
@@ -265,7 +265,7 @@ class WindDirection(object):
            is essentially meaningless.
            We therefore substitute this meaningless average wind
            direction value for the wind direction taken from the first
-           ensemble member.
+           ensemble realization.
 
         Args:
             wind_dir_deg (np.ndarray):
@@ -281,7 +281,7 @@ class WindDirection(object):
         Returns:
             reprocessed_wind_dir_mean (np.ndarray):
                 3D array - Wind direction degrees where ambigious values have
-                been replaced with data from first ensemble member.
+                been replaced with data from first ensemble realization.
         """
 
         # Mask True if r values below threshold.
@@ -291,12 +291,12 @@ class WindDirection(object):
         if not where_low_r.any():
             return wind_dir_deg_mean
 
-        # Takes first ensemble member.
-        first_member = wind_dir_deg[0]
+        # Takes first ensemble realization.
+        first_realization = wind_dir_deg[0]
 
         # If the r-value is low - subistite average wind direction value for
-        # the wind direction taken from the first ensemble member.
-        reprocessed_wind_dir_mean = np.where(where_low_r, first_member,
+        # the wind direction taken from the first ensemble realization.
+        reprocessed_wind_dir_mean = np.where(where_low_r, first_realization,
                                              wind_dir_deg_mean)
 
         return reprocessed_wind_dir_mean
@@ -304,16 +304,17 @@ class WindDirection(object):
     @staticmethod
     def process(cube_ens_wdir):
         """Create a cube containing the wind direction averaged over the
-        ensemble members.
+        ensemble realizations.
 
         Args:
             cube_ens_wdir (iris.cube.Cube):
-                Cube containing wind direction from multiple ensemble members.
+                Cube containing wind direction from multiple ensemble
+                realizations.
 
         Returns:
             cube_mean_wdir (iris.cube.Cube):
                 Cube containing the wind direction averaged from the
-                ensemble members.
+                ensemble realizations.
             cube_r_vals (np.ndarray):
                 3D array - Radius taken from average complex wind direction
                 angle.
@@ -381,7 +382,8 @@ class WindDirection(object):
             r_vals = WindDirection.find_r_values(wind_dir_complex_mean)
 
             # Calculate the confidence measure based on the difference
-            # between the complex average and the individual ensemble members.
+            # between the complex average and the individual ensemble
+            # realizations.
             # TODO: This will still need some further investigation.
             #        This is will be the subject of another ticket.
             confidence_measure = WindDirection.calc_confidence_measure(
@@ -389,7 +391,7 @@ class WindDirection(object):
                 realization_axis)
 
             # Finds any meaningless averages and substitute with
-            # the wind direction taken from the first ensemble member.
+            # the wind direction taken from the first ensemble realization.
             wind_dir_deg_mean = WindDirection.wind_dir_decider(
                 wind_dir_deg, wind_dir_deg_mean, r_vals, r_thresh)
 

--- a/tests/improver-ecc/00-null.bats
+++ b/tests/improver-ecc/00-null.bats
@@ -38,7 +38,7 @@ usage: improver-ecc [-h] [--no_of_percentiles NUMBER_OF_PERCENTILES]
                     (--reordering | --rebadging)
                     [--raw_forecast_filepath RAW_FORECAST_FILE]
                     [--random_ordering] [--random_seed RANDOM_SEED]
-                    [--member_numbers MEMBER_NUMBERS]
+                    [--realization_numbers REALIZATION_NUMBERS]
                     INPUT_FILE OUTPUT_FILE
 __TEXT__
   [[ "$output" =~ "$expected" ]]

--- a/tests/improver-ecc/01-help.bats
+++ b/tests/improver-ecc/01-help.bats
@@ -87,7 +87,7 @@ Reordering options:
                         percentiles can be ordered to match the raw ensemble.
 
 Rebadging options:
-  Options for rebadging the input percentiles as ensemble s.
+  Options for rebadging the input percentiles as ensemble realizations.
 
   --realization_numbers REALIZATION_NUMBERS
                         A list of ensemble realization numbers to use when

--- a/tests/improver-ecc/01-help.bats
+++ b/tests/improver-ecc/01-help.bats
@@ -38,7 +38,7 @@ usage: improver-ecc [-h] [--no_of_percentiles NUMBER_OF_PERCENTILES]
                     (--reordering | --rebadging)
                     [--raw_forecast_filepath RAW_FORECAST_FILE]
                     [--random_ordering] [--random_seed RANDOM_SEED]
-                    [--member_numbers MEMBER_NUMBERS]
+                    [--realization_numbers REALIZATION_NUMBERS]
                     INPUT_FILE OUTPUT_FILE
 
 Apply Ensemble Copula Coupling to a file whose data can be loaded as a single
@@ -52,22 +52,22 @@ optional arguments:
   -h, --help            show this help message and exit
   --no_of_percentiles NUMBER_OF_PERCENTILES
                         The number of percentiles to be generated. This is
-                        also equal to the number of ensemble members that will
-                        be generated.
+                        also equal to the number of ensemble realizations that
+                        will be generated.
   --sampling_method [PERCENTILE_SAMPLING_METHOD]
                         Method to be used for generating the list of
                         percentiles with forecasts generated at each
                         percentile. The options are "quantile" and "random".
                         "quantile" is the default option.
-  --reordering          The option used to create ensemble members from
+  --reordering          The option used to create ensemble realizations from
                         percentiles by reordering the input percentiles based
                         on the order of the raw ensemble forecast.
-  --rebadging           The option used to create ensemble members from
+  --rebadging           The option used to create ensemble realizations from
                         percentiles by rebadging the input percentiles.
 
 Reordering options:
   Options for reordering the input percentiles using the raw ensemble
-  forecast as required to create ensemble members.
+  forecast as required to create ensemble realizations.
 
   --raw_forecast_filepath RAW_FORECAST_FILE
                         A path to an raw forecast NetCDF file to be processed.
@@ -87,11 +87,11 @@ Reordering options:
                         percentiles can be ordered to match the raw ensemble.
 
 Rebadging options:
-  Options for rebadging the input percentiles as ensemble members.
+  Options for rebadging the input percentiles as ensemble s.
 
-  --member_numbers MEMBER_NUMBERS
-                        A list of ensemble member numbers to use when
-                        rebadging the percentiles into members.
+  --realization_numbers REALIZATION_NUMBERS
+                        A list of ensemble realization numbers to use when
+                        rebadging the percentiles into realizations.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-ecc/02-percentiles_reordering.bats
+++ b/tests/improver-ecc/02-percentiles_reordering.bats
@@ -37,7 +37,7 @@
 
   # Run Ensemble Copula Coupling to convert one set of percentiles to another
   # set of percentiles, and then reorder the ensemble using the raw ensemble
-  # members.
+  # realizations.
   run improver ecc  --sampling_method 'quantile' --no_of_percentiles 12 \
       --reordering --raw_forecast_filepath="$IMPROVER_ACC_TEST_DIR/ecc/percentiles_reordering/raw_forecast.nc"\
       --random_seed 0 \

--- a/tests/improver-ecc/03-percentiles_rebadging.bats
+++ b/tests/improver-ecc/03-percentiles_rebadging.bats
@@ -37,7 +37,7 @@
 
   # Run Ensemble Copula Coupling to convert one set of percentiles to another
   # set of percentiles, and then rebadge the percentiles to be ensemble
-  # members.
+  # realizations.
   run improver ecc  --sampling_method 'quantile' --no_of_percentiles 12 \
       --rebadging \
       "$IMPROVER_ACC_TEST_DIR/ecc/percentiles_rebadging/multiple_percentiles_wind_cube.nc" \

--- a/tests/improver-ensemble-calibration/00_null.bats
+++ b/tests/improver-ensemble-calibration/00_null.bats
@@ -35,7 +35,7 @@
   expected="usage: improver-ensemble-calibration [-h]
                                      [--predictor_of_mean CALIBRATE_MEAN_FLAG]
                                      [--save_mean_variance MEAN_VARIANCE_FILE]
-                                     [--num_members NUMBER_OF_MEMBERS]
+                                     [--num_realizations NUMBER_OF_REALIZATIONS]
                                      [--random_ordering]
                                      [--random_seed RANDOM_SEED]
                                      ENSEMBLE_CALIBRATION_METHOD

--- a/tests/improver-ensemble-calibration/01_help.bats
+++ b/tests/improver-ensemble-calibration/01_help.bats
@@ -36,7 +36,7 @@
 usage: improver-ensemble-calibration [-h]
                                      [--predictor_of_mean CALIBRATE_MEAN_FLAG]
                                      [--save_mean_variance MEAN_VARIANCE_FILE]
-                                     [--num_members NUMBER_OF_MEMBERS]
+                                     [--num_realizations NUMBER_OF_REALIZATIONS]
                                      [--random_ordering]
                                      [--random_seed RANDOM_SEED]
                                      ENSEMBLE_CALIBRATION_METHOD
@@ -46,7 +46,7 @@ usage: improver-ensemble-calibration [-h]
 
 Apply the requested ensemble calibration method using historical forecast and
 "truth" data. Then apply ensemble copula coupling to regenerate ensemble
-members from output.
+realizations from output.
 
 positional arguments:
   ENSEMBLE_CALIBRATION_METHOD
@@ -74,16 +74,16 @@ optional arguments:
   --predictor_of_mean CALIBRATE_MEAN_FLAG
                         String to specify the input to calculate the
                         calibrated mean. Currently the ensemble mean ("mean")
-                        and the ensemble members ("members") are supported as
-                        the predictors. Default: "mean".
+                        and the ensemble realizations ("realizations") are
+                        supported as the predictors. Default: "mean".
   --save_mean_variance MEAN_VARIANCE_FILE
                         Option to save output mean and variance from
                         EnsembleCalibration plugin. If used, a path to save
                         the output to must be provided.
-  --num_members NUMBER_OF_MEMBERS
+  --num_realizations NUMBER_OF_REALIZATIONS
                         Optional argument to specify the number of ensemble
-                        members to produce. Default will be the number in the
-                        raw input file.
+                        realizations to produce. Default will be the number in
+                        the raw input file.
   --random_ordering     Option to reorder the post-processed forecasts
                         randomly. If not set, the ordering of the raw ensemble
                         is used.

--- a/tests/improver-ensemble-calibration/02_gaussian.bats
+++ b/tests/improver-ensemble-calibration/02_gaussian.bats
@@ -45,7 +45,7 @@
 
   improver_check_recreate_kgo "output.nc" $KGO
 
-  # Run nccmp to compare the output and kgo members and check it passes.
+  # Run nccmp to compare the output and kgo realizations and check it passes.
   improver_compare_output "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-ensemble-calibration/03_trunc_gaussian.bats
+++ b/tests/improver-ensemble-calibration/03_trunc_gaussian.bats
@@ -46,7 +46,7 @@
 
   improver_check_recreate_kgo "output.nc" $KGO
 
-  # Run nccmp to compare the output and kgo members and check it passes.
+  # Run nccmp to compare the output and kgo realizations and check it passes.
   improver_compare_output "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-nbhood-iterate-with-mask/01-help.bats
+++ b/tests/improver-nbhood-iterate-with-mask/01-help.bats
@@ -33,7 +33,7 @@
   run improver nbhood-iterate-with-mask -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-usage: improver-nbhood-iterate-with-mask [-h]
+  usage: improver-nbhood-iterate-with-mask [-h]
                                          [--radius RADIUS | --radii-by-lead-time RADII_BY_LEAD_TIME LEAD_TIME_IN_HOURS]
                                          [--ens_factor ENS_FACTOR]
                                          [--sum_or_fraction {sum,fraction}]
@@ -80,10 +80,11 @@ optional arguments:
                         hours uses a radius of 12000m, etc.
   --ens_factor ENS_FACTOR
                         The factor with which to adjust the neighbourhood size
-                        for more than one ensemble member. If ens_factor = 1.0
-                        this essentially conserves ensemble members if every
-                        grid square is considered to be the equivalent of an
-                        ensemble member.Optional, defaults to 1.0.
+                        for more than one ensemble realization. If ens_factor
+                        = 1.0 this essentially conserves ensemble realizations
+                        if every grid square is considered to be the
+                        equivalent of an ensemble realization.Optional,
+                        defaults to 1.0.
   --sum_or_fraction {sum,fraction}
                         The neighbourhood output can either be in the form of
                         a sum of the neighbourhood, or a fraction calculated
@@ -114,7 +115,6 @@ optional arguments:
                         If provided the result after neighbourhooding, before
                         collapsing the extra dimension is saved in the given
                         filepath.
-
 
 __HELP__
   [[ "$output" == "$expected" ]]

--- a/tests/improver-nbhood-land-and-sea/01-help.bats
+++ b/tests/improver-nbhood-land-and-sea/01-help.bats
@@ -62,9 +62,9 @@ optional arguments:
   --ens_factor ENS_FACTOR
                         The factor with which to adjust the neighbourhood size
                         for more than one ensemble realization. If ens_factor
-                        = 1.0 this essentially conserves ensemble
-                        realizationss if every grid square is considered to be
-                        the equivalent of an ensemble realization.Optional,
+                        = 1.0 this essentially conserves ensemble realizations
+                        if every grid square is considered to be the
+                        equivalent of an ensemble realization.Optional,
                         defaults to 1.0.
   --sum_or_fraction {sum,fraction}
                         The neighbourhood output can either be in the form of

--- a/tests/improver-nbhood-land-and-sea/01-help.bats
+++ b/tests/improver-nbhood-land-and-sea/01-help.bats
@@ -64,7 +64,7 @@ optional arguments:
                         for more than one ensemble realization. If ens_factor
                         = 1.0 this essentially conserves ensemble realizations
                         if every grid square is considered to be the
-                        equivalent of an ensemble realization.Optional,
+                        equivalent of an ensemble realization. Optional,
                         defaults to 1.0.
   --sum_or_fraction {sum,fraction}
                         The neighbourhood output can either be in the form of
@@ -98,7 +98,6 @@ Neighbourhooding Radius - Set only one of the options:
                         For example: 10000,12000,14000 1,2,3 where a lead time
                         of 1 hour uses a radius of 10000m, a lead time of 2
                         hours uses a radius of 12000m, etc.
-
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-nbhood-land-and-sea/01-help.bats
+++ b/tests/improver-nbhood-land-and-sea/01-help.bats
@@ -61,10 +61,11 @@ optional arguments:
   -h, --help            show this help message and exit
   --ens_factor ENS_FACTOR
                         The factor with which to adjust the neighbourhood size
-                        for more than one ensemble member. If ens_factor = 1.0
-                        this essentially conserves ensemble members if every
-                        grid square is considered to be the equivalent of an
-                        ensemble member.Optional, defaults to 1.0.
+                        for more than one ensemble realization. If ens_factor
+                        = 1.0 this essentially conserves ensemble
+                        realizationss if every grid square is considered to be
+                        the equivalent of an ensemble realization.Optional,
+                        defaults to 1.0.
   --sum_or_fraction {sum,fraction}
                         The neighbourhood output can either be in the form of
                         a sum of the neighbourhood, or a fraction calculated
@@ -97,6 +98,7 @@ Neighbourhooding Radius - Set only one of the options:
                         For example: 10000,12000,14000 1,2,3 where a lead time
                         of 1 hour uses a radius of 10000m, a lead time of 2
                         hours uses a radius of 12000m, etc.
+
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-nbhood-vicinity/01-help.bats
+++ b/tests/improver-nbhood-vicinity/01-help.bats
@@ -73,14 +73,13 @@ optional arguments:
                         for more than one ensemble realization. If ens_factor
                         = 1.0 this essentially conserves ensemble realizations
                         if every grid square is considered to be the
-                        equivalent of an ensemble realization.Optional,
+                        equivalent of an ensemble realization. Optional,
                         defaults to 1.0.
   --weighted_mode       For neighbourhood processing using a circular kernel,
                         setting the weighted_mode indicates the weighting
                         decreases with radius. If weighted_mode is not set, a
                         constant weighting is assumed. Currently this keyword
                         does nothing as only a square kernel is applicable.
-
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-nbhood-vicinity/01-help.bats
+++ b/tests/improver-nbhood-vicinity/01-help.bats
@@ -70,15 +70,17 @@ optional arguments:
                         hours uses a radius of 12000m, etc.
   --ens_factor ENS_FACTOR
                         The factor with which to adjust the neighbourhood size
-                        for more than one ensemble member. If ens_factor = 1.0
-                        this essentially conserves ensemble members if every
-                        grid square is considered to be the equivalent of an
-                        ensemble member.Optional, defaults to 1.0.
+                        for more than one ensemble realization. If ens_factor
+                        = 1.0 this essentially conserves ensemble realizations
+                        if every grid square is considered to be the
+                        equivalent of an ensemble realization.Optional,
+                        defaults to 1.0.
   --weighted_mode       For neighbourhood processing using a circular kernel,
                         setting the weighted_mode indicates the weighting
                         decreases with radius. If weighted_mode is not set, a
                         constant weighting is assumed. Currently this keyword
                         does nothing as only a square kernel is applicable.
+
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-nbhood/01-help.bats
+++ b/tests/improver-nbhood/01-help.bats
@@ -82,10 +82,11 @@ optional arguments:
                         hours uses a radius of 12000m, etc.
   --ens_factor ENS_FACTOR
                         The factor with which to adjust the neighbourhood size
-                        for more than one ensemble member. If ens_factor = 1.0
-                        this essentially conserves ensemble members if every
-                        grid square is considered to be the equivalent of an
-                        ensemble member. Optional, defaults to 1.0.
+                        for more than one ensemble realization. If ens_factor
+                        = 1.0 this essentially conserves ensemble realizations
+                        if every grid square is considered to be the
+                        equivalent of an ensemble realization. Optional,
+                        defaults to 1.0.
   --weighted_mode       For neighbourhood processing using a circular kernel,
                         setting the weighted_mode indicates the weighting
                         decreases with radius. If weighted_mode is not set, a

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -40,13 +40,13 @@ usage: improver-percentile [-h]
                            INPUT_FILE OUTPUT_FILE
 
 Calculate percentiled data over a given coordinate by collapsing that
-coordinate. Typically used to convert realization (member) data into
-percentiled data, but may calculate over any dimension coordinate.
-Alternatively, calling this CLI with a dataset containing probabilities will
-convert those to percentiles using the ensemble copula coupling plugin. If no
-particular percentiles are given at which to calculate values and no 'number
-of percentiles' to calculate are specified, the following defaults will be
-used: [0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100]
+coordinate. Typically used to convert realization data into percentiled data,
+but may calculate over any dimension coordinate. Alternatively, calling this
+CLI with a dataset containing probabilities will convert those to percentiles
+using the ensemble copula coupling plugin. If no particular percentiles are
+given at which to calculate values and no 'number of percentiles' to calculate
+are specified, the following defaults will be used: [0, 5, 10, 20, 25, 30, 40,
+50, 60, 70, 75, 80, 90, 95, 100]
 
 positional arguments:
   INPUT_FILE            A path to an input NetCDF file to be processed
@@ -68,6 +68,7 @@ optional arguments:
                         Optional definition of the number of percentiles to be
                         generated, these distributed regularly with the aim of
                         dividing into blocks of equal probability.
+
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -68,7 +68,6 @@ optional arguments:
                         Optional definition of the number of percentiles to be
                         generated, these distributed regularly with the aim of
                         dividing into blocks of equal probability.
-
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-wind-direction/01-help.bats
+++ b/tests/improver-wind-direction/01-help.bats
@@ -35,7 +35,7 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-wind-direction [-h] INPUT_FILE OUTPUT_FILE
 
-Run wind direction to calculate mean wind direction from ensemble members
+Run wind direction to calculate mean wind direction from ensemble realizations
 
 positional arguments:
   INPUT_FILE   A path to an input NetCDF file to be processed


### PR DESCRIPTION
Addresses #543

Replace instances within Improver of `members` and `member` with the CF compliant ensemble terms `realizations` and `realization`, including updating unit tests. 

Testing:
 - [x] Ran tests and they passed OK
