### PR TITLE
Impro 621 improve snow

### DIFF
--- a/bin/improver-snow-falling-level
+++ b/bin/improver-snow-falling-level
@@ -60,6 +60,12 @@ def main():
                         "the orography height in m of the terrain "
                         "over which the continuous falling snow level is "
                         "being calculated.")
+    parser.add_argument("land_sea_mask", metavar="LAND_SEA_MASK",
+                        help="Path to a NetCDF file containing "
+                        "the binary land-sea mask for the points "
+                        "for which the continuous falling snow level is "
+                        "being calculated. Land points are set to 1, sea "
+                        "points are set to 0.")
     parser.add_argument("output_filepath", metavar="OUTPUT_FILE",
                         help="The output path for the processed NetCDF")
     parser.add_argument("--precision", metavar="NEWTON_PRECISION",
@@ -82,6 +88,7 @@ def main():
     relative_humidity = load_cube(args.relative_humidity, no_lazy_load=True)
     pressure = load_cube(args.pressure, no_lazy_load=True)
     orog = load_cube(args.orography, no_lazy_load=True)
+    land_sea = load_cube(args.land_sea_mask, no_lazy_load=True)
 
     result = FallingSnowLevel(
         precision=args.precision,
@@ -89,7 +96,8 @@ def main():
             temperature,
             relative_humidity,
             pressure,
-            orog)
+            orog,
+            land_sea)
 
     save_netcdf(result, args.output_filepath)
 

--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -666,7 +666,7 @@ class FallingSnowLevel(object):
         return snow_level_data
 
     def fill_in_missing_data(self, snow_level_data, orog_data, land_sea_data,
-                             highest_wb_int_data, highest_height,):
+                             highest_wb_int_data, highest_height):
         """
         Fill in missing data. Wet-bulb integral data
         is only available above ground level and there may be an insufficient

--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -785,8 +785,8 @@ class FallingSnowLevel(object):
         # Firstly we need to slice over height, x and y
         x_coord = wet_bulb_integral.coord(axis='x').name()
         y_coord = wet_bulb_integral.coord(axis='y').name()
-        for orog_cube in orog.slices([y_coord, x_coord]):
-            orog_data = orog_cube.data
+        orog_data = next(orog.slices([y_coord, x_coord])).data
+        land_sea_data = next(land_sea_mask.slices([y_coord, x_coord])).data
 
         snow = iris.cube.CubeList([])
         slice_list = ['height', y_coord, x_coord]
@@ -805,7 +805,7 @@ class FallingSnowLevel(object):
             # Interpolate missing data
             snow_cube.data = self.fill_in_missing_data(snow_cube.data,
                                                        orog_data,
-                                                       land_sea_mask.data,
+                                                       land_sea_data,
                                                        wb_integral.data[0, ::],
                                                        highest_height)
 

--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -665,8 +665,8 @@ class FallingSnowLevel(object):
 
         return snow_level_data
 
-    def fill_in_missing_data(self, snow_level_data, orog_data,
-                             highest_wb_int_data, highest_height):
+    def fill_in_missing_data(self, snow_level_data, orog_data, land_sea_data,
+                             highest_wb_int_data, highest_height,):
         """
         Fill in missing data. Wet-bulb integral data
         is only available above ground level and there may be an insufficient
@@ -693,6 +693,8 @@ class FallingSnowLevel(object):
                 Falling snow level data (m).
             orog_data (np.array):
                 Orographic data (m)
+            land_sea_data (np.array):
+                The binary land-sea mask array.
             highest_wb_int_data (np.array):
                 Wet bulb integral data on highest level (K m).
             highest_height (float):
@@ -708,13 +710,13 @@ class FallingSnowLevel(object):
         # Set these to highest_height
         sea_points_not_freezing = np.where(
             np.isnan(snow_level_data) &
-            (orog_data == 0.0) &
+            (land_sea_data < 1.0) &
             (highest_wb_int_data >
              self.falling_level_threshold))
         snow_level_data[sea_points_not_freezing] = highest_height
         # Now find any remaining sea_points and set these to 0
         sea_points = np.where(np.isnan(snow_level_data) &
-                              (orog_data == 0.0))
+                              (land_sea_data < 1.0))
         snow_level_data[sea_points] = 0.0
         # Interpolate linearly across the remaining points
         points = np.where(np.isfinite(snow_level_data))
