### PR TITLE
CFTime Version reset to 1.0.1 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 2.0 and all dependencies.
-  - conda install -c conda-forge iris=2.1
+  - conda install -c conda-forge iris=2.1 cftime=1.0.1
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage


### PR DESCRIPTION
Force cftime module back to version under which our unit tests pass. Ticket opened to look at changes that occur under 1.0.2.1 which cause the failures.

Testing:
 - [ ] Ran tests and they passed OK