### PR TITLE
Correctly handle forecast bounds coord for accumulation data

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -110,7 +110,7 @@ def rationalise_blend_time_coords(
     on the coordinate over which the blend will be performed.  Modifies cubes
     in place.
 
-    If blend_coord is forecast_reference_time, ensures the cube has
+    If blend_coord is forecast_reference_time, ensures the cube does not have
     a forecast_period dimension.  If weighting_coord is forecast_period,
     equalises forecast_reference_time on each cube before blending.
 
@@ -134,9 +134,8 @@ def rationalise_blend_time_coords(
     if "forecast_reference_time" in blend_coord:
         for cube in cubelist:
             coord_names = [x.name() for x in cube.coords()]
-            if "forecast_period" not in coord_names:
-                forecast_period = forecast_period_coord(cube)
-                cube.add_aux_coord(forecast_period, data_dims=None)
+            if "forecast_period" in coord_names:
+                cube.remove_coord("forecast_period")
 
     # if blending models using weights by forecast period, set forecast
     # reference times to current cycle time

--- a/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
+++ b/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
@@ -115,16 +115,12 @@ class Test_rationalise_blend_time_coords(IrisTest):
         rationalise_blend_time_coords(self.cubelist, "model")
         self.assertEqual(self.cubelist, reference_cubelist)
 
-    def test_create_fp(self):
-        """Test function creates forecast_period coord if blending over
+    def test_remove_fp(self):
+        """Test function removes forecast_period coord if blending over
         forecast_reference_time"""
-        reference_coord = self.cube.coord("forecast_period")
-        reference_coord.convert_units("seconds")
-        for cube in self.cubelist:
-            cube.remove_coord("forecast_period")
         rationalise_blend_time_coords(self.cubelist, "forecast_reference_time")
         merged_cube = merge_cubes(self.cubelist)
-        self.assertEqual(merged_cube.coord("forecast_period"), reference_coord)
+        self.assertTrue("forecast_period" not in merged_cube.coords())
 
     def test_unify_frt(self):
         """Test function equalises forecast reference times if weighting a

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -37,8 +37,7 @@ import numpy as np
 
 import iris
 
-from improver.utilities.cube_manipulation import (compare_coords,
-                                                  build_coordinate)
+from improver.utilities.cube_manipulation import compare_coords
 
 
 # Define correct v1.2.0 meta-data for v1.1.0 data.

--- a/tests/improver-weighted-blending/16-accum_cycle_blend.bats
+++ b/tests/improver-weighted-blending/16-accum_cycle_blend.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "weighted-blending linear default" {
+  improver_check_skip_acceptance
+  KGO="weighted_blending/accum_cycle_blend/kgo.nc"
+
+  # Run weighted blending with linear weights and check it passes.
+  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
+      $IMPROVER_ACC_TEST_DIR/weighted_blending/accum_cycle_blend/ukv_prob_accum_PT?H.nc \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Addresses #658, #284, #700

Modifies the feature-branch to handle bounds on time and forecast_period coords correctly for accumulation data.

Testing:
 - [X] Ran tests and they passed OK
 - [X] Added new tests for the new feature(s)
