### PR TITLE
Refactors wind direction code to make implementation of IMPRO 598 easier

### DIFF
--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -160,11 +160,13 @@ class Test__init__(IrisTest):
 
     def test_basic(self):
         """Test that the __init__ does not fail."""
-        WindDirection()
+        result = WindDirection()
+        self.assertIsInstance(result, WindDirection)
 
     def test_backup_method(self):
         """Test that the __init__ accepts this keyword."""
-        WindDirection(backup_method='neighbourhood')
+        result = WindDirection(backup_method='neighbourhood')
+        self.assertIsInstance(result, WindDirection)
 
     def test_invalid_method(self):
         """Test that the __init__ fails when an unrecognised option is given"""

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -97,13 +97,31 @@ WIND_DIR_R_VALS = np.array([[6.12323400e-17, 0.996194698],
                             [0.984807753, 0.984807753]])
 
 
+class Test__init__(IrisTest):
+    """Test the init method."""
+
+    def test_basic(self):
+        """Test that the __init__ does not fail."""
+        WindDirection()
+
+    def test_backup_method(self):
+        """Test that the __init__ accepts this keyword."""
+        WindDirection(low_confidence_method='neighbourhood')
+
+    def test_invalid_method(self):
+        """Test that the __init__ fails when an unrecognised option is given."""
+        msg = ('Invalid option for keyword low_confidence_method ')
+        with self.assertRaisesRegexp(ValueError, msg):
+            WindDirection(low_confidence_method='invalid')
+
+
 class Test__repr__(IrisTest):
     """Test the repr method."""
 
     def test_basic(self):
         """Test that the __repr__ returns the expected string."""
         result = str(WindDirection())
-        msg = ('<WindDirection>')
+        msg = ('<WindDirection: low_confidence_method "first realization">')
         self.assertEqual(result, msg)
 
 

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -265,11 +265,11 @@ class Test_wind_dir_mean(IrisTest):
         """Initialise plugin and supply data for tests"""
         self.plugin = WindDirection()
         # 5x3x4 3D Array containing wind direction in angles.
-        self.plugin.wdir_slice = make_wdir_cube_534()
+        cube = make_wdir_cube_534()
         self.plugin.wdir_complex = self.plugin.deg_to_complex(
-            self.plugin.wdir_slice.data)
+            cube.data)
         self.plugin.wdir_slice_mean = (
-            next(self.plugin.wdir_slice.slices_over("realization")))
+            next(cube.slices_over("realization")))
         self.plugin.realization_axis = 0
 
         self.expected_wind_mean = (
@@ -367,11 +367,9 @@ class Test_wind_dir_decider(IrisTest):
             self.plugin.deg_to_complex(WIND_DIR_DEG_MEAN))
         self.plugin.wdir_complex = WIND_DIR_COMPLEX
         self.plugin.realization_axis = 0
-        self.plugin.r_vals_slice = make_wdir_cube_222()[0]
-        self.plugin.r_vals_slice.data = WIND_DIR_R_VALS
-        self.plugin.wdir_slice = make_wdir_cube_222()
         self.plugin.wdir_slice_mean = make_wdir_cube_222()[0]
         self.plugin.wdir_slice_mean.data = WIND_DIR_DEG_MEAN
+        self.cube = make_wdir_cube_222()[0]
 
     def test_runs_function(self):
         """First element has two angles directly opposite (90 & 270 degs).
@@ -381,8 +379,10 @@ class Test_wind_dir_decider(IrisTest):
 
         expected_out = np.array([[90.0, 55.0],
                                  [280.0, 0.0]])
+        where_low_r = np.array([[True, False],
+                                [False, False]])
 
-        self.plugin.wind_dir_decider()
+        self.plugin.wind_dir_decider(where_low_r, self.cube.data)
         result = self.plugin.wdir_slice_mean.data
 
         self.assertIsInstance(result, np.ndarray)

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -345,8 +345,8 @@ class Test_calc_confidence_measure(IrisTest):
         far the individual ensemble realizationss are away from
         the mean point."""
 
-        expected_out = np.array([[0.0, 0.95638061],
-                                 [0.91284426, 0.91284426]])
+        expected_out = np.array([[0.0, 0.956422],
+                                 [0.913176, 0.913176]])
 
         self.plugin.calc_confidence_measure()
         result = self.plugin.confidence_slice.data

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -159,6 +159,38 @@ class Test_complex_to_deg(IrisTest):
         self.assertArrayAlmostEqual(result, DEGREE_ANGLES)
 
 
