### PR TITLE
IMPRO-639: GenerateProbabilitiesFromMeanAndVariance plugin

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -702,7 +702,7 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
-        desc = '<GeneratePercentilesFromProbabilities>'
+        desc = '<GenerateProbabilitiesFromMeanAndVariance>'
         return desc
 
     @staticmethod
@@ -757,9 +757,11 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
         try:
             mean_values.convert_units(threshold_units)
             variance_values.convert_units(threshold_units**2)
-        except ValueError:
-            raise ValueError('Mean, variance, and template cube threshold '
-                             'units are not equivalent/compatible.')
+        except ValueError as err:
+            msg = ('Error: {} This is likely because the mean '
+                   'variance and template cube threshold units are '
+                   'not equivalent/compatible.'.format(err))
+            raise ValueError(msg)
 
     @staticmethod
     def _mean_and_variance_to_probabilities(mean_values, variance_values,
@@ -779,7 +781,7 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
                 cube format.
 
         Returns:
-            probability_cube (Iris cube):
+            probability_cube (iris.cube.Cube):
                 Cube containing the data expressed as probabilities relative to
                 the provided thresholds in the way described by
                 relative_to_threshold.
@@ -806,7 +808,7 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
 
     def process(self, mean_values, variance_values, probability_cube_template):
         """
-        Generate ensemble percentiles from the mean and variance.
+        Generate probabilties from the mean and variance of distribution.
 
         Args:
             mean_values (iris.cube.Cube):

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -757,7 +757,8 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
         # and variance to calculate the probabilties relative to each
         # probability.
         probabilities = np.empty_like(probability_cube_template.data)
-        distribution = norm(loc=mean_values, scale=np.sqrt(variance_values))
+        distribution = norm(loc=mean_values.data,
+                            scale=np.sqrt(variance_values.data))
         probability_method = distribution.cdf
         if relative_to_threshold == 'above':
             probability_method = distribution.sf

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -1,0 +1,357 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Unit tests for GenerateProbabiltiesFromMeanAndVariance
+
+"""
+import unittest
+
+import iris
+from iris.cube import Cube, CubeList
+from iris.tests import IrisTest
+import numpy as np
+
+from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
+    GeneratePercentilesFromMeanAndVariance as Plugin)
+from improver.tests.ensemble_calibration.ensemble_calibration. \
+    helper_functions import (set_up_spot_temperature_cube,
+                             set_up_temperature_cube,
+                             add_forecast_reference_time_and_forecast_period)
+from improver.utilities.warnings_handler import ManageWarnings
+
+
+class Test__check_template_cube(IrisTest):
+
+    """Test the _mean_and_variance_to_percentiles plugin."""
+
+
+class Test__mean_and_variance_to_probabilities(IrisTest):
+
+    """Test the _mean_and_variance_to_percentiles plugin."""
+
+    def setUp(self):
+        """Set up temperature cube."""
+        self.current_temperature_forecast_cube = (
+            add_forecast_reference_time_and_forecast_period(
+                set_up_temperature_cube()))
+        self.current_temperature_spot_forecast_cube = (
+            add_forecast_reference_time_and_forecast_period(
+                set_up_spot_temperature_cube()))
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_check_data(self):
+        """
+        Test that the plugin returns an Iris.cube.Cube matching the expected
+        data values when a cube containing mean and variance is passed in.
+        The resulting data values are the percentiles, which have been
+        generated.
+        """
+        data = np.array([[[[225.56812863, 236.81812863, 248.06812863],
+                           [259.31812863, 270.56812863, 281.81812863],
+                           [293.06812863, 304.31812863, 315.56812863]]],
+                         [[[229.48333333, 240.73333333, 251.98333333],
+                           [263.23333333, 274.48333333, 285.73333333],
+                           [296.98333333, 308.23333333, 319.48333333]]],
+                         [[[233.39853804, 244.64853804, 255.89853804],
+                           [267.14853804, 278.39853804, 289.64853804],
+                           [300.89853804, 312.14853804, 323.39853804]]]])
+
+        cube = self.current_temperature_forecast_cube
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [10, 50, 90]
+        plugin = Plugin()
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance,
+            percentiles)
+        self.assertIsInstance(result, Cube)
+        self.assertArrayAlmostEqual(result.data, data)
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_simple_data(self):
+        """
+        Test that the plugin returns the expected values for the generated
+        percentiles when an idealised set of data values between 1 and 3
+        is used to create the mean and the variance.
+        """
+        data = np.array([[[[1, 1, 1],
+                           [1, 1, 1],
+                           [1, 1, 1]]],
+                         [[[2, 2, 2],
+                           [2, 2, 2],
+                           [2, 2, 2]]],
+                         [[[3, 3, 3],
+                           [3, 3, 3],
+                           [3, 3, 3]]]])
+
+        result_data = np.array([[[[0.71844843, 0.71844843, 0.71844843],
+                                  [0.71844843, 0.71844843, 0.71844843],
+                                  [0.71844843, 0.71844843, 0.71844843]]],
+                                [[[2., 2., 2.],
+                                  [2., 2., 2.],
+                                  [2., 2., 2.]]],
+                                [[[3.28155157, 3.28155157, 3.28155157],
+                                  [3.28155157, 3.28155157, 3.28155157],
+                                  [3.28155157, 3.28155157, 3.28155157]]]])
+
+        cube = self.current_temperature_forecast_cube
+        cube.data = data
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [10, 50, 90]
+        plugin = Plugin()
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance,
+            percentiles)
+        self.assertArrayAlmostEqual(result.data, result_data)
+
+    @ManageWarnings(
+        ignored_messages=["invalid value encountered",
+                          "Collapsing a non-contiguous coordinate."],
+        warning_types=[RuntimeWarning, UserWarning])
+    def test_if_identical_data(self):
+        """
+        Test that the plugin returns the expected values, if every
+        percentile has an identical value. This causes an issue because
+        the default for the underlying scipy function is to yield a NaN for
+        tied values. For this application, any NaN values are overwritten with
+        the predicted mean value for all probability thresholds.
+        """
+        data = np.array([[1, 1, 1],
+                         [2, 2, 2],
+                         [3, 3, 3]])
+        # Repeat data in the realization dimension.
+        data = np.repeat(data[np.newaxis, np.newaxis, :, :], 3, axis=0)
+
+        result_data = np.array([[[[1., 1., 1.],
+                                  [2., 2., 2.],
+                                  [3., 3., 3.]]],
+                                [[[1., 1., 1.],
+                                  [2., 2., 2.],
+                                  [3., 3., 3.]]],
+                                [[[1., 1., 1.],
+                                  [2., 2., 2.],
+                                  [3., 3., 3.]]]])
+
+        cube = self.current_temperature_forecast_cube
+        cube.data = data
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [10, 50, 90]
+        plugin = Plugin()
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance,
+            percentiles)
+        self.assertArrayAlmostEqual(result.data, result_data)
+
+    @ManageWarnings(
+        ignored_messages=["invalid value encountered",
+                          "Collapsing a non-contiguous coordinate."],
+        warning_types=[RuntimeWarning, UserWarning])
+    def test_if_nearly_identical_data(self):
+        """
+        Test that the plugin returns the expected values, if every
+        percentile has an identical value. This causes an issue because
+        the default for the underlying scipy function is to yield a NaN for
+        tied values. For this application, any NaN values are overwritten with
+        the predicted mean value for all probability thresholds.
+        """
+        data = np.array([[[[1., 1., 1.],
+                           [4., 2., 2.],
+                           [3., 3., 3.]]],
+                         [[[1., 1., 1.],
+                           [2., 2., 2.],
+                           [3., 3., 3.]]],
+                         [[[1., 1., 1.],
+                           [2., 2., 2.],
+                           [3., 3., 3.]]]])
+
+        result_data = np.array([[[[1., 1., 1.],
+                                  [1.18685838, 2., 2.],
+                                  [3., 3., 3.]]],
+                                [[[1., 1., 1.],
+                                  [2.66666667, 2., 2.],
+                                  [3., 3., 3.]]],
+                                [[[1., 1., 1.],
+                                  [4.14647495, 2., 2.],
+                                  [3., 3., 3.]]]])
+
+        cube = self.current_temperature_forecast_cube
+        cube.data = data
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [10, 50, 90]
+        plugin = Plugin()
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance,
+            percentiles)
+        self.assertArrayAlmostEqual(result.data, result_data)
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_many_percentiles(self):
+        """
+        Test that the plugin returns an iris.cube.Cube if many percentiles
+        are requested.
+        """
+        cube = self.current_temperature_forecast_cube
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = np.linspace(1, 99, num=1000, endpoint=True)
+        plugin = Plugin()
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance, percentiles)
+        self.assertIsInstance(result, Cube)
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_negative_percentiles(self):
+        """
+        Test that the plugin returns the expected values for the
+        percentiles if negative probabilities are requested.
+        """
+        cube = self.current_temperature_forecast_cube
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [-10, 10]
+        plugin = Plugin()
+        msg = "NaNs are present within the result for the"
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin._mean_and_variance_to_percentiles(
+                current_forecast_predictor, current_forecast_variance,
+                percentiles)
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_spot_forecasts_check_data(self):
+        """
+        Test that the plugin returns an Iris.cube.Cube matching the expected
+        data values when a cube containing mean and variance is passed in.
+        The resulting data values are the percentiles, which have been
+        generated for a spot forecast.
+        """
+        data = np.array([[[225.56812863, 236.81812863, 248.06812863,
+                           259.31812863, 270.56812863, 281.81812863,
+                           293.06812863, 304.31812863, 315.56812863]],
+                         [[229.48333333, 240.73333333, 251.98333333,
+                           263.23333333, 274.48333333, 285.73333333,
+                           296.98333333, 308.23333333, 319.48333333]],
+                         [[233.39853804, 244.64853804, 255.89853804,
+                           267.14853804, 278.39853804, 289.64853804,
+                           300.89853804, 312.14853804, 323.39853804]]])
+
+        cube = self.current_temperature_spot_forecast_cube
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [10, 50, 90]
+        plugin = Plugin()
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance,
+            percentiles)
+        self.assertIsInstance(result, Cube)
+        self.assertArrayAlmostEqual(result.data, data)
+
+
+class Test_process(IrisTest):
+
+    """Test the process plugin."""
+
+    def setUp(self):
+        """Set up temperature cube."""
+        self.current_temperature_forecast_cube = (
+            add_forecast_reference_time_and_forecast_period(
+                set_up_temperature_cube()))
+
+    @ManageWarnings(
+        ignored_messages=["Only a single cube so no differences",
+                          "Collapsing a non-contiguous coordinate."])
+    def test_basic(self):
+        """Test that the plugin returns an Iris.cube.Cube."""
+        cube = self.current_temperature_forecast_cube
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        raw_forecast = cube.copy()
+
+        predictor_and_variance = CubeList(
+            [current_forecast_predictor, current_forecast_variance])
+        no_of_percentiles = len(raw_forecast.coord("realization").points)
+
+        plugin = Plugin()
+        result = plugin.process(predictor_and_variance, no_of_percentiles)
+        self.assertIsInstance(result, Cube)
+
+    @ManageWarnings(
+        ignored_messages=["Only a single cube so no differences",
+                          "Collapsing a non-contiguous coordinate."])
+    def test_number_of_percentiles(self):
+        """
+        Test that the plugin returns a cube with the expected number of
+        percentiles.
+        """
+        cube = self.current_temperature_forecast_cube
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        raw_forecast = cube.copy()
+
+        predictor_and_variance = CubeList(
+            [current_forecast_predictor, current_forecast_variance])
+
+        no_of_percentiles = len(raw_forecast.coord("realization").points)
+
+        plugin = Plugin()
+        result = plugin.process(predictor_and_variance, no_of_percentiles)
+        self.assertEqual(
+            len(raw_forecast.coord("realization").points),
+            len(result.coord("percentile_over_realization").points))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -66,11 +66,12 @@ class Test__check_template_cube(IrisTest):
             set_up_probability_above_threshold_temperature_cube())
 
     def test_valid_cube(self):
