### PR TITLE
Travis package versions update for iris 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda install -c conda-forge iris=2.1
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.7.8 coverage
+  - conda install -c conda-forge filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage
   - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 
 language: python
 python:
-  - 3.6.5
+  - 3.6.6
 sudo: false
 
 git:
@@ -30,10 +30,10 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 2.0 and all dependencies.
-  - conda install -c conda-forge iris=2.0 numpy=1.13.3
+  - conda install -c conda-forge iris=2.1
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.3.1 pycodestyle pylint=1.9.1 pandas python-stratify sphinx=1.7.0 coverage
+  - conda install -c conda-forge filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.7.8 coverage
   - pip install codacy-coverage
 
   # List the name and version of all the dependencies within the conda environment.


### PR DESCRIPTION
Travis versions aligned with October 4th scitools/experimental-current stack for iris2.1.

Testing:
 - [ ] Ran tests and they passed OK