### PR TITLE
IMPRO722 part 2: added "in rain" condition

### DIFF
--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -774,9 +774,9 @@ class OpticalFlow(object):
         rain_pixels = vel_comp[rain_mask].size
 
         if zeroes_in_rain > rain_pixels*zero_vel_threshold:
-            msg = ("More than {:.1f}% of the cells within the domain have "
+            msg = ("More than {:.1f}% of rain cells within the domain have "
                    "zero advection velocities. It is expected that "
-                   "greater than {:.1f}% of the advection velocities "
+                   "greater than {:.1f}% of these advection velocities "
                    "will be non-zero.".format(
                        zero_vel_threshold*100,
                        (1-zero_vel_threshold)*100))

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -772,7 +772,7 @@ class OpticalFlow(object):
         """
         zeroes_in_rain = np.count_nonzero(vel_comp[rain_mask] == 0)
         rain_pixels = vel_comp[rain_mask].size
-        
+
         if zeroes_in_rain > rain_pixels*zero_vel_threshold:
             msg = ("More than {:.1f}% of the cells within the domain have "
                    "zero advection velocities. It is expected that "
@@ -821,10 +821,9 @@ class OpticalFlow(object):
             partial_dx, partial_dy, partial_dt)
 
         # Check for zeros where there should be valid displacements
-        rain_mask = np.where((data1 > 0) & (data2 > 0))
+        rain_mask = np.where((data1 > 0) | (data2 > 0))
         for vel_comp in [ucomp, vcomp]:
             self._zero_advection_velocities_warning(vel_comp, rain_mask)
-
         return ucomp, vcomp
 
     def process(self, cube1, cube2):

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -508,7 +508,7 @@ class Test__zero_advection_velocities_warning(IrisTest):
                                   [2., 2., 1.],
                                   [1., 1., 1.]])
         self.plugin._zero_advection_velocities_warning(nonzero_array,
-                                                      self.rain_mask)
+                                                       self.rain_mask)
         self.assertTrue(len(warning_list) == 0)
 
     @ManageWarnings(record=True)

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -474,12 +474,14 @@ class Test_calculate_displacement_vectors(IrisTest):
         self.assertAlmostEqual(np.mean(vmat), 0.121514428331)
 
 
-class Test_zero_advection_velocities_warning(IrisTest):
-    """Test the zero_advection_velocities_warning."""
+class Test__zero_advection_velocities_warning(IrisTest):
+    """Test the _zero_advection_velocities_warning."""
 
     def setUp(self):
         """Set up arrays of advection velocities"""
         self.plugin = OpticalFlow()
+        rain = np.ones((3, 3))
+        self.rain_mask = np.where(rain > 0)
 
     @ManageWarnings(record=True)
     def test_warning_raised(self, warning_list=None):
@@ -489,8 +491,8 @@ class Test_zero_advection_velocities_warning(IrisTest):
             np.array([[3., 5., 7.],
                       [0., 2., 1.],
                       [1., 1., 1.]]))
-        self.plugin.zero_advection_velocities_warning(
-            greater_than_10_percent_zeroes_array)
+        self.plugin._zero_advection_velocities_warning(
+            greater_than_10_percent_zeroes_array, self.rain_mask)
         self.assertTrue(len(warning_list) == 1)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
@@ -505,7 +507,8 @@ class Test_zero_advection_velocities_warning(IrisTest):
         nonzero_array = np.array([[3., 5., 7.],
                                   [2., 2., 1.],
                                   [1., 1., 1.]])
-        self.plugin.zero_advection_velocities_warning(nonzero_array)
+        self.plugin._zero_advection_velocities_warning(nonzero_array,
+                                                      self.rain_mask)
         self.assertTrue(len(warning_list) == 0)
 
     @ManageWarnings(record=True)
@@ -514,14 +517,15 @@ class Test_zero_advection_velocities_warning(IrisTest):
         """Test that no warning is raised if the number of zero values in the
         array is below the threshold used to define an excessive number of
         zero values when at least one zero exists within the array."""
+        rain = np.ones((5, 5))
         less_than_10_percent_zeroes_array = (
             np.array([[1., 3., 5., 7., 1.],
                       [0., 2., 1., 1., 1.],
                       [1., 1., 1., 1., 1.],
                       [1., 1., 1., 1., 1.],
                       [1., 1., 1., 1., 1.]]))
-        self.plugin.zero_advection_velocities_warning(
-            less_than_10_percent_zeroes_array)
+        self.plugin._zero_advection_velocities_warning(
+            less_than_10_percent_zeroes_array, np.where(rain > 0))
         self.assertTrue(len(warning_list) == 0)
 
     @ManageWarnings(record=True)
@@ -534,8 +538,22 @@ class Test_zero_advection_velocities_warning(IrisTest):
             np.array([[3., 5., 7.],
                       [0., 2., 1.],
                       [0., 1., 1.]]))
-        self.plugin.zero_advection_velocities_warning(
-            less_than_30_percent_zeroes_array, zero_vel_threshold=0.3)
+        self.plugin._zero_advection_velocities_warning(
+            less_than_30_percent_zeroes_array, self.rain_mask,
+            zero_vel_threshold=0.3)
+        self.assertTrue(len(warning_list) == 0)
+
+    @ManageWarnings(record=True)
+    def test_no_warning_raised_outside_rain(self, warning_list=None):
+        """Test warning ignores zeros outside the rain area mask"""
+        rain = np.array([[0, 0, 1],
+                         [0, 1, 1],
+                         [1, 1, 1]])
+        wind = np.array([[0, 0, 1],
+                         [0, 1, 1],
+                         [1, 1, 1]])
+        self.plugin._zero_advection_velocities_warning(
+            wind, np.where(rain > 0))
         self.assertTrue(len(warning_list) == 0)
 
 


### PR DESCRIPTION
Addresses #571 

This warning should only be raised where there is rain - we expect all other advection velocities to have a zero (or "no data") value.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
