### PR TITLE
Remove scalar coordinates after collapsing with percentiles.

### DIFF
--- a/bin/improver-ecc
+++ b/bin/improver-ecc
@@ -148,6 +148,9 @@ def main():
             result_cube, raw_forecast, random_ordering=args.random_ordering,
             random_seed=args.random_seed)
     elif args.rebadging:
+        if args.realization_numbers is not None:
+            args.realization_numbers = (
+                [int(num) for num in args.realization_numbers])
         result_cube = RebadgePercentilesAsRealizations().process(
             result_cube, ensemble_realization_numbers=args.realization_numbers)
 

--- a/bin/improver-ecc
+++ b/bin/improver-ecc
@@ -113,7 +113,7 @@ def main():
         'Rebadging options', 'Options for rebadging the input percentiles '
         'as ensemble realizations.')
     rebadging.add_argument('--realization_numbers', default=None,
-                           metavar='REALIZATION_NUMBERS',
+                           metavar='REALIZATION_NUMBERS', nargs="+",
                            help='A list of ensemble realization numbers to '
                                 'use when rebadging the percentiles '
                                 'into realizations.')

--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -69,7 +69,7 @@ def main():
                         "must be provided when collapsing a coordinate or "
                         "coordinates to create percentiles, but is redundant "
                         "when converting probabilities to percentiles and may "