-        """Pass in a valid cube that raises no exception. No assert statement
-        required as any other input will raise an exception."""
-
+        """Pass in a valid cube that raises no exception. Cube should be
+        unchanged by being passed into the function."""
         cube = iris.util.squeeze(self.cube)
+        expected = iris.util.squeeze(self.cube.copy())
         Plugin()._check_template_cube(cube)
+        self.assertEqual(expected, cube)
 
     def test_valid_cube_reordered(self):
         """Pass in a cube with the expected dimensions, but with threshold not

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -102,8 +102,11 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         # Thresholds such that we obtain probabilities of 75%, 50%, and 25% for
         # the mean and variance values set here.
         self.template_cube.coord('threshold').points = [8.65105, 10., 11.34895]
-        self.mean_values = np.ones((3, 3)) * 10
-        self.variance_values = np.ones((3, 3)) * 4
+        mean_values = np.ones((3, 3)) * 10
+        variance_values = np.ones((3, 3)) * 4
+        self.means = self.template_cube[0, :, :].copy(data=mean_values)
+        self.variances = self.template_cube[0, :, :].copy(data=variance_values)
+
 
     def test_threshold_above_cube(self):
         """Test that the expected probabilites are returned for a cube in which
@@ -111,7 +114,7 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
 
         expected = (np.ones((3, 3, 3)) * [0.75, 0.5, 0.25]).T
         result = Plugin()._mean_and_variance_to_probabilities(
-            self.mean_values, self.variance_values, self.template_cube)
+            self.means, self.variances, self.template_cube)
         np.testing.assert_allclose(result.data, expected, rtol=1.e-4)
 
     def test_threshold_below_cube(self):
