### PR TITLE
IMPRO586 Update metadata in circular_kernel.py

### DIFF
--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -447,13 +447,13 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
             if result.coords("realization", dimensions=[]):
                 result = iris.util.new_axis(result, "realization")
             required_order.append(result.coord_dims("realization")[0])
-        if result.coords("percentiles_over_neighbourhood"):
+        if result.coords("percentile_over_neighbourhood"):
             required_order.append(
-                result.coord_dims("percentiles_over_neighbourhood")[0])
+                result.coord_dims("percentile_over_neighbourhood")[0])
         other_coords = []
         for coord in result.dim_coords:
             if coord.name() not in ["realization",
-                                    "percentiles_over_neighbourhood"]:
+                                    "percentile_over_neighbourhood"]:
                 other_coords.append(result.coord_dims(coord.name())[0])
         required_order.extend(other_coords)
         result.transpose(required_order)
@@ -473,7 +473,7 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
                 Each slice along this coordinate is identical.
         """
         pctcubelist = iris.cube.CubeList()
-        pct_coord_name = "percentiles_over_neighbourhood"
+        pct_coord_name = "percentile_over_neighbourhood"
         for pct in self.percentiles:
             pctcube = cube.copy()
             pctcube.add_aux_coord(iris.coords.DimCoord(

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -83,9 +83,9 @@ class Test_make_percentile_cube(IrisTest):
             GeneratePercentilesFromACircularNeighbourhood(
             ).make_percentile_cube(cube))
         self.assertIsInstance(result.coord(
-            'percentiles_over_neighbourhood'), iris.coords.Coord)
+            'percentile_over_neighbourhood'), iris.coords.Coord)
         self.assertArrayEqual(result.coord(
-            'percentiles_over_neighbourhood').points, DEFAULT_PERCENTILES)
+            'percentile_over_neighbourhood').points, DEFAULT_PERCENTILES)
         self.assertArrayEqual(result[0].data, cube.data)
         self.assertDictEqual(
             cube.metadata._asdict(), result.metadata._asdict())
@@ -100,7 +100,7 @@ class Test_make_percentile_cube(IrisTest):
             GeneratePercentilesFromACircularNeighbourhood(
             ).make_percentile_cube(cube))
         self.assertEqual(
-            result.coord_dims("percentiles_over_neighbourhood")[0], 0)
+            result.coord_dims("percentile_over_neighbourhood")[0], 0)
 
     def test_coord_is_dim_scalar(self):
         """Test that the percentile coord is added as the zeroth dimension when
@@ -112,7 +112,7 @@ class Test_make_percentile_cube(IrisTest):
             GeneratePercentilesFromACircularNeighbourhood(
                 50.).make_percentile_cube(cube))
         self.assertEqual(
-            result.coord_dims("percentiles_over_neighbourhood")[0], 0)
+            result.coord_dims("percentile_over_neighbourhood")[0], 0)
 
 
 class Test_pad_and_unpad_cube(IrisTest):


### PR DESCRIPTION
Description:
Update metadata in circular_kernel.py
percentile_over_neighbourhood rather than
percentiles_over_neighbourhood.

Testing:
 - [X] Ran tests and they passed OK
