### PR TITLE
Enforce float32 output from forecast_period_coord

### DIFF
--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -119,6 +119,9 @@ class Test_forecast_period_coord(IrisTest):
 
     """Test determining of the lead times present within the input cube."""
 
+    def setUp(self):
+        self.expected_dtype = np.float32
+
     def test_basic(self):
         """Test that an iris.coord.DimCoord is returned."""
         cube = add_forecast_reference_time_and_forecast_period(set_up_cube())
@@ -134,8 +137,8 @@ class Test_forecast_period_coord(IrisTest):
 
     def test_check_coordinate(self):
         """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
-        """
+        expected units and dtype, when the input cube has a forecast_period
+        coordinate."""
         cube = add_forecast_reference_time_and_forecast_period(set_up_cube())
         fp_coord = cube.coord("forecast_period").copy()
         fp_coord.convert_units("seconds")
@@ -144,11 +147,12 @@ class Test_forecast_period_coord(IrisTest):
         result = forecast_period_coord(cube)
         self.assertArrayAlmostEqual(result.points, expected_points)
         self.assertEqual(str(result.units), expected_units)
+        self.assertEqual(result.dtype, self.expected_dtype)
 
     def test_check_coordinate_force_lead_time_calculation(self):
         """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
-        """
+        expected units and dtype, when the input cube has a forecast_period
+        coordinate."""
         cube = add_forecast_reference_time_and_forecast_period(set_up_cube())
         fp_coord = cube.coord("forecast_period").copy()
         fp_coord.convert_units("seconds")
@@ -158,6 +162,7 @@ class Test_forecast_period_coord(IrisTest):
             cube, force_lead_time_calculation=True)
         self.assertArrayAlmostEqual(result.points, expected_points)
         self.assertEqual(result.units, expected_units)
+        self.assertEqual(result.dtype, self.expected_dtype)
 
     def test_check_coordinate_without_forecast_period(self):
         """Test that the data within the coord is as expected with the

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -120,6 +120,7 @@ class Test_forecast_period_coord(IrisTest):
     """Test determining of the lead times present within the input cube."""
 
     def setUp(self):
+        """Set up for tests."""
         self.expected_dtype = np.float32
 
     def test_basic(self):

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -137,6 +137,7 @@ def forecast_period_coord(
     # Try to return forecast period coordinate in hours.
     if cube.coords("forecast_period") and not force_lead_time_calculation:
         fp_coord = cube.coord("forecast_period").copy()
+        fp_coord.points = fp_coord.points.astype(np.float32)
         try:
             fp_coord.convert_units(result_units)
         except ValueError as err:
@@ -149,7 +150,6 @@ def forecast_period_coord(
         time_units = cube.coord("time").units
         t_coord = cube.coord("time")
         fr_coord = cube.coord("forecast_reference_time")
-        fr_type = fr_coord.dtype
         try:
             fr_coord.convert_units(time_units)
         except ValueError as err:
@@ -163,7 +163,8 @@ def forecast_period_coord(
             time_points - forecast_reference_time_points)
         # Convert the timedeltas to a total in seconds.
         required_lead_times = np.array(
-            [x.total_seconds() for x in required_lead_times]).astype(fr_type)
+                [x.total_seconds() for x in required_lead_times]
+            ).astype(np.float32)
         coord_type = iris.coords.AuxCoord
         if cube.coords("forecast_period"):
             if isinstance(


### PR DESCRIPTION
Description
Modify forecast_period_coord to enforce the return of a float32 forecast_period coordinate. This is required, as we're currently not supporting the forecast_period being float64 within the save.

This is required to support the usage of blendcycles for the nowcast, as currently when a forecast period is calculated by forecast_period_coord it uses the units from the forecast_reference_time coordinate, which may legitimately be float64, as it is a time coordinate. 

Please note that this PR clashes with the changes made in #691, as they both modify forecast_period_coord, so this PR will need to be rebased once #691 is merged.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

