### PR TITLE
Force iris 2.0 to use earlier version of numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 2.0 and all dependencies.
-  - conda install -c conda-forge iris=2.0
+  - conda install -c conda-forge iris=2.0 numpy=1.13.3
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.3.1 numpy=1.13.3 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 coverage
+  - conda install -c conda-forge filelock mock netcdf4=1.3.1 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 coverage
   - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.


### PR DESCRIPTION
Force numpy version with iris install.

Attempt to change the iris version associated with iris back to a version below 1.14. Currently the conda defaults channel has upgraded to 1.15, which is breaking our tests.