### PR TITLE
Temporal.py changes to support orographic enhancement

### DIFF
--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -35,7 +35,8 @@ import iris
 from iris.exceptions import ConstraintMismatchError
 from improver.nbhood.nbhood import NeighbourhoodProcessing
 from improver.utilities.cube_checker import check_cube_coordinates
-from improver.utilities.temporal import iris_time_to_datetime
+from improver.utilities.temporal import (
+    extract_nearest_time_point, iris_time_to_datetime)
 from improver.utilities.rescale import apply_double_scaling, rescale
 
 
@@ -84,6 +85,7 @@ class NowcastLightning(object):
 
         heavy:  prob(precip > 7mm/hr) >= 0.4 => min lightning prob 0.25 (LR2)
                 equiv radar refl 37dBZ
+
         intense:prob(precip > 35mm/hr) >= 0.2 => min lightning prob 1.0 (LR1)
                 equiv radar refl 48dBZ
 
@@ -235,7 +237,6 @@ class NowcastLightning(object):
                 Must have same other dimensions as cube.
 
         Keyword Args:
-
             prob_vii_cube (iris.cube.Cube):
                 Radar-derived vertically integrated ice content (VII).
                 Must have same x and y dimensions as cube.
@@ -261,23 +262,14 @@ class NowcastLightning(object):
                 cube_slice.coord('time').copy())[0]
             lightning_rate_slice = lightning_rate_cube.extract(
                 iris.Constraint(time=this_time))
-            first_guess_time = iris_time_to_datetime(
-                first_guess_lightning_cube.coord('time').copy())[
-                    first_guess_lightning_cube.coord(
-                        'time'
-                        ).nearest_neighbour_index(this_point)]
-            first_guess_slice = first_guess_lightning_cube.extract(
-                iris.Constraint(time=first_guess_time))
             err_string = "No matching {} cube for {}"
             if not isinstance(lightning_rate_slice,
                               iris.cube.Cube):
                 raise ConstraintMismatchError(
                     err_string.format("lightning", this_time))
-            # Fail if the closest available "first guess" forecast is more
-            # than 2 hours away from the required validity time.
-            if abs((first_guess_time - this_time).total_seconds()) > 7201.:
-                raise ConstraintMismatchError(
-                    err_string.format("first-guess", this_time))
+            first_guess_slice = extract_nearest_time_point(
+                first_guess_lightning_cube, this_time,
+                allowed_dt_difference=7201)
             first_guess_slice = cube_slice.copy(data=first_guess_slice.data)
             first_guess_slice.coord('forecast_period').convert_units('minutes')
             fcmins = first_guess_slice.coord('forecast_period').points[0]
@@ -460,7 +452,6 @@ class NowcastLightning(object):
                     * (optional) Analysis of vertically integrated ice (VII)
                       from radar thresholded into probability slices
                       at self.ice_thresholds.
-
 
         Returns:
             new_cube (iris.cube.Cube):

--- a/lib/improver/spotdata/extrema.py
+++ b/lib/improver/spotdata/extrema.py
@@ -39,7 +39,7 @@ from iris.cube import Cube, CubeList
 from iris.coords import DimCoord
 from improver.utilities.temporal import (iris_time_to_datetime,
                                          datetime_constraint,
-                                         dt_to_utc_hours)
+                                         datetime_to_iris_time)
 
 
 class ExtractExtrema(object):
@@ -56,13 +56,11 @@ class ExtractExtrema(object):
             period (int (units: hours)):
                 Period in hours over which to calculate the extrema values,
                 e.g. 24 hours for maxima/minima in a whole day.
-
             start_hour (int (units: hours)):
                 Hour in local_time on the 24hr clock at which to start the
                 series of periods, e.g. period=12, start_hour=9 --> 09-21,
                 21-09, etc. The default hour of 0900 is chosen to align with
                 the NCM (national climate message) reporting period.
-
         """
         self.period = period
         self.start_hour = start_hour
@@ -84,7 +82,6 @@ class ExtractExtrema(object):
         Returns:
             period_cubes (iris.cube.CubeList):
                 CubeList of diagnostic extrema cubes.
-
         """
         # Change to 64 bit to avoid the 2038 problem with any time
         # manipulations on units in seconds since the epoch.
@@ -112,10 +109,10 @@ class ExtractExtrema(object):
             cube_over_period = local_tz_cube.extract(extrema_constraint)
             if cube_over_period is not None:
                 # Ensure time dimension of resulting cube reflects period.
