### PR TITLE
Patch for wind_downscaling's issues with merge_cube

### DIFF
--- a/bin/improver-wind-downscaling
+++ b/bin/improver-wind-downscaling
@@ -34,6 +34,7 @@
 from improver.argparser import ArgParser
 import warnings
 
+import numpy as np
 import iris
 from iris.exceptions import CoordinateNotFoundError
 
@@ -130,6 +131,12 @@ def main():
                 z0_cube=veg_roughness_cube,
                 height_levels_cube=height_levels).process(wind_speed_slice))
         wind_speed_list.append(result)
+
+    # Temporary fix for chunking problems when merging cubes
+    max_npoints = max([np.prod(cube.data.shape) for cube in wind_speed_list])
+    while iris._lazy_data._MAX_CHUNK_SIZE < max_npoints:
+        iris._lazy_data._MAX_CHUNK_SIZE *= 2
+
     wind_speed = wind_speed_list.merge_cube()
     non_dim_coords = [x.name() for x in wind_speed.coords(dim_coords=False)]
     if 'realization' in non_dim_coords:


### PR DESCRIPTION
Addresses #669 
Description
Increases Iris' lazy_data  '_MAX_CHUNK_SIZE' to avoid bug introduced in Iris v2.1.0/dask v0.18.1 which causes problems when realising large, chunked, multidim cubes in that have been dask.stack'd 

Testing:
 - [x] Ran tests and they passed OK
