### PR TITLE
Update weighted blending tests

### DIFF
--- a/tests/improver-weighted-blending/02-basic_nonlin.bats
+++ b/tests/improver-weighted-blending/02-basic_nonlin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/basic_nonlin/kgo.nc"
 
   # Run weighted blending with non linear weights and check it passes.
-  run improver weighted-blending 'nonlinear' 'time' 'weighted_mean'\
+  run improver weighted-blending 'nonlinear' 'forecast_reference_time' 'weighted_mean'\
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/03_basic_lin.bats
+++ b/tests/improver-weighted-blending/03_basic_lin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/basic_lin/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'linear' 'time' 'weighted_mean' \
+  run improver weighted-blending 'linear' 'forecast_reference_time' 'weighted_mean' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/05_options_nonlin.bats
+++ b/tests/improver-weighted-blending/05_options_nonlin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/options_nonlin/kgo.nc"
 
   # Run weighted blending with non linear weights and sub-options and check it passes.
-  run improver weighted-blending 'nonlinear' 'time' 'weighted_mean' --cval 1.0 \
+  run improver weighted-blending 'nonlinear' 'forecast_reference_time' 'weighted_mean' --cval 1.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/06_options_lin.bats
+++ b/tests/improver-weighted-blending/06_options_lin.bats
@@ -54,7 +54,7 @@
   KGO="weighted_blending/options_lin/kgo.nc"
 
   # Run weighted blending with linear weights and suboptions: y0val and ynval. Check it passes.
-  run improver weighted-blending 'linear' 'time' 'weighted_mean' --y0val 4.0 --ynval 0.0 \
+  run improver weighted-blending 'linear' 'forecast_reference_time' 'weighted_mean' --y0val 4.0 --ynval 0.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/06_options_lin.bats
+++ b/tests/improver-weighted-blending/06_options_lin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/options_lin/kgo.nc"
 
   # Run weighted blending with linear weights and suboptions: y0val and slope. Check it passes.
-  run improver weighted-blending 'linear' 'time' 'weighted_mean' --y0val 4.0 --slope -2.0 \
+  run improver weighted-blending 'linear' 'forecast_reference_time' 'weighted_mean' --y0val 4.0 --slope -2.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/07_coord_adj.bats
+++ b/tests/improver-weighted-blending/07_coord_adj.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/coord_adj/kgo.nc"
 
   # Run linear weighted blending with coord adj option.
-  run improver weighted-blending 'linear' 'time' 'weighted_mean' \
+  run improver weighted-blending 'linear' 'forecast_reference_time' 'weighted_mean' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc" \
       --coord_adj "lambda pnts: pnts[len(pnts)/2]"

--- a/tests/improver-weighted-blending/11-expected-coord-vals.bats
+++ b/tests/improver-weighted-blending/11-expected-coord-vals.bats
@@ -38,7 +38,7 @@
   # Run weighted blending with expected coordinate values.
   run improver weighted-blending 'nonlinear' \
       --coord_exp_val "415635.0, 415636.0, 415637.0, 415638.0" \
-      'time' 'weighted_mean' \
+      'forecast_reference_time' 'weighted_mean' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/11-expected-coord-vals.bats
+++ b/tests/improver-weighted-blending/11-expected-coord-vals.bats
@@ -38,8 +38,8 @@
   # Run weighted blending with expected coordinate values.
   run improver weighted-blending 'nonlinear' \
       --coord_exp_val "415635.0, 415636.0, 415637.0, 415638.0" \
-      'forecast_reference_time' 'weighted_mean' \
-      "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
+      'time' 'weighted_mean' \
+      "$IMPROVER_ACC_TEST_DIR/weighted_blending/coord_exp_val/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-weighted-blending/12-percentile_blending.bats
+++ b/tests/improver-weighted-blending/12-percentile_blending.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with non linear weights and sub-options and check it passes.
 
-  run improver weighted-blending 'nonlinear' 'time' 'weighted_mean' --cval 1.0 \
+  run improver weighted-blending 'nonlinear' 'forecast_reference_time' 'weighted_mean' --cval 1.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/percentiles/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/13-weighted_max.bats
+++ b/tests/improver-weighted-blending/13-weighted_max.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with linear weights and weighted_maximum method
   # and check it passes.
-  run improver weighted-blending 'linear' 'time' 'weighted_maximum' \
+  run improver weighted-blending 'linear' 'forecast_reference_time' 'weighted_maximum' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]


### PR DESCRIPTION
Change to CLI tests for weighted blending so that this simulates cycle blending (ie across forecast_reference_time rather than time).  This provides a better baseline for testing of #658 and is a prerequisite.

New CLI test inputs and outputs are referenced in the Jira ticket.

Testing:
 - [x] Ran tests and they passed OK