-                mid_time = dt_to_utc_hours(period_start +
-                                           (period_end - period_start)/2)
-                bounds = [dt_to_utc_hours(period_start),
-                          dt_to_utc_hours(period_end)]
+                mid_time = datetime_to_iris_time(period_start +
+                                                 (period_end - period_start)/2)
+                bounds = [datetime_to_iris_time(period_start),
+                          datetime_to_iris_time(period_end)]
 
                 extremas = [['max', iris.analysis.MAX],
                             ['min', iris.analysis.MIN]]
@@ -143,9 +140,7 @@ def make_local_time_cube(cube):
       UTC Coord  :  12   13   14   15   16
       Data: Site 1  300  302  296  294  290 (UTC offset = -2)
             Site 2  280  282  283  280  279 (UTC offset = +2)
-
     Data redistributed according to UTC offset to sit on local time::
-
       Local times:  10   11   12   13   14   15   16   17   18
       Data: Site 1  300  302  296  294  290  -    -    -    -
             Site 2  -    -    -    -    280  282  283  280  279
@@ -240,7 +235,6 @@ def get_datetime_limits(time_coord, start_hour):
     Args:
         time_coord (iris.coords.DimCoord):
             An iris time coordinate from which to extract the date limits.
-
         start_hour (int):
             The hour on a 24hr clock at which to set the returned times.
 
@@ -249,7 +243,6 @@ def get_datetime_limits(time_coord, start_hour):
             **start_time** (datetime.datetime object):
                 First day on a time coordinate, with the time set to the hour
                 given by start hour
-
             **end_time** (datetime.datetime object):
                 Last day on a time coordinate, with the time set to the hour
                 given by start hour

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -248,18 +248,6 @@ class Test__modify_first_guess(IrisTest):
                                             self.precip_cube,
                                             None)
 
-    def test_missing_first_guess(self):
-        """Test that the method raises an error if the first-guess cube doesn't
-        match the meta-data cube time coordinate."""
-        self.fg_cube.coord('time').points = [1.0]
-        msg = ("No matching first-guess cube for")
-        with self.assertRaisesRegex(ConstraintMismatchError, msg):
-            self.plugin._modify_first_guess(self.cube,
-                                            self.fg_cube,
-                                            self.ltng_cube,
-                                            self.precip_cube,
-                                            None)
-
     def test_cube_has_no_time_coord(self):
         """Test that the method raises an error if the meta-data cube has no
         time coordinate."""

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -248,6 +248,19 @@ class Test__modify_first_guess(IrisTest):
                                             self.precip_cube,
                                             None)
 
+    def test_missing_first_guess(self):
+        """Test that the method raises an error if the first-guess cube doesn't
+        match the meta-data cube time coordinate."""
+        self.fg_cube.coord('time').points = [1.0]
+        msg = ("is not available within the input cube within the "
+               "allowed difference")
+        with self.assertRaisesRegex(ValueError, msg):
+            self.plugin._modify_first_guess(self.cube,
+                                            self.fg_cube,
+                                            self.ltng_cube,
+                                            self.precip_cube,
+                                            None)
+
     def test_cube_has_no_time_coord(self):
         """Test that the method raises an error if the meta-data cube has no
         time coordinate."""

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -274,6 +274,14 @@ class Test_datetime_to_iris_time(IrisTest):
         self.assertIsInstance(result, float)
         self.assertEqual(result, expected)
 
+    def test_minutes(self):
+        """Test datetime_to_iris_time returns float with expected value
+        in minutes"""
+        result = datetime_to_iris_time(self.dt_in, time_units="minutes")
+        expected = 24788520.0
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, expected)
+
     def test_seconds(self):
         """Test datetime_to_iris_time returns float with expected value
         in seconds"""
@@ -487,6 +495,8 @@ class Test_extract_nearest_time_point(IrisTest):
     def setUp(self):
         """Set up a cube for the tests."""
         cube = set_up_cube(num_time_points=2)
+        # The time points specified correspond to 2015-11-23 07:00:00
+        # and 2015-11-23 08:00:00, respectively.
         self.cube = add_forecast_reference_time_and_forecast_period(
             cube, time_point=[402295.0, 402296.0], fp_point=[4.0, 5.0])
 
