### PR TITLE
IMPRO-862 Added function to promote threshold scalar coords to dims

### DIFF
--- a/lib/improver/blending/blend_across_adjacent_points.py
+++ b/lib/improver/blending/blend_across_adjacent_points.py
@@ -37,6 +37,7 @@ import iris
 from improver.blending.weights import ChooseDefaultWeightsTriangular
 from improver.utilities.cube_manipulation import concatenate_cubes
 from improver.blending.weighted_blend import WeightedBlendAcrossWholeDimension
+from improver.utilities.cube_checker import check_cube_coordinates
 
 
 class TriangularWeightedBlendAcrossAdjacentPoints(object):
@@ -172,5 +173,11 @@ class TriangularWeightedBlendAcrossAdjacentPoints(object):
         weights = self.WeightsPlugin.process(
             cube, self.coord, self.central_point)
         blended_cube = self.BlendingPlugin.process(cube, weights)
+
+        # With one threshold dimension (such as for low cloud), the threshold
+        # axis is demoted to a scalar co-ordinate by BlendingPlugin. This line
+        # promotes threshold to match the dimensions of central_point_cube.
+        blended_cube = check_cube_coordinates(central_point_cube, blended_cube)
+
         blended_cube = central_point_cube.copy(blended_cube.data)
         return blended_cube


### PR DESCRIPTION
Addresses #GitHubissuenum

Description

IMPRO-862.
Fix triangle time blending for cldlow processing chain.

After investigation it turned out that the problem lay in the class WeightedBlendAcrossWholeDimension which made the assumption that there would be multiple threshold axes.
When there was only one threshold axis, the merge_cubes function would then demote this to a scalar co-ordinate.

Added a line to "blend_across_adjacent_points.py" to reverse this as well as unit tests to ensure that this behaviour is enforced.

Testing:
 - [ x] Ran tests and they passed OK
 - [ x] Added new tests for the new feature(s)