### PR TITLE
Impro977 landsea regridding

### DIFF
--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -142,9 +142,14 @@ def main():
             raise ValueError(msg)
 
     if args.input_landmask_filepath and not args.target_grid_filepath:
-            msg = ("Cannot specify input_landmask_filepath without "
-                   "target_grid_filepath")
-            raise ValueError(msg)
+        msg = ("Cannot specify input_landmask_filepath without "
+               "target_grid_filepath")
+        raise ValueError(msg)
+
+    if args.input_landmask_filepath and not args.nearest:
+        msg = ("Land-mask-aware regridding is only configured for use "
+               "with nearest-neighbour regridding. Add --nearest flag.")
+        raise ValueError(msg)
 
     # Re-grid with options:
     # if a target grid file has been specified, then regrid optionally

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -34,6 +34,7 @@ meta-data and demoting float64 data to float32"""
 
 import iris
 import json
+import warnings
 
 from improver.argparser import ArgParser
 from improver.utilities.load import load_cube
@@ -173,11 +174,11 @@ def main():
             source_landsea = load_cube(args.input_landmask_filepath)
             if "land_binary_mask" not in source_landsea.name():
                 msg = ("Expected land_binary_mask in input_landmask_filepath "
-                       "but found {}".format(source_landsea))
+                       "but found {}".format(repr(source_landsea)))
                 warnings.warn(msg)
             if "land_binary_mask" not in target_grid.name():
                 msg = ("Expected land_binary_mask in target_grid_filepath "
-                       "but found {}".format(target_grid))
+                       "but found {}".format(repr(target_grid)))
                 warnings.warn(msg)
             output_data = RegridLandSea(
                 vicinity_radius=args.landmask_vicinity).process(

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -76,8 +76,9 @@ def main():
     regrid_group.add_argument(
         "--target_grid_filepath", metavar="TARGET_GRID",
         help=('If specified then regridding of the source '
-              'against the target grid is enabled. If also using landmask-aware'
-              ' regridding, then this must be land_binary_mask data.'))
+              'against the target grid is enabled. If also using '
+              'landmask-aware regridding, then this must be land_binary_mask '
+              'data.'))
 
     regrid_group.add_argument(
         "--nearest", action='store_true', default=False,

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -178,6 +178,11 @@ def main():
         output_data = output_data.regrid(target_grid, regridder)
 
         if args.regrid_mode in ["nearest-with-mask"]:
+            if not args.input_landmask_filepath:
+                msg = ("An argument has been specified that requires an input "
+                       "landmask filepath but none has been provided")
+                raise ValueError(msg)
+ 
             source_landsea = load_cube(args.input_landmask_filepath)
             if "land_binary_mask" not in source_landsea.name():
                 msg = ("Expected land_binary_mask in input_landmask_filepath "

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -45,20 +45,21 @@ from improver.utilities.spatial import RegridLandSea
 
 
 def main():
-    """Standardise a source cube. Standardisation options include regridding
-    (with options to fix float64 data, use Iris nearest and extrapolate
-    modes and update metadata. Standalone options included checking/fixing
-    float64 data and updating metadata. A check for float64 data compliance
-    can be made by only specify a source NetCDF file with no
-    other arguments."""
+    """
+    Standardise a source cube. Available options are regridding (bilinear or
+    nearest-neighbour, optionally with land-mask awareness), updating meta-data
+    and converting float64 data to float32. A check for float64 data compliance
+    can be made by only specify a source NetCDF file with no other arguments.
+    """
     parser = ArgParser(
         description='Standardise a source data cube. Three main options are '
-                    'available; checking and optionally fixing float64 data, '
-                    'regridding and updating metadata. If regridding then '
-                    'additional options are available to specify Iris nearest '
-                    'and extrapolation modes. If only a source file is '
-                    'specified with no other arguments, then an exception '
-                    'will be raised if float64 data is found on the source.')
+                    'available; fixing float64 data, regridding and updating '
+                    'metadata. If regridding then additional options are '
+                    'available to use bilinear or nearest-neighbour '
+                    '(optionally with land-mask awareness) modes. If only a '
+                    'source file is specified with no other arguments, then '
+                    'an exception will be raised if float64 data are found on '
+                    'the source.')
 
     parser.add_argument('source_data_filepath', metavar='SOURCE_DATA',
                         help='A cube of data that is to be standardised and '
@@ -81,16 +82,20 @@ def main():
               'data.'))
 
     regrid_group.add_argument(
-        "--nearest", action='store_true', default=False,
-        help='If True, regridding will be performed using '
-             'iris.analysis.Nearest() instead of Linear(). '
-             'Use for less continuous fields, '
-             'e.g. precipitation.')
+        "--regrid_mode", default='bilinear',
+        choices=['bilinear', 'nearest', 'nearest-with-mask'],
+        help=('Selects which regridding technique to use. Default uses '
+              'iris.analysis.Linear(); "nearest" uses Nearest() (Use for less '
+              'continuous fields, e.g. precipitation.); "nearest-with-mask" '
+              'ensures that target data are sourced from points with the same '
+              'mask value (Use for coast-line-dependent variables like '
+              'temperature).'))
 
     regrid_group.add_argument(
         "--extrapolation_mode", default='nanmask',
         help='Mode to use for extrapolating data into regions '
              'beyond the limits of the source_data domain. '
+             'Refer to online documentation for iris.analysis. '
              'Modes are: '
              'extrapolate - The extrapolation points will '
              'take their value from the nearest source point. '
@@ -129,6 +134,23 @@ def main():
 
     args = parser.parse_args()
 
+    if args.target_grid_filepath or args.json_file or args.fix_float64:
+        if not args.output_filepath:
+            msg = ("An argument has been specified that requires an output "
+                   "filepath but none has been provided")
+            raise ValueError(msg)
+
+    if (args.input_landmask_filepath and 
+        "nearest-with-mask" not in args.regrid_mode):
+        msg = ("Land-mask file supplied without appropriate regrid_mode. "
+               "Use --regrid_mode=nearest-with-mask.")
+        raise ValueError(msg)
+
+    if args.input_landmask_filepath and not args.target_grid_filepath:
+        msg = ("Cannot specify input_landmask_filepath without "
+               "target_grid_filepath")
+        raise ValueError(msg)
+
     # source file data path is a mandatory argument
     output_data = load_cube(args.source_data_filepath)
 
@@ -136,22 +158,6 @@ def main():
         check_cube_not_float64(output_data, fix=True)
     else:
         check_cube_not_float64(output_data, fix=False)
-
-    if args.target_grid_filepath or args.json_file or args.fix_float64:
-        if not args.output_filepath:
-            msg = ("An argument has been specified that requires an output "
-                   "filepath but none has been provided")
-            raise ValueError(msg)
-
-    if args.input_landmask_filepath and not args.target_grid_filepath:
-        msg = ("Cannot specify input_landmask_filepath without "
-               "target_grid_filepath")
-        raise ValueError(msg)
-
-    if args.input_landmask_filepath and not args.nearest:
-        msg = ("Land-mask-aware regridding is only configured for use "
-               "with nearest-neighbour regridding. Add --nearest flag.")
-        raise ValueError(msg)
 
     # Re-grid with options:
     # if a target grid file has been specified, then regrid optionally
@@ -165,13 +171,13 @@ def main():
         regridder = iris.analysis.Linear(
             extrapolation_mode=args.extrapolation_mode)
 
-        if args.nearest:
+        if args.regrid_mode in ["nearest", "nearest-with-mask"]:
             regridder = iris.analysis.Nearest(
                 extrapolation_mode=args.extrapolation_mode)
 
         output_data = output_data.regrid(target_grid, regridder)
 
-        if args.input_landmask_filepath:
+        if args.regrid_mode in ["nearest-with-mask"]:
             source_landsea = load_cube(args.input_landmask_filepath)
             if "land_binary_mask" not in source_landsea.name():
                 msg = ("Expected land_binary_mask in input_landmask_filepath "

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -40,6 +40,7 @@ from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 from improver.utilities.cube_checker import check_cube_not_float64
 from improver.utilities.cube_metadata import amend_metadata
+from improver.utilities.spatial import RegridLandSea
 
 
 def main():
@@ -70,38 +71,54 @@ def main():
                              "output file, then the source will be checked"
                              "for float64 data.")
 
-    parser.add_argument("--target_grid_filepath", metavar="TARGET_GRID",
-                        help='If specified then regridding of the source '
-                             'against the target grid is enabled.')
+    regrid_group = parser.add_argument_group("Regridding options")
+    regrid_group.add_argument(
+        "--target_grid_filepath", metavar="TARGET_GRID",
+        help=('If specified then regridding of the source '
+              'against the target grid is enabled. If also using landmask-aware'
+              ' regridding, then this must be land_binary_mask data.'))
+
+    regrid_group.add_argument(
+        "--nearest", action='store_true', default=False,
+        help='If True, regridding will be performed using '
+             'iris.analysis.Nearest() instead of Linear(). '
+             'Use for less continuous fields, '
+             'e.g. precipitation.')
+
+    regrid_group.add_argument(
+        "--extrapolation_mode", default='nanmask',
+        help='Mode to use for extrapolating data into regions '
+             'beyond the limits of the source_data domain. '
+             'Modes are: '
+             'extrapolate - The extrapolation points will '
+             'take their value from the nearest source point. '
+             'nan - The extrapolation points will be be '
+             'set to NaN. '
+             'error - A ValueError exception will be raised, '
+             'notifying an attempt to extrapolate. '
+             'mask  - The extrapolation points will always be '
+             'masked, even if the source data is not a '
+             'MaskedArray. '
+             'nanmask - If the source data is a MaskedArray '
+             'the extrapolation points will be masked. '
+             'Otherwise they will be set to NaN. '
+             'Defaults to nanmask.')
+
+    regrid_group.add_argument(
+        "--input_landmask_filepath", metavar="INPUT_LANDMASK_FILE",
+        help=("A path to a NetCDF file describing the land_binary_mask on "
+              "the source-grid if coastline-aware regridding is required."))
+
+    regrid_group.add_argument(
+        "--landmask_vicinity", metavar="LANDMASK_VICINITY",
+        default=25000., type=float,
+        help=("Radius of vicinity to search for a coastline, in metres. "
+              "Default value; 25000 m"))
 
     parser.add_argument("--fix_float64", action='store_true', default=False,
                         help="Check and fix cube for float64 data. Without "
                              "this option an exception will be raised if "
                              "float64 data is found but no fix applied.")
-
-    parser.add_argument("--nearest", action='store_true', default=False,
-                        help='If True, regridding will be performed using '
-                             'iris.analysis.Nearest() instead of Linear(). '
-                             'Use for less continuous fields, '
-                             'e.g. precipitation.')
-
-    parser.add_argument("--extrapolation_mode", default='nanmask',
-                        help='Mode to use for extrapolating data into regions '
-                             'beyond the limits of the source_data domain. '
-                             'Modes are: '
-                             'extrapolate - The extrapolation points will '
-                             'take their value from the nearest source point. '
-                             'nan - The extrapolation points will be be '
-                             'set to NaN. '
-                             'error - A ValueError exception will be raised, '
-                             'notifying an attempt to extrapolate. '
-                             'mask  - The extrapolation points will always be '
-                             'masked, even if the source data is not a '
-                             'MaskedArray. '
-                             'nanmask - If the source data is a MaskedArray '
-                             'the extrapolation points will be masked. '
-                             'Otherwise they will be set to NaN. '
-                             'Defaults to nanmask.')
 
     parser.add_argument("--json_file", metavar="JSON_FILE", default=None,
                         help='Filename for the json file containing required '
@@ -124,6 +141,11 @@ def main():
                    "filepath but none has been provided")
             raise ValueError(msg)
 
+    if args.input_landmask_filepath and not args.target_grid_filepath:
+            msg = ("Cannot specify input_landmask_filepath without "
+                   "target_grid_filepath")
+            raise ValueError(msg)
+
     # Re-grid with options:
     # if a target grid file has been specified, then regrid optionally
     # applying float64 data check, metadata change, Iris nearest and
@@ -141,6 +163,20 @@ def main():
                 extrapolation_mode=args.extrapolation_mode)
 
         output_data = output_data.regrid(target_grid, regridder)
+
+        if args.input_landmask_filepath:
+            source_landsea = load_cube(args.input_landmask_filepath)
+            if "land_binary_mask" not in source_landsea.name():
+                msg = ("Expected land_binary_mask in input_landmask_filepath "
+                       "but found {}".format(source_landsea))
+                warnings.warn(msg)
+            if "land_binary_mask" not in target_grid.name():
+                msg = ("Expected land_binary_mask in target_grid_filepath "
+                       "but found {}".format(target_grid))
+                warnings.warn(msg)
+            output_data = RegridLandSea(
+                vicinity_radius=args.landmask_vicinity).process(
+                output_data, source_landsea, target_grid)
 
         target_grid_attributes = (
             {k: v for (k, v) in target_grid.attributes.items()

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -182,7 +182,7 @@ def main():
                 msg = ("An argument has been specified that requires an input "
                        "landmask filepath but none has been provided")
                 raise ValueError(msg)
- 
+
             source_landsea = load_cube(args.input_landmask_filepath)
             if "land_binary_mask" not in source_landsea.name():
                 msg = ("Expected land_binary_mask in input_landmask_filepath "

--- a/bin/improver-standardise
+++ b/bin/improver-standardise
@@ -140,8 +140,8 @@ def main():
                    "filepath but none has been provided")
             raise ValueError(msg)
 
-    if (args.input_landmask_filepath and 
-        "nearest-with-mask" not in args.regrid_mode):
+    if (args.input_landmask_filepath and
+            "nearest-with-mask" not in args.regrid_mode):
         msg = ("Land-mask file supplied without appropriate regrid_mode. "
                "Use --regrid_mode=nearest-with-mask.")
         raise ValueError(msg)

--- a/lib/improver/tests/utilities/test_RegridLandSea.py
+++ b/lib/improver/tests/utilities/test_RegridLandSea.py
@@ -84,6 +84,7 @@ class Test__init__(IrisTest):
         result = RegridLandSea(vicinity_radius=30000.)
         vicinity = getattr(result, 'vicinity')
         self.assertTrue(isinstance(vicinity, OccurrenceWithinVicinity))
+        self.assertEqual(vicinity.distance, 30000.)
 
     def test_vicinity_arg_error(self):
         """Test with invalid vicinity_radius argument.

--- a/lib/improver/tests/utilities/test_RegridLandSea.py
+++ b/lib/improver/tests/utilities/test_RegridLandSea.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the RegridLandSea class from spatial.py."""
+
+import unittest
+import numpy as np
+
+import iris
+from iris.tests import IrisTest
+from iris.coords import DimCoord
+from iris.cube import Cube
+from iris.util import squeeze
+
+from improver.tests.nbhood.nbhood.test_BaseNeighbourhoodProcessing import (
+    set_up_cube)
+from improver.utilities.spatial import (
+    RegridLandSea, OccurrenceWithinVicinity)
+from improver.utilities.warnings_handler import ManageWarnings
+from improver.grids import ELLIPSOID
+
+
+class Test__init__(IrisTest):
+    """Tests for the initiation of the RegridLandSea class."""
+
+    def test_basic(self):
+        """Test that instantiating the class results in an object with
+        expected variables."""
+        expected_members = {'cube': None,
+                            'input_land': None,
+                            'output_land': None,
+                            'output_cube': None}
+        result = RegridLandSea()
+        members = {attr: getattr(result, attr) for attr in dir(result)
+                   if not callable(getattr(result, attr))
+                   and not attr.startswith("__")}
+        regridder = members.pop('regridder')
+        vicinity = members.pop('vicinity')
+        self.assertDictEqual(members, expected_members)
+        self.assertTrue(isinstance(regridder, iris.analysis.Nearest))
+        self.assertTrue(isinstance(vicinity, OccurrenceWithinVicinity))
+
+    def test_extrap_arg(self):
+        """Test with extrapolation_mode argument."""
+        result = RegridLandSea(extrapolation_mode="mask")
+        regridder = getattr(result, 'regridder')
+        self.assertTrue(isinstance(regridder, iris.analysis.Nearest))
+
+    def test_extrap_arg_error(self):
+        """Test with invalid extrapolation_mode argument."""
+        msg = "Extrapolation mode 'not_valid' not supported"
+        with self.assertRaisesRegex(ValueError, msg):
+            RegridLandSea(extrapolation_mode="not_valid")
+
+    def test_vicinity_arg(self):
+        """Test with vicinity_radius argument."""
+        result = RegridLandSea(vicinity_radius=30000.)
+        vicinity = getattr(result, 'vicinity')
+        self.assertTrue(isinstance(vicinity, OccurrenceWithinVicinity))
+
+    def test_vicinity_arg_error(self):
+        """Test with invalid vicinity_radius argument.
+        This is not possible as OccurrenceWithinVicinity does not check the
+        input value."""
+        pass
+
+
+class Test__repr__(IrisTest):
+    """Tests the __repr__ method of the RegridLandSea class."""
+
+    def test_basic(self):
+        """Test that the expected string is returned."""
+        expected = ("<RegridLandSea: regridder: Nearest('nanmask'); "
+                    "vicinity: <OccurrenceWithinVicinity: distance: 25000.0>>")
+        result = repr(RegridLandSea())
+        self.assertEqual(result, expected)
+
+
+class Test_correct_where_input_true(IrisTest):
+    """Tests the correct_where_input_true method of the RegridLandSea class."""
+
+    def setUp(self):
+        """Create a class-object containing the necessary cubes.
+        All cubes are on the target grid. Here this is defined as a 3x3 grid.
+        The grid contains ones everywhere except the centre point (a zero).
+        The output_cube has a value of 0.5 at [0, 1].
+        The move_sea_point cube has the zero value at [0, 1] instead of [1, 1],
+        this allows it to be used in place of input_land to trigger the
+        expected behaviour in the function.
+        """
+        self.plugin = RegridLandSea(vicinity_radius=2200.)
+        cube = squeeze(
+            set_up_cube(num_grid_points=3,
+                        zero_point_indices=((0, 0, 1, 1),)))
+        self.plugin.input_land = cube.copy()
+        self.plugin.output_land = cube.copy()
+        self.plugin.output_cube = cube.copy()
+        self.plugin.output_cube.data[0, 1] = 0.5
+        self.move_sea_point = squeeze(
+            set_up_cube(num_grid_points=3,
+                        zero_point_indices=((0, 0, 0, 1),)))
+
+    def test_basic_0(self):
+        """Test that nothing changes with argument zero (sea)."""
+        input_land = self.plugin.input_land.copy()
+        output_land = self.plugin.output_land.copy()
+        output_cube = self.plugin.output_cube.copy()
+        self.plugin.correct_where_input_true(0)
+        self.assertArrayEqual(input_land.data, self.plugin.input_land.data)
+        self.assertArrayEqual(output_land.data, self.plugin.output_land.data)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+    def test_basic_1(self):
+        """Test that nothing changes with argument one (land)."""
+        input_land = self.plugin.input_land.copy()
+        output_land = self.plugin.output_land.copy()
+        output_cube = self.plugin.output_cube.copy()
+        self.plugin.correct_where_input_true(1)
+        self.assertArrayEqual(input_land.data, self.plugin.input_land.data)
+        self.assertArrayEqual(output_land.data, self.plugin.output_land.data)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+    def test_work_0(self):
+        """Test for expected change with argument zero (sea)."""
+        self.plugin.input_land = self.move_sea_point
+        output_cube = self.plugin.output_cube.copy()
+        # The output sea point should have been changed to the value from the
+        # input sea point in the same grid.
+        output_cube.data[1, 1] = 0.5
+        self.plugin.correct_where_input_true(0)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+    def test_work_1(self):
+        """Test for expected change with argument one (land)."""
+        self.plugin.input_land = self.move_sea_point
+        output_cube = self.plugin.output_cube.copy()
+        # The input sea point should have been changed to the value from an
+        # input land point in the same grid.
+        output_cube.data[0, 1] = 1.0
+        self.plugin.correct_where_input_true(1)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+    def test_not_in_vicinity(self):
+        """Test for no change if the matching point is too far away."""
+        # We need larger arrays for this.
+        # Define 5 x 5 arrays with output sea point at [1, 1] and input sea
+        # point at [4, 4]. The alternative value of 0.5 at [4, 4] should not
+        # be selected with a small vicinity_radius.
+        self.plugin = RegridLandSea(vicinity_radius=2200.)
+        cube = squeeze(
+            set_up_cube(num_grid_points=5,
+                        zero_point_indices=((0, 0, 1, 1),)))
+        self.plugin.output_land = cube.copy()
+        self.plugin.output_cube = cube.copy()
+        self.plugin.output_cube.data[4, 4] = 0.5
+        self.plugin.input_land = squeeze(
+            set_up_cube(num_grid_points=5,
+                        zero_point_indices=((0, 0, 4, 4),)))
+
+        output_cube = self.plugin.output_cube.copy()
+        self.plugin.correct_where_input_true(0)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+    def test_no_matching_points(self):
+        """Test code runs and makes no changes if no sea points are present."""
+        self.plugin.input_land.data = np.ones_like(
+            self.plugin.input_land.data)
+        self.plugin.output_land.data = np.ones_like(
+            self.plugin.output_land.data)
+        output_cube = self.plugin.output_cube.copy()
+        self.plugin.correct_where_input_true(0)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+    def test_all_matching_points(self):
+        """Test code runs and makes no changes if all land points are
+        present."""
+        self.plugin.input_land.data = np.ones_like(
+            self.plugin.input_land.data)
+        self.plugin.output_land.data = np.ones_like(
+            self.plugin.output_land.data)
+        output_cube = self.plugin.output_cube.copy()
+        self.plugin.correct_where_input_true(1)
+        self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
+
+
+class Test_process(IrisTest):
+    """Tests the process method of the RegridLandSea class."""
+
+    def setUp(self):
+        """Create a class-object containing the necessary cubes.
+        All cubes are on the target grid. Here this is defined as a 5x5 grid.
+        The cubes have values of one everywhere except:
+        input_land: zeroes (sea points) at [0, 1], [4, 4]
+        output_land: zeroes (sea points) at [0, 0], [1, 1]
+        input_cube: 0. at [1, 1]; 0.5 at [0, 1]; 0.1 at [4, 4]
+        These should trigger all the behavior we expect.
+        """
+        self.plugin = RegridLandSea(vicinity_radius=2200.)
+
+        self.output_land = squeeze(
+            set_up_cube(num_grid_points=5,
+                        zero_point_indices=((0, 0, 1, 1),
+                                            (0, 0, 0, 0))))
+
+        self.cube = squeeze(
+            set_up_cube(num_grid_points=5,
+                        zero_point_indices=((0, 0, 1, 1),)))
+        self.cube.data[0, 1] = 0.5
+        self.cube.data[4, 4] = 0.1
+
+        self.input_land = squeeze(
+            set_up_cube(num_grid_points=5,
+                        zero_point_indices=((0, 0, 0, 1),
+                                            (0, 0, 4, 4))))
+
+        # Lat-lon coords for reprojection
+        # These coords result in a 1:1 regridding with the above cubes.
+        x_coord = DimCoord(np.linspace(-3.281, -3.153, 5),
+                           standard_name='longitude',
+                           units='degrees',
+                           coord_system=ELLIPSOID)
+        y_coord = DimCoord(np.linspace(54.896, 54.971, 5),
+                           standard_name='latitude',
+                           units='degrees',
+                           coord_system=ELLIPSOID)
+        self.input_land_ll = Cube(self.input_land.data,
+                                  long_name='land_sea_mask',
+                                  units='1',
+                                  dim_coords_and_dims=[(y_coord, 0),
+                                                       (x_coord, 1)])
+
+    # The warning messages are internal to the iris.analysis module v2.2.0.
+    @ManageWarnings(ignored_messages=["Using a non-tuple sequence for "],
+                    warning_types=[FutureWarning])
+    def test_basic(self):
+        """Test that the expected changes occur and meta-data are unchanged."""
+        expected = self.cube.data.copy()
+        # Output sea-point populated with data from input sea-point:
+        expected[0, 0] = 0.5
+        # Output sea-point populated with data from input sea-point:
+        expected[1, 1] = 0.5
+        # Output land-point populated with data from input sea-point due to
+        # vicinity-constraint:
+        expected[4, 4] = 1.
+        result = self.plugin.process(self.cube,
+                                     self.input_land,
+                                     self.output_land)
+        self.assertIsInstance(result, Cube)
+        self.assertArrayEqual(result.data, expected)
+        self.assertDictEqual(result.attributes, self.cube.attributes)
+        self.assertEqual(result.name(), self.cube.name())
+
+    @ManageWarnings(ignored_messages=["Using a non-tuple sequence for "],
+                    warning_types=[FutureWarning])
+    def test_with_regridding(self):
+        """Test when input grid is on a different projection."""
+        self.input_land = self.input_land_ll
+        expected = self.cube.data.copy()
+        # Output sea-point populated with data from input sea-point:
+        expected[0, 0] = 0.5
+        # Output sea-point populated with data from input sea-point:
+        expected[1, 1] = 0.5
+        # Output land-point populated with data from input sea-point due to
+        # vicinity-constraint:
+        expected[4, 4] = 1.
+        result = self.plugin.process(self.cube,
+                                     self.input_land,
+                                     self.output_land)
+        self.assertIsInstance(result, Cube)
+        self.assertArrayEqual(result.data, expected)
+        self.assertDictEqual(result.attributes, self.cube.attributes)
+        self.assertEqual(result.name(), self.cube.name())
+
+    def test_raises_gridding_error(self):
+        """Test error raised when cube and output grids don't match."""
+        self.cube = self.input_land_ll
+        msg = "X and Y coordinates do not match for cubes"
+        with self.assertRaisesRegex(ValueError, msg):
+            self.plugin.process(self.cube,
+                                self.input_land,
+                                self.output_land)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/utilities/test_RegridLandSea.py
+++ b/lib/improver/tests/utilities/test_RegridLandSea.py
@@ -128,7 +128,7 @@ class Test_correct_where_input_true(IrisTest):
             set_up_cube(num_grid_points=3,
                         zero_point_indices=((0, 0, 0, 1),)))
 
