### PR TITLE
Add KGO0 to nowcast-extrapolate with metadata BATS test

### DIFF
--- a/tests/improver-nowcast-extrapolate/04-metadata.bats
+++ b/tests/improver-nowcast-extrapolate/04-metadata.bats
@@ -33,6 +33,7 @@
 
 @test "extrapolate with json file" {
   improver_check_skip_acceptance
+  KGO0="optical-flow/extrapolate/kgo0_with_metadata.nc"
   KGO1="optical-flow/extrapolate/kgo1_with_metadata.nc"
   KGO2="optical-flow/extrapolate/kgo2_with_metadata.nc"
 
@@ -49,13 +50,17 @@
     --northward_advection "$VCOMP"
   [[ "$status" -eq 0 ]]
 
+  T0="20180410T0500Z-PT0000H00M-rainfall_rate_composite.nc"
   T1="20180410T0515Z-PT0000H15M-rainfall_rate_composite.nc"
   T2="20180410T0530Z-PT0000H30M-rainfall_rate_composite.nc"
 
+  improver_check_recreate_kgo "$T0" $KGO0
   improver_check_recreate_kgo "$T1" $KGO1
   improver_check_recreate_kgo "$T2" $KGO2
 
   # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/$T0" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO0"
   improver_compare_output "$TEST_DIR/$T1" \
       "$IMPROVER_ACC_TEST_DIR/$KGO1"
   improver_compare_output "$TEST_DIR/$T2" \


### PR DESCRIPTION
After PR's #679 and #673 went in, the AT data associated with PR #633 was out of date.
I didn't notice this when merging (my bad), so I've updated the AT data and the test coverage.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
