### PR TITLE
Address trunk travis failure - Additional changes required long term.

### DIFF
--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -883,11 +883,10 @@ class Test__apply_params(IrisTest):
             predictor_cube, variance_cube, optimised_coeffs,
             self.coeff_names, predictor_of_mean_flag)
 
-        self.assertTrue(len(warning_list) == 1)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
-        self.assertTrue("Ensemble calibration not available"
-                        in str(warning_list[0]))
+        self.assertTrue(any(["Ensemble calibration not available"
+                             in str(warning) for warning in warning_list]))
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -462,11 +462,10 @@ class Test_crps_minimiser_wrapper(IrisTest):
         result = plugin.crps_minimiser_wrapper(
             initial_guess, forecast_predictor, truth, forecast_variance,
             predictor_of_mean_flag, distribution)
-        self.assertTrue(len(warning_list) == 1)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
-        self.assertTrue("Minimisation did not result in convergence after"
-                        in str(warning_list[0]))
+        self.assertTrue(any(["Minimisation did not result in convergence after"
+                             in str(warning) for warning in warning_list]))
 
     @ManageWarnings(
         record=True,
@@ -496,13 +495,13 @@ class Test_crps_minimiser_wrapper(IrisTest):
         result = plugin.crps_minimiser_wrapper(
             initial_guess, forecast_predictor, truth, forecast_variance,
             predictor_of_mean_flag, distribution)
-        self.assertTrue(len(warning_list) == 2)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
-        self.assertTrue("Minimisation did not result in convergence after"
-                        in str(warning_list[0]))
-        self.assertTrue("The final iteration resulted in a percentage "
-                        "change" in str(warning_list[1]))
+        self.assertTrue(any(["Minimisation did not result in convergence after"
+                             in str(warning) for warning in warning_list]))
+        self.assertTrue(any(["The final iteration resulted in a percentage "
+                             "change" in str(warning) for warning in
+                             warning_list]))
 
     """Test minimising the CRPS for a truncated_normal distribution."""
     @ManageWarnings(
@@ -705,11 +704,10 @@ class Test_crps_minimiser_wrapper(IrisTest):
         result = plugin.crps_minimiser_wrapper(
             initial_guess, forecast_predictor, truth, forecast_variance,
             predictor_of_mean_flag, distribution)
-        self.assertTrue(len(warning_list) == 1)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
-        self.assertTrue("Minimisation did not result in convergence after"
-                        in str(warning_list[0]))
+        self.assertTrue(any(["Minimisation did not result in convergence after"
+                             in str(warning) for warning in warning_list]))
 
     @ManageWarnings(
         record=True,
@@ -741,13 +739,13 @@ class Test_crps_minimiser_wrapper(IrisTest):
         result = plugin.crps_minimiser_wrapper(
             initial_guess, forecast_predictor, truth, forecast_variance,
             predictor_of_mean_flag, distribution)
-        self.assertTrue(len(warning_list) == 2)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
-        self.assertTrue("Minimisation did not result in convergence after"
-                        in str(warning_list[0]))
-        self.assertTrue("The final iteration resulted in a percentage "
-                        "change" in str(warning_list[1]))
+        self.assertTrue(any(["Minimisation did not result in convergence after"
+                             in str(warning) for warning in warning_list]))
+        self.assertTrue(any(["The final iteration resulted in a percentage "
+                             "change" in str(warning) for warning in
+                             warning_list]))
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -61,10 +61,11 @@ IGNORED_MESSAGES = ["Collapsing a non-contiguous coordinate.",
                     " convergence",
                     "\nThe final iteration resulted in a percentage "
                     "change that is greater than the"
-                    " accepted threshold "]
+                    " accepted threshold ",
+                    "Conversion of the second argument of issubdtype"]
 WARNING_TYPES = [UserWarning, ImportWarning, FutureWarning, RuntimeWarning,
                  ImportWarning, DeprecationWarning, ImportWarning, UserWarning,
-                 UserWarning, UserWarning]
+                 UserWarning, UserWarning, FutureWarning]
 
 
 class Test__init__(IrisTest):


### PR DESCRIPTION
Changes to some tests to make them more robust to warnings occurring in different orders, or new warnings occuring as underlying packages change. This addresses our immediate failures. A follow on ticket has been raised to deal with extending these changes elsewhere and addressing the new warnings that we encounter with a newer version of numpy.


Testing:
 - [x] Ran tests and they passed OK

