### PR TITLE
Sphinx: Swap pngmath for mathjax, as pngmath is deprecated.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.mathjax',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Following #591.

Description
This PR switches the use of pngmath, which is a deprecated Sphinx extension for mathjax, which appears to display correctly locally. mathjax has been used in preference to imgmath, as the usage of imgmath led to a number of LaTeX related error messages when run locally.

Reference to maths support within Sphinx: http://www.sphinx-doc.org/en/stable/ext/math.html.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

