### PR TITLE
Requirements.txt dependency fix - point at scitools instead of linkedin.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies for a feature complete installation
 # ------------------------------------------------
 
-iris>=2.0.0
+scitools-iris>=2.2.0
 cartopy>=0.16.0
 cf_units>=1.2.0
 netCDF4>=1.3.1
@@ -10,4 +10,3 @@ python-stratify>=0.1
 sphinx>=1.7
 sqlite3>=2.6.0
 statsmodels>=0.9.0
-


### PR DESCRIPTION
Fix to requirements.txt to remove dependency on linkedin/iris and replace with scitools/iris.

Testing:
- No testable features changed.