### PR TITLE
Add test for licence information

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -66,22 +66,23 @@ read -d '' expected <<'__TEXT__' || true
 # POSSIBILITY OF SUCH DAMAGE.
 __TEXT__
 
-FILES_TO_TEST=$@
+    FILES_TO_TEST=$@
 
-count=0
-for FILE in $FILES_TO_TEST; do
-    if [[ -s $FILE ]]; then
-        file_contents=$(<$FILE)
-        if [[ "$file_contents" != *"$expected"* ]]; then
-            echo "Unexpected licence information: ${FILE#$IMPROVER_DIR}"
-            count=$((count+1))
+    count=0
+    for FILE in $FILES_TO_TEST; do
+        # Check whether file has a size greater than zero.
+        if [[ -s $FILE ]]; then
+            file_contents=$(<$FILE)
+            if [[ "$file_contents" != *"$expected"* ]]; then
+                echo "Unexpected licence information: ${FILE#$IMPROVER_DIR}"
+                count=$((count+1))
+            fi
         fi
+    done
+    if (( $count > 0 )); then
+        echo_fail "IMPROVER licences"
+        exit 1
     fi
-done
-if (( $count > 0 )); then
-    echo_fail "IMPROVER licences"
-    exit 1
-fi
 }
 
 function improver_test_licence {

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -18,11 +18,76 @@ function echo_ok {
     echo -e "\033[1;32m[OK]\033[0m $1"
 }
 
+function echo_fail {
+    echo -e "\033[1;31m[FAIL]\033[0m $1"
+}
+
 function get_python_files {
     FILES_TO_TEST=`find $IMPROVER_DIR -type f \( -name '*.py' \
                                               -o -name 'improver-*' \
                                                ! -name 'improver-tests' \
                                                ! -name '*~' \)`
+}
+
+function licence_check {
+    # Iterate through files to check whether they contain the expected
+    # licence information. If any files do not contain the expected licence
+    # information, then this test will fail.
+read -d '' expected <<'__TEXT__' || true
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+__TEXT__
+
+FILES_TO_TEST=$@
+
+count=0
+for FILE in $FILES_TO_TEST; do
+    if [[ -s $FILE ]]; then
+        file_contents=$(<$FILE)
+        if [[ "$file_contents" != *"$expected"* ]]; then
+            echo "Unexpected licence information: ${FILE#$IMPROVER_DIR}"
+            count=$((count+1))
+        fi
+    fi
+done
+if (( $count > 0 )); then
+    echo_fail "IMPROVER licences"
+    exit 1
+fi
+}
+
+function improver_test_licence {
+    # utf8 and BSD 3-clause licence testing.
+    licence_check $FILES_TO_TEST
+    echo_ok "IMPROVER licences"
 }
 
 function improver_test_pycodestyle {
@@ -109,8 +174,8 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: pycodestyle, pylint, pylintE, doc, unit, cli.
-                    pycodestyle, pylintE, doc, unit, and cli are the default tests.
+                    Valid names are: pycodestyle, pylint, pylintE, licence, doc, unit, cli.
+                    pycodestyle, pylintE, licence, doc, unit, and cli are the default tests.
     SUBCLI          Name(s) of cli subtests to run without running the rest.
                     Valid names are tasks which appear in /improver/tests/
                     without the "improver-" prefix. The default is to run all
@@ -151,7 +216,7 @@ for arg in "$@"; do
         print_usage
         exit 0
         ;;
-        pycodestyle|pylint|pylintE|doc|unit|cli)
+        pycodestyle|pylint|pylintE|licence|doc|unit|cli)
         SUBTESTS="$SUBTESTS $arg"
         ;;
         $cli_tasks)
@@ -169,7 +234,7 @@ if [[ -n "$SUBTESTS" ]]; then
     TESTS="$SUBTESTS"
 else
     # Default tests.
-    TESTS="pycodestyle pylintE doc unit cli"
+    TESTS="pycodestyle pylintE licence doc unit cli"
 fi
 
 # If cli sub test is not specified by user, do all cli tests.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,33 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 #
 # IMPROVER documentation build configuration file, created by
 # sphinx-quickstart on Fri May 19 13:27:21 2017.

--- a/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #

--- a/lib/improver/tests/wind_downscaling/test_FrictionVelocity.py
+++ b/lib/improver/tests/wind_downscaling/test_FrictionVelocity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017 Met Office.
+# (C) British Crown Copyright 2017-2018 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -44,8 +44,8 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: pycodestyle, pylint, pylintE, doc, unit, cli.
-                    pycodestyle, pylintE, doc, unit, and cli are the default tests.
+                    Valid names are: pycodestyle, pylint, pylintE, licence, doc, unit, cli.
+                    pycodestyle, pylintE, licence, doc, unit, and cli are the default tests.
     SUBCLI          Name(s) of cli subtests to run without running the rest.
                     Valid names are tasks which appear in /improver/tests/
                     without the "improver-" prefix. The default is to run all

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -44,8 +44,8 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: pycodestyle, pylint, pylintE, doc, unit, cli.
-                    pycodestyle, pylintE, doc, unit, and cli are the default tests.
+                    Valid names are: pycodestyle, pylint, pylintE, licence, doc, unit, cli.
+                    pycodestyle, pylintE, licence, doc, unit, and cli are the default tests.
     SUBCLI          Name(s) of cli subtests to run without running the rest.
                     Valid names are tasks which appear in /improver/tests/
                     without the "improver-" prefix. The default is to run all


### PR DESCRIPTION
Addresses #6 

Description
Add a test to check whether the desired licence information is present within each file. This test runs alongside the existing tests e.g. pycodestyle, pylintE to ensure that the licence information is recorded correctly. Files where the licence information did not match the expected licence information have been updated.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)