### PR TITLE
ECC: Masked data replaced with nans to avoid processing fill values

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
@@ -62,6 +62,9 @@ def convert_cube_data_to_2d(
 
     """
     forecast_data = []
+    if np.ma.is_masked(forecast.data):
+        forecast.data = np.ma.filled(forecast.data, np.nan)
+
     for coord_slice in forecast.slices_over(coord):
         forecast_data.append(coord_slice.data.flatten())
     if transpose:


### PR DESCRIPTION
Replace masked points with nans to avoid the use of fill values in further processing. This is to avoid issues with precision leading to different behaviours.

Testing:
 - [x] Ran tests and they passed OK