### PR TITLE
IMPRO-875: Spot data neighbour finding plugin

### DIFF
--- a/lib/improver/spotdata_new/neighbour_finding.py
+++ b/lib/improver/spotdata_new/neighbour_finding.py
@@ -402,7 +402,11 @@ class NeighbourSelection(object):
         Args:
             sites (list of dicts):
                 A list of dictionaries defining the spot sites for which
-                neighbours are to be found.
+                neighbours are to be found. e.g.:
+
+                   [{'altitude': 11.0, 'latitude': 57.867000579833984,
+                    'longitude': -5.632999897003174, 'wmo_id': 3034}]
+
             orography (iris.cube.Cube):
                 A cube of orography, used to obtain the grid point altitudes.
             land_mask (iris.cube.Cube):

--- a/lib/improver/spotdata_new/neighbour_finding.py
+++ b/lib/improver/spotdata_new/neighbour_finding.py
@@ -212,15 +212,18 @@ class NeighbourSelection(object):
         # Values beyond the imposed search radius are set to inf,
         # these need to be excluded.
         valid_indices = np.where(np.isfinite(distance))
+
+        # If no valid neighbours are available in the tree, return None.
         if valid_indices[0].shape[0] == 0:
             return None
-        distance = distance[valid_indices]
-        indices = indices[valid_indices]
 
         # If we have no site altitude information, return nearest neighbour.
         # Must use the tree nearest to ensure a land point if required.
         if site_altitudes[index] is None:
-            print ('BOOOOO, I need the nearest point returned from here')
+            return index_nodes[indices[0]]
+
+        distance = distance[valid_indices]
+        indices = indices[valid_indices]
 
 #        print('land indices', index_nodes[indices])
         print('land mindz', land_mask.data[tuple(index_nodes[indices].T)])
@@ -301,7 +304,7 @@ class NeighbourSelection(object):
 
                 for index, (distance, indices) in enumerate(zip(
                         distances[0], node_indices[0])):
-
+                    print('Going in', nearest_indices[index])
                     grid_point = self.select_minimum_dz(
                         orography, site_altitudes, index_nodes, index,
                         distance, indices, land_mask)
@@ -309,24 +312,10 @@ class NeighbourSelection(object):
                         nearest_indices[index] = grid_point
 
         # Return cube of neighbours
-        print("Returning cube of neighbours")
-        print(nearest_indices.T)
         print('Land?', land_mask.data[tuple(nearest_indices.T)])
         notset = np.where(land_mask.data[tuple(nearest_indices.T)] == 0)
-        print(notset)
         for item in notset[0]:
             print('Still not land', sites[item])
+            print('{} {}'.format(sites[item]['latitude'], sites[item]['longitude']))
 
-        return nearest_indices, sites, site_coords, index_nodes
-
-    def plotit(cube, nearest, site_coords):
-        import matplotlib.pyplot as plt
-        import iris.quickplot as qplt
-        import iris.plot as iplt
-        qplt.pcolormesh(cube)
-        for ii, site in enumerate(site_coords):
-            xx = cube.coord(axis='x').points[nearest[ii, 0]]
-            yy = cube.coord(axis='y').points[nearest[ii, 1]]
-            plt.plot(site_coords[ii, 0], site_coords[ii, 1], 'ro')
-            plt.plot([site_coords[ii, 0], xx], [site_coords[ii, 1], yy])
-        plt.show()
+        return nearest_indices, site_coords

