### PR TITLE
Add warning if too many zero values for advection velocities

### DIFF
--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -735,10 +735,10 @@ class OpticalFlow(object):
 
     @staticmethod
     def zero_advection_velocities_warning(
-            vel_comp, non_zero_vel_threshold=0.9):
+            vel_comp, zero_vel_threshold=0.1):
         """
-        Raise warning if fewer than 90% of the cells within the domain have
-        non-zero advection velocities.
+        Raise warning if more than 10% of the cells within the domain have
+        zero advection velocities.
 
         Args:
             vel_comp (np.ndarray):
@@ -746,25 +746,25 @@ class OpticalFlow(object):
                 proportion of zeroes present in this field.
 
         Keyword Args:
-            non_zero_vel_threshold (float):
-                Fractional value to specify the proportion of non-zero values
-                that the advection field should contain at a minimum.
-                For example, if non_zero_vel_threshold=0.9 then up to 90% of
+            zero_vel_threshold (float):
+                Fractional value to specify the proportion of zero values
+                that the advection field should contain at a maximum.
+                For example, if zero_vel_threshold=0.1 then up to 10% of
                 the advection velocities can be zero before a warning will be
                 raised.
 
         Warns:
-            Warning: If the proportion of non-zero advection velocities is
-                below the threshold specified by non_zero_vel_threshold.
+            Warning: If the proportion of zero advection velocities is
+                above the threshold specified by zero_vel_threshold.
 
         """
