### PR TITLE
Add facility for running a single CLI test

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -145,17 +145,26 @@ function improver_test_cli {
     fi
 
     for SUBTEST in $CLISUBTEST; do
-        test_dir=$IMPROVER_DIR/tests/improver-$SUBTEST/
-        test_dir="$(echo -e "${test_dir}" | tr -d '[:space:]')"
+        if [[ -f $SUBTEST ]]; then
+            # A particular file rather than a subdir name.
+            TEST_TARGET="$SUBTEST"
+        else
+            TEST_TARGET="$IMPROVER_DIR/tests/improver-$SUBTEST/"
+        fi
         if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
             PROVE_VERBOSE_OPT=
             if [[ -n $DEBUG_OPT ]]; then
                 PROVE_VERBOSE_OPT='-v'
             fi
             prove $PROVE_VERBOSE_OPT --directives -r -j 4 \
-                -e "bats --tap" --ext ".bats" --timer $test_dir
+                -e "bats --tap" --ext ".bats" --timer $TEST_TARGET
         else
-            bats $(find $test_dir -name "*.bats")
+            if [[ -f "$TEST_TARGET" ]]; then
+                # A particular file rather than a directory.
+                bats $TEST_TARGET
+            else
+                bats $(find $TEST_TARGET -name "*.bats")
+            fi
         fi
     done
     echo_ok "CLI tests"
@@ -175,14 +184,18 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: pycodestyle, pylint, pylintE, licence, doc, unit, cli.
-                    pycodestyle, pylintE, licence, doc, unit, and cli are the default tests.
-    SUBCLI          Name(s) of cli subtests to run without running the rest.
-                    Valid names are tasks which appear in /improver/tests/
-                    without the "improver-" prefix. The default is to run all
-                    cli tests in the /improver/tests/ directory.
-                    e.g. 'improver tests cli nbhood' will run neighbourhood
-                    processing cli tests only.
+                    Valid names are: pycodestyle, pylint, pylintE, licence,
+                    doc, unit, cli. pycodestyle, pylintE, licence, doc, unit,
+                    and cli are the default tests.
+    SUBCLI          Name(s) of cli tests to run without running the rest.
+                    Valid names are either directory names which appear in
+                    tests/ minus the "improver-" prefix, or paths to individual
+                    BATS test files. The default is to run all cli tests in the
+                    tests/ directory. For example, 'improver tests cli nbhood'
+                    will run neighbourhood processing cli tests in
+                    tests/improver-nbhood/*.bats.
+                    'improver tests cli ~/improver/tests/improver-nbhood/01-help.bats'
+                    will only run that specific nbhood CLI test.
 __USAGE__
 }
 
@@ -198,6 +211,7 @@ for i in $opts; do
   if [[ "$fname" != "bin" ]] && [[ "$fname" != "lib" ]]; then
     cli_tasks+="${fname##*improver-}|"
   fi
+  cli_tasks+='*.bats|'
 done
 cli_tasks+=')'
 

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -145,14 +145,15 @@ function improver_test_cli {
     fi
 
     for SUBTEST in $CLISUBTEST; do
-        if [[ -f "$SUBTEST" ]]; then
-            # A particular file rather than a subdir name.
-            TEST_TARGET="$SUBTEST"
-        elif [[ -f "$TEST_INPUT_PWD/$SUBTEST" ]]; then
-            # A particular file relative to the original $PWD.
+        if [[ -e "$IMPROVER_DIR/tests/improver-$SUBTEST" ]]; then
+            # A shorthand path.
+            TEST_TARGET="$IMPROVER_DIR/tests/improver-$SUBTEST"
+        elif [[ -e "$TEST_INPUT_PWD/$SUBTEST" ]]; then
+            # A relative path to a file or directory.
             TEST_TARGET="$TEST_INPUT_PWD/$SUBTEST"
         else
-            TEST_TARGET="$IMPROVER_DIR/tests/improver-$SUBTEST/"
+            # Assume a full path to a file or directory.
+            TEST_TARGET="$SUBTEST"
         fi
         if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
             PROVE_VERBOSE_OPT=
@@ -191,10 +192,20 @@ Arguments:
                     doc, unit, cli. pycodestyle, pylintE, licence, doc, unit,
                     and cli are the default tests.
     SUBCLI          Name(s) of cli tests to run without running the rest.
-                    Valid names are either directory names which appear in
-                    tests/ minus the "improver-" prefix, or paths to individual
-                    BATS test files. The default is to run all cli tests in the
-                    tests/ directory. For example, 'improver tests cli nbhood'
+                    Valid names are either:
+                     * directory names which appear in tests/ minus the
+                       "improver-" prefix, e.g. 'nbhood'
+                     * as above, but also including a bats file, e.g.
+                       'nbhood/01-help.bats'
+                     * full or relative paths to directories or individual BATS
+                       test files, e.g.
+                       'tests/improver-nbhood/01-help.bats' or
+                       '$HOME/improver/tests/improver-nbhood/'.
+                    The default is to run all cli tests in the tests/
+                    directory. If a directory is given, all tests within the
+                    directory will be run. If a specific BATS file is given,
+                    only that will be run. For example,
+                    'improver tests cli nbhood'
                     will run neighbourhood processing cli tests in
                     tests/improver-nbhood/*.bats.
                     'improver tests cli ~/improver/tests/improver-nbhood/01-help.bats'
@@ -214,6 +225,7 @@ for i in $opts; do
   fname=${i##*/}
   if [[ "$fname" != "bin" ]] && [[ "$fname" != "lib" ]]; then
     cli_tasks+="${fname##*improver-}|"