-                        "be omitted. This coordinate(s) will be removed from "
+                        "be omitted. This coordinate(s) will be removed "
                         "and replaced by a percentile coordinate.")
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument("--percentiles", metavar="PERCENTILES",

--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -69,7 +69,8 @@ def main():
                         "must be provided when collapsing a coordinate or "
                         "coordinates to create percentiles, but is redundant "
                         "when converting probabilities to percentiles and may "
-                        "be omitted.")
+                        "be omitted. This coordinate(s) will be removed from "
+                        "and replaced by a percentile coordinate.")
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument("--percentiles", metavar="PERCENTILES",
                        nargs="+", default=None, type=float,

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -51,9 +51,9 @@ Bounds = namedtuple("bounds", "value units")
 
 BOUNDS_FOR_ECDF = {
     "air_temperature": (
-        Bounds((-110-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
+        Bounds((-140-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "wind_speed": Bounds((0, 50), "m s^-1"),
-    "wind_speed_of_gust": Bounds((0, 280), "m s^-1"),
+    "wind_speed_of_gust": Bounds((0, 350), "m s^-1"),
     "air_pressure_at_sea_level": Bounds((94000, 107000), "Pa"),
     ("cloud_base_altitude_assuming_only_consider_cloud_area" +
      "_fraction_greater_than_2p5_oktas"): Bounds((-300, 20000), "m"),

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -51,9 +51,9 @@ Bounds = namedtuple("bounds", "value units")
 
 BOUNDS_FOR_ECDF = {
     "air_temperature": (
-        Bounds((-40-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
+        Bounds((-110-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "wind_speed": Bounds((0, 50), "m s^-1"),
-    "wind_speed_of_gust": Bounds((0, 70), "m s^-1"),
+    "wind_speed_of_gust": Bounds((0, 280), "m s^-1"),
     "air_pressure_at_sea_level": Bounds((94000, 107000), "Pa"),
     ("cloud_base_altitude_assuming_only_consider_cloud_area" +
      "_fraction_greater_than_2p5_oktas"): Bounds((-300, 20000), "m"),
@@ -64,7 +64,7 @@ BOUNDS_FOR_ECDF = {
     "precipitation_rate": Bounds((0, 0.00003), "m s-1"),
     "rainfall_rate": Bounds((0, 0.00003), "m s-1"),
     "rainfall_rate_in_vicinity": Bounds((0, 0.00003), "m s-1"),
-    "relative_humidity": Bounds((0, 1.1), "1"),
+    "relative_humidity": Bounds((0, 2.0), "1"),
     "thickness_of_precipitation_amount": Bounds((0, 0.2), "m"),
     "thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.2), "m"),
     "lwe_snowfall_rate": Bounds((0, 0.00001), "m s-1"),

--- a/lib/improver/percentile.py
+++ b/lib/improver/percentile.py
@@ -124,6 +124,8 @@ class PercentileConverter(object):
                 percent=self.percentiles,
                 fast_percentile_method=self.fast_percentile_method)
             result.data = result.data.astype(data_type)
+            for coord in self.collapse_coord:
+                result.remove_coord(coord)
             return result
 
         raise CoordinateNotFoundError(

--- a/lib/improver/percentile.py
+++ b/lib/improver/percentile.py
@@ -53,7 +53,9 @@ class PercentileConverter(object):
 
         Args:
             collapse_coord (str or list of str):
-                The name of the coordinate(s) to collapse over.
+                The name of the coordinate(s) to collapse over. This
+                coordinate(s) will no longer be present on the output cube, as
+                it will have been replaced by the percentile coordinate.
 
             percentiles (Iterable list of floats or None):
                 Percentile values at which to calculate; if not provided uses

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -536,15 +536,15 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific number of percentiles.
         """
-        data = np.array([[[[21.5, 8.75, 11.],
-                           [8.33333333, 8.75, -16.],
-                           [-16., -25., -28.]]],
-                         [[[31., 10., 12.],
+        data = np.array([[[[24., 8.75, 11.],
+                           [8.33333333, 8.75, -66.],
+                           [-66., -93.75, -103.]]],
+                         [[[36., 10., 12.],
                            [10., 10., 8.],
-                           [8., -10., -16.]]],
-                         [[[40.5, 11.66666667, 31.],
+                           [8., -47.5, -66.]]],
+                         [[[48., 11.66666667, 36.],
                            [11.66666667, 11., 10.5],
-                           [9.66666667, 5., -4.]]]])
+                           [9.66666667, -1.25, -29.]]]])
 
         cube = self.current_temperature_forecast_cube
         no_of_percentiles = 3
@@ -561,9 +561,9 @@ class Test_process(IrisTest):
         data values for a specific percentile passes in as a single realization
         list.
         """
-        data = np.array([[[[21.5, 8.75, 11.],
-                           [8.33333333, 8.75, -16.],
-                           [-16., -25., -28.]]]])
+        data = np.array([[[[24., 8.75, 11.],
+                           [8.33333333, 8.75, -66.],
+                           [-66., -93.75, -103.]]]])
 
         cube = self.current_temperature_forecast_cube
         percentiles = [25]
@@ -579,9 +579,9 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific percentile passed in as a value.
         """
-        data = np.array([[[[21.5, 8.75, 11.],
-                           [8.33333333, 8.75, -16.],
-                           [-16., -25., -28.]]]])
+        data = np.array([[[[24., 8.75, 11.],
+                           [8.33333333, 8.75, -66.],
+                           [-66., -93.75, -103.]]]])
 
         cube = self.current_temperature_forecast_cube
         percentiles = 25
@@ -597,15 +597,15 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific set of percentiles.
         """
-        data = np.array([[[[21.5, 8.75, 11.],
-                           [8.33333333, 8.75, -16.],
-                           [-16., -25., -28.]]],
-                         [[[31., 10., 12.],
+        data = np.array([[[[24., 8.75, 11.],
+                           [8.33333333, 8.75, -66.],
+                           [-66., -93.75, -103.]]],
+                         [[[36., 10., 12.],
                            [10., 10., 8.],
-                           [8., -10., -16.]]],
-                         [[[40.5, 11.66666667, 31.],
+                           [8., -47.5, -66.]]],
+                         [[[48., 11.66666667, 36.],
                            [11.66666667, 11., 10.5],
-                           [9.66666667, 5., -4.]]]])
+                           [9.66666667, -1.25, -29.]]]])
 
         cube = self.current_temperature_forecast_cube
         percentiles = [25, 50, 75]
@@ -621,15 +621,15 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values without specifying the number of percentiles.
         """
-        data = np.array([[[[21.5, 8.75, 11.],
-                           [8.33333333, 8.75, -16.],
-                           [-16., -25., -28.]]],
-                         [[[31., 10., 12.],
+        data = np.array([[[[24., 8.75, 11.],
+                           [8.33333333, 8.75, -66.],
+                           [-66., -93.75, -103.]]],
+                         [[[36., 10., 12.],
                            [10., 10., 8.],
-                           [8., -10., -16.]]],
-                         [[[40.5, 11.66666667, 31.],
+                           [8., -47.5, -66.]]],
+                         [[[48., 11.66666667, 36.],
                            [11.66666667, 11., 10.5],
-                           [9.66666667, 5., -4.]]]])
+                           [9.66666667, -1.25, -29.]]]])
 
         cube = self.current_temperature_forecast_cube
         plugin = Plugin()

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ensemble_copula_coupling_utilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ensemble_copula_coupling_utilities.py
@@ -352,7 +352,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         """
         cube_name = "air_temperature"
         cube_units = Unit("degreesC")
-        bounds_pairing = (-40, 50)
+        bounds_pairing = (-140, 60)
         result = (
             get_bounds_of_distribution(cube_name, cube_units))
         self.assertArrayAlmostEqual(result, bounds_pairing)
@@ -365,7 +365,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         """
         cube_name = "air_temperature"
         cube_units = Unit("fahrenheit")
-        bounds_pairing = (-40, 122)  # In fahrenheit
+        bounds_pairing = (-220, 140)  # In fahrenheit
         result = (
             get_bounds_of_distribution(cube_name, cube_units))
         self.assertArrayAlmostEqual(result, bounds_pairing)

--- a/lib/improver/tests/percentile/test_PercentileConverter.py
+++ b/lib/improver/tests/percentile/test_PercentileConverter.py
@@ -108,9 +108,6 @@ class Test_process(IrisTest):
             [0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100])
         # Check resulting data shape.
         self.assertEqual(result.data.shape, (15, 3, 1, 11))
-        # Check demoted longitude coordinate exists as scalar with bounds.
-        self.assertArrayEqual(result.coord('longitude').bounds,
-                              [[-180., 180.]])
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -136,10 +133,6 @@ class Test_process(IrisTest):
             [0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100])
         # Check resulting data shape.
         self.assertEqual(result.data.shape, (15, 3, 1))
-        # Check demoted dimension coordinates exists as scalars with bounds.
-        self.assertArrayEqual(result.coord('longitude').bounds,
-                              [[-180., 180.]])
-        self.assertArrayEqual(result.coord('latitude').bounds, [[-90., 90.]])
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -169,9 +162,6 @@ class Test_process(IrisTest):
             [0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100])
         # Check resulting data shape.
         self.assertEqual(result.data.shape, (15, 3, 1, 11))
-        # Check demoted longitude coordinate exists as scalar with bounds.
-        self.assertArrayEqual(result.coord('longitude').bounds,
-                              [[-180., 180.]])
 
     def test_unavailable_collapse_coord(self):
         """Test that the plugin handles a collapse_coord that is not

--- a/tests/improver-ecc/00-null.bats
+++ b/tests/improver-ecc/00-null.bats
@@ -39,7 +39,7 @@ usage: improver-ecc [-h] [--profile] [--profile_file PROFILE_FILE]
                     (--reordering | --rebadging)
                     [--raw_forecast_filepath RAW_FORECAST_FILE]
                     [--random_ordering] [--random_seed RANDOM_SEED]
-                    [--realization_numbers REALIZATION_NUMBERS]
+                    [--realization_numbers REALIZATION_NUMBERS [REALIZATION_NUMBERS ...]]
                     INPUT_FILE OUTPUT_FILE
 __TEXT__
   [[ "$output" =~ "$expected" ]]

--- a/tests/improver-ecc/01-help.bats
+++ b/tests/improver-ecc/01-help.bats
@@ -39,7 +39,7 @@ usage: improver-ecc [-h] [--profile] [--profile_file PROFILE_FILE]
                     (--reordering | --rebadging)
                     [--raw_forecast_filepath RAW_FORECAST_FILE]
                     [--random_ordering] [--random_seed RANDOM_SEED]
-                    [--realization_numbers REALIZATION_NUMBERS]
+                    [--realization_numbers REALIZATION_NUMBERS [REALIZATION_NUMBERS ...]]
                     INPUT_FILE OUTPUT_FILE
 
 Apply Ensemble Copula Coupling to a file whose data can be loaded as a single
@@ -93,7 +93,7 @@ Reordering options:
 Rebadging options:
   Options for rebadging the input percentiles as ensemble realizations.
 
-  --realization_numbers REALIZATION_NUMBERS
+  --realization_numbers REALIZATION_NUMBERS [REALIZATION_NUMBERS ...]
                         A list of ensemble realization numbers to use when
                         rebadging the percentiles into realizations.
 __HELP__

--- a/tests/improver-ecc/04-percentiles_rebading_extra_option.bats
+++ b/tests/improver-ecc/04-percentiles_rebading_extra_option.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "ecc --sampling_method 'quantile' --no_of_percentiles 12 --rebadging input output --realization_numbers $(seq 100 1 111) " {
+  improver_check_skip_acceptance
+  KGO="ecc/percentiles_rebadging_extra_option/kgo.nc"
+
+  # Run Ensemble Copula Coupling to convert one set of percentiles to another
+  # set of percentiles, and then rebadge the percentiles to be ensemble
+  # realizations.
+  run improver ecc "$IMPROVER_ACC_TEST_DIR/ecc/percentiles_rebadging/multiple_percentiles_wind_cube.nc" \
+      "$TEST_DIR/output.nc" --sampling_method 'quantile' --no_of_percentiles 12 \
+      --rebadging --realization_numbers $(seq 100 1 111)
+
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -63,7 +63,9 @@ optional arguments:
                         'latitude longitude'. This argument must be provided
                         when collapsing a coordinate or coordinates to create
                         percentiles, but is redundant when converting
-                        probabilities to percentiles and may be omitted.
+                        probabilities to percentiles and may be omitted. This
+                        coordinate(s) will be removed from and replaced by a
+                        percentile coordinate.
   --percentiles PERCENTILES [PERCENTILES ...]
                         Optional definition of percentiles at which to
                         calculate data, e.g. --percentiles 0 33.3 66.6 100

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -64,7 +64,7 @@ optional arguments:
                         when collapsing a coordinate or coordinates to create
                         percentiles, but is redundant when converting
                         probabilities to percentiles and may be omitted. This
-                        coordinate(s) will be removed from and replaced by a
+                        coordinate(s) will be removed and replaced by a
                         percentile coordinate.
   --percentiles PERCENTILES [PERCENTILES ...]
                         Optional definition of percentiles at which to


### PR DESCRIPTION
 Also other minor changes to get suite to work

Addresses IMPRO-912

When using the ECC CLI to convert percentiles to members for global data there were a few things that needed changing. This included removing the collapsed scalar coordinate when using members_to_percentiles and changing the ECC bounds to be suitable for global data.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

