### PR TITLE
Adds neighbourhooding to wind direction as a backup

### DIFF
--- a/lib/improver/nbhood/square_kernel.py
+++ b/lib/improver/nbhood/square_kernel.py
@@ -521,7 +521,7 @@ class SquareNeighbourhood(object):
         # Set up mask_cube
         if not mask_cube:
             mask = cube.copy()
-            mask.data[::] = 1.0
+            mask.data = np.real(np.ones_like(mask.data))
         else:
             mask = mask_cube
         # If there is a mask, fill the data array of the mask_cube with a

--- a/lib/improver/tests/nbhood/square_kernel/test_SquareNeighbourhood.py
+++ b/lib/improver/tests/nbhood/square_kernel/test_SquareNeighbourhood.py
@@ -1090,9 +1090,6 @@ class Test_run(IrisTest):
         result = SquareNeighbourhood(re_mask=False).run(cube, self.RADIUS)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
-    @ManageWarnings(
-        ignored_messages=["Casting complex values to real discards the "
-                          "imaginary part"], warning_types=[np.ComplexWarning])
     def test_complex(self):
         """Test that a cube containing complex numbers is sensibly processed"""
         cube = set_up_cube(

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -355,9 +355,6 @@ class Test_calc_confidence_measure(IrisTest):
 class Test_wind_dir_decider(IrisTest):
     """Test the wind_dir_decider function."""
 
-    @ManageWarnings(
-        ignored_messages=["Casting complex values"],
-        warning_types=[np.ComplexWarning])
     def test_runs_function_1st_member(self):
         """First element has two angles directly opposite (90 & 270 degs).
         Therefore the calculated mean angle of 180 degs is basically
@@ -413,12 +410,12 @@ class Test_wind_dir_decider(IrisTest):
         self.plugin.wdir_complex = np.pad(WIND_DIR_COMPLEX,
                                           ((0, 0), (4, 4), (4, 4)),
                                           "constant",
-                                          constant_values=(0.0, 0.0))
+                                          constant_values=(0.0+ 0.0j))
         self.plugin.wdir_slice_mean = pad_wdir_cube_222()[0]
         self.plugin.wdir_slice_mean.data = np.pad(wind_dir_deg_mean,
                                                   ((4, 4), (4, 4)),
                                                   "constant",
-                                                  constant_values=(0.0, 0.0))
+                                                  constant_values=(0.0+ 0.0j))
 
         self.plugin.wind_dir_decider(where_low_r, cube)
         result = self.plugin.wdir_slice_mean.data

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -250,8 +250,8 @@ class Test_complex_to_deg_roundtrip(IrisTest):
         self.assertArrayAlmostEqual(result, COMPLEX_ANGLES)
 
 
-class Test_wind_dir_mean(IrisTest):
-    """Test the wind_dir_mean function."""
+class Test_calc_wind_dir_mean(IrisTest):
+    """Test the calc_wind_dir_mean function."""
 
     def setUp(self):
         """Initialise plugin and supply data for tests"""
@@ -271,7 +271,7 @@ class Test_wind_dir_mean(IrisTest):
 
     def test_complex(self):
         """Test that the function defines correct complex mean."""
-        self.plugin.wind_dir_mean()
+        self.plugin.calc_wind_dir_mean()
         result = self.plugin.wdir_mean_complex
         expected_complex = (
             self.plugin.deg_to_complex(self.expected_wind_mean,
@@ -280,7 +280,7 @@ class Test_wind_dir_mean(IrisTest):
 
     def test_degrees(self):
         """Test that the function defines correct degrees cube."""
-        self.plugin.wind_dir_mean()
+        self.plugin.calc_wind_dir_mean()
         result = self.plugin.wdir_slice_mean
         self.assertIsInstance(result, Cube)
         self.assertIsInstance(result.data, np.ndarray)
@@ -496,7 +496,8 @@ class Test_process(IrisTest):
             confidence_measure, self.expected_confidence_measure)
 
     def test_with_backup(self):
-        """Test behaviour changes for a low-confidence point."""
+        """Test that wind_dir_decider is invoked to select a better value for
+        a low-confidence point."""
 
         self.cube.data[:, 0, 1, 1] = [0., 72., 144., 216., 288.]
         self.expected_wind_mean[0, 1, 1] = 30.77989074

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -381,7 +381,8 @@ class Test_wind_dir_decider(IrisTest):
 
     @ManageWarnings(
         ignored_messages=["Casting complex values"],
-        warning_types=[np.ComplexWarning])
+        warning_types=[np.ComplexWarning],
+        warnings_list=True)
     def test_runs_function_nbhood(self):
         """First element has two angles directly opposite (90 & 270 degs).
         Therefore the calculated mean angle of 180 degs is basically

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -173,7 +173,7 @@ class Test__repr__(IrisTest):
         """Test that the __repr__ returns the expected string."""
         result = str(WindDirection())
         msg = ('<WindDirection: backup_method "neighbourhood"; neighbourhood '
-            'radius "6000.0"m>')
+               'radius "6000.0"m>')
         self.assertEqual(result, msg)
 
 