@@ -495,6 +505,22 @@ class Test_extract_nearest_time_point(IrisTest):
         extracted."""
         expected = self.cube[:, 0, :, :]
         time_point = datetime.datetime(2015, 11, 23, 6, 0)
+        result = extract_nearest_time_point(self.cube, time_point)
+        self.assertEqual(result, expected)
+
+    def test_time_coord_lower_case(self):
+        """Test that the nearest time point within the time coordinate is
+        extracted, when a time of 07:30 is requested."""
+        expected = self.cube[:, 0, :, :]
+        time_point = datetime.datetime(2015, 11, 23, 7, 30)
+        result = extract_nearest_time_point(self.cube, time_point)
+        self.assertEqual(result, expected)
+
+    def test_time_coord_upper_case(self):
+        """Test that the nearest time point within the time coordinate is
+        extracted, when a time of 07:31 is requested."""
+        expected = self.cube[:, 1, :, :]
+        time_point = datetime.datetime(2015, 11, 23, 7, 31)
         result = extract_nearest_time_point(self.cube, time_point)
         self.assertEqual(result, expected)
 
@@ -507,14 +533,24 @@ class Test_extract_nearest_time_point(IrisTest):
             self.cube, time_point, time_name="forecast_reference_time")
         self.assertEqual(result, expected)
 
-    def test_exception_raised(self):
-        """Test that an exception raised, if the time point is outside of
+    def test_exception_using_allowed_dt_difference(self):
+        """Test that an exception is raised, if the time point is outside of
         the allowed difference specified in seconds."""
         time_point = datetime.datetime(2017, 11, 23, 6, 0)
         msg = "is not available within the input cube"
         with self.assertRaisesRegex(ValueError, msg):
             extract_nearest_time_point(self.cube, time_point,
                                        allowed_dt_difference=3600)
+
+    def test_time_name_exception(self):
+        """Test that an exception is raised, if an invalid time name
+        is specified."""
+        time_point = datetime.datetime(2017, 11, 23, 6, 0)
+        msg = ("The time_name must be either "
+               "'time' or 'forecast_reference_time'")
+        with self.assertRaisesRegex(ValueError, msg):
+            extract_nearest_time_point(self.cube, time_point,
+                                       time_name="forecast_period")
 
 
 # temporary utility - to be removed

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -45,9 +45,10 @@ from iris.time import PartialDateTime
 
 from improver.utilities.temporal import (
     cycletime_to_datetime, cycletime_to_number, forecast_period_coord,
-    iris_time_to_datetime, dt_to_utc_hours, datetime_constraint,
+    iris_time_to_datetime, datetime_constraint,
     extract_cube_at_time, set_utc_offset, get_forecast_times,
-    unify_forecast_reference_time, find_latest_cycletime)
+    unify_forecast_reference_time, find_latest_cycletime,
+    extract_nearest_time_point, datetime_to_iris_time)
 from improver.tests.blending.weights.helper_functions import (
     set_up_temperature_cube, add_model_id_and_model_configuration)
 from improver.tests.ensemble_calibration.ensemble_calibration.helper_functions\
@@ -257,15 +258,45 @@ class Test_iris_time_to_datetime(Test_common_functions):
         self.assertEqual(result[0], datetime.datetime(2017, 2, 17, 6, 0))
 
 
-class Test_dt_to_utc_hours(IrisTest):
-    """ Test dt_to_utc_hours """
-    def test_basic(self):
-        """Test dt_to_utc_hours returns float with expected value """
-        dt_in = datetime.datetime(2017, 2, 17, 6, 0)
-        result = dt_to_utc_hours(dt_in)
+class Test_datetime_to_iris_time(IrisTest):
+
+    """Test the datetime_to_iris_time function."""
+
+    def setUp(self):
+        """Define datetime for use in tests."""
+        self.dt_in = datetime.datetime(2017, 2, 17, 6, 0)
+
+    def test_hours(self):
+        """Test datetime_to_iris_time returns float with expected value
+        in hours"""
+        result = datetime_to_iris_time(self.dt_in)
         expected = 413142.0
         self.assertIsInstance(result, float)
         self.assertEqual(result, expected)