+class Test_wind_dir_mean(IrisTest):
+    """Test the wind_dir_mean function."""
+
+    def test_basic(self):
+        """Test that the function returns correct 2D array of floats. """
+        # 5x3x4 3D Array containing wind direction in angles.
+        data = np.array([[[[170.0, 50.0, 90.0, 90.0],
+                           [170.0, 170.0, 47.0, 350.0],
+                           [10.0, 309.0, 10.0, 10.0]]],
+                         [[[170.0, 50.0, 90.0, 90.0],
+                           [170.0, 170.0, 47.0, 47.0],
+                           [10.0, 10.0, 10.0, 10.0]]],
+                         [[[10.0, 50.0, 90.0, 90.0],
+                           [170.0, 170.0, 47.0, 47.0],
+                           [310.0, 309.0, 10.0, 10.0]]],
+                         [[[190.0, 40.0, 270.0, 90.0],
+                           [170.0, 170.0, 47.0, 47.0],
+                           [310.0, 309.0, 10.0, 10.0]]],
+                         [[[190.0, 40.0, 270.0, 270.0],
+                           [170.0, 170.0, 47.0, 47.0],
+                           [310.0, 309.0, 10.0, 10.0]]]])
+
+        expected_wind_mean = (
+            np.array([[[176.636273, 46.002444, 90.0, 90.0],
+                       [170.0, 170.0, 47.0, 36.544233],
+                       [333.413224, 320.035216, 10.0, 10.0]]]))
+
+        result, _ = WindDirection().wind_dir_mean(data, axis=0)
+        self.assertIsInstance(result, np.ndarray)
+        self.assertArrayAlmostEqual(result, expected_wind_mean)
+
+
 class Test_find_r_values(IrisTest):
     """Test the find_r_values function."""
 

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -243,9 +243,9 @@ class Test_wind_dir_decider(IrisTest):
         expected_out = np.array([[90.0, 55.0],
                                  [280.0, 0.0]])
 
-        result = WindDirection.wind_dir_decider(WIND_DIR_DEG,
-                                                WIND_DIR_DEG_MEAN,
-                                                WIND_DIR_R_VALS, 0.01)
+        result = WindDirection().wind_dir_decider(WIND_DIR_DEG,
+                                                  WIND_DIR_DEG_MEAN,
+                                                  WIND_DIR_R_VALS, 0.01)
 
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayAlmostEqual(result, expected_out)

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -164,13 +164,13 @@ class Test__init__(IrisTest):
 
     def test_backup_method(self):
         """Test that the __init__ accepts this keyword."""
-        WindDirection(low_confidence_method='neighbourhood')
+        WindDirection(backup_method='neighbourhood')
 
     def test_invalid_method(self):
         """Test that the __init__ fails when an unrecognised option is given"""
-        msg = ('Invalid option for keyword low_confidence_method ')
+        msg = ('Invalid option for keyword backup_method ')
         with self.assertRaisesRegexp(ValueError, msg):
-            WindDirection(low_confidence_method='invalid')
+            WindDirection(backup_method='invalid')
 
 
 class Test__repr__(IrisTest):
@@ -179,7 +179,7 @@ class Test__repr__(IrisTest):
     def test_basic(self):
         """Test that the __repr__ returns the expected string."""
         result = str(WindDirection())
-        msg = ('<WindDirection: low_confidence_method "first realization">')
+        msg = ('<WindDirection: backup_method "first realization">')
         self.assertEqual(result, msg)
 
 
@@ -232,6 +232,16 @@ class Test_complex_to_deg(IrisTest):
         """Tests that array of complex values are converted to degrees."""
         result = WindDirection().complex_to_deg(COMPLEX_ANGLES)
         self.assertIsInstance(result, np.ndarray)
+        self.assertArrayAlmostEqual(result, DEGREE_ANGLES)
+
+
+class Test_complex_to_deg_roundtrip(IrisTest):
+    """Test the complex_to_deg and deg_to_complex functions together."""
+
+    def test_basic(self):
+        """Tests that array of values are converted to complex and back."""
+        tmp_complex = WindDirection().deg_to_complex(DEGREE_ANGLES)
+        result = WindDirection().complex_to_deg(tmp_complex)
         self.assertArrayAlmostEqual(result, DEGREE_ANGLES)
 
 

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -285,7 +285,8 @@ class Test_find_r_values(IrisTest):
         self.plugin = WindDirection()
 
     def test_converts_single(self):
-        """Tests that r-value correctly extracted from complex value."""
+        """Tests that r-value is correctly extracted from complex value."""
+        # Attach a cube for the plugin to copy in creating the resulting cube:
         self.plugin.wdir_slice_mean = make_wdir_cube_222()[0][0][0]
         expected_out = 2.0
         # Set-up complex values for angle=45 and r=2
@@ -301,6 +302,7 @@ class Test_find_r_values(IrisTest):
         cube = Cube(COMPLEX_ANGLES, standard_name="wind_from_direction",
                     dim_coords_and_dims=[(longitude, 0)],
                     units="degree")
+        # Attach a cube for the plugin to copy in creating the resulting cube:
         self.plugin.wdir_slice_mean = cube
         self.plugin.wdir_mean_complex = COMPLEX_ANGLES
         expected_out = np.ones(COMPLEX_ANGLES.shape, dtype=np.float32)

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -325,6 +325,8 @@ class Test_calc_confidence_measure(IrisTest):
             np.array([[6.12323400e-17, 0.996194698],
                       [0.984807753, 0.984807753]]))
         self.plugin.wdir_slice_mean = make_wdir_cube_222()[0]