@@ -411,12 +411,12 @@ class Test_wind_dir_decider(IrisTest):
         self.plugin.wdir_complex = np.pad(WIND_DIR_COMPLEX,
                                           ((0, 0), (4, 4), (4, 4)),
                                           "constant",
-                                          constant_values=(0.0+ 0.0j))
+                                          constant_values=(0.0 + 0.0j))
         self.plugin.wdir_slice_mean = pad_wdir_cube_222()[0]
         self.plugin.wdir_slice_mean.data = np.pad(wind_dir_deg_mean,
                                                   ((4, 4), (4, 4)),
                                                   "constant",
-                                                  constant_values=(0.0+ 0.0j))
+                                                  constant_values=(0.0 + 0.0j))
 
         self.plugin.wind_dir_decider(where_low_r, cube)
         result = self.plugin.wdir_slice_mean.data

--- a/lib/improver/tests/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_direction/test_WindDirection.py
@@ -380,9 +380,6 @@ class Test_wind_dir_decider(IrisTest):
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayAlmostEqual(result, expected_out)
 
-    @ManageWarnings(
-        ignored_messages=["Casting complex values"],
-        warning_types=[np.ComplexWarning])
     def test_runs_function_nbhood(self):
         """First element has two angles directly opposite (90 & 270 degs).
         Therefore the calculated mean angle of 180 degs is basically
@@ -498,9 +495,6 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(
             confidence_measure, self.expected_confidence_measure)
 
-    @ManageWarnings(
-        ignored_messages=["Casting complex values"],
-        warning_types=[np.ComplexWarning])
     def test_with_backup(self):
         """Test behaviour changes for a low-confidence point."""
 

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -203,7 +203,7 @@ class WindDirection(object):
 
         return angle
 
-    def wind_dir_mean(self):
+    def calc_wind_dir_mean(self):
         """Find the mean wind direction using complex average which actually
            signifies a point between all of the data points in POLAR
            coordinates - NOT the average DEGREE ANGLE.
@@ -375,7 +375,7 @@ class WindDirection(object):
                 wdir_cube.copy(data=self.wdir_complex)).data
             child_class.realization_axis = self.realization_axis
             child_class.wdir_slice_mean = self.wdir_slice_mean.copy()
-            child_class.wind_dir_mean()
+            child_class.calc_wind_dir_mean()
             improved_values = child_class.wdir_slice_mean.data
         else:
             # Takes realization zero (control member).
@@ -444,7 +444,7 @@ class WindDirection(object):
             self.wdir_slice_mean.remove_coord("realization")
 
             # Derive average wind direction.
-            self.wind_dir_mean()
+            self.calc_wind_dir_mean()
 
             # Find radius values for wind direction average.
             self.find_r_values()

--- a/lib/improver/wind_direction.py
+++ b/lib/improver/wind_direction.py
@@ -33,8 +33,10 @@
 import iris
 from iris.coords import CellMethod
 import numpy as np
+import math
 from improver.utilities.cube_checker import check_cube_coordinates
 from improver.utilities.cube_manipulation import enforce_float32_precision
+from improver.nbhood.nbhood import NeighbourhoodProcessing
 
 
 class WindDirection(object):
@@ -84,14 +86,14 @@ class WindDirection(object):
         backup_method (str):
             Backup method to use if the complex numbers approach has low
             confidence.