+
+    def test_seconds(self):
+        """Test datetime_to_iris_time returns float with expected value
+        in seconds"""
+        result = datetime_to_iris_time(self.dt_in, time_units="seconds")
+        expected = 1487311200.0
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, expected)
+
+    def test_seconds_from_origin(self):
+        """Test datetime_to_iris_time returns float with expected value
+        in seconds when an origin is supplied."""
+        result = datetime_to_iris_time(
+            self.dt_in, time_units="seconds since 1970-01-01 00:00:00")
+        expected = 1487311200.0
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, expected)
+
+    def test_exception_raised(self):
+        """Test an exception is raised if the if the time unit does not
+        contain hours, minutes or seconds."""
+        msg = "The time unit must contain 'hours', 'minutes' or 'seconds'"
+        with self.assertRaisesRegex(ValueError, msg):
+            datetime_to_iris_time(self.dt_in, time_units="days")
 
 
 class Test_datetime_constraint(Test_common_functions):
@@ -310,7 +341,6 @@ class Test_datetime_constraint(Test_common_functions):
 class Test_extract_cube_at_time(Test_common_functions):
     """
     Test wrapper for iris cube extraction at desired times.
-
     """
 
     def test_valid_time(self):
@@ -348,14 +378,12 @@ class Test_extract_cube_at_time(Test_common_functions):
 class Test_set_utc_offset(IrisTest):
     """
     Test setting of UTC_offsets with longitudes using crude 15 degree bins.
-
     """
 
     def test_output(self):
         """
         Test full span of crude timezones from UTC-12 to UTC+12. Note the
         degeneracy at +-180.
-
         """
         longitudes = np.arange(-180, 185, 15)
         expected = np.arange(-12, 13, 1)