-        if np.count_nonzero(vel_comp) < vel_comp.size*non_zero_vel_threshold:
-            msg = ("Fewer than {:.1f}% of the cells within the domain have "
-                   "non-zero advection velocities. It is expected that "
-                   "less than {:.1f}% of the advection velocities "
-                   "will be zero.".format(
-                       non_zero_vel_threshold*100,
-                       (1-non_zero_vel_threshold)*100))
+        if np.count_nonzero(vel_comp == 0) > vel_comp.size*zero_vel_threshold:
+            msg = ("More than {:.1f}% of the cells within the domain have "
+                   "zero advection velocities. It is expected that "
+                   "greater than {:.1f}% of the advection velocities "
+                   "will be non-zero.".format(
+                       zero_vel_threshold*100,
+                       (1-zero_vel_threshold)*100))
             warnings.warn(msg)
 
     def process_dimensionless(self, data1, data2, xaxis, yaxis):

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -741,7 +741,8 @@ class OpticalFlow(object):
         if np.count_nonzero(vel_comp) < vel_comp.size*non_zero_vel_threshold:
             msg = ("Fewer than {:.1f}% of the cells within the domain have "
                    "non-zero advection velocities. It is expected that "
-                   "<{:.1f}% of the advection velocities will be zero.".format(
+                   "less than {:.1f}% of the advection velocities "
+                   "will be zero.".format(
                        non_zero_vel_threshold*100,
                        (1-non_zero_vel_threshold)*100))
             warnings.warn(msg)

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -445,12 +445,13 @@ class OpticalFlow(object):
                 Size of boxes to be output
 
         Returns:
-            boxes (list):
-                List of np.ndarrays of size boxsize*boxsize containing slices
-                of data from input field.
-            weights (np.ndarray):
-                1D numpy array containing weights values associated with each
-                listed box.
+            (tuple) : tuple containing:
+                **boxes** (list):
+                    List of np.ndarrays of size boxsize*boxsize containing
+                    slices of data from input field.
+                **weights** (np.ndarray):
+                    1D numpy array containing weights values associated with
+                    each listed box.
         """
         boxes = []
         weights = []
@@ -506,6 +507,14 @@ class OpticalFlow(object):
              [ 0.      0.125   0.25    0.125   0.    ]
              [ 0.      0.0625  0.125   0.0625  0.    ]
              [ 0.      0.      0.      0.      0.    ]]
+
+        Args:
+            radius (int):
+                Kernel radius or half box size for smoothing
+
+        Returns:
+            kernel_2d (np.ndarray):
+                Kernel to use for generating a smoothed field.
 
         """
         kernel_1d = 1 - np.abs(np.linspace(-1, 1, radius*2+1))
@@ -689,10 +698,11 @@ class OpticalFlow(object):
                 2D array of partial input field derivatives d/dt
 
         Returns:
-            umat (np.ndarray):
-                2D array of displacements in the x-direction
-            vmat (np.ndarray):
-                2D array of displacements in the y-direction
+            (tuple) : tuple containing:
+                **umat** (np.ndarray):
+                    2D array of displacements in the x-direction
+                **vmat** (np.ndarray):
+                    2D array of displacements in the y-direction
         """
 
         # (a) Generate lists of subboxes over which velocity is constant
@@ -737,8 +747,8 @@ class OpticalFlow(object):
     def zero_advection_velocities_warning(
             vel_comp, zero_vel_threshold=0.1):
         """
-        Raise warning if more than 10% of the cells within the domain have
-        zero advection velocities.
+        Raise warning if more than a fixed threshold (default 10%)
+        of the cells within the domain have zero advection velocities.
 
         Args:
             vel_comp (np.ndarray):
@@ -783,10 +793,11 @@ class OpticalFlow(object):
                 Index of y coordinate axis
 
         Returns:
-            ucomp (np.ndarray):
-                Advection displacement (grid squares) in the x direction
-            vcomp (np.ndarray):
-                Advection displacement (grid squares) in the y direction
+            (tuple) : tuple containing:
+                **ucomp** (np.ndarray):
+                    Advection displacement (grid squares) in the x direction
+                **vcomp** (np.ndarray):
+                    Advection displacement (grid squares) in the y direction
         """
         # Smooth input data
         self.shape = data1.shape
@@ -825,10 +836,11 @@ class OpticalFlow(object):
                 2D cube from (later) time 2
 
         Returns:
-            ucube (iris.cube.Cube):
-                2D cube of advection velocities in the x-direction
-            vcube (iris.cube.Cube):
-                2D cube of advection velocities in the y-direction
+            (tuple) : tuple containing:
+                **ucube** (iris.cube.Cube):
+                    2D cube of advection velocities in the x-direction
+                **vcube** (iris.cube.Cube):
+                    2D cube of advection velocities in the y-direction
         """
 
         # check cubes have exactly two spatial dimension coordinates and a

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -304,7 +304,7 @@ class OpticalFlow(object):
         Initialise the class with smoothing parameters for estimating gridded
         u- and v- velocities via optical flow.
 
-        input:
+        Keyword Args:
             data_smoothing_radius_km (float):
                 Kernel radius in km over which to smooth input data before
                 estimating partial derivatives.  Should not be less than 3x
@@ -736,8 +736,28 @@ class OpticalFlow(object):
     @staticmethod
     def zero_advection_velocities_warning(
             vel_comp, non_zero_vel_threshold=0.9):
-        # Raise warning if fewer than 90% of the cells within the domain have
-        # non-zero advection velocities.
+        """
+        Raise warning if fewer than 90% of the cells within the domain have
+        non-zero advection velocities.
+
+        Args:
+            vel_comp (np.ndarray):
+                Advection velocity that will be checked to assess the
+                proportion of zeroes present in this field.
+
+        Keyword Args:
+            non_zero_vel_threshold (float):
+                Fractional value to specify the proportion of non-zero values
+                that the advection field should contain at a minimum.
+                For example, if non_zero_vel_threshold=0.9 then up to 90% of
+                the advection velocities can be zero before a warning will be
+                raised.
+
+        Warns:
+            Warning: If the proportion of non-zero advection velocities is
+                below the threshold specified by non_zero_vel_threshold.
+
+        """
         if np.count_nonzero(vel_comp) < vel_comp.size*non_zero_vel_threshold:
             msg = ("Fewer than {:.1f}% of the cells within the domain have "
                    "non-zero advection velocities. It is expected that "

--- a/lib/improver/tests/nowcasting/optical_flow/test_AdvectField.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_AdvectField.py
@@ -28,7 +28,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-""" Unit tests for the optical_flow.AdvectField plugin """
+""" Unit tests for the nowcasting.AdvectField plugin """
 
 import datetime
 import unittest

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -480,31 +480,62 @@ class Test_zero_advection_velocities_warning(IrisTest):
     def setUp(self):
         """Set up arrays of advection velocities"""
         self.plugin = OpticalFlow()
-        self.nonzero_array = np.array([[3., 5., 7.],
-                                       [2., 2., 1.],
-                                       [1., 1., 1.]])
-
-        self.array_with_zero = np.array([[3., 5., 7.],
-                                         [0., 2., 1.],
-                                         [1., 1., 1.]])
 
     @ManageWarnings(record=True)
     def test_warning_raised(self, warning_list=None):
         """Test that a warning is raised if an excess number of zero values
         are present within the input array."""
-        self.plugin.zero_advection_velocities_warning(self.array_with_zero)
+        greater_than_10_percent_zeroes_array = (
+            np.array([[3., 5., 7.],
+                      [0., 2., 1.],
+                      [1., 1., 1.]]))
+        self.plugin.zero_advection_velocities_warning(
+            greater_than_10_percent_zeroes_array)
         self.assertTrue(len(warning_list) == 1)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
-        self.assertTrue("cells within the domain have non-zero advection"
+        self.assertTrue("cells within the domain have zero advection"
                         in str(warning_list[0]))
 
     @ManageWarnings(record=True)
-    def test_no_warning_raised(self, warning_list=None):
-        """Test that no warning is raised the number of zero values in the
+    def test_no_warning_raised_if_no_zeroes(self, warning_list=None):
+        """Test that no warning is raised if the number of zero values in the
         array is below the threshold used to define an excessive number of
         zero values."""
-        self.plugin.zero_advection_velocities_warning(self.nonzero_array)
+        nonzero_array = np.array([[3., 5., 7.],
+                                  [2., 2., 1.],
+                                  [1., 1., 1.]])
+        self.plugin.zero_advection_velocities_warning(nonzero_array)
+        self.assertTrue(len(warning_list) == 0)
+
+    @ManageWarnings(record=True)
+    def test_no_warning_raised_if_fewer_zeroes_than_threshold(
+            self, warning_list=None):
+        """Test that no warning is raised if the number of zero values in the
+        array is below the threshold used to define an excessive number of
+        zero values when at least one zero exists within the array."""
+        less_than_10_percent_zeroes_array = (
+            np.array([[1., 3., 5., 7., 1.],
+                      [0., 2., 1., 1., 1.],
+                      [1., 1., 1., 1., 1.],
+                      [1., 1., 1., 1., 1.],
+                      [1., 1., 1., 1., 1.]]))
+        self.plugin.zero_advection_velocities_warning(
+            less_than_10_percent_zeroes_array)
+        self.assertTrue(len(warning_list) == 0)
+
+    @ManageWarnings(record=True)
+    def test_no_warning_raised_for_modified_threshold(
+            self, warning_list=None):
+        """Test that no warning is raised if the number of zero values in the
+        array is below the threshold used to define an excessive number of
+        zero values when the threshold is modified."""
+        less_than_30_percent_zeroes_array = (
+            np.array([[3., 5., 7.],
+                      [0., 2., 1.],
+                      [0., 1., 1.]]))
+        self.plugin.zero_advection_velocities_warning(
+            less_than_30_percent_zeroes_array, zero_vel_threshold=0.3)
         self.assertTrue(len(warning_list) == 0)
 
 

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -28,7 +28,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-""" Unit tests for the optical_flow.OpticalFlow plugin """
+""" Unit tests for the nowcasting.OpticalFlow plugin """
 
 import unittest
 import numpy as np

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -69,15 +69,17 @@ class BasicThreshold(object):
         case, the thresholded exceedance probabilities between 4.5 mm/hr and
         7.5 mm/hr would follow the pattern:
 
-         Data value | Probability
-        ------------|-------------
-            4.5     |   0
-            5.0     |   0.167
-            5.5     |   0.333
-            6.0     |   0.5
-            6.5     |   0.667
-            7.0     |   0.833
-            7.5     |   1.0
+        ::
+
+            Data value | Probability
+            ------------|-------------
+                4.5     |   0
+                5.0     |   0.167
+                5.5     |   0.333
+                6.0     |   0.5
+                6.5     |   0.667
+                7.0     |   0.833
+                7.5     |   1.0
 
         Args:
             thresholds (list of floats or float):


### PR DESCRIPTION
Addresses #571 

Description
Edits to optical flow to add a warning being raised, if an excess of zero values is calculated within the advection velocities. At the moment, the threshold for when a warning is raised is hard-coded within `optical_flow.py`. This could be modified, if this is desirable.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