-    def test_basic_0(self):
+    def test_basic_sea(self):
         """Test that nothing changes with argument zero (sea)."""
         input_land = self.plugin.input_land.copy()
         output_land = self.plugin.output_land.copy()
@@ -138,7 +138,7 @@ class Test_correct_where_input_true(IrisTest):
         self.assertArrayEqual(output_land.data, self.plugin.output_land.data)
         self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
 
-    def test_basic_1(self):
+    def test_basic_land(self):
         """Test that nothing changes with argument one (land)."""
         input_land = self.plugin.input_land.copy()
         output_land = self.plugin.output_land.copy()
@@ -148,7 +148,7 @@ class Test_correct_where_input_true(IrisTest):
         self.assertArrayEqual(output_land.data, self.plugin.output_land.data)
         self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
 
-    def test_work_0(self):
+    def test_work_sea(self):
         """Test for expected change with argument zero (sea)."""
         self.plugin.input_land = self.move_sea_point
         output_cube = self.plugin.output_cube.copy()
@@ -158,7 +158,7 @@ class Test_correct_where_input_true(IrisTest):
         self.plugin.correct_where_input_true(0)
         self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
 
-    def test_work_1(self):
+    def test_work_land(self):
         """Test for expected change with argument one (land)."""
         self.plugin.input_land = self.move_sea_point
         output_cube = self.plugin.output_cube.copy()
