### PR TITLE
Enable serial running of CLI tests with debug option

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -157,10 +157,12 @@ function improver_test_cli {
         fi
         if [[ -z $BATS_OPT ]] && type prove &>/dev/null; then
             PROVE_VERBOSE_OPT=
+            PROVE_PARALLEL_OPT='-j 4'
             if [[ -n $DEBUG_OPT ]]; then
                 PROVE_VERBOSE_OPT='-v'
+                PROVE_PARALLEL_OPT=
             fi
-            prove $PROVE_VERBOSE_OPT --directives -r -j 4 \
+            prove $PROVE_VERBOSE_OPT --directives -r $PROVE_PARALLEL_OPT \
                 -e "bats --tap" --ext ".bats" --timer $TEST_TARGET
         else
             if [[ -f "$TEST_TARGET" ]]; then


### PR DESCRIPTION
Description
Enable the debug option for the CLI tests to run CLI tests serially, as running serially provides more verbose output messages, which are useful for debugging. The debug option would only typically be used when trying to debug a specific set of CLI tests.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

