### PR TITLE
Private function doc-strings in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -76,6 +76,8 @@ extensions = [
     'sphinx.ext.mathjax',
 ]
 
+autodoc_default_flags = ['members', 'private-members']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/lib/improver/convection.py
+++ b/lib/improver/convection.py
@@ -116,6 +116,7 @@ class DiagnoseConvectivePrecipitation(object):
     def _calculate_convective_ratio(self, cubelist, threshold_list):
         """
         Calculate the convective ratio by:
+
         1. Apply neighbourhood processing to cubes that have been thresholded
            using an upper and lower threshold.
         2. Calculate the convective ratio by:

--- a/lib/improver/nbhood/square_kernel.py
+++ b/lib/improver/nbhood/square_kernel.py
@@ -548,6 +548,7 @@ class SquareNeighbourhood(object):
             self, cube, mask, grid_cells_x, grid_cells_y):
         """
         Apply neighbourhood processing consisting of the following steps:
+
         1. Pad a halo around the input cube to allow vectorised
            neighbourhooding at edgepoints.
         2. Cumulate the array along the x and y axes.

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -429,7 +429,6 @@ def _equalise_cell_methods(cubes):
             they do not match.
     Warns:
         Warning: If only a single cube.
-.
     """
     if len(cubes) == 1:
         msg = ('Only a single cube so no differences will be found '


### PR DESCRIPTION
Add the inclusion of doc strings relating to private functions into the documentation. Fix the issues identified by warnings that arise with this change.

I noticed that they are missing with the addition of the orographic_enhancement plugin which includes lots of private functions.

Testing:
 - [x] Ran tests and they passed OK