### PR TITLE
IMPRO-877: Spot data neighbour finding CLI

### DIFF
--- a/bin/improver-neighbour-finding
+++ b/bin/improver-neighbour-finding
@@ -38,7 +38,7 @@ from textwrap import wrap
 
 import iris
 import cartopy.crs as ccrs
-from improver.argparser import ArgParser
+from improver.argparser import ArgParser, safe_eval
 from improver.spotdata_new.neighbour_finding import NeighbourSelection
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -90,14 +90,12 @@ def main():
         " neighbours to spot sites as defined by each possible combination of"
         " constraints.")
 
-    l_group = parser.add_argument_group('Ensure neighbour is a land point')
-    l_group.add_argument(
+    group = parser.add_argument_group('Apply constraints to neighbour choice')
+    group.add_argument(
         "--land_constraint", default=False, action='store_true',
         help="If set this will return a cube containing the nearest grid point"
         " neighbours to spot sites that are also land points. May be used with"
         " the minimum_dz option.")
-
-    group = parser.add_argument_group('Minimise neighbour height difference')
     group.add_argument(
         "--minimum_dz", default=False, action='store_true',
         help="If set this will return a cube containing the nearest grid point"
@@ -107,8 +105,18 @@ def main():
     group.add_argument(
         "--search_radius", metavar="SEARCH_RADIUS", type=float,
         help="The radius in metres about a spot site within which to search"
-        " for a grid point neighbour with a smaller height difference than the"
-        " nearest. The default value is 10000m (10km).")
+        " for a grid point neighbour that is land or which has a smaller "
+        " height difference than the nearest. The default value is 10000m "
+        "(10km).")
+    group.add_argument(
+        "--node_limit", metavar="NODE_LIMIT", type=int,
+        help="When searching within the defined search_radius for suitable "
+        "neighbours, a KDTree is constructed. This node_limit prevents the "
+        "tree from becoming too large for large search radii. A default of 36"
+        " is set, which is to say the nearest 36 grid points will be "
+        "considered. If the search_radius is likely to contain more than 36 "
+        "points, this value should be increased to ensure all points are "
+        "considered.")
 
     s_group = parser.add_argument_group('Site list options')
     s_group.add_argument(
@@ -120,15 +128,15 @@ def main():
         " complete definition, including parameters required to modify a"
         " default system, e.g. Miller(central_longitude=90). If a globe is"
         " required this can be specified as e.g."
-        " ccrs.Globe(semimajor_axis=100, semiminor_axis=100).")
+        " Globe(semimajor_axis=100, semiminor_axis=100).")
     s_group.add_argument(
         "--site_x_coordinate", metavar="SITE_X_COORDINATE",
-        help="The x coordinate key within the JSON file. The default is"
-        "'longitude', but can be changed using this option if required.")
+        help="The x coordinate key within the JSON file. The plugin default is"
+        " 'longitude', but can be changed using this option if required.")
     s_group.add_argument(
         "--site_y_coordinate", metavar="SITE_Y_COORDINATE",
-        help="The y coordinate key within the JSON file. The default is"
-        "'latitude', but can be changed using this option if required.")
+        help="The y coordinate key within the JSON file. The plugin default is"
+        " 'latitude', but can be changed using this option if required.")
 
     m_group = parser.add_argument_group('Metadata')
     m_group.add_argument(
@@ -151,25 +159,16 @@ def main():
     # Filter kwargs for those expected by plugin and which are set.
     # This preserves the plugin defaults for unset options.
     kwarg_list = ['land_constraint', 'minimum_dz', 'search_radius',
-                  'site_coordinate_system', 'site_x_coordinate',
+                  'site_coordinate_system', 'site_x_coordinate', 'node_limit',
                   'site_y_coordinate', 'grid_metadata_identifier']
     kwargs = {k: v for (k, v) in vars(args).items() if k in kwarg_list and
               v is not None}
 
     # Deal with coordinate systems for sites other than PlateCarree.
     if 'site_coordinate_system' in kwargs.keys():
-        safe_dict = {k: ccrs.__dict__.get(k, None) for k in PROJECTION_LIST}
-        safe_dict['ccrs'] = ccrs
-        no_builtins = {"__builtins__": None}
-
         scrs = kwargs['site_coordinate_system']
-        try:
-            site_crs = eval('ccrs.{}'.format(scrs), no_builtins, safe_dict)
-        except AttributeError:
-            raise AttributeError(
-                'Provided site_coordinate_system is not a recognised cartopy '
-                'coordinate system')
-        kwargs['site_coordinate_system'] = site_crs
+        kwargs['site_coordinate_system'] = safe_eval(scrs, ccrs,
+                                                     PROJECTION_LIST)
 
     # Check valid options have been selected.
     if args.all_methods is True and (kwargs['land_constraint'] is True or
@@ -178,9 +177,7 @@ def main():
             'Cannot use all_methods option with other constraints.')
 
     # Call plugin to generate neighbour cubes
-    if args.all_methods is False:
-        result = NeighbourSelection(**kwargs).process(*fargs)
-    else:
+    if args.all_methods:
         methods = []
         methods.append({
             **kwargs, 'land_constraint': False, 'minimum_dz': False})
@@ -198,6 +195,8 @@ def main():
         for index, cube in enumerate(all_methods):
             cube.coord('neighbour_selection_method').points = index
         result = merge_cubes(all_methods)
+    else:
+        result = NeighbourSelection(**kwargs).process(*fargs)
 
     result = enforce_coordinate_ordering(
         result,

--- a/bin/improver-neighbour-finding
+++ b/bin/improver-neighbour-finding
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to create neighbour cubes for extracting spot data."""
+
+import json
+import iris
+
+from argparse import RawDescriptionHelpFormatter
+from textwrap import wrap
+
+import cartopy.crs as ccrs
+from improver.argparser import ArgParser
+from improver.spotdata_new.neighbour_finding import NeighbourSelection
+from improver.utilities.load import load_cube
+from improver.utilities.save import save_netcdf
+from improver.utilities.cube_manipulation import (merge_cubes,
+                                                  enforce_coordinate_ordering)
+
+def main():
+    """Load in arguments and get going."""
+    description = (
+        "Determine grid point coordinates within the provided cubes that "
+        "neighbour spot data sites defined within the provided JSON "
+        "file. If no options are set the returned netCDF file will contain the"
+        " nearest neighbour found for each site. Other constrained neighbour "
+        "finding methods can be set with options below.")
+    options = ("\n\nThese methods are:\n\n 1. nearest neighbour\n"
+               " 2. nearest land point neighbour\n"
+               " 3. nearest neighbour with minimum height difference\n"
+               " 4. nearest land point neighbour with minimum height "
+               "difference")
+
+    parser = ArgParser(
+        description=('\n'.join(wrap(description, width=79)) + options),
+        formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument("site_list_filepath", metavar="SITE_LIST_FILEPATH",
+                        help="Path to a JSON file that contains the spot sites"
+                        " for which neighbouring grid points are to be found.")
+    parser.add_argument("orography_filepath", metavar="OROGRAPHY_FILEPATH",
+                        help="Path to a NetCDF file of model orography for the"
+                        " model grid on which neighbours are being found.")
+    parser.add_argument("landmask_filepath", metavar="LANDMASK_FILEPATH",
+                        help="Path to a NetCDF file of model land mask for the"
+                        " model grid on which neighbours are being found.")
+    parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
+                        help="The output path for the resulting NetCDF")
+
+    parser.add_argument(
+        "--all_methods", default=False, action='store_true',
+        help="If set this will return a cube containing the nearest grid point"
+        " neighbours to spot sites as defined by each possible combination of"
+        " constraints.")
+
+    l_group = parser.add_argument_group('Ensure neighbour is a land point')
+    l_group.add_argument(
+        "--land_constraint", default=False, action='store_true',
+        help="If set this will return a cube containing the nearest grid point"
+        " neighbours to spot sites that are also land points. May be used with"
+        " the minimum_dz option.")
+
+    group = parser.add_argument_group('Minimise neighbour height difference')
+    group.add_argument(
+        "--minimum_dz", default=False, action='store_true',
+        help="If set this will return a cube containing the nearest grid point"
+        " neighbour to each spot site that is found, within a given search"
+        " radius, to minimise the height difference between the two. May be"
+        " used with the land_constraint option.")
+    group.add_argument(
+        "--search_radius", metavar="SEARCH_RADIUS", type=float,
+        help="The radius in metres about a spot site within which to search"
+        " for a grid point neighbour with a smaller height difference than the"
+        " nearest. The default value is 10000m (10km).")
+
+    s_group = parser.add_argument_group('Site list options')
+    s_group.add_argument(
+        "--site_coordinate_system", metavar="SITE_COORDINATE_SYSTEM",
+        help="The coordinate system in which the site coordinates are provided"
+        " within the site list. This must be provided as the name of a cartopy"
+        " coordinate system. The default is a PlateCarree system, with site"
+        " coordinates given by latitude/longitude pairs. This can be a"
+        " complete definition, including parameters required to modify a"
+        " default system, e.g. Miller(central_longitude=90). If a globe is"
+        " required this can be specified as e.g."
+        " ccrs.Globe(semimajor_axis=100, semiminor_axis=100).")
+    s_group.add_argument(
+        "--site_x_coordinate", metavar="SITE_X_COORDINATE",
+        help="The x coordinate key within the JSON file. The default is"
+        "'longitude', but can be changed using this option if required.")
+    s_group.add_argument(
+        "--site_y_coordinate", metavar="SITE_Y_COORDINATE",
+        help="The y coordinate key within the JSON file. The default is"
+        "'latitude', but can be changed using this option if required.")
+
+    m_group = parser.add_argument_group('Metadata')
+    m_group.add_argument(
+        "--grid_metadata_identifier", metavar="GRID_METADATA_IDENTIFIER",
+        help="A string to identify attributes from the netCDF files that"
+        " should be copied onto the output cube. Attributes are compared"
+        " for a partial match. The default is 'mosg_' which corresponds"
+        " to Met Office Standard Grid attributes which should be copied"
+        " across.")
+
+    args = parser.parse_args()
+
+    # Open input files
+    with open(args.site_list_filepath, 'r') as site_file:
+        sitelist = json.load(site_file)
+    orography = load_cube(args.orography_filepath)
+    landmask = load_cube(args.landmask_filepath)
+    fargs = (sitelist, orography, landmask)
+
+    # Filter kwargs for those expected by plugin and which are set.
+    # This preserves the plugin defaults for unset options.
+    kwarg_list = ['land_constraint', 'minimum_dz', 'search_radius',
+                  'site_coordinate_system', 'site_x_coordinate',
+                  'site_y_coordinate', 'grid_metadata_identifier']
+    kwargs = {k:v for (k, v) in vars(args).items() if k in kwarg_list and
+              v is not None}
+
+    # Deal with coordinate systems for sites other than PlateCarree.
+    if 'site_coordinate_system' in kwargs.keys():
+        scrs = kwargs['site_coordinate_system']
+        try:
+            site_crs = eval('ccrs.{}'.format(scrs))
+        except AttributeError:
+            raise AttributeError(
+                'Provided site_coordinate_system is not a recognised cartopy '
+                'coordinate system')
+        kwargs['site_coordinate_system'] = site_crs
+
+    # Check valid options have been selected.
+    if args.all_methods is True and (kwargs['land_constraint'] is True or
+                                     kwargs['minimum_dz'] is True):
+        raise ValueError(
+            'Cannot use all_methods option with other constraints.')
+
+    # Call plugin to generate neighbour cubes
+    if args.all_methods is False:
+        result = NeighbourSelection(**kwargs).process(*fargs)
+    else:
+        methods = []
+        methods.append({
+                **kwargs, 'land_constraint': False, 'minimum_dz': False})
+        methods.append({
+                **kwargs, 'land_constraint': True, 'minimum_dz': False})
+        methods.append({
+                **kwargs, 'land_constraint': False, 'minimum_dz': True})
+        methods.append({
+                **kwargs, 'land_constraint': True, 'minimum_dz': True})
+
+        all_methods = iris.cube.CubeList([])
+        for method in methods:
+            all_methods.append(NeighbourSelection(**method).process(*fargs))
+
+        for index, cube in enumerate(all_methods):
+            cube.coord('neighbour_selection_method').points = index
+        result = merge_cubes(all_methods)
+
+    result = enforce_coordinate_ordering(
+        result,
+        ['spot_index', 'neighbour_selection_method', 'grid_attributes'])
+
+    # Save the neighbour cube
+    save_netcdf(result, args.output_filepath)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/improver-neighbour-finding
+++ b/bin/improver-neighbour-finding
@@ -32,11 +32,11 @@
 """Script to create neighbour cubes for extracting spot data."""
 
 import json
-import iris
 
 from argparse import RawDescriptionHelpFormatter
 from textwrap import wrap
 
+import iris
 import cartopy.crs as ccrs
 from improver.argparser import ArgParser
 from improver.spotdata_new.neighbour_finding import NeighbourSelection
@@ -44,6 +44,16 @@ from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 from improver.utilities.cube_manipulation import (merge_cubes,
                                                   enforce_coordinate_ordering)
+
+PROJECTION_LIST = [
+    'AlbersEqualArea', 'AzimuthalEquidistant', 'EuroPP', 'Geocentric',
+    'Geodetic', 'Geostationary', 'Globe', 'Gnomonic',
+    'LambertAzimuthalEqualArea', 'LambertConformal', 'LambertCylindrical',
+    'Mercator', 'Miller', 'Mollweide', 'NearsidePerspective',
+    'NorthPolarStereo', 'OSGB', 'OSNI', 'Orthographic', 'PlateCarree',
+    'Projection', 'Robinson', 'RotatedGeodetic', 'RotatedPole', 'Sinusoidal',
+    'SouthPolarStereo', 'Stereographic', 'TransverseMercator', 'UTM']
+
 
 def main():
     """Load in arguments and get going."""
@@ -125,7 +135,7 @@ def main():
         "--grid_metadata_identifier", metavar="GRID_METADATA_IDENTIFIER",
         help="A string to identify attributes from the netCDF files that"
         " should be copied onto the output cube. Attributes are compared"
-        " for a partial match. The default is 'mosg_' which corresponds"
+        " for a partial match. The default is 'mosg' which corresponds"
         " to Met Office Standard Grid attributes which should be copied"
         " across.")
 
@@ -143,14 +153,18 @@ def main():
     kwarg_list = ['land_constraint', 'minimum_dz', 'search_radius',
                   'site_coordinate_system', 'site_x_coordinate',
                   'site_y_coordinate', 'grid_metadata_identifier']
-    kwargs = {k:v for (k, v) in vars(args).items() if k in kwarg_list and
+    kwargs = {k: v for (k, v) in vars(args).items() if k in kwarg_list and
               v is not None}
 
     # Deal with coordinate systems for sites other than PlateCarree.
     if 'site_coordinate_system' in kwargs.keys():
+        safe_dict = {k: ccrs.__dict__.get(k, None) for k in PROJECTION_LIST}
+        safe_dict['ccrs'] = ccrs
+        no_builtins = {"__builtins__": None}
+
         scrs = kwargs['site_coordinate_system']
         try:
-            site_crs = eval('ccrs.{}'.format(scrs))
+            site_crs = eval('ccrs.{}'.format(scrs), no_builtins, safe_dict)
         except AttributeError:
             raise AttributeError(
                 'Provided site_coordinate_system is not a recognised cartopy '
@@ -169,13 +183,13 @@ def main():
     else:
         methods = []
         methods.append({
-                **kwargs, 'land_constraint': False, 'minimum_dz': False})
+            **kwargs, 'land_constraint': False, 'minimum_dz': False})
         methods.append({
-                **kwargs, 'land_constraint': True, 'minimum_dz': False})
+            **kwargs, 'land_constraint': True, 'minimum_dz': False})
         methods.append({
-                **kwargs, 'land_constraint': False, 'minimum_dz': True})
+            **kwargs, 'land_constraint': False, 'minimum_dz': True})
         methods.append({
-                **kwargs, 'land_constraint': True, 'minimum_dz': True})
+            **kwargs, 'land_constraint': True, 'minimum_dz': True})
 
         all_methods = iris.cube.CubeList([])
         for method in methods:

--- a/lib/improver/argparser.py
+++ b/lib/improver/argparser.py
@@ -208,3 +208,39 @@ class ArgParser(ArgumentParser):
         """
         msg = 'Method: {} does not accept arguments: {}'
         self.error(msg.format(method, args))
+
+
+def safe_eval(command, module, allowed):
+    """
+    A wrapper for the python eval() function that enforces the use of a list of
+    allowable commands and excludes python builtin functions. This enables the
+    use of an eval statement to convert user string input into a function or
+    method without it being readily possible to trigger malicious code.
+
+    Args:
+        command (string):
+            A string identifying the function/method/object that is to be
+            returned from the provided module.
+        module (module):
+            The python module from within which the function/method/object is
+            to be found.
+        allowed (list):
+            A list of the functions/methods/objects that the user is allowed to
+            request.
+    Returns:
+        function/method/object:
+            The desired function, method, or object.
+    Raises:
+        TypeError if the requested module component is not allowed or does not
+        exist.
+    """
+    no_builtins = {"__builtins__": None}
+    safe_dict = {k: module.__dict__.get(k, None) for k in allowed}
+
+    try:
+        result = eval('{}'.format(command), no_builtins, safe_dict)
+    except TypeError:
+        raise TypeError(
+            'Function/method/object "{}" not available in module {}.'.format(
+                command, module.__name__))
+    return result

--- a/lib/improver/spotdata_new/neighbour_finding.py
+++ b/lib/improver/spotdata_new/neighbour_finding.py
@@ -115,10 +115,12 @@ class NeighbourSelection(object):
         """Represent the configured plugin instance as a string."""
         return ('<NeighbourSelection: land_constraint: {}, ' +
                 'minimum_dz: {}, search_radius: {}, site_coordinate_system'
-                ': {}, site_x_coordinate:{}, site_y_coordinate: {}>').format(
+                ': {}, site_x_coordinate:{}, site_y_coordinate: {}, '
+                'grid_metadata_identifier: {}>').format(
                     self.land_constraint, self.minimum_dz, self.search_radius,
                     self.site_coordinate_system.__class__,
-                    self.site_x_coordinate, self.site_y_coordinate)
+                    self.site_x_coordinate, self.site_y_coordinate,
+                    self.grid_metadata_identifier)
 
     def neighbour_finding_method_name(self):
         """
@@ -519,18 +521,18 @@ class NeighbourSelection(object):
         wmo_ids = [site.get('wmo_id', None) for site in sites]
 
         # Construct a name to describe the neighbour finding method employed
-        method_name = self.neighbour_finding_method_name
+        method_name = self.neighbour_finding_method_name()
 
         # Create an array of indices and displacements to return
         data = np.stack((nearest_indices[:, 0], nearest_indices[:, 1],
                          vertical_displacements), axis=1)
-        data = np.expand_dims(data, 1)
+        data = np.expand_dims(data, 1).astype(np.float32)
 
         # Create a cube of neighbours
         neighbour_cube = build_spotdata_cube(
-            data, 'grid_neighbours', 1, site_altitudes,
-            site_y_coords, site_x_coords, wmo_ids,
-            neighbour_methods=[method_name],
+            data, 'grid_neighbours', 1, site_altitudes.astype(np.float32),
+            site_y_coords.astype(np.float32), site_x_coords.astype(np.float32),
+            wmo_ids, neighbour_methods=[method_name],
             grid_attributes=['x_index', 'y_index', 'vertical_displacement'])
 
         # Apply the grid identifiers from the input cubes to the output cube.

--- a/lib/improver/spotdata_new/neighbour_finding.py
+++ b/lib/improver/spotdata_new/neighbour_finding.py
@@ -116,11 +116,11 @@ class NeighbourSelection(object):
         return ('<NeighbourSelection: land_constraint: {}, ' +
                 'minimum_dz: {}, search_radius: {}, site_coordinate_system'
                 ': {}, site_x_coordinate:{}, site_y_coordinate: {}, '
-                'grid_metadata_identifier: {}>').format(
+                'grid_metadata_identifier: {}, node_limit: {}>').format(
                     self.land_constraint, self.minimum_dz, self.search_radius,
                     self.site_coordinate_system.__class__,
                     self.site_x_coordinate, self.site_y_coordinate,
-                    self.grid_metadata_identifier)
+                    self.grid_metadata_identifier, self.node_limit)
 
     def neighbour_finding_method_name(self):
         """

--- a/lib/improver/tests/argparser/test_safe_eval.py
+++ b/lib/improver/tests/argparser/test_safe_eval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # (C) British Crown Copyright 2017-2018 Met Office.
 # All rights reserved.
@@ -28,23 +28,41 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for argparser.safe_eval."""
 
-@test "neighbour-finding no arguments" {
-  run improver neighbour-finding
-  [[ "$status" -eq 2 ]]
-  read -d '' expected <<'__TEXT__' || true
-usage: improver-neighbour-finding [-h] [--profile]
-                                  [--profile_file PROFILE_FILE]
-                                  [--all_methods] [--land_constraint]
-                                  [--minimum_dz]
-                                  [--search_radius SEARCH_RADIUS]
-                                  [--node_limit NODE_LIMIT]
-                                  [--site_coordinate_system SITE_COORDINATE_SYSTEM]
-                                  [--site_x_coordinate SITE_X_COORDINATE]
-                                  [--site_y_coordinate SITE_Y_COORDINATE]
-                                  [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
-                                  SITE_LIST_FILEPATH OROGRAPHY_FILEPATH
-                                  LANDMASK_FILEPATH OUTPUT_FILEPATH
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
-}
+
+import os
+import unittest
+import cartopy.crs as ccrs
+import iris
+import iris.coords as ic
+from improver.argparser import safe_eval
+
+
+class Test_safe_eval(unittest.TestCase):
+
+    """Test function for safely using the eval command."""
+
+    def test_iris_coords(self):
+        """Test the return of an iris.coords component."""
+        allowed = ['coords']
+        result = safe_eval('coords', iris, allowed=allowed)
+        self.assertEqual(result, iris.coords)
+
+    def test_cartopy_projection(self):
+        """Test the return of a cartopy projection."""
+        allowed = ['Mercator', 'Miller']
+        result = safe_eval('Mercator', ccrs, allowed=allowed)
+        self.assertEqual(result, ccrs.Mercator)
+
+    def test_unallowed_cartopy(self):
+        """Test the raising of an error when requesting a projection not in the
+        allowed list."""
+        allowed = ['Mercator']
+        msg = 'Function/method/object "Miller" not available in module'
+        with self.assertRaisesRegex(TypeError, msg):
+            safe_eval('Miller', ccrs, allowed=allowed)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/argparser/test_safe_eval.py
+++ b/lib/improver/tests/argparser/test_safe_eval.py
@@ -31,11 +31,9 @@
 """Unit tests for argparser.safe_eval."""
 
 
-import os
 import unittest
 import cartopy.crs as ccrs
 import iris
-import iris.coords as ic
 from improver.argparser import safe_eval
 
 

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -132,7 +132,7 @@ class Test__repr__(IrisTest):
         msg = ("<NeighbourSelection: land_constraint: False, minimum_dz: False"
                ", search_radius: 10000.0, site_coordinate_system: <class "
                "'cartopy.crs.PlateCarree'>, site_x_coordinate:longitude, "
-               "site_y_coordinate: latitude>")
+               "site_y_coordinate: latitude, grid_metadata_identifier: mosg>")
         self.assertEqual(result, msg)
 
     def test_non_default(self):
@@ -141,12 +141,13 @@ class Test__repr__(IrisTest):
                                     search_radius=1000,
                                     site_coordinate_system=ccrs.Mercator(),
                                     site_x_coordinate='x_axis',
-                                    site_y_coordinate='y_axis')
+                                    site_y_coordinate='y_axis',
+                                    grid_metadata_identifier='mymodel')
         result = str(plugin)
         msg = ("<NeighbourSelection: land_constraint: True, minimum_dz: True,"
                " search_radius: 1000, site_coordinate_system: <class "
                "'cartopy.crs.Mercator'>, site_x_coordinate:x_axis, "
-               "site_y_coordinate: y_axis>")
+               "site_y_coordinate: y_axis, grid_metadata_identifier: mymodel>")
         self.assertEqual(result, msg)
 
 

--- a/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata_new/spotdata_new/test_NeighbourSelection.py
@@ -132,7 +132,8 @@ class Test__repr__(IrisTest):
         msg = ("<NeighbourSelection: land_constraint: False, minimum_dz: False"
                ", search_radius: 10000.0, site_coordinate_system: <class "
                "'cartopy.crs.PlateCarree'>, site_x_coordinate:longitude, "
-               "site_y_coordinate: latitude, grid_metadata_identifier: mosg>")
+               "site_y_coordinate: latitude, grid_metadata_identifier: mosg, "
+               "node_limit: 36>")
         self.assertEqual(result, msg)
 
     def test_non_default(self):
@@ -142,12 +143,14 @@ class Test__repr__(IrisTest):
                                     site_coordinate_system=ccrs.Mercator(),
                                     site_x_coordinate='x_axis',
                                     site_y_coordinate='y_axis',
-                                    grid_metadata_identifier='mymodel')
+                                    grid_metadata_identifier='mymodel',
+                                    node_limit=100)
         result = str(plugin)
         msg = ("<NeighbourSelection: land_constraint: True, minimum_dz: True,"
                " search_radius: 1000, site_coordinate_system: <class "
                "'cartopy.crs.Mercator'>, site_x_coordinate:x_axis, "
-               "site_y_coordinate: y_axis, grid_metadata_identifier: mymodel>")
+               "site_y_coordinate: y_axis, grid_metadata_identifier: mymodel,"
+               " node_limit: 100>")
         self.assertEqual(result, msg)
 
 

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -28,7 +28,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Module for loading cubes and for loading json files."""
+"""Module for loading cubes."""
 
 import glob
 

--- a/tests/improver-neighbour-finding/00-null.bats
+++ b/tests/improver-neighbour-finding/00-null.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "neighbour-finding no arguments" {
+  run improver neighbour-finding
+  [[ "$status" -eq 2 ]]
+  read -d '' expected <<'__TEXT__' || true
+usage: improver-neighbour-finding [-h] [--profile]
+                                  [--profile_file PROFILE_FILE]
+                                  [--all_methods] [--land_constraint]
+                                  [--minimum_dz]
+                                  [--search_radius SEARCH_RADIUS]
+                                  [--site_coordinate_system SITE_COORDINATE_SYSTEM]
+                                  [--site_x_coordinate SITE_X_COORDINATE]
+                                  [--site_y_coordinate SITE_Y_COORDINATE]
+                                  [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
+                                  SITE_LIST_FILEPATH OROGRAPHY_FILEPATH
+                                  LANDMASK_FILEPATH OUTPUT_FILEPATH
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-neighbour-finding/01-help.bats
+++ b/tests/improver-neighbour-finding/01-help.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "neighbour-finding -h" {
+  run improver neighbour-finding -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__HELP__' || true
+usage: improver-neighbour-finding [-h] [--profile]
+                                  [--profile_file PROFILE_FILE]
+                                  [--all_methods] [--land_constraint]
+                                  [--minimum_dz]
+                                  [--search_radius SEARCH_RADIUS]
+                                  [--site_coordinate_system SITE_COORDINATE_SYSTEM]
+                                  [--site_x_coordinate SITE_X_COORDINATE]
+                                  [--site_y_coordinate SITE_Y_COORDINATE]
+                                  [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
+                                  SITE_LIST_FILEPATH OROGRAPHY_FILEPATH
+                                  LANDMASK_FILEPATH OUTPUT_FILEPATH
+
+Determine grid point coordinates within the provided cubes that neighbour spot
+data sites defined within the provided JSON file. If no options are set the
+returned netCDF file will contain the nearest neighbour found for each site.
+Other constrained neighbour finding methods can be set with options below.
+
+These methods are:
+
+ 1. nearest neighbour
+ 2. nearest land point neighbour
+ 3. nearest neighbour with minimum height difference
+ 4. nearest land point neighbour with minimum height difference
+
+positional arguments:
+  SITE_LIST_FILEPATH    Path to a JSON file that contains the spot sites for
+                        which neighbouring grid points are to be found.
+  OROGRAPHY_FILEPATH    Path to a NetCDF file of model orography for the model
+                        grid on which neighbours are being found.
+  LANDMASK_FILEPATH     Path to a NetCDF file of model land mask for the model
+                        grid on which neighbours are being found.
+  OUTPUT_FILEPATH       The output path for the resulting NetCDF
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --profile             Switch on profiling information.
+  --profile_file PROFILE_FILE
+                        Dump profiling info to a file. Implies --profile.
+  --all_methods         If set this will return a cube containing the nearest
+                        grid point neighbours to spot sites as defined by each
+                        possible combination of constraints.
+
+Ensure neighbour is a land point:
+  --land_constraint     If set this will return a cube containing the nearest
+                        grid point neighbours to spot sites that are also land
+                        points. May be used with the minimum_dz option.
+
+Minimise neighbour height difference:
+  --minimum_dz          If set this will return a cube containing the nearest
+                        grid point neighbour to each spot site that is found,
+                        within a given search radius, to minimise the height
+                        difference between the two. May be used with the
+                        land_constraint option.
+  --search_radius SEARCH_RADIUS
+                        The radius in metres about a spot site within which to
+                        search for a grid point neighbour with a smaller
+                        height difference than the nearest. The default value
+                        is 10000m (10km).
+
+Site list options:
+  --site_coordinate_system SITE_COORDINATE_SYSTEM
+                        The coordinate system in which the site coordinates
+                        are provided within the site list. This must be
+                        provided as the name of a cartopy coordinate system.
+                        The default is a PlateCarree system, with site
+                        coordinates given by latitude/longitude pairs. This
+                        can be a complete definition, including parameters
+                        required to modify a default system, e.g.
+                        Miller(central_longitude=90). If a globe is required
+                        this can be specified as e.g.
+                        ccrs.Globe(semimajor_axis=100, semiminor_axis=100).
+  --site_x_coordinate SITE_X_COORDINATE
+                        The x coordinate key within the JSON file. The default
+                        is'longitude', but can be changed using this option if
+                        required.
+  --site_y_coordinate SITE_Y_COORDINATE
+                        The y coordinate key within the JSON file. The default
+                        is'latitude', but can be changed using this option if
+                        required.
+
+Metadata:
+  --grid_metadata_identifier GRID_METADATA_IDENTIFIER
+                        A string to identify attributes from the netCDF files
+                        that should be copied onto the output cube. Attributes
+                        are compared for a partial match. The default is
+                        'mosg_' which corresponds to Met Office Standard Grid
+                        attributes which should be copied across.
+__HELP__
+  [[ "$output" == "$expected" ]]
+}

--- a/tests/improver-neighbour-finding/01-help.bats
+++ b/tests/improver-neighbour-finding/01-help.bats
@@ -38,6 +38,7 @@ usage: improver-neighbour-finding [-h] [--profile]
                                   [--all_methods] [--land_constraint]
                                   [--minimum_dz]
                                   [--search_radius SEARCH_RADIUS]
+                                  [--node_limit NODE_LIMIT]
                                   [--site_coordinate_system SITE_COORDINATE_SYSTEM]
                                   [--site_x_coordinate SITE_X_COORDINATE]
                                   [--site_y_coordinate SITE_Y_COORDINATE]
@@ -75,12 +76,10 @@ optional arguments:
                         grid point neighbours to spot sites as defined by each
                         possible combination of constraints.
 
-Ensure neighbour is a land point:
+Apply constraints to neighbour choice:
   --land_constraint     If set this will return a cube containing the nearest
                         grid point neighbours to spot sites that are also land
                         points. May be used with the minimum_dz option.
-
-Minimise neighbour height difference:
   --minimum_dz          If set this will return a cube containing the nearest
                         grid point neighbour to each spot site that is found,
                         within a given search radius, to minimise the height
@@ -88,9 +87,18 @@ Minimise neighbour height difference:
                         land_constraint option.
   --search_radius SEARCH_RADIUS
                         The radius in metres about a spot site within which to
-                        search for a grid point neighbour with a smaller
-                        height difference than the nearest. The default value
-                        is 10000m (10km).
+                        search for a grid point neighbour that is land or
+                        which has a smaller height difference than the
+                        nearest. The default value is 10000m (10km).
+  --node_limit NODE_LIMIT
+                        When searching within the defined search_radius for
+                        suitable neighbours, a KDTree is constructed. This
+                        node_limit prevents the tree from becoming too large
+                        for large search radii. A default of 36 is set, which
+                        is to say the nearest 36 grid points will be
+                        considered. If the search_radius is likely to contain
+                        more than 36 points, this value should be increased to
+                        ensure all points are considered.
 
 Site list options:
   --site_coordinate_system SITE_COORDINATE_SYSTEM
@@ -103,15 +111,15 @@ Site list options:
                         required to modify a default system, e.g.
                         Miller(central_longitude=90). If a globe is required
                         this can be specified as e.g.
-                        ccrs.Globe(semimajor_axis=100, semiminor_axis=100).
+                        Globe(semimajor_axis=100, semiminor_axis=100).
   --site_x_coordinate SITE_X_COORDINATE
-                        The x coordinate key within the JSON file. The default
-                        is'longitude', but can be changed using this option if
-                        required.
+                        The x coordinate key within the JSON file. The plugin
+                        default is 'longitude', but can be changed using this
+                        option if required.
   --site_y_coordinate SITE_Y_COORDINATE
-                        The y coordinate key within the JSON file. The default
-                        is'latitude', but can be changed using this option if
-                        required.
+                        The y coordinate key within the JSON file. The plugin
+                        default is 'latitude', but can be changed using this
+                        option if required.
 
 Metadata:
   --grid_metadata_identifier GRID_METADATA_IDENTIFIER

--- a/tests/improver-neighbour-finding/01-help.bats
+++ b/tests/improver-neighbour-finding/01-help.bats
@@ -118,7 +118,7 @@ Metadata:
                         A string to identify attributes from the netCDF files
                         that should be copied onto the output cube. Attributes
                         are compared for a partial match. The default is
-                        'mosg_' which corresponds to Met Office Standard Grid
+                        'mosg' which corresponds to Met Office Standard Grid
                         attributes which should be copied across.
 __HELP__
   [[ "$output" == "$expected" ]]

--- a/tests/improver-neighbour-finding/02-nearest-uk.bats
+++ b/tests/improver-neighbour-finding/02-nearest-uk.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_uk_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/03-nearest-land-constraint-uk.bats
+++ b/tests/improver-neighbour-finding/03-nearest-land-constraint-uk.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_land_uk_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --land_constraint
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/04-nearest-minimum-dz-uk.bats
+++ b/tests/improver-neighbour-finding/04-nearest-minimum-dz-uk.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_minimum_dz_uk_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --minimum_dz --search_radius 50000
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/05-nearest-land-constraint-minimum-dz-uk.bats
+++ b/tests/improver-neighbour-finding/05-nearest-land-constraint-minimum-dz-uk.bats
@@ -42,7 +42,7 @@
       "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
       "$TEST_DIR/output.nc" \
       --land_constraint \
-      --minimum_dz --search_radius 50000
+      --minimum_dz --search_radius 50000 --node_limit 100
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-neighbour-finding/05-nearest-land-constraint-minimum-dz-uk.bats
+++ b/tests/improver-neighbour-finding/05-nearest-land-constraint-minimum-dz-uk.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_land_constraint_minimum_dz_uk_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --land_constraint \
+      --minimum_dz --search_radius 50000
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/06-all-methods-uk.bats
+++ b/tests/improver-neighbour-finding/06-all-methods-uk.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/all_methods_uk_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --all_methods
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/07-nearest-global.bats
+++ b/tests/improver-neighbour-finding/07-nearest-global.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/08-nearest-land-constraint-global.bats
+++ b/tests/improver-neighbour-finding/08-nearest-land-constraint-global.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_land_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --land_constraint
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/09-nearest-minimum-dz-global.bats
+++ b/tests/improver-neighbour-finding/09-nearest-minimum-dz-global.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_minimum_dz_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --minimum_dz --search_radius 50000
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/10-nearest-land-constraint-minimum-dz-global.bats
+++ b/tests/improver-neighbour-finding/10-nearest-land-constraint-minimum-dz-global.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_land_constraint_minimum_dz_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --land_constraint \
+      --minimum_dz --search_radius 50000
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/11-all-methods-global.bats
+++ b/tests/improver-neighbour-finding/11-all-methods-global.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/all_methods_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --all_methods
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
+++ b/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
@@ -41,7 +41,7 @@
       "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
       "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
       "$TEST_DIR/output.nc" \
-      --site_coordinate_system "LambertAzimuthalEqualArea(central_latitude=54.9, central_longitude=-2.5, false_easting=0.0, false_northing=0.0, globe=ccrs.Globe(semimajor_axis=6378137.0, semiminor_axis=6356752.314140356))" \
+      --site_coordinate_system "LambertAzimuthalEqualArea(central_latitude=54.9, central_longitude=-2.5, false_easting=0.0, false_northing=0.0, globe=Globe(semimajor_axis=6378137.0, semiminor_axis=6356752.314140356))" \
       --site_x_coordinate 'projection_x_coordinate' \
       --site_y_coordinate 'projection_y_coordinate'
   [[ "$status" -eq 0 ]]

--- a/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
+++ b/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/LAEA_grid_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc" \
+      --site_coordinate_system "LambertAzimuthalEqualArea(central_latitude=54.9, central_longitude=-2.5, false_easting=0.0, false_northing=0.0, globe=ccrs.Globe(semimajor_axis=6378137.0, semiminor_axis=6356752.314140356))" \
+      --site_x_coordinate 'projection_x_coordinate' \
+      --site_y_coordinate 'projection_y_coordinate'
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  # Note this is a special case. The site coordinates are different, but the
+  # data (neighbour indices and vertical displacements) should be identical
+  # to the 07 test in which sites were defined with latitudes and longitudes.
+  # For this reason we invoke nccmp here directly to use different options.
+  run nccmp -dm "$TEST_DIR/output.nc" "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/13-incompatible-constraints.bats
+++ b/tests/improver-neighbour-finding/13-incompatible-constraints.bats
@@ -48,17 +48,3 @@ ValueError: Cannot use all_methods option with other constraints.
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/improver-neighbour-finding/13-incompatible-constraints.bats
+++ b/tests/improver-neighbour-finding/13-incompatible-constraints.bats
@@ -33,23 +33,32 @@
 
 @test "neighbour-finding" {
   improver_check_skip_acceptance
-  KGO="neighbour-finding/outputs/nearest_global_kgo.nc"
 
   # Run cube extraction processing and check it passes.
   run improver neighbour-finding \
-      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/LAEA_grid_sites.json" \
-      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
-      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
       "$TEST_DIR/output.nc" \
-      --site_coordinate_system "LambertAzimuthalEqualArea(central_latitude=54.9, central_longitude=-2.5, false_easting=0.0, false_northing=0.0, globe=ccrs.Globe(semimajor_axis=6378137.0, semiminor_axis=6356752.314140356))" \
-      --site_x_coordinate 'projection_x_coordinate' \
-      --site_y_coordinate 'projection_y_coordinate'
-  [[ "$status" -eq 0 ]]
-
-  # Run nccmp to compare the output and kgo.
-  # Note this is a special case. The site coordinates are different, but the
-  # data (neighbour indices and vertical displacements) should be identical
-  # to the 07 test in which sites were defined with latitudes and longitudes.
-  # For this reason we invoke nccmp here directly to use different options.
-  run nccmp -dm "$TEST_DIR/output.nc" "$IMPROVER_ACC_TEST_DIR/$KGO"
+      --land_constraint --all_methods
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Cannot use all_methods option with other constraints.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/improver-neighbour-finding/14-different-grid-metadata.bats
+++ b/tests/improver-neighbour-finding/14-different-grid-metadata.bats
@@ -33,23 +33,20 @@
 
 @test "neighbour-finding" {
   improver_check_skip_acceptance
-  KGO="neighbour-finding/outputs/nearest_global_kgo.nc"
+  KGO="neighbour-finding/outputs/different_grid_metadata_kgo.nc"
 
   # Run cube extraction processing and check it passes.
   run improver neighbour-finding \
-      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/LAEA_grid_sites.json" \
-      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
-      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
       "$TEST_DIR/output.nc" \
-      --site_coordinate_system "LambertAzimuthalEqualArea(central_latitude=54.9, central_longitude=-2.5, false_easting=0.0, false_northing=0.0, globe=ccrs.Globe(semimajor_axis=6378137.0, semiminor_axis=6356752.314140356))" \
-      --site_x_coordinate 'projection_x_coordinate' \
-      --site_y_coordinate 'projection_y_coordinate'
+      --grid_metadata_identifier institution
   [[ "$status" -eq 0 ]]
 
+  improver_check_recreate_kgo "output.nc" $KGO
+
   # Run nccmp to compare the output and kgo.
-  # Note this is a special case. The site coordinates are different, but the
-  # data (neighbour indices and vertical displacements) should be identical
-  # to the 07 test in which sites were defined with latitudes and longitudes.
-  # For this reason we invoke nccmp here directly to use different options.
-  run nccmp -dm "$TEST_DIR/output.nc" "$IMPROVER_ACC_TEST_DIR/$KGO"
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
 }


### PR DESCRIPTION
This PR adds a CLI and associated tests for the neighbour finding plugin. This allows users to build cubes of grid point neighbours that can be used to extract gridded data to represent off-grid spot sites.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
