### PR TITLE
Fix warnings breaking unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ install:
   - conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION
   - source activate $ENV_NAME
 
-  # Download Iris 2.0 and all dependencies.
-  - conda install -c conda-forge iris=2.0
+  # Download Iris 2.1 and all dependencies.
+  - conda install -c conda-forge iris=2.1
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 dask=0.18.2 distributed=1.22.1 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda install -c conda-forge iris=2.0
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 coverage
+  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 dask=0.18.2 coverage
   - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda install -c conda-forge iris=2.0
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 dask=0.18.2 coverage
+  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 dask=0.18.2 distributed=1.22.1 coverage
   - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ install:
   - conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION
   - source activate $ENV_NAME
 
-  # Download Iris 2.1 and all dependencies.
-  - conda install -c conda-forge iris=2.1
+  # Download Iris 2.X and all dependencies.
+  - conda install -c conda-forge iris
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 dask=0.18.2 distributed=1.22.1 coverage


### PR DESCRIPTION
This attempts to fix a current failure on master where a number of future warnings appear and break tests that count warnings:

`iris/coords.py:1162: FutureWarning: Conversion of the second argument of issubdtype from `str` to `str` is deprecated. In future, it will be treated as `np.str_ == np.dtype(str).type`.`