### PR TITLE
Selects pylint version 1.9.1 to fix Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda install -c conda-forge iris=2.0
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint pandas python-stratify sphinx=1.7.0 coverage
+  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 coverage
   - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.


### PR DESCRIPTION
Travis has started failing for some PRs. (e.g. #653 )
Fixing the pylint version in Travis to 1.9.1 resolves this problem, so this PR applies this change.

Testing:
 - [x] Ran tests and they passed OK
