### PR TITLE
Correctly inherit time coord dtypes

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -31,6 +31,7 @@
 """Module containing classes for doing weighted blending by collapsing a
    whole dimension."""
 import warnings
+from cf_units import Unit
 
 import numpy as np
 import iris
@@ -76,12 +77,16 @@ def unify_forecast_reference_time(cubes, cycletime):
     result_cubes = iris.cube.CubeList([])
     for cube in cubes:
         frt_units = cube.coord('forecast_reference_time').units
-        frt_points = [frt_units.date2num(cycletime)]
         frt_type = cube.coord('forecast_reference_time').dtype
+        new_frt_units = Unit('seconds since 1970-01-01 00:00:00')
+        frt_points = np.round(
+            [new_frt_units.date2num(cycletime)]).astype(frt_type)
         frt_coord = build_coordinate(
             frt_points, standard_name="forecast_reference_time", bounds=None,
             template_coord=cube.coord('forecast_reference_time'),
-            data_type=frt_type)
+            units=new_frt_units)
+        frt_coord.convert_units(frt_units)
+        frt_coord.points = frt_coord.points.astype(frt_type)
         cube.remove_coord("forecast_reference_time")
         cube.add_aux_coord(frt_coord, data_dims=None)
 

--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -151,8 +151,6 @@ def rationalise_blend_time_coords(
                     "cube - cannot replace a dimension coordinate")
 
             frt_coord = cubelist[0].coord("forecast_reference_time").copy()
-            # Preserve the data type to avoid converting ints to floats.
-            frt_type = frt_coord.dtype
             for cube in cubelist:
                 next_coord = cube.coord("forecast_reference_time").copy()
                 next_coord.convert_units(frt_coord.units)

--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -77,10 +77,11 @@ def unify_forecast_reference_time(cubes, cycletime):
     for cube in cubes:
         frt_units = cube.coord('forecast_reference_time').units
         frt_points = [frt_units.date2num(cycletime)]
+        frt_type = cube.coord('forecast_reference_time').dtype
         frt_coord = build_coordinate(
             frt_points, standard_name="forecast_reference_time", bounds=None,
             template_coord=cube.coord('forecast_reference_time'),
-            data_type=np.float64)
+            data_type=frt_type)
         cube.remove_coord("forecast_reference_time")
         cube.add_aux_coord(frt_coord, data_dims=None)
 
@@ -145,13 +146,15 @@ def rationalise_blend_time_coords(
                     "cube - cannot replace a dimension coordinate")
 
             frt_coord = cubelist[0].coord("forecast_reference_time").copy()
+            # Preserve the data type to avoid converting ints to floats.
+            frt_type = frt_coord.dtype
             for cube in cubelist:
                 next_coord = cube.coord("forecast_reference_time").copy()
                 next_coord.convert_units(frt_coord.units)
                 if next_coord.points[0] > frt_coord.points[0]:
                     frt_coord = next_coord
-            cycletime, = (frt_coord.units).num2date(
-                frt_coord.points.astype(np.float64))
+            cycletime, = frt_coord.units.num2date(
+                frt_coord.points)
         else:
             cycletime = cycletime_to_datetime(cycletime)
         cubelist = unify_forecast_reference_time(cubelist, cycletime)
@@ -221,8 +224,8 @@ def conform_metadata(
                     cycletime, time_unit=cycletime_units,
                     calendar=cycletime_calendar)
                 # Preserve the data type to avoid converting ints to floats.
-                fr_type = cube.coord("forecast_reference_time").dtype
-                new_cycletime = np.round(new_cycletime).astype(fr_type)
+                frt_type = cube.coord("forecast_reference_time").dtype
+                new_cycletime = np.round(new_cycletime).astype(frt_type)
             cube.coord("forecast_reference_time").points = new_cycletime
             cube.coord("forecast_reference_time").bounds = None
 

--- a/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
+++ b/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
@@ -136,10 +136,10 @@ class Test_rationalise_blend_time_coords(IrisTest):
         merged_cube = merge_cubes(self.cubelist)
         for coord in ["forecast_reference_time", "forecast_period"]:
             self.assertEqual(len(merged_cube.coord(coord).points), 1)
