### PR TITLE
Changes to make sure that time bounds are preserved in the correct way.

### DIFF
--- a/lib/improver/tests/utilities/cube_manipulation/test__equalise_coord_bounds.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test__equalise_coord_bounds.py
@@ -116,7 +116,7 @@ class Test__equalise_coord_bounds(IrisTest):
 
     def test_one_bounds(self):
         """Test that if there is only 1 set of bounds on the cubes
-        a warning is raised."""
+        an error is raised."""
         cube_with_bounds = self.cube.copy()
         cube_with_bounds.coord('time').bounds = [0., 1.]
         result = iris.cube.CubeList([cube_with_bounds, self.cube])
@@ -125,7 +125,7 @@ class Test__equalise_coord_bounds(IrisTest):
             _equalise_coord_bounds(result)
 
     def test_one_bounds_threecubes(self):
-        """Test that when one of the input cubes has no bounds a warning is
+        """Test that when one of the input cubes has no bounds an error is
         raised."""
         cube_with_bounds = self.cube.copy()
         cube_with_bounds.coord('time').bounds = [0., 1.]
@@ -160,9 +160,9 @@ class Test__equalise_coord_bounds(IrisTest):
         cubeB.coord('forecast_period').bounds = bounds
         result = iris.cube.CubeList([cubeA, cubeB])
         _equalise_coord_bounds(result)
-        self.assertArrayAlmostEqual(result[0].coord('forecast_period').bounds,
+        self.assertArrayEqual(result[0].coord('forecast_period').bounds,
                                     [bounds])
-        self.assertArrayAlmostEqual(result[1].coord('forecast_period').bounds,
+        self.assertArrayEqual(result[1].coord('forecast_period').bounds,
                                     [bounds])
 
     def test_with_no_forecast_period_bounds(self):

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -444,9 +444,7 @@ def _equalise_coord_bounds(cubes):
     """
     # Check each cube against all remaining cubes
     def warn(cube):
-        """Raise warning about  mismatched bounds"""
-        warnings.warn('Removing mismatched bounds from cube {}'.format(
-            cube.name))
+        """Raise warning about mismatched bounds"""
     for i, this_cube in enumerate(cubes):
         for later_cube in cubes[i+1:]:
             for coord in this_cube.coords():
@@ -456,12 +454,14 @@ def _equalise_coord_bounds(cubes):
                     continue
                 if coord.bounds is None and match_coord.bounds is None:
                     continue
-                elif coord.bounds is None:
-                    match_coord.bounds = None
-                    warn(later_cube)
-                elif match_coord.bounds is None:
-                    coord.bounds = None
-                    warn(this_cube)
+                elif coord.bounds is None and match_coord.bounds is not None:
+                    msg = ('Cubes with mismatching bounds are not '
+                           'compatible')
+                    raise ValueError(msg)
+                elif coord.bounds is not None and match_coord.bounds is None:
+                    msg = ('Cubes with mismatching bounds are not '
+                           'compatible')
+                    raise ValueError(msg)
                 elif np.allclose(np.array(coord.bounds),
                                  np.array(match_coord.bounds)):
                     continue

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -443,7 +443,6 @@ def _equalise_coord_bounds(cubes):
             If two cubes with different valid bounds are found.
     """
     # Check each cube against all remaining cubes
-    """Raise warning about mismatched bounds"""
     for i, this_cube in enumerate(cubes):
         for later_cube in cubes[i+1:]:
             for coord in this_cube.coords():

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -443,8 +443,7 @@ def _equalise_coord_bounds(cubes):
             If two cubes with different valid bounds are found.
     """
     # Check each cube against all remaining cubes
-    def warn(cube):
-        """Raise warning about mismatched bounds"""
+    """Raise warning about mismatched bounds"""
     for i, this_cube in enumerate(cubes):
         for later_cube in cubes[i+1:]:
             for coord in this_cube.coords():


### PR DESCRIPTION
Addresses #700 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

I have looked at cube_manipulation.py and changed the functionality of _equalise_coord_bounds slightly. This was doing most of what we wanted it to do, but if there was a cube which didn't have bounds, and one that did, it would get rid of the bounds. This was a historic fix, which after discussion with Stephen Moseley we realised we didn't need. So this functionality has been taken out.

There were unit tests to cover some of the work already, but I have updated and added to the unit tests within test_equalise_coord_bounds. This should run as required. The unit tests now cover these cases (for both the coordinate 'time' and also 'forecast_period':

- Where the cubes have identical bounds
- Where none of the cubes have bounds
- Where the cubes have mismatched bounds (but still values within the bounds)
- Where there is a cube that doesn't have bounds, and a cube that does