@@ -121,7 +124,7 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         self.template_cube.attributes['relative_to_threshold'] = 'below'
         expected = (np.ones((3, 3, 3)) * [0.25, 0.5, 0.75]).T
         result = Plugin()._mean_and_variance_to_probabilities(
-            self.mean_values, self.variance_values, self.template_cube)
+            self.means, self.variances, self.template_cube)
         np.testing.assert_allclose(result.data, expected, rtol=1.e-4)
 
 
@@ -136,14 +139,17 @@ class Test_Process(IrisTest):
         self.template_cube = iris.util.squeeze(self.template_cube)
 
         self.template_cube.coord('threshold').points = [8.65105, 10., 11.34895]
-        self.mean_values = np.ones((3, 3)) * 10
-        self.variance_values = np.ones((3, 3)) * 4
+        mean_values = np.ones((3, 3)) * 10
+        variance_values = np.ones((3, 3)) * 4
+        self.means = self.template_cube[0, :, :].copy(data=mean_values)
+        self.variances = self.template_cube[0, :, :].copy(data=variance_values)
+
 
     def test_metadata_matches_template(self):
         """Test that the returned cube's metadata matches the template cube."""
 
         result = Plugin()._mean_and_variance_to_probabilities(
-            self.mean_values, self.variance_values, self.template_cube)
+            self.means, self.variances, self.template_cube)
         self.assertTrue(result.metadata == self.template_cube.metadata)
         self.assertTrue(result.name() == self.template_cube.name())
 
