### PR TITLE
Added source of modules to remove ambiguity.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Dependencies for a feature complete installation
 # ------------------------------------------------
 
-iris>=2.0.0
-cartopy>=0.16.0
-cf_units>=1.2.0
+SciTools/iris>=2.0.0
+SciTools/cartopy>=0.16.0
+SciTools/cf_units>=1.2.0
 netCDF4>=1.3.1
 pandas>=0.23.0
-python-stratify>=0.1
+SciTools-incubator/python-stratify>=0.1
 sphinx>=1.7
 sqlite3>=2.6.0
 statsmodels>=0.9.0


### PR DESCRIPTION
Added scitools prefix to modules to remove ambiguity; specifically iris is being identified as a linkedin module, rather than scitools.