@@ -450,6 +478,43 @@ class Test_get_forecast_times(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             get_forecast_times(144, forecast_date=forecast_date,
                                forecast_time=6)
+
+
+class Test_extract_nearest_time_point(IrisTest):
+
+    """Test the extract_nearest_time_point function."""
+
+    def setUp(self):
+        """Set up a cube for the tests."""
+        cube = set_up_cube(num_time_points=2)
+        self.cube = add_forecast_reference_time_and_forecast_period(
+            cube, time_point=[402295.0, 402296.0], fp_point=[4.0, 5.0])
+
+    def test_time_coord(self):
+        """Test that the nearest time point within the time coordinate is
+        extracted."""
+        expected = self.cube[:, 0, :, :]
+        time_point = datetime.datetime(2015, 11, 23, 6, 0)
+        result = extract_nearest_time_point(self.cube, time_point)
+        self.assertEqual(result, expected)
+
+    def test_forecast_reference_time_coord(self):
+        """Test that the nearest time point within the forecast_reference_time
+        coordinate is extracted."""
+        expected = self.cube
+        time_point = datetime.datetime(2015, 11, 23, 6, 0)
+        result = extract_nearest_time_point(
+            self.cube, time_point, time_name="forecast_reference_time")
+        self.assertEqual(result, expected)
+
+    def test_exception_raised(self):
+        """Test that an exception raised, if the time point is outside of
+        the allowed difference specified in seconds."""
+        time_point = datetime.datetime(2017, 11, 23, 6, 0)
+        msg = "is not available within the input cube"
+        with self.assertRaisesRegex(ValueError, msg):
+            extract_nearest_time_point(self.cube, time_point,
+                                       allowed_dt_difference=3600)
 
 
 # temporary utility - to be removed

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -35,6 +35,7 @@ import re
 from datetime import datetime
 from datetime import time as dt_time
 from datetime import timedelta
+from datetime import timezone
 from time import mktime
 import warnings
 
@@ -133,7 +134,6 @@ def forecast_period_coord(
             forecast_period coord is already present in the cube as a
             DimCoord and this coord does not need changing, otherwise
             it will be an AuxCoord. Units are result_units.
-
     """
     if cube.coords("forecast_period"):
         fp_type = cube.coord("forecast_period").dtype
@@ -223,26 +223,42 @@ def iris_time_to_datetime(time_coord):
     Returns:
         list of datetime.datetime objects
             The time element(s) recast as a python datetime object.
-
     """
     time_coord.convert_units('seconds since 1970-01-01 00:00:00')
     return [datetime.utcfromtimestamp(value) for value in time_coord.points]
 
 
-def dt_to_utc_hours(dt_in):
+def datetime_to_iris_time(dt_in, time_units="hours"):
     """
-    Convert python datetime.datetime into hours since 1970-01-01 00Z.
+    Convert python datetime.datetime into hours, minutes or seconds
+    since 1970-01-01 00Z.
 
     Args:
         dt_in (datetime.datetime object):
             Time to be converted.
+
+        time_units (str):
+            Name of time unit. Currently only "hours", "minutes" or
+            "seconds" are supported. Alternatively, an origin time can be
+            supported, for example "seconds since 1970-01-01 00:00:00".
+
     Returns:
         float:
-            hours since epoch
-
+            time since epoch in the units defined by the time_units.
     """
-    utc_seconds = mktime(dt_in.utctimetuple())
-    return utc_seconds/3600.
+    if all(time_unit not in time_units for time_unit in
+           ["hours", "minutes", "seconds"]):
+        msg = ("The time unit must contain 'hours', 'minutes' or 'seconds'. "
+               "The time unit was {}".format(time_units))
+        raise ValueError(msg)
+    result = dt_in.replace(tzinfo=timezone.utc).timestamp()
+    if "hours" in time_units:
+        result /= 3600.
+    elif "minutes" in time_units:
+        result /= 60
+    elif "seconds" in time_units:
+        pass
+    return result
 
 
 def datetime_constraint(time_in, time_max=None):
@@ -260,7 +276,6 @@ def datetime_constraint(time_in, time_max=None):
         time_extract (iris.Constraint):
             An iris constraint to be used in extracting data at the given time
             from a cube.
-
     """
     time_start = PartialDateTime(
         time_in.year, time_in.month, time_in.day, time_in.hour)
@@ -282,10 +297,8 @@ def extract_cube_at_time(cubes, time, time_extract):
     Args:
         cubes (iris.cube.CubeList):
             CubeList of a given diagnostic over several times.
-
         time (datetime.datetime object):
             Time at which forecast data is needed.
-
         time_extract (iris.Constraint):
             Iris constraint for the desired time.
 
@@ -295,7 +308,6 @@ def extract_cube_at_time(cubes, time, time_extract):
 
     Raises:
         ValueError if the desired time is not available within the cubelist.
-
     """
     try:
         cube_in, = cubes.extract(time_extract)
@@ -320,7 +332,6 @@ def set_utc_offset(longitudes):
     Returns:
         utc_offsets (List):
             List of utc_offsets calculated using longitude.
-
     """
     return np.floor((np.array(longitudes) + 7.5)/15.)
 
@@ -337,11 +348,9 @@ def get_forecast_times(forecast_length, forecast_date=None,
         forecast_length (int):
             An integer giving the desired length of the forecast output in
             hours (e.g. 48 for a two day forecast period).
-
         forecast_date (string (YYYYMMDD)):
             A string of format YYYYMMDD defining the start date for which
             forecasts are required. If unset it defaults to today in UTC.
-
         forecast_time (int):
             An integer giving the hour on the forecast_date at which to start
             the forecast output; 24hr clock such that 17 = 17Z for example. If
@@ -354,7 +363,6 @@ def get_forecast_times(forecast_length, forecast_date=None,
 
     Raises:
         ValueError : raised if the input date is not in the expected format.
-
     """
     date_format = re.compile('[0-9]{8}')
 
@@ -452,6 +460,7 @@ def find_latest_cycletime(cubelist):
         cubelist (iris.cube.CubeList):
             A list of cubes each containing single time step from different
             forecast cycles.
+
     Returns:
         cycletime (datetime object):
             A datetime object corresponding to the latest forecast reference
@@ -493,10 +502,8 @@ class TemporalInterpolation(object):
                 Specifies the interval in minutes at which to interpolate
                 between the two input cubes. A number of minutes which does not
                 divide up the interval equally will raise an exception::
-
                     e.g. cube_t0 valid at 03Z, cube_t1 valid at 06Z,
                     interval_in_minutes = 60 --> interpolate to 04Z and 05Z.
-
             times (list or tuple of datetime.datetime objects):
                 A list of datetime objects specifying the times to which to
                 interpolate.
@@ -533,9 +540,9 @@ class TemporalInterpolation(object):
                 A list containing a tuple that specifies the coordinate and a
                 list of points along that coordinate to which to interpolate,
                 as required by the iris interpolation method:
-
                     e.g. [('time', [<datetime object 0>,
                                     <datetime object 1>])]
+
         Raises:
             ValueError: If list of times provided falls outside the range
                         specified by the initial and final times.
@@ -576,7 +583,6 @@ class TemporalInterpolation(object):
             cube_t0 (iris.cube.Cube):
                 A diagnostic cube valid at the beginning of the period within
                 which interpolation is to be permitted.
-
             cube_t1 (iris.cube.Cube):
                 A diagnostic cube valid at the end of the period within which
                 interpolation is to be permitted.
@@ -624,3 +630,50 @@ class TemporalInterpolation(object):
             interpolated_cubes.append(single_time)
 
         return interpolated_cubes
+
+
+def extract_nearest_time_point(
+        cube, dt, time_name="time", allowed_dt_difference=None):
+    """Find the nearest time point to the time point provided.
+
+    Args:
+        cube (iris.cube.Cube):
+            Cube or CubeList that will be extracted from using the supplied
+            time_point
+        dt (datetime.datetime):
+            Datetime representation of a time that will be used within the
+            extraction from the cube supplied.
+        time_name (str):
+            Name of the "time" coordinate that will be extracted. For example,
+            this could be "time" or "forecast_reference_time".
+        allowed_dt_difference (float or None):
+            Defines a limit to the maximum difference between the datetime
+            provided and the time points available within the cube. If
+            this limit is exceeded, then an error is raised.
+            This must be defined in seconds.
+
+    Returns:
+        cube (iris.cube.Cube):
+            Cube following extraction to return the cube that is nearest
+            to the time point supplied.
+
+    Raises:
+        ValueError: The requested datetime is not available within the
+            allowed difference.
+    """
+    time_point = datetime_to_iris_time(
+        dt, time_units=cube.coord(time_name).units.origin)
+    time_point_index = (
+        cube.coord(time_name).nearest_neighbour_index(time_point))
+    nearest_dt, = (
+        iris_time_to_datetime(cube.coord(time_name).copy()[time_point_index]))
+    if allowed_dt_difference:
+        if abs((dt - nearest_dt).total_seconds()) > allowed_dt_difference:
+            msg = ("The datetime {} is not available within the input cube "
+                   "within the allowed difference {}. "
+                   "The nearest datetime available was {}".format(
+                       dt, allowed_dt_difference, nearest_dt))
+            raise ValueError(msg)
+    constr = iris.Constraint(coord_values={time_name: nearest_dt})
+    cube = cube.extract(constr)
+    return cube

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -36,7 +36,6 @@ from datetime import datetime
 from datetime import time as dt_time
 from datetime import timedelta
 from datetime import timezone
-from time import mktime
 import warnings
 
 import numpy as np
@@ -240,11 +239,13 @@ def datetime_to_iris_time(dt_in, time_units="hours"):
         time_units (str):
             Name of time unit. Currently only "hours", "minutes" or
             "seconds" are supported. Alternatively, an origin time can be
-            supported, for example "seconds since 1970-01-01 00:00:00".
+            supported, for example "seconds since 1970-01-01 00:00:00",
+            however, "since 1970-01-01 00:00:00" will be ignored.
 
     Returns:
-        float:
-            time since epoch in the units defined by the time_units.
+        result (float):
+            Time since epoch in the units defined by the time_units
+            with default floating point precision.
     """
     if all(time_unit not in time_units for time_unit in
            ["hours", "minutes", "seconds"]):
@@ -644,8 +645,8 @@ def extract_nearest_time_point(
             Datetime representation of a time that will be used within the
             extraction from the cube supplied.
         time_name (str):
-            Name of the "time" coordinate that will be extracted. For example,
-            this could be "time" or "forecast_reference_time".
+            Name of the "time" coordinate that will be extracted. This must be
+            "time" or "forecast_reference_time".
         allowed_dt_difference (float or None):
             Defines a limit to the maximum difference between the datetime
             provided and the time points available within the cube. If
@@ -661,6 +662,12 @@ def extract_nearest_time_point(
         ValueError: The requested datetime is not available within the
             allowed difference.
     """
+    if time_name not in ["time", "forecast_reference_time"]:
+        msg = ("{} is not a valid time_name. "
+               "The time_name must be either "
+               "'time' or 'forecast_reference_time'.")
+        raise ValueError(msg)
+
     time_point = datetime_to_iris_time(
         dt, time_units=cube.coord(time_name).units.origin)
     time_point_index = (


### PR DESCRIPTION
Changes to temporal.py for usage in the future addition of the orographic enhancement to the extrapolate and optical-flow CLIs.

Addresses #169 

Description
Factored out the changes required to temporal.py from #726, so that #726 can be made simpler.

Primarily this PR factors out the nearest time point extraction capability from lightning.py into a separate function with unit tests. The dt_to_utc_hours function is modified to be datetime_to_iris_time for usage in the new extract_nearest_time_point function.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

