### PR TITLE
IMPRO586 percentile metadata - update percentile_over_nbhood

### DIFF
--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -68,7 +68,7 @@ class Test__recycle_raw_ensemble_realizations(IrisTest):
         cube = set_up_cube(data, "air_temperature", "degreesC")
         self.realization_cube = (
             add_forecast_reference_time_and_forecast_period(cube.copy()))
-        self.perc_coord = "percentile_over_nbhood"
+        self.perc_coord = "percentile_over_neighbourhood"
         cube.coord("realization").rename(self.perc_coord)
         self.percentile_cube = (
             add_forecast_reference_time_and_forecast_period(cube))
@@ -587,7 +587,7 @@ class Test_process(IrisTest):
         self.post_processed_percentiles = (
             add_forecast_reference_time_and_forecast_period(
                 set_up_temperature_cube()))
-        self.perc_coord = "percentile_over_nbhood"
+        self.perc_coord = "percentile_over_neighbourhood"
         self.post_processed_percentiles.coord("realization").rename(
             self.perc_coord)
         self.post_processed_percentiles.coord(

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsMembers.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsMembers.py
@@ -100,8 +100,8 @@ class Test_process(IrisTest):
         """Check this still works if a different percentile coord used."""
         cube = self.current_temperature_cube
         cube.coord("percentile_over_realization").rename(
-            "percentile_over_nbhood")
-        plen = len(cube.coord("percentile_over_nbhood").points)
+            "percentile_over_neighbourhood")
+        plen = len(cube.coord("percentile_over_neighbourhood").points)
         plugin = Plugin()
         result = plugin.process(cube)
         self.assertEqual(len(result.coord("realization").points), plen)

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -159,7 +159,7 @@ class Test__interpolate_percentiles(IrisTest):
         data[0] -= 1
         data[1] += 1
         data[2] += 3
-        self.perc_coord = "percentile_over_nbhood"
+        self.perc_coord = "percentile_over_neighbourhood"
         cube = set_up_cube(data, "air_temperature", "degreesC")
         cube.coord("realization").rename(self.perc_coord)
         cube.coord(self.perc_coord).points = (
@@ -456,7 +456,7 @@ class Test_process(IrisTest):
             np.array([10, 50, 90]))
         self.percentile_cube = (
             add_forecast_reference_time_and_forecast_period(cube))
-        self.perc_coord_mismatch = "percentile_over_nbhood"
+        self.perc_coord_mismatch = "percentile_over_neighbourhood"
         cube_mismatch = set_up_cube(data, "air_temperature", "degreesC")
         cube_mismatch.coord("realization").rename(self.perc_coord_mismatch)
         cube_mismatch.coord(self.perc_coord_mismatch).points = (

--- a/lib/improver/tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -43,11 +43,12 @@ from improver.wind_calculations.wind_gust_diagnostic import WindGustDiagnostic
 from improver.utilities.warnings_handler import ManageWarnings
 
 
-def create_cube_with_percentile_coord(data=None,
-                                      standard_name=None,
-                                      perc_values=None,
-                                      perc_name='percentile_over_nbhood',
-                                      units=None):
+def create_cube_with_percentile_coord(
+        data=None,
+        standard_name=None,
+        perc_values=None,
+        perc_name='percentile_over_neighbourhood',
+        units=None):
     """Create a cube with percentile coord."""
     if perc_values is None:
         perc_values = [50.0]
@@ -154,7 +155,7 @@ class Test_update_metadata_after_max(IrisTest):
                                               perc_values=percentile_values,
                                               standard_name=gust))
         self.perc_coord = DimCoord(percentile_values,
-                                   long_name="percentile_over_nbhood",
+                                   long_name="percentile_over_neighbourhood",
                                    units="%")
         self.cube = cube.collapsed(self.perc_coord, iris.analysis.MAX)
 
@@ -241,8 +242,8 @@ class Test_extract_percentile_data(IrisTest):
             plugin.extract_percentile_data(self.cube_wg,
                                            self.wg_perc,
                                            "wind_speed_of_gust"))
-        self.assertEqual(perc_coord.name(), "percentile_over_nbhood")
-        self.assertEqual(result.coord("percentile_over_nbhood").points,
+        self.assertEqual(perc_coord.name(), "percentile_over_neighbourhood")
+        self.assertEqual(result.coord("percentile_over_neighbourhood").points,
                          [self.wg_perc])
 
 


### PR DESCRIPTION
Description : Changing percentile_over_nbhood to percentile_over_neighbourhood in unit tests.

Testing:
 - [X] Ran tests and they passed OK
