### PR TITLE
Modification to the load function to handle merging cubes with different history attributes

### DIFF
--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -233,8 +233,8 @@ class Test_load_cube(IrisTest):
 
     def test_prefix_cube_removed(self):
         """Test metadata prefix cube is discarded during load"""
-        msg = "no cubes found"
-        with self.assertRaisesRegexp(ConstraintMismatchError, msg):
+        msg = "No cubes found"
+        with self.assertRaisesRegexp(ValueError, msg):
             load_cube(self.filepath, 'prefixes')
 
     def test_no_lazy_load(self):

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -35,7 +35,8 @@ import glob
 import iris
 from iris.exceptions import ConstraintMismatchError
 
-from improver.utilities.cube_manipulation import enforce_coordinate_ordering
+from improver.utilities.cube_manipulation import (
+    enforce_coordinate_ordering, merge_cubes)
 
 
 def load_cube(filepath, constraints=None, no_lazy_load=False):
@@ -63,8 +64,14 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
     # Remove metadata prefix cube if present
     constraints = iris.Constraint(
         cube_func=lambda cube: cube.long_name != 'prefixes') & constraints
-    cube = iris.load_cube(filepath, constraint=constraints)
-
+    cubes = iris.load(filepath, constraints=constraints)
+    if len(cubes) is 0:
+        message = "No cubes found using contraints {}".format(constraints)
+        raise ValueError(message)
+    elif len(cubes) is not 1:
+        cube = merge_cubes(cubes)
+    else:
+        cube = cubes[0]
     # Remove metadata prefix cube attributes
     if 'bald__isPrefixedBy' in cube.attributes.keys():
         cube.attributes.pop('bald__isPrefixedBy')
@@ -117,7 +124,7 @@ def load_cubelist(filepath, constraints=None, no_lazy_load=False):
     for filepath in filepaths:
         try:
             cube = load_cube(filepath, constraints=constraints)
-        except ConstraintMismatchError:
+        except ValueError:
             continue
         if no_lazy_load:
             # Force the cube's data into memory by touching the .data.

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -65,7 +65,7 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
     constraints = iris.Constraint(
         cube_func=lambda cube: cube.long_name != 'prefixes') & constraints
     cubes = iris.load(filepath, constraints=constraints)
-    if len(cubes) == 0:
+    if not cubes:
         message = "No cubes found using contraints {}".format(constraints)
         raise ValueError(message)
     elif len(cubes) == 1:

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -65,13 +65,13 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
     constraints = iris.Constraint(
         cube_func=lambda cube: cube.long_name != 'prefixes') & constraints
     cubes = iris.load(filepath, constraints=constraints)
-    if len(cubes) is 0:
+    if len(cubes) == 0:
         message = "No cubes found using contraints {}".format(constraints)
         raise ValueError(message)
-    elif len(cubes) is not 1:
-        cube = merge_cubes(cubes)
-    else:
+    elif len(cubes) == 1:
         cube = cubes[0]
+    else:
+        cube = merge_cubes(cubes)
     # Remove metadata prefix cube attributes
     if 'bald__isPrefixedBy' in cube.attributes.keys():
         cube.attributes.pop('bald__isPrefixedBy')


### PR DESCRIPTION
Addresses IMPRO-734

When testing the triangular blending in the suite we realised that if the history attributes are different then the load function fails. These changes address this problem.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)


