### PR TITLE
Fix indexing in coord adjust weighted blend CLI test.

### DIFF
--- a/tests/improver-weighted-blending/07_coord_adj.bats
+++ b/tests/improver-weighted-blending/07_coord_adj.bats
@@ -39,7 +39,7 @@
   run improver weighted-blending 'linear' 'time' 'weighted_mean' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc" \
-      --coord_adj "lambda pnts: pnts[len(pnts)/2]"
+      --coord_adj "lambda pnts: pnts[len(pnts)//2]"
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO


### PR DESCRIPTION
In newer versions of numpy, e.g: 1.15.1, it is no longer permitted to index an array with a float.
Updated the BATS test to return an integer. Data should be unchanged.
(In Python 2, integer division returned an integer, but at Python 3, this returns a float - need to use explicit integer division in Python 3)

Testing:
 - [x] Ran tests and they passed OK