### PR TITLE
Updated cycle blending tests to have sensible weights

### DIFF
--- a/tests/improver-weighted-blending/06-options_lin.bats
+++ b/tests/improver-weighted-blending/06-options_lin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/options_lin/kgo.nc"
 
   # Run weighted blending with linear weights and suboptions: y0val and ynval. Check it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' --y0val 4.0 --ynval 0.0 \
+  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' --y0val 0.0 --ynval 4.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/11-cycletime.bats
+++ b/tests/improver-weighted-blending/11-cycletime.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with linear weights and check it passes.
   run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
-      --y0val 0.0 --ynval 4.0 --cycletime '20171129T0900Z'\
+      --y0val 1.0 --ynval 4.0 --cycletime '20171129T0900Z'\
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/cycletime/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/11-cycletime.bats
+++ b/tests/improver-weighted-blending/11-cycletime.bats
@@ -36,7 +36,8 @@
   KGO="weighted_blending/cycletime/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' --cycletime '20171129T0900Z'\
+  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
+      --y0val 0.0 --ynval 4.0 --cycletime '20171129T0900Z'\
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/cycletime/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]


### PR DESCRIPTION
Addresses #713 

Changed parameters for the cycle blending tests that use the "ChooseDefaultWeightsLinear" plugin so that more recent forecasts receive a higher weighting.