-        self.assertAlmostEqual(
+        self.assertEqual(
             merged_cube.coord("forecast_reference_time").points[0],
             expected_frt)
-        self.assertAlmostEqual(
+        self.assertEqual(
             merged_cube.coord("forecast_period").points[0], expected_fp)
 
     def test_cycletime(self):
@@ -153,10 +153,10 @@ class Test_rationalise_blend_time_coords(IrisTest):
         merged_cube = merge_cubes(self.cubelist)
         for coord in ["forecast_reference_time", "forecast_period"]:
             self.assertEqual(len(merged_cube.coord(coord).points), 1)
-        self.assertAlmostEqual(
+        self.assertEqual(
             merged_cube.coord("forecast_reference_time").points[0],
             expected_frt)
-        self.assertAlmostEqual(
+        self.assertEqual(
             merged_cube.coord("forecast_period").points[0], expected_fp)
 
     def test_error_frt_dim(self):

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -39,7 +39,6 @@ from iris.tests import IrisTest
 from iris.cube import Cube
 from iris.coords import DimCoord, AuxCoord
 from cf_units import Unit
-from datetime import datetime
 
 from improver.utilities.cube_metadata import (
     add_coord,
@@ -54,7 +53,6 @@ from improver.utilities.cube_metadata import (
 from improver.utilities.warnings_handler import ManageWarnings
 from improver.tests.ensemble_calibration.ensemble_calibration.\
     helper_functions import set_up_temperature_cube
-from improver.utilities.cube_manipulation import build_coordinate
 from improver.utilities.temporal import forecast_period_coord
 
 

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -47,7 +47,7 @@ from improver.utilities.temporal import (
     iris_time_to_datetime, dt_to_utc_hours, datetime_constraint,
     extract_cube_at_time, set_utc_offset, get_forecast_times)
 from improver.tests.blending.weights.helper_functions import (
-    set_up_temperature_cube, add_model_id_and_model_configuration)
+    set_up_temperature_cube)
 from improver.tests.ensemble_calibration.ensemble_calibration.helper_functions\
     import add_forecast_reference_time_and_forecast_period
 from improver.tests.nbhood.nbhood.test_NeighbourhoodProcessing import (

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -144,7 +144,7 @@ class Test_forecast_period_coord(IrisTest):
         expected_points = fp_coord.points
         expected_units = str(fp_coord.units)
         result = forecast_period_coord(cube)
-        self.assertArrayAlmostEqual(result.points, expected_points)
+        self.assertArrayEqual(result.points, expected_points)
         self.assertEqual(str(result.units), expected_units)
 
     def test_check_coordinate_force_lead_time_calculation(self):
@@ -158,7 +158,7 @@ class Test_forecast_period_coord(IrisTest):
         expected_units = str(fp_coord.units)
         result = forecast_period_coord(
             cube, force_lead_time_calculation=True)
-        self.assertArrayAlmostEqual(result.points, expected_points)
+        self.assertArrayEqual(result.points, expected_points)
         self.assertEqual(result.units, expected_units)
 
     def test_check_coordinate_in_hours_force_lead_time_calculation(self):
@@ -172,7 +172,7 @@ class Test_forecast_period_coord(IrisTest):
         result = forecast_period_coord(
             cube, force_lead_time_calculation=True,
             result_units=fp_coord.units)
-        self.assertArrayAlmostEqual(result.points, expected_points)
+        self.assertArrayEqual(result.points, expected_points)
         self.assertEqual(result.units, expected_units)
 
     def test_check_coordinate_without_forecast_period(self):

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -131,6 +131,10 @@ def forecast_period_coord(
             it will be an AuxCoord. Units are result_units.
 
     """
+    if cube.coords("forecast_period"):
+        fp_type = cube.coord("forecast_period").dtype
+    else:
+        fp_type = np.int32
     if cube.coords("forecast_period") and not force_lead_time_calculation:
         result_coord = cube.coord("forecast_period").copy()
         try:
@@ -197,9 +201,9 @@ def forecast_period_coord(
                "the forecast_period.".format(cube))
         raise CoordinateNotFoundError(msg)
 
-    result_coord.points = result_coord.points.astype(np.float32)
+    result_coord.points = result_coord.points.astype(fp_type)
     if result_coord.bounds is not None:
-        result_coord.bounds = result_coord.bounds.astype(np.float32)
+        result_coord.bounds = result_coord.bounds.astype(fp_type)
 
     return result_coord
 


### PR DESCRIPTION
Addresses #658

When running a blend-models configuration of improver-weighted-blending, which requires the forecast_reference_time and forecast_period coords to be recalculated, the dtype of those coords is not preserved. This causes a fault in the pre-verification task because the precision is not suitable for integer-comparison.
This PR inherits the dtype from the input coord and sets this again at the end of each relevant function.

Testing:
 - [X] Ran tests and they passed OK
 - [X] Added new tests for the new feature(s)
