### PR TITLE
Addition of library/module requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ cartopy>=0.16.0
 cf_units>=1.2.0
 netCDF4>=1.3.1
 pandas>=0.23.0
-sphinx>=1.7
-statsmodels>=0.9.0
 python-stratify>=0.1
+sphinx>=1.7
+sqlite3>=2.6.0
+statsmodels>=0.9.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Dependencies for a feature complete installation
 # ------------------------------------------------
 
-iris
-cartopy
-cf_units
-pandas
-sphinx
-statsmodels
-
-
+iris>=2.0.0
+cartopy>=0.16.0
+cf_units>=1.2.0
+netCDF4>=1.3.1
+pandas>=0.23.0
+sphinx>=1.7
+statsmodels>=0.9.0
+python-stratify>=0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Dependencies for a feature complete installation
+# ------------------------------------------------
+
+iris
+cartopy
+cf_units
+pandas
+sphinx
+statsmodels
+
+


### PR DESCRIPTION
Addition of a requirements.txt file such that github can show the necessary library dependiencies. Currently excludes default modules like scipy/numpy.

This feels like an omission on our part, so I thought I would add this requirements file to help collaborators ascertain what they need to run IMPROVER. We may wish to include version information, and it's possible I have missed a library/module or thought something is a standard library that is not (e.g. sqlite3).