### PR TITLE
Speed up serial performance of masked nbhood

### DIFF
--- a/bin/improver-nbhood-land-and-sea
+++ b/bin/improver-nbhood-land-and-sea
@@ -115,7 +115,7 @@ def main():
     args = parser.parse_args()
 
     cube = load_cube(args.input_filepath)
-    mask = load_cube(args.input_mask_filepath)
+    mask = load_cube(args.input_mask_filepath, no_lazy_load=True)
     masking_coordinate = None
 
     if any(['topographic_zone' in coord.name()
@@ -131,7 +131,7 @@ def main():
                           'of topographic zones to collapse the resulting '
                           'vertical dimension.')
 
-        weights = load_cube(args.weights_for_collapsing_dim)
+        weights = load_cube(args.weights_for_collapsing_dim, no_lazy_load=True)
         if weights.attributes['topographic_zones_include_seapoints'] == 'True':
             raise ValueError('The weights cube must be masked to exclude sea '
                              'points, but topographic_zones_include_seapoints '

--- a/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -276,8 +276,8 @@ class Test_process(IrisTest):
         result = ApplyNeighbourhoodProcessingWithAMask(
             coord_for_masking, radii).process(cube, self.mask_cube)
         self.assertEqual(result.data.shape, expected_shape)
-        for slice in result.slices_over("realization"):
-            self.assertArrayAlmostEqual(slice.data, expected)
+        for realization_slice in result.slices_over("realization"):
+            self.assertArrayAlmostEqual(realization_slice.data, expected)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/lib/improver/tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -259,7 +259,7 @@ class Test_process(IrisTest):
               [np.nan, np.nan, 1.00, 1.00, 1.00],
               [np.nan, np.nan, 1.00, 1.00, 1.00]]])
         cube = set_up_cube(
-            zero_point_indices=((0, 0, 2, 2),(1, 0, 2, 2)), num_grid_points=5,
+            zero_point_indices=((0, 0, 2, 2), (1, 0, 2, 2)), num_grid_points=5,
             num_realization_points=2)
         # The neighbourhood code adds bounds to the coordinates if they are
         # not present so add them now to make it easier to compare input and

--- a/tests/improver-nbhood-land-and-sea/11-topographic_bands_probs.bats
+++ b/tests/improver-nbhood-land-and-sea/11-topographic_bands_probs.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "nbhood-land-and-sea input mask output probs" --radius=20000 {
+  improver_check_skip_acceptance
+  KGO="nbhood-land-and-sea/topographic_bands/kgo_probs.nc"
+
+  # Run neighbourhood processing and check it passes.
+  run improver nbhood-land-and-sea "$IMPROVER_ACC_TEST_DIR/nbhood-land-and-sea/topographic_bands/input_probs.nc" "$IMPROVER_ACC_TEST_DIR/nbhood-land-and-sea/topographic_bands/topographic_bands_land.nc" "$TEST_DIR/output.nc" --radius=20000 --weights "$IMPROVER_ACC_TEST_DIR/nbhood-land-and-sea/topographic_bands/weights_land.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Contributes towards #583 and closes #473.

This should go in after #637, which gives a proper control result for this to be proved against.

This speeds up masked neighbourhood processing, particularly when probabilities are sometimes the same from one threshold to the next (e.g. for very low or very high thresholds).

One speedup comes from non-lazy-loading the weights and masks cubes in nbhood-land-and-sea (#473). These are small enough not to make a real difference to memory, and otherwise get read in repeatedly, incurring an I/O cost in elapsed time. This is definitely a worthwhile thing to switch off.

The other result comes from reusing the previous neighbourhood processing result when the previous input is the same as the current one. This is true when we take 2D slices over thresholds where successive thresholds' arrays are uniform - e.g. all zero or all one, such as very low or very high air temperatures. This speeds current code up, and reduces the cost of adding extra thresholds at low or high ends.

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added test in #637 and it ran OK