@@ -168,7 +168,7 @@ class Test_correct_where_input_true(IrisTest):
         self.plugin.correct_where_input_true(1)
         self.assertArrayEqual(output_cube.data, self.plugin.output_cube.data)
 
-    def test_work_01_eq_10(self):
+    def test_work_sealand_eq_landsea(self):
         """Test result is independent of order of sea/land handling."""
         self.plugin.input_land = self.move_sea_point.copy()
         reset_cube = self.plugin.output_cube.copy()

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -223,6 +223,24 @@ def find_dimension_coordinate_mismatch(
     return mismatch
 
 
+def spatial_coords_match(first_cube, second_cube):
+    """
+    Determine if the x and y coords in the two cubes are the same.
+
+    Args:
+        first_cube (Iris.cube.Cube):
+            First cube to compare.
+        second_cube (Iris.cube.Cube):
+            Second cube to compare.
+
+    Returns:
+        result (bool):
+            True if the x and y coords are the same, otherwise False.
+    """
+    return (first_cube.coord(axis='x') == second_cube.coord(axis='x') and
+            first_cube.coord(axis='y') == second_cube.coord(axis='y'))
+
+
 def find_percentile_coordinate(cube):
     """Find percentile coord in cube.
 

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -235,7 +235,9 @@ def spatial_coords_match(first_cube, second_cube):
 
     Returns:
         result (bool):
-            True if the x and y coords are the same, otherwise False.
+            True if the x and y coords are the exactly the same to the
+            precision of the floating-point values (this should be true for
+            any cubes derived using cube.regrid()), otherwise False.
     """
     return (first_cube.coord(axis='x') == second_cube.coord(axis='x') and
             first_cube.coord(axis='y') == second_cube.coord(axis='y'))

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -37,9 +37,12 @@ from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError
 import numpy as np
 import scipy.ndimage
+from scipy.interpolate import griddata
 import cartopy.crs as ccrs
 
-from improver.utilities.cube_checker import check_cube_coordinates
+from improver.utilities.cube_checker import (
+    check_cube_coordinates, spatial_coords_match)
+from improver.threshold import BasicThreshold
 
 
 # Maximum radius of the neighbourhood width in grid cells.
@@ -525,3 +528,149 @@ def get_nearest_coords(cube, latitude, longitude, iname, jname):
     i_latitude = cube.coord(iname).nearest_neighbour_index(latitude)
     j_longitude = cube.coord(jname).nearest_neighbour_index(longitude)
     return i_latitude, j_longitude
+
+
+class RegridLandSea():
+    """
+    Replace data values at points where the nearest-regridding technique
+    selects a source grid-point with an opposite land-sea-mask value to the
+    target grid-point.
+    The replacement data values are selected from a vicinity of points on the
+    source-grid and the closest point of the correct mask is used.
+    Where no match is found within the vicinity, the data value is not changed.
+    """
+
+    def __init__(self, extrapolation_mode="nanmask", vicinity_radius=25000.):
+        """
+        Initialise class
+
+        Keyword Args:
+            extrapolation_mode (string):
+                Mode to use for extrapolating data into regions
+                beyond the limits of the source_data domain.
+                Modes are:
+
+                "extrapolate" - The extrapolation points will
+                take their value from the nearest source point.
+
+                "nan" - The extrapolation points will be be
+                set to NaN.
+
+                "error" - A ValueError exception will be raised,
+                notifying an attempt to extrapolate.
+
+                "mask"  - The extrapolation points will always be
+                masked, even if the source data is not a
+                MaskedArray.
+
+                "nanmask" - If the source data is a MaskedArray
+                the extrapolation points will be masked.
+                Otherwise they will be set to NaN.
+
+                Defaults to "nanmask".
+            vicinity_radius (float):
+                Distance in metres to search for a sea or land point.
+        """
+        self.input_land = None
+        self.cube = None
+        self.output_land = None
+        self.output_cube = None
+        self.regridder = iris.analysis.Nearest(
+            extrapolation_mode=extrapolation_mode)
+        self.vicinity = OccurrenceWithinVicinity(vicinity_radius)
+
+    def __repr__(self):
+        """
+        Print a human-readable representation of the instantiated object.
+        """
+        return "<RegridLandSea: regridder: {}; vicinity: {}>".format(
+            self.regridder, self.vicinity)
+
+    def correct_where_input_true(self, selector_val):
+        """
+        Replace points in the output_cube where output_land matches the
+        selector_val and the input_land does not match, but has matching
+        points in the vicinity, with the nearest matching point in the
+        vicinity.
+
+        Updates self.output_cube.data
+
+        Args:
+            selector_val (int):
+                Value of mask to replace if needed.
+                Intended to be 1 for filling land points near the coast
+                and 0 for filling sea points near the coast.
+        """
+        # Get shape of output grid
+        ynum, xnum = self.output_land.shape
+
+        # Find all points on output grid matching selector_val
+        use_points = np.where(self.input_land.data == selector_val)
+
+        # If there are no matching points on the input grid, no alteration can
+        # be made. This tests the size of the y-coordinate of use_points.
+        if use_points[0].size is not 0:
+            # Using only these points, extrapolate to fill domain using nearest
+            # neighbour. This will generate a grid where the non-selector_val
+            # points are filled with the most appropriate value.
+            (y_points, x_points) = np.mgrid[0:ynum, 0:xnum]
+            selector_data = griddata(use_points,
+                                     self.output_cube.data[use_points],
+                                     (y_points, x_points), method="nearest")
+
+            # Identify nearby points on regridded input_land that match the
+            # selector_value
+            if selector_val > 0.5:
+                thresholder = BasicThreshold(0.5)
+            else:
+                thresholder = BasicThreshold(0.5, below_thresh_ok=True)
+            in_vicinity = self.vicinity.process(
+                thresholder.process(self.input_land))
+
+            # Identify those points sourced from the opposite mask that are
+            # close to a source point of the correct mask
+            mismatch_points, = np.logical_and(
+                np.logical_and(self.output_land.data == selector_val,
+                               self.input_land.data != selector_val),
+                in_vicinity.data > 0.5)
+
+            # Replace these points with the filled-domain data
+            self.output_cube.data[mismatch_points] = (
+                selector_data[mismatch_points])
+
+    def process(self, cube, input_land, output_land):
+        """
+        Update cube.data so that output_land and sea points match an input_land
+        or sea point respectively so long as one is present within the
+        specified vicinity radius.
+
+        Args:
+            cube (Iris.cube.Cube):
+                Cube of data to be updated (on same grid as output_land).
+            input_land (Iris.cube.Cube):
+                Cube of land_binary_mask data on the grid from which cube has
+                been reprojected (it is expected that the iris.analysis.Nearest
+                method would have been used).
+            output_land (Iris.cube.Cube):
+                Cube of land_binary_mask data on target grid.
+        """
+        # Check cube and output_land are on the same grid:
+        if not spatial_coords_match(cube, output_land):
+            raise ValueError('X and Y coordinates do not match for cubes {}'
+                             'and {}'.format(repr(cube), repr(output_land)))
+        self.cube = cube
+        self.output_land = output_land
+
+        # Regrid input_land to output_land grid.
+        self.input_land = input_land.regrid(self.output_land, self.regridder)
+
+        # Regrid cube to output grid
+        self.output_cube = cube.regrid(self.output_land, self.regridder)
+
+        # Update sea points that were incorrectly sourced from land points
+        self.correct_where_input_true(0)
+
+        # Update land points that were incorrectly sourced from sea points
+        self.correct_where_input_true(1)
+
+        return self.output_cube

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -548,7 +548,7 @@ class RegridLandSea():
             extrapolation_mode (string):
                 Mode to use for extrapolating data into regions
                 beyond the limits of the source_data domain.
-                Available modes are documented in 
+                Available modes are documented in
                 `iris.analysis <https://scitools.org.uk/iris/docs/latest/iris/
                 iris/analysis.html#iris.analysis.Nearest>`_
 

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -572,7 +572,7 @@ class RegridLandSea():
                 Distance in metres to search for a sea or land point.
         """
         self.input_land = None
-        self.cube = None
+        self.nearest_cube = None
         self.output_land = None
         self.output_cube = None
         self.regridder = iris.analysis.Nearest(
@@ -591,7 +591,7 @@ class RegridLandSea():
         Replace points in the output_cube where output_land matches the
         selector_val and the input_land does not match, but has matching
         points in the vicinity, with the nearest matching point in the
-        vicinity.
+        vicinity in the original nearest_cube.
 
         Updates self.output_cube.data
 
@@ -615,7 +615,7 @@ class RegridLandSea():
             # points are filled with the most appropriate value.
             (y_points, x_points) = np.mgrid[0:ynum, 0:xnum]
             selector_data = griddata(use_points,
-                                     self.output_cube.data[use_points],
+                                     self.nearest_cube.data[use_points],
                                      (y_points, x_points), method="nearest")
 
             # Identify nearby points on regridded input_land that match the
@@ -658,14 +658,14 @@ class RegridLandSea():
         if not spatial_coords_match(cube, output_land):
             raise ValueError('X and Y coordinates do not match for cubes {}'
                              'and {}'.format(repr(cube), repr(output_land)))
-        self.cube = cube
         self.output_land = output_land
 
         # Regrid input_land to output_land grid.
         self.input_land = input_land.regrid(self.output_land, self.regridder)
 
         # Regrid cube to output grid
-        self.output_cube = cube.regrid(self.output_land, self.regridder)
+        self.nearest_cube = cube.regrid(self.output_land, self.regridder)
+        self.output_cube = self.nearest_cube.copy()
 
         # Update sea points that were incorrectly sourced from land points
         self.correct_where_input_true(0)

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -548,24 +548,9 @@ class RegridLandSea():
             extrapolation_mode (string):
                 Mode to use for extrapolating data into regions
                 beyond the limits of the source_data domain.
-                Modes are:
-
-                "extrapolate" - The extrapolation points will
-                take their value from the nearest source point.
-
-                "nan" - The extrapolation points will be be
-                set to NaN.
-
-                "error" - A ValueError exception will be raised,
-                notifying an attempt to extrapolate.
-
-                "mask"  - The extrapolation points will always be
-                masked, even if the source data is not a
-                MaskedArray.
-
-                "nanmask" - If the source data is a MaskedArray
-                the extrapolation points will be masked.
-                Otherwise they will be set to NaN.
+                Available modes are documented in 
+                `iris.analysis <https://scitools.org.uk/iris/docs/latest/iris/
+                iris/analysis.html#iris.analysis.Nearest>`_
 
                 Defaults to "nanmask".
             vicinity_radius (float):
@@ -648,9 +633,11 @@ class RegridLandSea():
             cube (Iris.cube.Cube):
                 Cube of data to be updated (on same grid as output_land).
             input_land (Iris.cube.Cube):
-                Cube of land_binary_mask data on the grid from which cube has
+                Cube of land_binary_mask data on the grid from which "cube" has
                 been reprojected (it is expected that the iris.analysis.Nearest
                 method would have been used).
+                This is used to determine where the input model data is
+                representing land and sea points.
             output_land (Iris.cube.Cube):
                 Cube of land_binary_mask data on target grid.
         """
@@ -663,8 +650,8 @@ class RegridLandSea():
         # Regrid input_land to output_land grid.
         self.input_land = input_land.regrid(self.output_land, self.regridder)
 
-        # Regrid cube to output grid
-        self.nearest_cube = cube.regrid(self.output_land, self.regridder)
+        # Store and copy cube ready for the output data
+        self.nearest_cube = cube
         self.output_cube = self.nearest_cube.copy()
 
         # Update sea points that were incorrectly sourced from land points

--- a/tests/improver-standardise/00-null.bats
+++ b/tests/improver-standardise/00-null.bats
@@ -35,10 +35,11 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-standardise [-h] [--profile] [--profile_file PROFILE_FILE]
                             [--output_filepath OUTPUT_FILE]
-                            [--target_grid_filepath TARGET_GRID]
-                            [--fix_float64] [--nearest]
+                            [--target_grid_filepath TARGET_GRID] [--nearest]
                             [--extrapolation_mode EXTRAPOLATION_MODE]
-                            [--json_file JSON_FILE]
+                            [--input_landmask_filepath INPUT_LANDMASK_FILE]
+                            [--landmask_vicinity LANDMASK_VICINITY]
+                            [--fix_float64] [--json_file JSON_FILE]
                             SOURCE_DATA
 __TEXT__
   [[ "$output" =~ "$expected" ]]

--- a/tests/improver-standardise/00-null.bats
+++ b/tests/improver-standardise/00-null.bats
@@ -35,7 +35,8 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-standardise [-h] [--profile] [--profile_file PROFILE_FILE]
                             [--output_filepath OUTPUT_FILE]
-                            [--target_grid_filepath TARGET_GRID] [--nearest]
+                            [--target_grid_filepath TARGET_GRID]
+                            [--regrid_mode {bilinear,nearest,nearest-with-mask}]
                             [--extrapolation_mode EXTRAPOLATION_MODE]
                             [--input_landmask_filepath INPUT_LANDMASK_FILE]
                             [--landmask_vicinity LANDMASK_VICINITY]

--- a/tests/improver-standardise/01-help.bats
+++ b/tests/improver-standardise/01-help.bats
@@ -35,18 +35,19 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-standardise [-h] [--profile] [--profile_file PROFILE_FILE]
                             [--output_filepath OUTPUT_FILE]
-                            [--target_grid_filepath TARGET_GRID] [--nearest]
+                            [--target_grid_filepath TARGET_GRID]
+                            [--regrid_mode {bilinear,nearest,nearest-with-mask}]
                             [--extrapolation_mode EXTRAPOLATION_MODE]
                             [--input_landmask_filepath INPUT_LANDMASK_FILE]
                             [--landmask_vicinity LANDMASK_VICINITY]
                             [--fix_float64] [--json_file JSON_FILE]
                             SOURCE_DATA
 
-Standardise a source data cube. Three main options are available; checking and
-optionally fixing float64 data, regridding and updating metadata. If
-regridding then additional options are available to specify Iris nearest and
-extrapolation modes. If only a source file is specified with no other
-arguments, then an exception will be raised if float64 data is found on the
+Standardise a source data cube. Three main options are available; fixing
+float64 data, regridding and updating metadata. If regridding then additional
+options are available to use bilinear or nearest-neighbour (optionally with
+land-mask awareness) modes. If only a source file is specified with no other
+arguments, then an exception will be raised if float64 data are found on the
 source.
 
 positional arguments:
@@ -76,12 +77,17 @@ Regridding options:
                         If specified then regridding of the source against the
                         target grid is enabled. If also using landmask-aware
                         regridding, then this must be land_binary_mask data.
-  --nearest             If True, regridding will be performed using
-                        iris.analysis.Nearest() instead of Linear(). Use for
-                        less continuous fields, e.g. precipitation.
+  --regrid_mode {bilinear,nearest,nearest-with-mask}
+                        Selects which regridding technique to use. Default
+                        uses iris.analysis.Linear(); "nearest" uses Nearest()
+                        (Use for less continuous fields, e.g. precipitation.);
+                        "nearest-with-mask" ensures that target data are
+                        sourced from points with the same mask value (Use for
+                        coast-line-dependent variables like temperature).
   --extrapolation_mode EXTRAPOLATION_MODE
                         Mode to use for extrapolating data into regions beyond
-                        the limits of the source_data domain. Modes are:
+                        the limits of the source_data domain. Refer to online
+                        documentation for iris.analysis. Modes are:
                         extrapolate - The extrapolation points will take their
                         value from the nearest source point. nan - The
                         extrapolation points will be be set to NaN. error - A

--- a/tests/improver-standardise/01-help.bats
+++ b/tests/improver-standardise/01-help.bats
@@ -35,10 +35,11 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-standardise [-h] [--profile] [--profile_file PROFILE_FILE]
                             [--output_filepath OUTPUT_FILE]
-                            [--target_grid_filepath TARGET_GRID]
-                            [--fix_float64] [--nearest]
+                            [--target_grid_filepath TARGET_GRID] [--nearest]
                             [--extrapolation_mode EXTRAPOLATION_MODE]
-                            [--json_file JSON_FILE]
+                            [--input_landmask_filepath INPUT_LANDMASK_FILE]
+                            [--landmask_vicinity LANDMASK_VICINITY]
+                            [--fix_float64] [--json_file JSON_FILE]
                             SOURCE_DATA
 
 Standardise a source data cube. Three main options are available; checking and
@@ -62,12 +63,19 @@ optional arguments:
                         The output path for the processed NetCDF. If only a
                         source file is specified and no output file, then the
                         source will be checkedfor float64 data.
-  --target_grid_filepath TARGET_GRID
-                        If specified then regridding of the source against the
-                        target grid is enabled.
   --fix_float64         Check and fix cube for float64 data. Without this
                         option an exception will be raised if float64 data is
                         found but no fix applied.
+  --json_file JSON_FILE
+                        Filename for the json file containing required changes
+                        that will be applied to the metadata. Defaults to
+                        None.
+
+Regridding options:
+  --target_grid_filepath TARGET_GRID
+                        If specified then regridding of the source against the
+                        target grid is enabled. If also using landmask-aware
+                        regridding, then this must be land_binary_mask data.
   --nearest             If True, regridding will be performed using
                         iris.analysis.Nearest() instead of Linear(). Use for
                         less continuous fields, e.g. precipitation.
@@ -84,10 +92,13 @@ optional arguments:
                         a MaskedArray the extrapolation points will be masked.
                         Otherwise they will be set to NaN. Defaults to
                         nanmask.
-  --json_file JSON_FILE
-                        Filename for the json file containing required changes
-                        that will be applied to the metadata. Defaults to
-                        None.
+  --input_landmask_filepath INPUT_LANDMASK_FILE
+                        A path to a NetCDF file describing the
+                        land_binary_mask on the source-grid if coastline-aware
+                        regridding is required.
+  --landmask_vicinity LANDMASK_VICINITY
+                        Radius of vicinity to search for a coastline, in
+                        metres. Default value; 25000 m
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-standardise/03-regrid_nearest.bats
+++ b/tests/improver-standardise/03-regrid_nearest.bats
@@ -39,7 +39,7 @@
   run improver standardise \
       "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
       --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/ukvx_grid.nc" \
-      --output_filepath "$TEST_DIR/output.nc" --nearest
+      --output_filepath "$TEST_DIR/output.nc" --regrid_mode="nearest"
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-standardise/04-regrid_extrapolate.bats
+++ b/tests/improver-standardise/04-regrid_extrapolate.bats
@@ -40,7 +40,7 @@
       "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/ukvx_grid.nc" \
       --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
       --output_filepath "$TEST_DIR/output.nc" \
-      --nearest --extrapolation_mode extrapolate
+      --regrid_mode="nearest" --extrapolation_mode extrapolate
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-standardise/09-check_output_filepath.bats
+++ b/tests/improver-standardise/09-check_output_filepath.bats
@@ -32,6 +32,7 @@
 . $IMPROVER_DIR/tests/lib/utils
 
 @test "standardise check output filepath specified" {
+  improver_check_skip_acceptance
   run improver standardise \
        "$IMPROVER_ACC_TEST_DIR/standardise/float64/float64_data.nc" --fix_float64
   [[ "$status" -eq 1 ]]

--- a/tests/improver-standardise/10-regrid_nearest_landmask.bats
+++ b/tests/improver-standardise/10-regrid_nearest_landmask.bats
@@ -31,13 +31,21 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "standardise check output filepath specified" {
-  run improver standardise \
-       "$IMPROVER_ACC_TEST_DIR/standardise/float64/float64_data.nc" --fix_float64
-  [[ "$status" -eq 1 ]]
-  read -d '' expected <<'__TEXT__' || true
-ValueError: An argument has been specified that requires an output filepath but none has been provided
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
-}
+@test "standardise with land-mask" {
+  improver_check_skip_acceptance
+  KGO="standardise/regrid-nearest/kgo.nc"
 
+  # Run cube regrid processing with iris nearest option and check it passes.
+  run improver standardise \
+      "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
+      --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/ukvx_landmask.nc" \
+      --input_landmask_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/glm_landmask.nc" \
+      --output_filepath "$TEST_DIR/output.nc" --nearest
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-standardise/10-regrid_nearest_landmask.bats
+++ b/tests/improver-standardise/10-regrid_nearest_landmask.bats
@@ -33,14 +33,14 @@
 
 @test "standardise with land-mask" {
   improver_check_skip_acceptance
-  KGO="standardise/regrid-nearest/kgo.nc"
+  KGO="standardise/regrid-landmask/kgo.nc"
 
   # Run cube regrid processing with iris nearest option and check it passes.
   run improver standardise \
       "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
       --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/ukvx_landmask.nc" \
       --input_landmask_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/glm_landmask.nc" \
-      --output_filepath "$TEST_DIR/output.nc" --nearest
+      --output_filepath "$TEST_DIR/output.nc" --regrid_mode="nearest-with-mask"
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-standardise/11_check_landmask_input.bats
+++ b/tests/improver-standardise/11_check_landmask_input.bats
@@ -39,10 +39,10 @@
       "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
       --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/ukvx_grid.nc" \
       --input_landmask_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/glm_landmask.nc" \
-      --output_filepath "$TEST_DIR/output.nc" --nearest
+      --output_filepath "$TEST_DIR/output.nc" --regrid_mode="nearest-with-mask"
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true
-Expected land_binary_mask in input_landmask_filepath
+UserWarning: Expected land_binary_mask in target_grid_filepath
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 

--- a/tests/improver-standardise/11_check_landmask_input.bats
+++ b/tests/improver-standardise/11_check_landmask_input.bats
@@ -31,13 +31,25 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "standardise check output filepath specified" {
+@test "standardise check input filepath contains mask" {
+  improver_check_skip_acceptance
+  KGO="standardise/regrid-nearest/kgo.nc"
+
   run improver standardise \
-       "$IMPROVER_ACC_TEST_DIR/standardise/float64/float64_data.nc" --fix_float64
-  [[ "$status" -eq 1 ]]
+      "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
+      --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/ukvx_grid.nc" \
+      --input_landmask_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/glm_landmask.nc" \
+      --output_filepath "$TEST_DIR/output.nc" --nearest
+  [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true
-ValueError: An argument has been specified that requires an output filepath but none has been provided
+Expected land_binary_mask in input_landmask_filepath
 __TEXT__
   [[ "$output" =~ "$expected" ]]
+
+  # Don't recreate KGO for this test as it is the same as test 03.
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
 }
 

--- a/tests/improver-standardise/12-args_error_landmask_present.bats
+++ b/tests/improver-standardise/12-args_error_landmask_present.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "standardise check input landmask file specified" {
+  improver_check_skip_acceptance
+  run improver standardise \
+      "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
+      --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/ukvx_landmask.nc" \
+      --input_landmask_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/glm_landmask.nc" \
+      --output_filepath "$TEST_DIR/output.nc"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Land-mask file supplied without appropriate regrid_mode. Use --regrid_mode=nearest-with-mask.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}
+

--- a/tests/improver-standardise/13-args_error_no_target_with_landmask.bats
+++ b/tests/improver-standardise/13-args_error_no_target_with_landmask.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "standardise check input landmask file specified" {
+  improver_check_skip_acceptance
+  run improver standardise \
+      "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
+      --input_landmask_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/glm_landmask.nc" \
+      --output_filepath "$TEST_DIR/output.nc" --regrid_mode="nearest-with-mask"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Cannot specify input_landmask_filepath without target_grid_filepath
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}
+

--- a/tests/improver-standardise/14-args_error_no_landmask_file.bats
+++ b/tests/improver-standardise/14-args_error_no_landmask_file.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "standardise check input landmask file specified" {
+  improver_check_skip_acceptance
+  run improver standardise \
+      "$IMPROVER_ACC_TEST_DIR/standardise/regrid-basic/global_cutout.nc" \
+      --target_grid_filepath "$IMPROVER_ACC_TEST_DIR/standardise/regrid-landmask/ukvx_landmask.nc" \
+      --output_filepath "$TEST_DIR/output.nc" --regrid_mode="nearest-with-mask"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: An argument has been specified that requires an input landmask filepath but none has been provided
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}
+


### PR DESCRIPTION
Addresses #719 

Adds a plugin to update a regridded cube around coastlines to ensure that output sea-points use input sea-point data (where possible) and vice-versa.

Adds options to the improver-standardise CLI to use this plugin.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
