### PR TITLE
Change to threshold fuzzy factor acceptance test to make it useful.

### DIFF
--- a/tests/improver-threshold/06-fuzzy_factor.bats
+++ b/tests/improver-threshold/06-fuzzy_factor.bats
@@ -38,7 +38,7 @@
   # Run threshold processing and check it passes.
   run improver threshold \
       "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
-      280 --fuzzy_factor 0.2
+      280 --fuzzy_factor 0.99
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO


### PR DESCRIPTION
Changed fuzzy_factor test to give a field demonstrating the effect. Previously, as the fuzzy factor was too large, it gave a huge range in kelvin that encompassed all the data, making the output look like the unthresholded input.

Fuzzy factor changed to give a much smaller range.

Acceptance test data linke to from IMPRO-408

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)