### PR TITLE
Removal of usage of ensemble_realization_id coordinate in ensemble calibration

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -42,7 +42,7 @@ import cf_units as unit
 import iris
 
 from improver.ensemble_calibration.ensemble_calibration_utilities import (
-    convert_cube_data_to_2d, rename_coordinate, check_predictor_of_mean_flag)
+    convert_cube_data_to_2d, check_predictor_of_mean_flag)
 from improver.utilities.cube_manipulation import (
     concatenate_cubes, enforce_coordinate_ordering)
 from improver.utilities.temporal import iris_time_to_datetime
@@ -576,11 +576,6 @@ class EstimateCoefficientsForEnsembleCalibration(object):
             warnings.warn(msg)
             return optimised_coeffs, coeff_names
 
-        rename_coordinate(
-            current_forecast_cubes, "ensemble_realization_id", "realization")
-        rename_coordinate(
-            historic_forecast_cubes, "ensemble_realization_id", "realization")
-
         current_forecast_cubes = concatenate_cubes(
             current_forecast_cubes)
         historic_forecast_cubes = concatenate_cubes(
@@ -806,9 +801,6 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
         """
         # Ensure predictor_of_mean_flag is valid.
         check_predictor_of_mean_flag(self.predictor_of_mean_flag)
-
-        rename_coordinate(
-            self.current_forecast, "ensemble_realization_id", "realization")
 
         current_forecast_cubes = concatenate_cubes(
             self.current_forecast)

--- a/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
@@ -69,52 +69,6 @@ def convert_cube_data_to_2d(
     return np.array(forecast_data)
 
 
-def rename_coordinate(cubes, original_coord, renamed_coord):
-    """
-    Renames a coordinate to an alternative name for an
-    input Iris Cube or Iris CubeList.
-
-    Args:
-        cubes (iris.cube.CubeList or iris.cube.Cube):
-            Cubes with coordinates to be renamed.
-        original_coord (string):
-            Original name for the coordinate.
-        renamed_coord (string):
-            Name for the coordinate to be renamed to.
-
-    """
-    if isinstance(cubes, iris.cube.Cube):
-        _renamer(cubes, original_coord, renamed_coord)
-    elif isinstance(cubes, iris.cube.CubeList):
-        for cube in cubes:
-            _renamer(cube, original_coord, renamed_coord)
-    else:
-        msg = ("A Cube or CubeList is not provided for renaming "
-               "{} to {}. Variable provided "
-               "is of type: {}".format(
-                   original_coord, renamed_coord, type(cubes)))
-        raise TypeError(msg)
-
-
-def _renamer(cube, original_coord, renamed_coord):
-    """
-    Renames a coordinate to an alternative name.
-    If the coordinate is not found within the cube, then the
-    original cube is returned.
-
-    Args:
-        cube (iris.cube.Cube):
-            Cube with coordinates to be renamed.
-        original_coord (string):
-            Original name for the coordinate.
-        renamed_coord (string):
-            Name for the coordinate to be renamed to.
-
-    """
-    if cube.coords(original_coord):
-        cube.coord(original_coord).rename(renamed_coord)
-
-
 def check_predictor_of_mean_flag(predictor_of_mean_flag):
     """
     Check the predictor_of_mean_flag at the start of the

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -40,8 +40,7 @@ from iris.tests import IrisTest
 import numpy as np
 
 from improver.ensemble_calibration.ensemble_calibration_utilities import (
-    convert_cube_data_to_2d, rename_coordinate, _renamer,
-    check_predictor_of_mean_flag)
+    convert_cube_data_to_2d, check_predictor_of_mean_flag)
 from improver.tests.ensemble_calibration.ensemble_calibration.\
     helper_functions import set_up_temperature_cube
 
@@ -169,83 +168,6 @@ class Test_convert_cube_data_to_2d(IrisTest):
 
         result = convert_cube_data_to_2d(cube)
         self.assertArrayAlmostEqual(result, data)
-
-
-class Test_rename_coordinate(IrisTest):
-
-    """Test the rename_coordinate utility."""
-
-    def setUp(self):
-        """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
-
-    def test_basic_cube(self):
-        """Test that the utility returns an iris.cube.Cube."""
-        rename_coordinate(
-            self.cube, "realization", "ensemble_realization_id")
-        self.assertIsInstance(self.cube, iris.cube.Cube)
-
-    def test_basic_cubelist(self):
-        """
-        Test that the utility returns an iris.cube.CubeList and that
-        the cubes in the cubelist have an ensemble_realization_id coordinate.
-        """
-        cube1 = self.cube.copy()
-        cube2 = self.cube.copy()
-        cubes = iris.cube.CubeList([cube1, cube2])
-        rename_coordinate(
-            cubes, "realization", "ensemble_realization_id")
-        self.assertIsInstance(cubes, iris.cube.CubeList)
-        for cube in cubes:
-            self.assertTrue(cube.coord("ensemble_realization_id"))
-
-    def test_check_coordinate_name(self):
-        """
-        Test that the utility returns an iris.cube.Cube with an
-        ensemble_realization_id coordinate.
-        """
-        rename_coordinate(
-            self.cube, "realization", "ensemble_realization_id")
-        self.assertTrue(self.cube.coord("ensemble_realization_id"))
-
-    def test_check_type_error(self):
-        """
-        Test that a TyoeError is raised, if the input variable is not an
-        iris.cube.Cube.
-        """
-        fake_cube = "fake"
-        msg = "A Cube or CubeList is not provided for renaming"
-        with self.assertRaisesRegex(TypeError, msg):
-            rename_coordinate(
-                fake_cube, "realization", "ensemble_realization_id")
-
-
-class Test__renamer(IrisTest):
-
-    """Test the _renamer utility."""
-
-    def setUp(self):
-        """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
-
-    def test_check_coordinate_name(self):
-        """
-        Test that the utility returns an iris.cube.Cube with an
-        ensemble_realization_id coordinate following renaming.
-        """
-        _renamer(
-            self.cube, "realization", "ensemble_realization_id")
-        self.assertTrue(self.cube.coord("ensemble_realization_id"))
-
-    def test_absent_original_coord(self):
-        """
-        Test that the utility returns an iris.cube.Cube after the renaming
-        was not successful, as the original coordinate was not found in
-        the cube.
-        """
-        _renamer(
-            self.cube, "fake", "ensemble_realization_id")
-        self.assertFalse(self.cube.coords("ensemble_realization_id"))
 
 
 class Test_check_predictor_of_mean_flag(IrisTest):


### PR DESCRIPTION
Removal of renaming of coordinates within ensemble calibration, as this functionality is not used, as no input is provided with ensemble_member_id or ensemble_realization_id as a coordinate. This functionality existed to support an old input format that no longer needs to be supported.

Addresses #543 

Description:
As part of some clean up following the implementation, there is no need for ensemble calibration to support the existence of an `ensemble_realization_id` coordinate. Ensemble calibration uses the realization coordinate, however, support for `ensemble_member_id` was previously added to support an old input format.

Testing:
 - [x] Ran tests and they passed OK