--- a/lib/improver/spotdata_new/neighbour_finding.py
+++ b/lib/improver/spotdata_new/neighbour_finding.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Neighbour finding for the Improver site specific process chain."""
+
+import numpy as np
+from scipy import spatial
+
+import cartopy.crs as ccrs
+
+from improver.utilities.spatial import (
+    get_nearest_coords, lat_lon_determine, lat_lon_transform, coordinate_transform)
+from improver.utilities.cube_manipulation import enforce_coordinate_ordering
+from improver.spotdata.common_functions import (
+    ConditionalListExtract, nearest_n_neighbours,
+    index_of_minimum_difference, list_entry_from_index, node_edge_check,
+    apply_bias)
+
+
+class NeighbourSelection(object):
+    """
+    For the selection of a grid point near an arbitrary coordinate, where the
+    selection may be the nearest point, or a point that fulfils other
+    imposed constraints.
+
+    Constraints available for determining the neighbours are:
+
+    1. land_constraint which requires the selected point to be on land.
+    2. minimum_dz which minimises the vertical displacement between the
+       given coordinate (when an altitude is provided) and the grid point
+       where its altitude is provided by the relevant model or high resolution
+       orography.
+    3. A combination of the above, where the land constraint is primary and out
+       of available land points, the one with the minimal vertical displacement
+       is chosen.
+    """
+
+    def __init__(self, land_constraint=False, minimum_dz=False,
+                 search_radius=1.0E4,
+                 site_coordinate_system=ccrs.PlateCarree()):
+        """
+        Args:
+            land_constraint (bool):
+                If True the selected neighbouring grid point must be on land,
+                where this is determined using a land_mask.
+            minimum_dz (bool):
+                If True the selected neighbouring grid point must be chosen to
+                minimise the vertical displacement compared to the site
+                altitude.
+            neighbourhood_size (int):
+                The length/width of a square neighbourhood centred upon the
+                nearest neighbour within which to find a neighbour that matches
+                the applied constraints. This number should typically be small
+                as we are looking for a nearby point.
+            site_coordinate_system (cartopy coordinate system):
+                The coordinate system of the sitelist coordinates that will be
+                provided. This defaults to be a latitude/longitude grid, a
+                PlateCarree projection.
+        """
+        self.minimum_dz = minimum_dz
+        self.land_constraint = land_constraint
+        self.search_radius = search_radius
+        self.site_coordinate_system = site_coordinate_system
+        self.site_x_axis = 'longitude'
+        self.site_y_axis = 'latitude'
+        self.geodectic_coordinate_system = False
+
+    def __repr__(self):
+        """Represent the configured plugin instance as a string."""
+        return ('<NeighbourSelection: land_constraint: {}, ' +
+                'minimum_dz: {}>').format(self.land_constraint,
+                                          self.minimum_dz)
+
+    def _transform_sites_coordinate_system(self, sites, orography):
+
+        target_coordinate_system = orography.coord_system().as_cartopy_crs()
+        y_points = np.array([site[self.site_y_axis] for site in sites])
+        x_points = np.array([site[self.site_x_axis] for site in sites])
+
+        return coordinate_transform(self.site_coordinate_system,
+                                    target_coordinate_system,
+                                    x_points, y_points)[:, 0:2]
+
+    @staticmethod
+    def get_nearest_indices(site_coords, cube):
+        """
+        Uses the iris cube method nearest_neighbour_index to find the nearest
+        grid points to a site.
+
+        Args:
+            site_coords (list):
+                A list of shape (2, n_sites) that contains the x and y
+                coordinates of the sites.
+            cube (iris.cube.Cube):
+                Cube containing a representative grid.
+        Returns:
+            nearest_indices (list):
+                A list of shape (2, n_sites) that contains the x and y
+                indices of the nearest grid points to the sites.
+        """
+        nearest_indices = np.zeros((2, len(site_coords))).astype(np.int)
+        for index, (x_point, y_point) in enumerate(site_coords):
+            nearest_indices[0, index] = (
+                cube.coord(axis='x').nearest_neighbour_index(x_point))
+            nearest_indices[1, index] = (
+                cube.coord(axis='y').nearest_neighbour_index(y_point))
+        return nearest_indices
+
+    def select_minimum_dz(self, site_coords, nearest_indices, land_mask):
+
+        for x_index, y_index in nearest_indices:
+            central_point = list_entry_from_index(nearest_indices, point)
+
+            nbhood = self.neighbourhood_indices(*central_point, land_mask)
+
+
+    def geocentric_cartesian(self, cube, x_coords, y_coords):
+        coordinate_system = cube.coord_system().as_cartopy_crs()
+        cartesian_calculator = coordinate_system.as_geocentric()
+        z_coords = np.zeros_like(x_coords)
+        cartesian_nodes = cartesian_calculator.transform_points(
+            coordinate_system, x_coords, y_coords, z_coords)
+        return cartesian_nodes
+
+    def build_KDTree(self, orography, land_mask):
+
+        if self.land_constraint:
+            included_points = np.nonzero(land_mask.data)
+        else:
+            included_points = np.where(np.isfinite(land.data.data))
+
+        x_indices = included_points[0]
+        y_indices = included_points[1]
+        x_coords = land_mask.coord(axis='x').points[x_indices]
+        y_coords = land_mask.coord(axis='y').points[y_indices]
+
+        if self.geodetic_coordinate_system:
+            nodes = self.geocentric_cartesian(orography, x_coords, y_coords)
+        else:
+            nodes = list(zip(x_coords, y_coords))
+
+        index_nodes = np.array(list(zip(x_indices, y_indices)))
+
+        return spatial.cKDTree(nodes), index_nodes
+
+    def process(self, sites, orography, land_mask):
+
+        # Check if we are dealing with a global grid
+        self.geodetic_coordinate_system = (
+            orography.coord_system().as_cartopy_crs().is_geodetic())
+
+        # Enforce x-y coordinate order for input cubes.
+        orography = enforce_coordinate_ordering(
+            orography, [orography.coord(axis='x').name(),
+                        orography.coord(axis='y').name()])
+        land_mask = enforce_coordinate_ordering(
+            land_mask, [land_mask.coord(axis='x').name(),
+                        land_mask.coord(axis='y').name()])
+
+        # Remap site coordinates on to coordinate system of the model grid.
+        site_coords = self._transform_sites_coordinate_system(sites, orography)
+
+        # Find nearest neighbour point using quick iris method.
+        nearest_indices = self.get_nearest_indices(site_coords, orography)
+
+        # If further constraints are being applied, build a KD Tree which
+        # includes points filtered by constraint.
+        if self.land_constraint or self.minimum_dz:
+            tree, index_nodes = self.build_KDTree(orography, land_mask)
+
+            # Site coordinates made cartesian for global coordinate system
+            if self.geodetic_coordinate_system:
+                site_coords = self.geocentric_cartesian(
+                    orography, site_coords[:, 0], site_coords[:, 1])
+
+            if not self.minimum_dz:
+                distances, node_indices = tree.query([site_coords])
+                land_neighbour_indices, = index_nodes[node_indices]
+                distances = np.array([distances[0], distances[0]])
+                nearest_indices = np.where(distances < self.search_radius,
+                                               land_neighbour_indices.T,
+                                               nearest_indices)
+            else:
+                distances, node_indices = tree.query(
+                    [site_coords], distance_upper_bound=self.search_radius)
+
+        # Return cube of neighbours
+        print("Returning cube of neighbours")
+        print(nearest_indices.T)
+        print('Land?', land_mask.data[tuple(nearest_indices)])
+        return nearest_indices, site_coords

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -541,7 +541,6 @@ class Test_select_minimum_dz(Test_NeighbourSelection):
         assert issubclass(warning_list[0].category, UserWarning)
 
 
-
 class Test_process(Test_NeighbourSelection):
 
     """Test the process method of the NeighbourSelection class."""

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -532,9 +532,9 @@ class Test_select_minimum_dz(Test_NeighbourSelection):
         distance = np.arange(5)
         indices = np.arange(5)
 
-        result = plugin.select_minimum_dz(self.region_orography,
-                                          site_altitude, nodes,
-                                          distance, indices)
+        plugin.select_minimum_dz(self.region_orography,
+                                 site_altitude, nodes,
+                                 distance, indices)
 
         msg = "Limit on number of nearest neighbours"
         self.assertTrue(any([msg in str(warning) for warning in warning_list]))
@@ -564,8 +564,8 @@ class Test_process(Test_NeighbourSelection):
         msg = 'Orography and land_mask cubes are not on the same'
         plugin = NeighbourSelection()
         with self.assertRaisesRegex(ValueError, msg):
-            result = plugin.process(self.region_sites, self.region_orography,
-                                    self.global_land_mask)
+            plugin.process(self.region_sites, self.region_orography,
+                           self.global_land_mask)
 
     def test_global_attribute(self):
         """Test that a cube is returned with an attribute identifying the

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -53,8 +53,8 @@ class Test_NeighbourSelection(IrisTest):
         land_data[0:2, 4] = 1
         land_data[4, 4] = 1
         orography_data = np.zeros((9, 9))
