### PR TITLE
Adding wind_speed_of_gust to BOUNDS_FOR_ECDF

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -53,6 +53,7 @@ BOUNDS_FOR_ECDF = {
     "air_temperature": (
         Bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
     "wind_speed": Bounds((0, 50), "m s^-1"),
+    "wind_speed_of_gust": Bounds((0, 50), "m s^-1"),
     "air_pressure_at_sea_level": Bounds((94000, 107000), "Pa"),
     ("cloud_base_altitude_assuming_only_consider_cloud_area" +
      "_fraction_greater_than_2p5_oktas"): Bounds((-300, 20000), "m"),


### PR DESCRIPTION
Required to add windgusttypical as a verification parameter for https://exxconfigmgmt:6391/browse/IMPRO-770

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