@@ -740,7 +742,8 @@ class FallingSnowLevel(object):
         snow_level_updated[remaining_points] = self.missing_data
         return snow_level_updated
 
-    def process(self, temperature, relative_humidity, pressure, orog):
+    def process(self, temperature, relative_humidity, pressure, orog,
+                land_sea_mask):
         """
         Calculate the wet bulb temperature integral by firstly calculating
         the wet bulb temperature from the inputs provided, and then
@@ -758,6 +761,8 @@ class FallingSnowLevel(object):
                 Cube of air pressures (Pa).
             orog (iris.cube.Cube):
                 Cube of orography (m).
+            land_sea_mask (iris.cube.Cube):
+                Cube containing a binary land-sea mask.
 
         Returns:
             falling_snow_level (iris.cube.Cube):
@@ -800,6 +805,7 @@ class FallingSnowLevel(object):
             # Interpolate missing data
             snow_cube.data = self.fill_in_missing_data(snow_cube.data,
                                                        orog_data,
+                                                       land_sea_mask.data,
                                                        wb_integral.data[0, ::],
                                                        highest_height)
 

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -234,6 +234,12 @@ class Test_process(IrisTest):
         self.orog.add_dim_coord(iris.coords.DimCoord(np.linspace(120, 180, 3),
                                                      'longitude',
                                                      units='degrees'), 1)
+        self.land_sea.add_dim_coord(
+            iris.coords.DimCoord(np.linspace(-45.0, 45.0, 3),
+                                 'latitude', units='degrees'), 0)
+        self.land_sea.add_dim_coord(
+            iris.coords.DimCoord(np.linspace(120, 180, 3),
+                                 'longitude', units='degrees'), 1)
 
     def test_basic(self):
         """Test that process returns a cube with the right name and units."""

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -103,6 +103,7 @@ class Test_fill_in_missing_data(IrisTest):
                                              [1.0, np.nan, 2.0],
                                              [1.0, 2.0, np.nan]])
         self.orog = np.ones((3, 3))
+        self.land_sea = np.ones((3, 3))
         self.highest_wb_int = np.ones((3, 3))
         self.highest_height = 300.0
 
@@ -113,7 +114,8 @@ class Test_fill_in_missing_data(IrisTest):
                              [1.0, 1.5, 2.0],
                              [1.0, 2.0, 2.0]])
         result = plugin.fill_in_missing_data(self.snow_level_data,
-                                             self.orog, self.highest_wb_int,
+                                             self.orog, self.land_sea,
+                                             self.highest_wb_int,
                                              self.highest_height)
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayEqual(result, expected)
@@ -123,11 +125,14 @@ class Test_fill_in_missing_data(IrisTest):
         plugin = FallingSnowLevel()
         orog = self.orog
         orog[1, 1] = 0.0
+        land_sea = self.land_sea
+        land_sea[1, 1] = 0.0
         expected = np.array([[1.0, 1.0, 2.0],
                              [1.0, 0.0, 2.0],
                              [1.0, 2.0, 2.0]])
         result = plugin.fill_in_missing_data(self.snow_level_data,
-                                             orog, self.highest_wb_int,
+                                             orog, land_sea,
+                                             self.highest_wb_int,
                                              self.highest_height)
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayEqual(result, expected)
@@ -138,13 +143,15 @@ class Test_fill_in_missing_data(IrisTest):
         plugin = FallingSnowLevel()
         orog = self.orog
         orog[1, 1] = 0.0
+        land_sea = self.land_sea
+        land_sea[1, 1] = 0.0
         highest_wb_int = self.highest_wb_int
         highest_wb_int[1, 1] = 100.0
         expected = np.array([[1.0, 1.0, 2.0],
                              [1.0, 300.0, 2.0],
                              [1.0, 2.0, 2.0]])
         result = plugin.fill_in_missing_data(self.snow_level_data,
-                                             orog, highest_wb_int,
+                                             orog, land_sea, highest_wb_int,
                                              self.highest_height)
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayEqual(result, expected)
@@ -160,7 +167,8 @@ class Test_fill_in_missing_data(IrisTest):
                              [1.0, 1.5, 2.0],
                              [1.0, 2.0, 301.0]])
         result = plugin.fill_in_missing_data(self.snow_data_no_interp,
-                                             self.orog, highest_wb_int,
+                                             self.orog, self.land_sea,
+                                             highest_wb_int,
                                              self.highest_height)
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayEqual(result, expected)
@@ -174,7 +182,8 @@ class Test_fill_in_missing_data(IrisTest):
                              [1.0, 1.5, 2.0],
                              [1.0, 2.0, -300.0]])
         result = plugin.fill_in_missing_data(self.snow_data_no_interp,
-                                             self.orog, self.highest_wb_int,
+                                             self.orog, self.land_sea,
+                                             self.highest_wb_int,
                                              self.highest_height)
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayEqual(result, expected)
@@ -216,6 +225,9 @@ class Test_process(IrisTest):
 
         self.orog = iris.cube.Cube(np.ones((3, 3)),
                                    standard_name='surface_altitude', units='m')
+        self.land_sea = iris.cube.Cube(np.ones((3, 3)),
+                                       standard_name='land_binary_mask',
+                                       units='m')
         self.orog.add_dim_coord(
             iris.coords.DimCoord(np.linspace(-45.0, 45.0, 3),
                                  'latitude', units='degrees'), 0)
@@ -227,7 +239,7 @@ class Test_process(IrisTest):
         """Test that process returns a cube with the right name and units."""
         result = FallingSnowLevel().process(
             self.temperature_cube, self.relative_humidity_cube,
-            self.pressure_cube, self.orog)
+            self.pressure_cube, self.orog, self.land_sea)
         expected = np.ones((2, 3, 3)) * 66.88732723
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "falling_snow_level_asl")
@@ -241,9 +253,11 @@ class Test_process(IrisTest):
         expected[:, 1, 1] = 0.0
         orog = self.orog
         orog.data = orog.data * 0.0
+        land_sea = self.land_sea
+        land_sea = land_sea * 0.0
         result = FallingSnowLevel().process(
             self.temperature_cube, self.relative_humidity_cube,
-            self.pressure_cube, self.orog)
+            self.pressure_cube, orog, land_sea)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(result.data, expected)
 

--- a/tests/improver-snow-falling-level/00-null.bats
+++ b/tests/improver-snow-falling-level/00-null.bats
@@ -37,6 +37,6 @@
                                    [--precision NEWTON_PRECISION]
                                    [--falling_level_threshold FALLING_LEVEL_THRESHOLD]
                                    TEMPERATURE RELATIVE_HUMIDITY PRESSURE
-                                   OROGRAPHY OUTPUT_FILE"
+                                   OROGRAPHY LAND_SEA_MASK OUTPUT_FILE"
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-snow-falling-level/01-help.bats
+++ b/tests/improver-snow-falling-level/01-help.bats
@@ -38,7 +38,7 @@ usage: improver-snow-falling-level [-h] [--profile]
                                    [--precision NEWTON_PRECISION]
                                    [--falling_level_threshold FALLING_LEVEL_THRESHOLD]
                                    TEMPERATURE RELATIVE_HUMIDITY PRESSURE
-                                   OROGRAPHY OUTPUT_FILE
+                                   OROGRAPHY LAND_SEA_MASK OUTPUT_FILE
 
 Calculate the continuous falling snow level
 
@@ -55,6 +55,10 @@ positional arguments:
   OROGRAPHY             Path to a NetCDF file containing the orography height
                         in m of the terrain over which the continuous falling
                         snow level is being calculated.
+  LAND_SEA_MASK         Path to a NetCDF file containing the binary land-sea
+                        mask for the points for which the continuous falling
+                        snow level is being calculated. Land points are set to
+                        1, sea points are set to 0.
   OUTPUT_FILE           The output path for the processed NetCDF
 
 optional arguments:

--- a/tests/improver-snow-falling-level/02-basic.bats
+++ b/tests/improver-snow-falling-level/02-basic.bats
@@ -41,6 +41,7 @@
       "$IMPROVER_ACC_TEST_DIR/snow-falling-level/basic/relative_humidity.nc" \
       "$IMPROVER_ACC_TEST_DIR/snow-falling-level/basic/pressure.nc" \
       "$IMPROVER_ACC_TEST_DIR/snow-falling-level/basic/orog.nc" \
+      "$IMPROVER_ACC_TEST_DIR/snow-falling-level/basic/land_mask.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 


### PR DESCRIPTION
Addresses #511 

Updating to use land-sea mask rather than orography to determine sea points.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