-        orography_data[0, :] = 1
-        orography_data[1, :] = 5
+        orography_data[0, 4] = 1
+        orography_data[1, 4] = 5
 
         # Global coordinates and cubes
         projection = iris.coord_systems.GeogCS(6371229.0)

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -527,8 +527,8 @@ class Test_process(Test_NeighbourSelection):
 
         plugin = NeighbourSelection()
         with self.assertRaisesRegex(ValueError, msg):
-            result = plugin.process(self.region_sites, self.region_orography,
-                                    self.region_land_mask)
+            plugin.process(self.region_sites, self.region_orography,
+                           self.region_land_mask)
 
     def test_different_cube_grids(self):
         """Test an error is raised if the land mask and orography cubes

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -1,0 +1,596 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for NeighbourSelection class"""
+
+import unittest
+import numpy as np
+import scipy
+from cf_units import Unit
+
+import iris
+from iris.coords import AuxCoord
+from iris.tests import IrisTest
+import cartopy.crs as ccrs
+
+from improver.spotdata_new.neighbour_finding import NeighbourSelection
+from improver.utilities.warnings_handler import ManageWarnings
+
+
+class Test_NeighbourSelection(IrisTest):
+
+    """Test class for the NeighbourSelection tests, setting up inputs."""
+
+    def setUp(self):
+        """Set up cubes and sitelists for use in testing NeighbourSelection"""
+        # Set up orography and land mask data
+        land_data = np.zeros((9, 9))
+        land_data[0:2, 4] = 1
+        land_data[4, 4] = 1
+        orography_data = np.zeros((9, 9))
+        orography_data[0, :] = 1
+        orography_data[1, :] = 5
+
+        # Global coordinates and cubes
+        projection = iris.coord_systems.GeogCS(6371229.0)
+        xcoord = iris.coords.DimCoord(
+            np.linspace(-160, 160, 9), standard_name='longitude',
+            units='degrees', coord_system=projection,
+            circular=True)
+        xcoord.guess_bounds()
+        ycoord = iris.coords.DimCoord(
+            np.linspace(-80, 80, 9), standard_name='latitude',
+            units='degrees', coord_system=projection,
+            circular=False)
+        ycoord.guess_bounds()
+
+        global_land_mask = iris.cube.Cube(
+            land_data, standard_name="land_binary_mask", units=1,
+            dim_coords_and_dims=[(ycoord, 1), (xcoord, 0)])
+        global_orography = iris.cube.Cube(
+            orography_data, standard_name="surface_altitude", units='m',
+            dim_coords_and_dims=[(ycoord, 1), (xcoord, 0)])
+
+        # Regional grid coordinates and cubes
+        projection = iris.coord_systems.LambertAzimuthalEqualArea(
+            ellipsoid=iris.coord_systems.GeogCS(
+                semi_major_axis=6378137.0, semi_minor_axis=6356752.314140356))
+        xcoord = iris.coords.DimCoord(
+            np.linspace(-1E5, 1E5, 9), standard_name='projection_x_coordinate',
+            units='m', coord_system=projection)
+        xcoord.guess_bounds()
+        ycoord = iris.coords.DimCoord(
+            np.linspace(-5E4, 5E4, 9), standard_name='projection_y_coordinate',
+            units='degrees', coord_system=projection)
+        ycoord.guess_bounds()
+
+        region_land_mask = iris.cube.Cube(
+            land_data, standard_name="land_binary_mask", units=1,
+            dim_coords_and_dims=[(ycoord, 1), (xcoord, 0)])
+        region_orography = iris.cube.Cube(
+            orography_data, standard_name="surface_altitude", units='m',
+            dim_coords_and_dims=[(ycoord, 1), (xcoord, 0)])
+
+        # Regional sites need to be converted to lat/lon as this is the
+        # standard site list input coordinate system.
+        x = np.array([-4E4, 7.5E4])
+        y = np.array([0, 0])
+
+        # Create site lists
+        self.global_sites = [
+            {'altitude': 2.0, 'latitude': 0.0, 'longitude': -64.0,
+             'wmo_id': 1}]
+        self.region_sites = [
+            {'altitude': 2.0, 'projection_x_coordinate': -4.0E4,
+             'projection_y_coordinate': 0.0, 'wmo_id': 1}]
+
+        self.global_land_mask = global_land_mask
+        self.global_orography = global_orography
+        self.region_land_mask = region_land_mask
+        self.region_orography = region_orography
+        self.region_projection = projection
+
+
+class Test__repr__(IrisTest):
+
+    """Tests the class __repr__ function."""
+
+    def test_basic(self):
+        """Test that the __repr__ returns the expected string with defaults."""
+        plugin = NeighbourSelection()
+        result = str(plugin)
+        msg = ("<NeighbourSelection: land_constraint: False, minimum_dz: False"
+               ", search_radius: 10000.0, site_coordinate_system: <class "
+               "'cartopy.crs.PlateCarree'>, site_x_coordinate:longitude, "
+               "site_y_coordinate: latitude>")
+        self.assertEqual(result, msg)
+
+    def test_non_default(self):
+        """Test that the __repr__ returns the expected string with defaults."""
+        plugin = NeighbourSelection(land_constraint=True, minimum_dz=True,
+                                    search_radius=1000,
+                                    site_coordinate_system=ccrs.Mercator(),
+                                    site_x_coordinate='x_axis',
+                                    site_y_coordinate='y_axis')
+        result = str(plugin)
+        msg = ("<NeighbourSelection: land_constraint: True, minimum_dz: True,"
+               " search_radius: 1000, site_coordinate_system: <class "
+               "'cartopy.crs.Mercator'>, site_x_coordinate:x_axis, "
+               "site_y_coordinate: y_axis>")
+        self.assertEqual(result, msg)
+
+
+class Test_neighbour_finding_method_name(IrisTest):
+
+    """Test the function for generating the name that describes the neighbour
+    finding method."""
+
+    def test_nearest(self):
+        """Test name generated when using the default nearest neighbour
+        method."""
+        plugin = NeighbourSelection()
+        expected = 'nearest'
+        result = plugin.neighbour_finding_method_name()
+        self.assertEqual(result, expected)
+
+    def test_nearest_land(self):
+        """Test name generated when using the nearest land neighbour
+        method."""
+        plugin = NeighbourSelection(land_constraint=True)
+        expected = 'nearest_land'
+        result = plugin.neighbour_finding_method_name()
+        self.assertEqual(result, expected)
+
+    def test_nearest_land_minimum_dz(self):
+        """Test name generated when using the nearest land neighbour
+        with smallest vertical displacment method."""
+        plugin = NeighbourSelection(land_constraint=True, minimum_dz=True)
+        expected = 'nearest_land_minimum_dz'
+        result = plugin.neighbour_finding_method_name()
+        self.assertEqual(result, expected)
+
+    def test_nearest_minimum_dz(self):
+        """Test name generated when using the nearest neighbour with the
+        smallest vertical displacment method."""
+        plugin = NeighbourSelection(minimum_dz=True)
+        expected = 'nearest_minimum_dz'
+        result = plugin.neighbour_finding_method_name()
+        self.assertEqual(result, expected)
+
+
+class Test__transform_sites_coordinate_system(Test_NeighbourSelection):
+
+    """Test the function for converting arrays of site coordinates into the
+    correct coordinate system for the model/grid cube."""
+
+    def test_global_to_region(self):
+        """Test coordinates generated when transforming from a global to
+        regional coordinate system, in this case PlateCarree to Lambert
+        Azimuthal Equal Areas."""
+        plugin = NeighbourSelection()
+        x_points = np.array([0, 10, 20])
+        y_points = np.array([0, 0, 10])
+        expected = [[0., 0.], [1111782.53516264, 0.],
+                    [2189747.33076441, 1121357.32401753]]
+        result = plugin._transform_sites_coordinate_system(
+            x_points, y_points, self.region_orography)
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_region_to_global(self):
+        """Test coordinates generated when transforming from a regional to
+        global coordinate system, in this case Lambert Azimuthal Equal Areas
+        to PlateCarree."""
+        plugin = NeighbourSelection(
+            site_coordinate_system=self.region_projection.as_cartopy_crs())
+        x_points = np.array([0, 1, 2])
+        y_points = np.array([0, 0, 1])
+        expected = [[0., 0.], [8.98315284e-06, 0.],
+                    [1.79663057e-05, 9.04369476e-06]]
+        result = plugin._transform_sites_coordinate_system(
+            x_points, y_points, self.global_orography)
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_global_to_global(self):
+        """Test coordinates generated when the input and output coordinate
+        systems are the same, in this case Plate-Carree."""
+        plugin = NeighbourSelection()
+        x_points = np.array([0, 10, 20])
+        y_points = np.array([0, 0, 10])
+        expected = np.stack((x_points, y_points), axis=1)
+        result = plugin._transform_sites_coordinate_system(
+            x_points, y_points, self.global_orography)
+
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_region_to_region(self):
+        """Test coordinates generated when the input and output coordinate
+        systems are the same, in this case Lambert Azimuthal Equal Areas."""
+        plugin = NeighbourSelection(
+            site_coordinate_system=self.region_projection.as_cartopy_crs())
+        x_points = np.array([0, 1, 2])
+        y_points = np.array([0, 0, 1])
+        expected = np.stack((x_points, y_points), axis=1)
+        result = plugin._transform_sites_coordinate_system(
+            x_points, y_points, self.region_orography)
+
+        self.assertArrayAlmostEqual(result, expected)
+
+
+class Test_check_sites_are_within_domain(Test_NeighbourSelection):
+
+    """Test the function that removes sites falling outside the model domain
+    from the site list and raises a warning."""
+
+    def test_all_valid(self):
+        """Test case in which all sites are valid and fall within domain."""
+        plugin = NeighbourSelection()
+        sites = [{'longitude': 1.0E4, 'latitude': 1.0E4},
+                 {'longitude': 1.0E5, 'latitude': 5.0E4}]
+        x_points = np.array([site['longitude'] for site in sites])
+        y_points = np.array([site['latitude'] for site in sites])
+        site_coords = np.stack((x_points, y_points), axis=1)
+
+        sites_out, site_coords_out, out_x, out_y = (
+            plugin.check_sites_are_within_domain(
+                sites, site_coords, x_points, y_points,
+                self.region_orography))
+
+        self.assertArrayEqual(sites_out, sites)
+        self.assertArrayEqual(site_coords, site_coords)
+        self.assertArrayEqual(out_x, x_points)
+        self.assertArrayEqual(out_y, y_points)
+
+    @ManageWarnings(record=True)
+    def test_some_invalid(self, warning_list=None):
+        """Test case with some sites falling outside the regional domain."""
+        plugin = NeighbourSelection()
+        sites = [{'longitude': 1.0E4, 'latitude': 1.0E4},
+                 {'longitude': 1.0E5, 'latitude': 5.0E4},
+                 {'longitude': 1.0E6, 'latitude': 1.0E5}]
+        x_points = np.array([site['longitude'] for site in sites])
+        y_points = np.array([site['latitude'] for site in sites])
+        site_coords = np.stack((x_points, y_points), axis=1)
+
+        sites_out, site_coords_out, out_x, out_y = (
+            plugin.check_sites_are_within_domain(
+                sites, site_coords, x_points, y_points,
+                self.region_orography))
+
+        self.assertArrayEqual(sites_out, sites[0:2])
+        self.assertArrayEqual(site_coords[0:2], site_coords[0:2])
+        self.assertArrayEqual(out_x, x_points[0:2])
+        self.assertArrayEqual(out_y, y_points[0:2])
+
+        msg = "1 spot sites fall outside the grid"
+        self.assertTrue(any([msg in str(warning) for warning in warning_list]))
+        assert issubclass(warning_list[0].category, UserWarning)
+
+
+class Test_get_nearest_indices(Test_NeighbourSelection):
+
+    """Test function wrapping iris functionality to get nearest grid point
+    indices to arbitrary coordinates."""
+
+    def test_basic(self):
+        """Test that expected coordinates are returned."""
+
+        plugin = NeighbourSelection()
+
+        x_points = np.array([site['projection_x_coordinate']
+                             for site in self.region_sites])
+        y_points = np.array([site['projection_y_coordinate']
+                             for site in self.region_sites])
+        site_coords = np.stack((x_points, y_points), axis=1)
+
+        expected = [[2, 4]]
+        result = plugin.get_nearest_indices(site_coords,
+                                            self.region_orography)
+        self.assertArrayEqual(result, expected)
+
+
+class Test_geocentric_cartesian(Test_NeighbourSelection):
+
+    """Test conversion of global coordinates to geocentric cartesians. In  this
+    coordinate system, x and y are in the equitorial plane, and z is towards
+    the poles."""
+
+    def test_basic(self):
+        """Test a (0, 0) coordinate conversion to geocentric cartesian. This is
+        expected to give an x coordinate which is the semi-major axis of the
+        globe defined in the global coordinate system."""
+
+        plugin = NeighbourSelection()
+        x_points = np.array([0])
+        y_points = np.array([0])
+        result = plugin.geocentric_cartesian(self.global_orography,
+                                             x_points, y_points)
+        radius = self.global_orography.coord_system().semi_major_axis
+        expected = [[radius, 0, 0]]
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_north_pole(self):
+        """Test a (0, 90) coordinate conversion to geocentric cartesian, this
+        being the north pole. This is expected to give an x coordinate which 0
+        and a z coordinate equivalent to the semi-major axis of the globe
+        defined in the global coordinate system."""
+
+        plugin = NeighbourSelection()
+        x_points = np.array([0])
+        y_points = np.array([90])
+        result = plugin.geocentric_cartesian(self.global_orography,
+                                             x_points, y_points)
+        radius = self.global_orography.coord_system().semi_major_axis
+        expected = [[0, 0, radius]]
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_45_degrees_latitude(self):
+        """Test a (0, 45) coordinate conversion to geocentric cartesian. In
+        this case the components of the semi-major axis of the globe
+        defined in the global coordinate system should be shared between the
+        resulting x and z coordinates."""
+
+        plugin = NeighbourSelection()
+        x_points = np.array([0])
+        y_points = np.array([45])
+        result = plugin.geocentric_cartesian(self.global_orography,
+                                             x_points, y_points)
+        radius = self.global_orography.coord_system().semi_major_axis
+        component = radius/np.sqrt(2.)
+        expected = [[component, 0, component]]
+
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_45_degrees_longitude(self):
+        """Test a (45, 0) coordinate conversion to geocentric cartesian. In
+        this case the components of the semi-major axis of the globe
+        defined in the global coordinate system should be shared between the
+        resulting x and y coordinates."""
+
+        plugin = NeighbourSelection()
+        x_points = np.array([45])
+        y_points = np.array([0])
+        result = plugin.geocentric_cartesian(self.global_orography,
+                                             x_points, y_points)
+        radius = self.global_orography.coord_system().semi_major_axis
+        component = radius/np.sqrt(2.)
+        expected = [[component, component, 0]]
+
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_45_degrees_latitude_and_longitude(self):
+        """Test a (45, 45) coordinate conversion to geocentric cartesian. In
+        this case the z component should be a cos(45) component of the
+        semi-major axis of the globe defined in the global coordinate system.
+        The x and y coordinates should be cos(45) components of the remaining
+        cos(45) component of the semi-major axis."""
+
+        plugin = NeighbourSelection()
+        x_points = np.array([45])
+        y_points = np.array([45])
+        result = plugin.geocentric_cartesian(self.global_orography,
+                                             x_points, y_points)
+        radius = self.global_orography.coord_system().semi_major_axis
+        component = radius/np.sqrt(2.)
+        sub_component = component/np.sqrt(2.)
+        expected = [[sub_component, sub_component, component]]
+
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_negative_45_degrees_latitude_and_longitude(self):
+        """Test a (-45, -45) coordinate conversion to geocentric cartesian.
+        In this case the x is expected to remain positive, whilst y and z
+        become negative."""
+
+        plugin = NeighbourSelection()
+        x_points = np.array([-45])
+        y_points = np.array([-45])
+        result = plugin.geocentric_cartesian(self.global_orography,
+                                             x_points, y_points)
+        radius = self.global_orography.coord_system().semi_major_axis
+        component = radius/np.sqrt(2.)
+        sub_component = component/np.sqrt(2.)
+        expected = [[sub_component, -sub_component, -component]]
+
+        self.assertArrayAlmostEqual(result, expected)
+
+
+class Test_build_KDTree(Test_NeighbourSelection):
+
+    """Test construction of a KDTree with scipy."""
+
+    def test_basic(self):
+        """Test that the expected number of nodes are created and that a tree
+        is returned; this should be the lengths of the x and y coordinates
+        multiplied in the simple case."""
+
+        plugin = NeighbourSelection()
+        result, result_nodes = plugin.build_KDTree(self.region_land_mask)
+        expected_length = (self.region_land_mask.shape[0] *
+                           self.region_land_mask.shape[1])
+
+        self.assertEqual(result_nodes.shape[0], expected_length)
+        self.assertIsInstance(result, scipy.spatial.ckdtree.cKDTree)
+
+    def test_only_land(self):
+        """Test that the expected number of nodes are created and that a tree
+        is returned. In this case the number of nodes should be this should be
+        equal to the number of land points."""
+
+        plugin = NeighbourSelection(land_constraint=True)
+        result, result_nodes = plugin.build_KDTree(self.region_land_mask)
+        expected_length = np.nonzero(self.region_land_mask.data)[0].shape[0]
+
+        self.assertEqual(result_nodes.shape[0], expected_length)
+        self.assertIsInstance(result, scipy.spatial.ckdtree.cKDTree)
+
+
+class Test_select_minimum_dz(Test_NeighbourSelection):
+
+    """Test extraction of the minimum height difference points from a provided
+    array of neighbours."""
+
+    def test_basic(self):
+        """Test a simple case where the first element in the provided lists
+        has the smallest vertical displacement to the site. Expect the
+        coordinates of the first node to be returned."""
+
+        plugin = NeighbourSelection()
+        site_altitude = 3.
+        nodes = np.array([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+        distance = np.arange(5)
+        indices = np.arange(5)
+
+        result = plugin.select_minimum_dz(self.region_orography,
+                                          site_altitude, nodes,
+                                          distance, indices)
+        self.assertArrayEqual(result, nodes[0])
+
+    def test_some_invalid_points(self):
+        """Test a case where some nodes are beyond the imposed search_radius,
+        which means they have a distance of np.inf, ensuring this is handled.
+        Also change the site height so the second node is the expected
+        result."""
+
+        plugin = NeighbourSelection()
+        site_altitude = 5.
+        nodes = np.array([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+        distance = np.array([0, 1, 2, 3, np.inf])
+        indices = np.arange(5)
+
+        result = plugin.select_minimum_dz(self.region_orography,
+                                          site_altitude, nodes,
+                                          distance, indices)
+        self.assertArrayEqual(result, nodes[1])
+
+    def test_all_invalid_points(self):
+        """Test a case where all nodes are beyond the imposed search_radius,
+        so the returned value should be None."""
+
+        plugin = NeighbourSelection()
+        site_altitude = 5.
+        nodes = np.array([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+        distance = np.full(5, np.inf)
+        indices = np.arange(5)
+
+        result = plugin.select_minimum_dz(self.region_orography,
+                                          site_altitude, nodes,
+                                          distance, indices)
+        self.assertEqual(result, None)
+
+
+class Test_process(Test_NeighbourSelection):
+
+    """Test the process method of the NeighbourSelection class."""
+
+    def test_global_nearest(self):
+        """Test that a cube is returned, here using a conventional site list
+        with lat/lon site coordinates. Neighbour coordinates of [2, 4] are
+        expected, with a vertical displacement of 2.."""
+
+        plugin = NeighbourSelection()
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
+        expected = [[[2, 4, 2]]]
+
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertArrayEqual(result.data, expected)
+
+    def test_global_land(self):
+        """Test how the neighbour index changes when a land constraint is
+        imposed. Here we expect to go 'west' to the first band of land
+        which has an altitude of 5m. So we expect [1, 4, -3]."""
+
+        plugin = NeighbourSelection(land_constraint=True, search_radius=1E7)
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
+        expected = [[[1, 4, -3]]]
+
+        self.assertArrayEqual(result.data, expected)
+
+    def test_global_land_minimum_dz(self):
+        """Test how the neighbour index changes when a land constraint is
+        imposed and a minimum height difference condition. Here we expect to go
+        'west' to the second band of land that we encounter, which has an
+        altitude closer to that of the site. So we expect [0, 4, 1]."""
+
+        plugin = NeighbourSelection(land_constraint=True, minimum_dz=True,
+                                    search_radius=1E8)
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
+        expected = [[[0, 4, 1]]]
+
+        self.assertArrayEqual(result.data, expected)
+
+    def test_region_nearest(self):
+        """Test that a cube is returned, this time using the site list in
+        which site coordinates are defined in metres in an equal areas
+        projection. Neighbour coordinates of [2, 4] are expected, with a
+        vertical displacement of 2."""
+
+        plugin = NeighbourSelection(
+            site_coordinate_system=self.region_projection.as_cartopy_crs(),
+            site_x_coordinate='projection_x_coordinate',
+            site_y_coordinate='projection_y_coordinate')
+        result = plugin.process(self.region_sites, self.region_orography,
+                                self.region_land_mask)
+        expected = [[[2, 4, 2]]]
+
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertArrayEqual(result.data, expected)
+
+    def test_region_land(self):
+        """Test how the neighbour index changes when a land constraint is
+        imposed. Here we expect to go 'west' to the first island of land
+        which has an altitude of 5m. So we expect [1, 4, -3]."""
+
+        plugin = NeighbourSelection(land_constraint=True, search_radius=1E7)
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
+        expected = [[[1, 4, -3]]]
+
+        self.assertArrayEqual(result.data, expected)
+
+    def test_region_land_minimum_dz(self):
+        """Test how the neighbour index changes when a land constraint is
+        imposed and a minimum height difference condition. Here we expect to go
+        'west' to the second band of land that we encounter, which has an
+        altitude closer to that of the site. So we expect [0, 4, 1]."""
+
+        plugin = NeighbourSelection(land_constraint=True, minimum_dz=True,
+                                    search_radius=1E8)
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
+        expected = [[[0, 4, 1]]]
+
+        self.assertArrayEqual(result.data, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -471,8 +471,8 @@ class Test_select_minimum_dz(Test_NeighbourSelection):
     at a y index of 4, changing elevation with x. As such the nodes are chosen
     along this line, e.g. [0, 4], [1, 4], etc."""
 
-    @ManageWarnings(record=True)
-    def test_basic(self, warning_list=True):
+    @ManageWarnings(ignored_messages=["Limit on number of nearest neighbours"])
+    def test_basic(self):
         """Test a simple case where the first element in the provided lists
         has the smallest vertical displacement to the site. Expect the
         coordinates of the first node to be returned."""

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -547,7 +547,4 @@ def coordinate_transform(src_crs, trg_crs, x_points, y_points):
         x, y (floats):
             x and y coordinates transformed into the target coordinate system.
     """
-    if src_crs == trg_crs:
-        return x_points, y_points
-    else:
-        return trg_crs.transform_points(src_crs, x_points, y_points)
+    return trg_crs.transform_points(src_crs, x_points, y_points)

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -525,26 +525,3 @@ def get_nearest_coords(cube, latitude, longitude, iname, jname):
     i_latitude = cube.coord(iname).nearest_neighbour_index(latitude)
     j_longitude = cube.coord(jname).nearest_neighbour_index(longitude)
     return i_latitude, j_longitude
-
-
-def coordinate_transform(src_crs, trg_crs, x_points, y_points):
-    """
-    Transforms x_point and y_point coordinate pairs from lists of coordinates
-    into an alternative projection defined by trg_crs.
-
-    Args:
-        src_crs (cartopy.crs/None):
-            Source coordinate system in cartopy format or None.
-        trg_crs (cartopy.crs/None):
-            Target coordinate system in cartopy format or None.
-        x_points (np.array):
-            Array containing the x coordinate values in the src_crs coordinate
-            system.
-        y_points (np.array):
-            Array containing the y coordinate values in the src_crs coordinate
-            system.
-    Returns:
-        x, y (floats):
-            x and y coordinates transformed into the target coordinate system.
-    """
-    return trg_crs.transform_points(src_crs, x_points, y_points)

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -527,7 +527,7 @@ def get_nearest_coords(cube, latitude, longitude, iname, jname):
     return i_latitude, j_longitude
 
 
-def coordinate_transform(src_crs, trg_crs, y_points, x_points):
+def coordinate_transform(src_crs, trg_crs, x_points, y_points):
     """
     Transforms x_point and y_point coordinate pairs from lists of coordinates
     into an alternative projection defined by trg_crs.
@@ -535,23 +535,19 @@ def coordinate_transform(src_crs, trg_crs, y_points, x_points):
     Args:
         src_crs (cartopy.crs/None):
             Source coordinate system in cartopy format or None.
-
         trg_crs (cartopy.crs/None):
             Target coordinate system in cartopy format or None.
-
-        latitude (float):
-            Latitude coordinate.
-
-        longitude (float):
-            Longitude coordinate.
-
+        x_points (np.array):
+            Array containing the x coordinate values in the src_crs coordinate
+            system.
+        y_points (np.array):
+            Array containing the y coordinate values in the src_crs coordinate
+            system.
     Returns:
         x, y (floats):
-            Longitude and latitude transformed into the target coordinate
-            system.
-
+            x and y coordinates transformed into the target coordinate system.
     """
     if src_crs == trg_crs:
-        return y_points, x_points
+        return x_points, y_points
     else:
         return trg_crs.transform_points(src_crs, x_points, y_points)

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -525,3 +525,33 @@ def get_nearest_coords(cube, latitude, longitude, iname, jname):
     i_latitude = cube.coord(iname).nearest_neighbour_index(latitude)
     j_longitude = cube.coord(jname).nearest_neighbour_index(longitude)
     return i_latitude, j_longitude
+
+
+def coordinate_transform(src_crs, trg_crs, y_points, x_points):
+    """
+    Transforms x_point and y_point coordinate pairs from lists of coordinates
+    into an alternative projection defined by trg_crs.
+
+    Args:
+        src_crs (cartopy.crs/None):
+            Source coordinate system in cartopy format or None.
+
+        trg_crs (cartopy.crs/None):
+            Target coordinate system in cartopy format or None.
+
+        latitude (float):
+            Latitude coordinate.
+
+        longitude (float):
+            Longitude coordinate.
+
+    Returns:
+        x, y (floats):
+            Longitude and latitude transformed into the target coordinate
+            system.
+
+    """
+    if src_crs == trg_crs:
+        return y_points, x_points
+    else:
+        return trg_crs.transform_points(src_crs, x_points, y_points)


### PR DESCRIPTION
A new plugin for neighbour finding as part of the spot data redesign. Allows selection of neighbours using constraints in different combinations and returns a cube of neighbours for use later at the data extraction step.

There is an associated notebook to go with this PR. See improver_aux.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)