### PR TITLE
Specify dtype of float64 in unit test for demote_float64_precision

### DIFF
--- a/lib/improver/tests/utilities/cube_manipulation/test_demote_float64_precision.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_demote_float64_precision.py
@@ -49,8 +49,8 @@ class Test_demote_float64_precision(IrisTest):
 
     def setUp(self):
         """Create two temperature cubes to test with."""
-        self.cube1 = set_up_temperature_cube()
-        self.cube2 = set_up_temperature_cube()
+        self.cube1 = set_up_temperature_cube(dtype=np.float64)
+        self.cube2 = set_up_temperature_cube(dtype=np.float64)
         self.assertEqual(self.cube1.dtype, np.float64)
 
     def test_basic(self):


### PR DESCRIPTION
Description
Following rebasing the feature branch on upstream/master, the demote_float64_precision unit tests failed, as a result of a change to the default dtype used within the set_up_temperature_cube helper function. This PR sets the dtype to be float64 for the purposes of these unit tests.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

