### PR TITLE
Impro858 optical flow radius bug

### DIFF
--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -931,8 +931,9 @@ class OpticalFlow(object):
             msg = "Expected positive time difference cube2 - cube1: got {} s"
             raise InvalidCubeError(msg.format(cube_time_diff.total_seconds()))
 
-        # if time difference is not 15 minutes, update data smoothing radius
-        if cube_time_diff.total_seconds() != 900:
+        # if time difference is greater 15 minutes, increase data smoothing
+        # radius so that larger advection displacements can be resolved
+        if cube_time_diff.total_seconds() > 900:
             data_smoothing_radius_km = self.data_smoothing_radius_km * (
                 cube_time_diff.total_seconds()/900.)
         else:

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -933,15 +933,17 @@ class OpticalFlow(object):
 
         # if time difference is not 15 minutes, update data smoothing radius
         if cube_time_diff.total_seconds() != 900:
-            self.data_smoothing_radius_km *= (
+            data_smoothing_radius_km = self.data_smoothing_radius_km * (
                 cube_time_diff.total_seconds()/900.)
+        else:
+            data_smoothing_radius_km = self.data_smoothing_radius_km
 
         # calculate smoothing radius in grid square units
         new_coord = cube1.coord(axis='x').copy()
         new_coord.convert_units('km')
         grid_length_km = np.float32(np.diff((new_coord).points)[0])
         data_smoothing_radius = \
-            int(self.data_smoothing_radius_km / grid_length_km)
+            int(data_smoothing_radius_km / grid_length_km)
 
         # Fail verbosely if data smoothing radius is too small and will
         # trigger silent failures downstream

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -141,7 +141,7 @@ class Test_interp_to_midpoint(OpticalFlowUtilityTest):
         """Test returns empty array if averaging over an axis of length 1"""
         small_array = self.plugin.data1[0, :].reshape((1, 5))
         result = self.plugin.interp_to_midpoint(small_array)
-        self.assertFalse(result)
+        self.assertEqual(result.size, 0.)
 
     def test_small_array_single_axis(self):
         """Test sensible output if averaging over one valid axis"""
@@ -654,9 +654,9 @@ class Test_process(IrisTest):
         self.assertAlmostEqual(np.mean(vcube.data), 2.1719084)
 
     def test_update_smoothing_radius(self):
-        """Test data smoothing radius is updated if cube time difference is not
-        15 minutes.  We don't care about the error this trips, we just want to
-        make sure the radius is updated correctly."""
+        """Test data smoothing radius is updated if cube time difference is
+        greater than 15 minutes.  The updated radius value (12 km = 6 grid
+        squares) causes an error to be raised."""
         time_unit = self.cube2.coord("time").units
         new_time = time_unit.num2date(self.cube2.coord("time").points[0])
         new_time += datetime.timedelta(seconds=900)
@@ -664,9 +664,9 @@ class Test_process(IrisTest):
         time_coord = DimCoord(time_unit.date2num(new_time),
                               standard_name="time", units=time_unit)
         self.cube2.add_aux_coord(time_coord)
-        with self.assertRaises(ValueError):
+        msg = "data smoothing radius 6"
+        with self.assertRaisesRegex(ValueError, msg):
             _, _ = self.plugin.process(self.cube1, self.cube2, boxsize=3)
-        self.assertAlmostEqual(self.plugin.data_smoothing_radius_km, 12.)
 
     def test_error_small_kernel(self):
         """Test failure if data smoothing radius is too small"""


### PR DESCRIPTION
Addresses #638 

Two functional changes:

- Changed radius to be set explicitly rather than iteratively modified every time "process" is called
- Set radius to increase for larger time offsets but NOT to decrease for smaller offsets (this is justified separately)

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