-            "first realization" (default) uses the value of realization zero.
-            "neighbourhood" recalculates using the complex numbers approach
-            with additional realizations extracted from neighbouring grid
-            points from all available realizations.
+            "first realization" uses the value of realization zero.
+            "neighbourhood" (default) recalculates using the complex numbers
+            approach with additional realizations extracted from neighbouring
+            grid points from all available realizations.
 
     """
 
-    def __init__(self, backup_method='first realization'):
+    def __init__(self, backup_method='neighbourhood'):
         """Initialise class."""
         self.backup_methods = ['first realization', 'neighbourhood']
         self.backup_method = backup_method
@@ -333,34 +335,51 @@ class WindDirection(object):
                 Array of boolean values. True where original wind direction
                 estimate has low confidence. These points are replaced
                 according to self.backup_method
-            first_member (np.array):
-                Array of wind direction data from the first ensemble
+            first_member (iris.cube.Cube):
+                Contains array of wind direction data from the first ensemble
                 realization
 
         Uses:
-            self.wdir_slice.data (np.ndarray):
-                3D array - wind direction angles from ensembles (in degrees).
-            self.wdir_slice_mean.data (np.ndarray):
-                2D array - average wind direction angle (in degrees).
+            self.wdir_slice_mean (iris.cube.Cube):
+                Containing average wind direction angle (in degrees).
+            self.wdir_complex (np.ndarray):
+                3D array - wind direction angles from ensembles (in complex).
             self.r_vals_slice.data (np.ndarray):
                 2D array - Radius taken from average complex wind direction
                 angle.
             self.r_thresh (float):
                 Any r value below threshold is regarded as meaningless.
+            self.realization_axis (int):
+                Axis to collapse over.
+            self.n_realizations (int):
+                Number of realizations available in the plugin. Used to set the
+                neighbourhood radius as this is used to adjust the radius again
+                in the neighbourhooding plugin.
 
         Defines:
             self.wdir_slice_mean.data (np.ndarray):
                 2D array - Wind direction degrees where ambigious values have
                 been replaced with data from first ensemble realization.
         """
-
         if self.backup_method == 'neighbourhood':
-            improved_values = np.full_like(self.wdir_slice_mean.data, None)
+            # Performs smoothing over a 6km square neighbourhood.
+            # Then calculates the mean wind direction.
+            nb_radius = math.sqrt((6000.**2.) * self.n_realizations)
+            nbhood = NeighbourhoodProcessing('square',
+                                             nb_radius,
+                                             weighted_mode=False)
+            child_class = WindDirection(backup_method="first realization")
+            child_class.wdir_complex = nbhood.process(
+                first_member.copy(data=self.wdir_complex)).data
+            child_class.realization_axis = self.realization_axis
+            child_class.wdir_slice_mean = self.wdir_slice_mean.copy()
+            child_class.wind_dir_mean()
+            improved_values = child_class.wdir_slice_mean.data
         else:
             # Takes first ensemble realization.
-            improved_values = first_member
+            improved_values = first_member[0].data
 
-        # If the r-value is low - subistite average wind direction value for
+        # If the r-value is low - substitute average wind direction value for
         # the wind direction taken from the first ensemble realization.
         self.wdir_slice_mean.data = np.where(where_low_r, improved_values,
                                              self.wdir_slice_mean.data)
@@ -404,6 +423,7 @@ class WindDirection(object):
         # Force input cube to float32.
         enforce_float32_precision(cube_ens_wdir)
 
+        self.n_realizations = len(cube_ens_wdir.coord('realization').points)
         y_coord_name = cube_ens_wdir.coord(axis="y").name()
         x_coord_name = cube_ens_wdir.coord(axis="x").name()
         for wdir_slice in cube_ens_wdir.slices(["realization",
@@ -429,8 +449,6 @@ class WindDirection(object):
             # Calculate the confidence measure based on the difference
             # between the complex average and the individual ensemble
             # realizations.
-            # TODO: This will still need some further investigation.
-            #        This is will be the subject of another ticket.
             self.calc_confidence_measure()
 
             # Finds any meaningless averages and substitute with
@@ -441,7 +459,7 @@ class WindDirection(object):
             # If the any point in the array contains poor r-values,
             # trigger decider function.
             if where_low_r.any():
-                self.wind_dir_decider(where_low_r, wdir_slice.data[0])
+                self.wind_dir_decider(where_low_r, wdir_slice)
 
             # Append to cubelists.
             self.wdir_cube_list.append(self.wdir_slice_mean)


### PR DESCRIPTION
Addresses #495 

Adds a new (and default) backup method for most-likely wind direction to sample the local neighbourhood as well as other ensemble members when the derived wind direction comes with low confidence.

Follows PR #592

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