+        self.plugin.wdir_slice_mean.data = np.array([[180.0, 55.0],
+                                                     [280.0, 0.0]])
 
     def test_returns_confidence(self):
         """First element has two angles directly opposite (90 & 270 degs).
@@ -333,9 +335,8 @@ class Test_calc_confidence_measure(IrisTest):
         far the individual ensemble realizationss are away from
         the mean point."""
 
-        expected_out = np.array([[0.0, 0.956422],
-                                 [0.913176, 0.913176]])
-
+        expected_out = np.array([[0.0, 0.95638061],
+                                 [0.91284426, 0.91284426]])
         self.plugin.calc_confidence_measure()
         result = self.plugin.confidence_slice.data
 

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -358,7 +358,6 @@ class WindDirection(object):
 
         if self.backup_method == 'neighbourhood':
             improved_values = np.full_like(self.wdir_slice_mean.data, None)
-            #nbhood.process(self.wdir_complex)
         else:
             # Takes first ensemble realization.
             improved_values = self.wdir_slice.data[0]

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -96,7 +96,7 @@ class WindDirection(object):
         self.backup_methods = ['first realization', 'neighbourhood']
         self.backup_method = backup_method
         if self.backup_method not in self.backup_methods:
-            msg = ('Invalid option for keyword low_confidence_method ' +
+            msg = ('Invalid option for keyword backup_method ' +
                    '({})'.format(self.backup_method))
             raise ValueError(msg)
 
@@ -112,7 +112,7 @@ class WindDirection(object):
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
         return (
-            '<WindDirection: low_confidence_method "{}">'
+            '<WindDirection: backup_method "{}">'
         ).format(self.backup_method)
 
     def _reset(self):

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -229,7 +229,8 @@ class WindDirection(object):
             self.wdir_mean_complex (np.ndarray or float):
                 3D array or float - wind direction angles in complex numbers.
             self.wdir_slice_mean (iris.cube.Cube):
-                3D array or float - wind direction angles in complex numbers.
+                3D array or float - mean wind direction angles in complex
+                numbers.
 
         Defines:
             self.r_vals_slice (iris.cube.Cube):

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -98,12 +98,13 @@ class WindDirection(object):
         if self.backup_method not in self.backup_methods:
             msg = ('Invalid option for keyword low_confidence_method ' +
                    '({})'.format(self.backup_method))
-            raise(ValueError, msg)
+            raise ValueError(msg)
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
-        desc = ('<WindDirection>')
-        return desc
+        return (
+            '<WindDirection: low_confidence_method "{}">'
+        ).format(self.backup_method)
 
     @staticmethod
     def deg_to_complex(angle_deg, radius=1):

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -435,8 +435,8 @@ class WindDirection(object):
             # Finds any meaningless averages and substitute with
             # the wind direction taken from the first ensemble realization.
             # Mask True if r values below threshold.
-            where_low_r = np.where(self.r_vals_slice.data < self.r_thresh, True,
-                                  False)
+            where_low_r = np.where(self.r_vals_slice.data < self.r_thresh,
+                                   True, False)
             # If the any point in the array contains poor r-values,
             # trigger decider function.
             if where_low_r.any():

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -274,21 +274,20 @@ class WindDirection(object):
                 Any r value below threshold is regarded as meaningless.
 
         Defines:
-            self.wdir_mean_complex (np.ndarray):
-                Contains average wind direction in complex numbers.
             self.confidence_slice (iris.cube.Cube):
                 Contains the average distance from mean normalised - used
                 as a confidence value. Inherits meta-data from
                 self.wdir_slice_mean
         """
 
-        self.wdir_mean_complex = self.deg_to_complex(self.wdir_slice_mean.data)
+        # Recalculate complex mean with radius=1.
+        wdir_mean_complex_r1 = self.deg_to_complex(self.wdir_slice_mean.data)
 
         # Find difference in the distance between all the observed points and
         # mean point with fixed r=1.
-        # For maths to work - the "self.wdir_mean_complex array" needs to
+        # For maths to work - the "wdir_mean_complex_r1 array" needs to
         # be "tiled" so that it is the same dimension as "self.wdir_complex".
-        wind_dir_complex_mean_tile = np.tile(self.wdir_mean_complex,
+        wind_dir_complex_mean_tile = np.tile(wdir_mean_complex_r1,
                                              (self.wdir_complex.shape[0],
                                               1, 1))
 


### PR DESCRIPTION
Addresses #495 

Refactors wind direction code to make implementation of IMPRO 598 easier.

One unit test is slightly modified at the 3rd significant figure, otherwise functionality is unchanged.

Testing:
 - [X] Ran tests and they passed OK
 - [X] Added new tests for the new feature(s)