@@ -153,7 +159,7 @@ class Test_Process(IrisTest):
 
         self.template_cube.data = np.ones((3, 3, 3))
         result = Plugin()._mean_and_variance_to_probabilities(
-            self.mean_values, self.variance_values, self.template_cube)
+            self.means, self.variances, self.template_cube)
         self.assertTrue((result.data != self.template_cube.data).all())
 
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -51,7 +51,7 @@ class Test__repr__(IrisTest):
 
     def test_basic(self):
         """Test string representation"""
-        expected_string = "<GeneratePercentilesFromProbabilities>"
+        expected_string = "<GenerateProbabilitiesFromMeanAndVariance>"
         result = str(Plugin())
         self.assertEqual(result, expected_string)
 
@@ -122,18 +122,19 @@ class Test__check_unit_compatibility(IrisTest):
                                            self.template_cube)
 
     def test_convertible_units(self):
-        """Pass in cubes with units tha can be made equivalent by modification
+        """Pass in cubes with units that can be made equivalent by modification
         to match the threshold units."""
         self.means.units = 'Fahrenheit'
         self.variances.units = 'Fahrenheit2'
         Plugin()._check_unit_compatibility(self.means, self.variances,
                                            self.template_cube)
+        self.assertEqual(self.means.units, "Celsius")
 
     def test_incompatible_units(self):
         """Pass in cubes of incompatible units that should raise an
         exception."""
         self.means.units = 'm s-1'
-        msg = 'Mean, variance, and template cube threshold'
+        msg = 'This is likely because the mean'
         with self.assertRaisesRegex(ValueError, msg):
             Plugin()._check_unit_compatibility(self.means, self.variances,
                                                self.template_cube)
@@ -141,7 +142,7 @@ class Test__check_unit_compatibility(IrisTest):
 
 class Test__mean_and_variance_to_probabilities(IrisTest):
 
-    """Test the _mean_and_variance_to_percentiles function."""
+    """Test the _mean_and_variance_to_probabilities function."""
 
     def setUp(self):
         """Set up temperature cube."""
@@ -179,7 +180,7 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         np.testing.assert_allclose(result.data, expected, rtol=1.e-4)
 
 
-class Test_Process(IrisTest):
+class Test_process(IrisTest):
 
     """Test the process function."""
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -107,7 +107,6 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         self.means = self.template_cube[0, :, :].copy(data=mean_values)
         self.variances = self.template_cube[0, :, :].copy(data=variance_values)
 
-
     def test_threshold_above_cube(self):
         """Test that the expected probabilites are returned for a cube in which
         they are calculated above the thresholds."""
@@ -143,7 +142,6 @@ class Test_Process(IrisTest):
         variance_values = np.ones((3, 3)) * 4
         self.means = self.template_cube[0, :, :].copy(data=mean_values)
         self.variances = self.template_cube[0, :, :].copy(data=variance_values)
-
 
     def test_metadata_matches_template(self):
         """Test that the returned cube's metadata matches the template cube."""

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -80,6 +80,19 @@ class Test_check_for_x_and_y_axes(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             check_for_x_and_y_axes(sliced_cube)
 
+    def test_pass_dimension_requirement(self):
+        """Test that the expected exception is raised, if there the x and y
+        coordinates are not dimensional coordinates."""
+        check_for_x_and_y_axes(self.cube, require_dim_coords=True)
+
+    def test_fail_dimension_requirement(self):
+        """Test that the expected exception is raised, if there the x and y
+        coordinates are not dimensional coordinates."""
+        msg = "The cube does not contain the expected"
+        cube = self.cube[0, 0, :, 0]
+        with self.assertRaisesRegex(ValueError, msg):
+            check_for_x_and_y_axes(cube, require_dim_coords=True)
+
 
 class Test_check_cube_coordinates(IrisTest):
 

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -81,8 +81,9 @@ class Test_check_for_x_and_y_axes(IrisTest):
             check_for_x_and_y_axes(sliced_cube)
 
     def test_pass_dimension_requirement(self):
-        """Test that the expected exception is raised, if there the x and y
-        coordinates are not dimensional coordinates."""
+        """Pass in compatible cubes that should not raise an exception. No
+        assert statement required as any other input will raise an
+        exception."""
         check_for_x_and_y_axes(self.cube, require_dim_coords=True)
 
     def test_fail_dimension_requirement(self):

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -35,20 +35,27 @@ from iris.exceptions import CoordinateNotFoundError, InvalidCubeError
 import numpy as np
 
 
-def check_for_x_and_y_axes(cube):
+def check_for_x_and_y_axes(cube, require_dim_coords=False):
     """
     Check whether the cube has an x and y axis, otherwise raise an error.
 
     Args:
         cube (Iris.cube.Cube):
             Cube to be checked for x and y axes.
+        require_dim_coords (bool):
+            If true the x and y coordinates must be dimension coordinates.
 
     Raises:
         ValueError : Raise an error if non-uniform increments exist between
                       grid points.
     """
     for axis in ["x", "y"]:
-        if cube.coords(axis=axis):
+        if require_dim_coords:
+            coord = cube.coords(axis=axis, dim_coords=True)
+        else:
+            coord = cube.coords(axis=axis)
+
+        if coord:
             pass
         else:
             msg = ("The cube does not contain the expected {}"


### PR DESCRIPTION
A plugin to generate probabilities from the mean and variance of a parameter distribution at a list of thresholds provided by a template cube. The code has been structured in this way as we will have an input probability cube that will contain the thresholds and metadata that we want in the output.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
