### PR TITLE
Run multiple CLI tests at once

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -152,7 +152,7 @@ function improver_test_cli {
             if [[ -n $DEBUG_OPT ]]; then
                 PROVE_VERBOSE_OPT='-v'
             fi
-            prove $PROVE_VERBOSE_OPT --directives -r \
+            prove $PROVE_VERBOSE_OPT --directives -r -j 4 \
                 -e "bats --tap" --ext ".bats" --timer $test_dir
         else
             bats $(find $test_dir -name "*.bats")


### PR DESCRIPTION
Speeds up prove-run CLI BATS tests by using prove's parallel option.

This number of tests at once seems to fit just about OK within the memory we typically have here for our current test data. Memory use gets a bit spiky with some of the nbhood tests!

Testing:
 - [x] Ran tests and they passed OK