+    cli_tasks+="*/${fname}?(/)|"
   fi
   cli_tasks+='*.bats|'
 done

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -173,7 +173,7 @@ function improver_test_cli {
 function print_usage {
     # Output CLI usage information.
     cat <<'__USAGE__'
-improver tests [OPTIONS] [SUBTEST...]
+improver tests [OPTIONS] [SUBTEST...] [SUBCLI...]
 
 Run pycodestyle, pylint, documentation, unit and CLI acceptance tests.
 

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -145,9 +145,12 @@ function improver_test_cli {
     fi
 
     for SUBTEST in $CLISUBTEST; do
-        if [[ -f $SUBTEST ]]; then
+        if [[ -f "$SUBTEST" ]]; then
             # A particular file rather than a subdir name.
             TEST_TARGET="$SUBTEST"
+        elif [[ -f "$TEST_INPUT_PWD/$SUBTEST" ]]; then
+            # A particular file relative to the original $PWD.
+            TEST_TARGET="$TEST_INPUT_PWD/$SUBTEST"
         else
             TEST_TARGET="$IMPROVER_DIR/tests/improver-$SUBTEST/"
         fi
@@ -161,9 +164,9 @@ function improver_test_cli {
         else
             if [[ -f "$TEST_TARGET" ]]; then
                 # A particular file rather than a directory.
-                bats $TEST_TARGET
+                bats "$TEST_TARGET"
             else
-                bats $(find $TEST_TARGET -name "*.bats")
+                bats $(find "$TEST_TARGET" -name "*.bats")
             fi
         fi
     done
@@ -199,6 +202,7 @@ Arguments:
 __USAGE__
 }
 
+TEST_INPUT_PWD=$(cd $PWD && pwd -P)
 cd $IMPROVER_DIR/lib
 #cd $IMPROVER_DIR
 

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -227,8 +227,8 @@ for i in $opts; do
     cli_tasks+="${fname##*improver-}|"
     cli_tasks+="*/${fname}?(/)|"
   fi
-  cli_tasks+='*.bats|'
 done
+cli_tasks+='*.bats|'
 cli_tasks+=')'
 
 BATS_OPT=
@@ -270,7 +270,7 @@ fi
 
 # If cli sub test is not specified by user, do all cli tests.
 # Otherwise set CLISUBTEST to the sub test to run.
-CLISUBTEST=$cli_tasks
+CLISUBTEST="$IMPROVER_DIR/tests/"
 STRIPPED_TEST="$(echo -e "${TESTS}" | tr -d '[:space:]')"
 if [[ $STRIPPED_TEST == "cli" ]]; then
     if [[ -n "$SUBCLI" ]]; then

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -48,10 +48,20 @@ Arguments:
                     doc, unit, cli. pycodestyle, pylintE, licence, doc, unit,
                     and cli are the default tests.
     SUBCLI          Name(s) of cli tests to run without running the rest.
-                    Valid names are either directory names which appear in
-                    tests/ minus the "improver-" prefix, or paths to individual
-                    BATS test files. The default is to run all cli tests in the
-                    tests/ directory. For example, 'improver tests cli nbhood'
+                    Valid names are either:
+                     * directory names which appear in tests/ minus the
+                       "improver-" prefix, e.g. 'nbhood'
+                     * as above, but also including a bats file, e.g.
+                       'nbhood/01-help.bats'
+                     * full or relative paths to directories or individual BATS
+                       test files, e.g.
+                       'tests/improver-nbhood/01-help.bats' or
+                       '$HOME/improver/tests/improver-nbhood/'.
+                    The default is to run all cli tests in the tests/
+                    directory. If a directory is given, all tests within the
+                    directory will be run. If a specific BATS file is given,
+                    only that will be run. For example,
+                    'improver tests cli nbhood'
                     will run neighbourhood processing cli tests in
                     tests/improver-nbhood/*.bats.
                     'improver tests cli ~/improver/tests/improver-nbhood/01-help.bats'

--- a/tests/improver-tests/00-help.bats
+++ b/tests/improver-tests/00-help.bats
@@ -33,7 +33,7 @@
   run improver tests -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [OPTIONS] [SUBTEST...]
+improver tests [OPTIONS] [SUBTEST...] [SUBCLI...]
 
 Run pycodestyle, pylint, documentation, unit and CLI acceptance tests.
 
@@ -44,14 +44,18 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: pycodestyle, pylint, pylintE, licence, doc, unit, cli.
-                    pycodestyle, pylintE, licence, doc, unit, and cli are the default tests.
-    SUBCLI          Name(s) of cli subtests to run without running the rest.
-                    Valid names are tasks which appear in /improver/tests/
-                    without the "improver-" prefix. The default is to run all
-                    cli tests in the /improver/tests/ directory.
-                    e.g. 'improver tests cli nbhood' will run neighbourhood
-                    processing cli tests only.
+                    Valid names are: pycodestyle, pylint, pylintE, licence,
+                    doc, unit, cli. pycodestyle, pylintE, licence, doc, unit,
+                    and cli are the default tests.
+    SUBCLI          Name(s) of cli tests to run without running the rest.
+                    Valid names are either directory names which appear in
+                    tests/ minus the "improver-" prefix, or paths to individual
+                    BATS test files. The default is to run all cli tests in the
+                    tests/ directory. For example, 'improver tests cli nbhood'
+                    will run neighbourhood processing cli tests in
+                    tests/improver-nbhood/*.bats.
+                    'improver tests cli ~/improver/tests/improver-nbhood/01-help.bats'
+                    will only run that specific nbhood CLI test.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -33,7 +33,7 @@
   run improver tests --silly-option
   [[ "$status" -eq 2 ]]
   read -d '' expected <<'__HELP__' || true
-improver tests [OPTIONS] [SUBTEST...]
+improver tests [OPTIONS] [SUBTEST...] [SUBCLI...]
 
 Run pycodestyle, pylint, documentation, unit and CLI acceptance tests.
 
@@ -44,14 +44,18 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: pycodestyle, pylint, pylintE, licence, doc, unit, cli.
-                    pycodestyle, pylintE, licence, doc, unit, and cli are the default tests.
-    SUBCLI          Name(s) of cli subtests to run without running the rest.
-                    Valid names are tasks which appear in /improver/tests/
-                    without the "improver-" prefix. The default is to run all
-                    cli tests in the /improver/tests/ directory.
-                    e.g. 'improver tests cli nbhood' will run neighbourhood
-                    processing cli tests only.
+                    Valid names are: pycodestyle, pylint, pylintE, licence,
+                    doc, unit, cli. pycodestyle, pylintE, licence, doc, unit,
+                    and cli are the default tests.
+    SUBCLI          Name(s) of cli tests to run without running the rest.
+                    Valid names are either directory names which appear in
+                    tests/ minus the "improver-" prefix, or paths to individual
+                    BATS test files. The default is to run all cli tests in the
+                    tests/ directory. For example, 'improver tests cli nbhood'
+                    will run neighbourhood processing cli tests in
+                    tests/improver-nbhood/*.bats.
+                    'improver tests cli ~/improver/tests/improver-nbhood/01-help.bats'
+                    will only run that specific nbhood CLI test.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-tests/01-bad-option.bats
+++ b/tests/improver-tests/01-bad-option.bats
@@ -48,10 +48,20 @@ Arguments:
                     doc, unit, cli. pycodestyle, pylintE, licence, doc, unit,
                     and cli are the default tests.
     SUBCLI          Name(s) of cli tests to run without running the rest.
-                    Valid names are either directory names which appear in
-                    tests/ minus the "improver-" prefix, or paths to individual
-                    BATS test files. The default is to run all cli tests in the
-                    tests/ directory. For example, 'improver tests cli nbhood'
+                    Valid names are either:
+                     * directory names which appear in tests/ minus the
+                       "improver-" prefix, e.g. 'nbhood'
+                     * as above, but also including a bats file, e.g.
+                       'nbhood/01-help.bats'
+                     * full or relative paths to directories or individual BATS
+                       test files, e.g.
+                       'tests/improver-nbhood/01-help.bats' or
+                       '$HOME/improver/tests/improver-nbhood/'.
+                    The default is to run all cli tests in the tests/
+                    directory. If a directory is given, all tests within the
+                    directory will be run. If a specific BATS file is given,
+                    only that will be run. For example,
+                    'improver tests cli nbhood'
                     will run neighbourhood processing cli tests in
                     tests/improver-nbhood/*.bats.
                     'improver tests cli ~/improver/tests/improver-nbhood/01-help.bats'


### PR DESCRIPTION
Allows running a single CLI test from the command line.

This saves quite a bit of time when you have a problem with a
particular test in a slow category like nbhood.

Testing:
 - [ ] Ran tests and they passed OK

