### PR TITLE
Fix temperature lapse rate plugin to add lapse rate units and add extra unit tests.

### DIFF
--- a/lib/improver/lapse_rate.py
+++ b/lib/improver/lapse_rate.py
@@ -150,6 +150,10 @@ class LapseRate(object):
             msg = "Neighbourhood radius is less than zero"
             raise ValueError(msg)
 
+        if self.max_height_diff < 0:
+            msg = "Maximum height difference is less than zero"
+            raise ValueError(msg)
+
         # nbhood_size=3 corresponds to a 3x3 array centred on the
         # central point.
         self.nbhood_size = int((2*nbhood_radius) + 1)

--- a/lib/improver/lapse_rate.py
+++ b/lib/improver/lapse_rate.py
@@ -142,6 +142,14 @@ class LapseRate(object):
         self.max_lapse_rate = max_lapse_rate
         self.min_lapse_rate = min_lapse_rate
 
+        if self.max_lapse_rate < self.min_lapse_rate:
+            msg = "Maximum lapse rate is less than minimum lapse rate"
+            raise ValueError(msg)
+
+        if self.nbhood_radius < 0:
+            msg = "Neighbourhood radius is less than zero"
+            raise ValueError(msg)
+
         # nbhood_size=3 corresponds to a 3x3 array centred on the
         # central point.
         self.nbhood_size = int((2*nbhood_radius) + 1)
@@ -373,5 +381,6 @@ class LapseRate(object):
         lapse_rate_cube = lapse_rate_cube_list.merge_cube()
         lapse_rate_cube.rename('temperature_lapse_rate')
         lapse_rate_cube.long_name = "lapse_rate"
+        lapse_rate_cube.units = 'K m-1'
 
         return lapse_rate_cube

--- a/lib/improver/lapse_rate.py
+++ b/lib/improver/lapse_rate.py
@@ -107,8 +107,9 @@ class LapseRate(object):
     4) Loop through array of neighbourhoods and take the height and temperature
        of all grid points and calculate the
        temperature/height gradient = lapse rate
-    5) Default constraints for the lapse rate set as > DALR and < -3.0*DALR.
-
+    5) Constrain the returned lapse rates between min_lapse_rate and
+       max_lapse_rate. These default to > DALR and < -3.0*DALR but are user
+       configurable
     """
 
     def __init__(self, max_height_diff=35, nbhood_radius=7,

--- a/lib/improver/lapse_rate.py
+++ b/lib/improver/lapse_rate.py
@@ -107,7 +107,7 @@ class LapseRate(object):
     4) Loop through array of neighbourhoods and take the height and temperature
        of all grid points and calculate the
        temperature/height gradient = lapse rate
-    5) Constrain the lapse rate as > DALR and < -3.0*DALR.
+    5) Default constraints for the lapse rate set as > DALR and < -3.0*DALR.
 
     """
 

--- a/lib/improver/tests/lapse_rate/Test_LapseRate.py
+++ b/lib/improver/tests/lapse_rate/Test_LapseRate.py
@@ -311,7 +311,7 @@ class Test_process(IrisTest):
                                                 self.land_sea_mask)
 
     def test_fails_if_max_height_diff_less_than_zero(self):
-        """Test code raises a Value Error if input neighbourhood radius
+        """Test code raises a Value Error if the maximum height difference
         is less than zero"""
         msg = "Maximum height difference is less than zero"
 

--- a/lib/improver/tests/lapse_rate/Test_LapseRate.py
+++ b/lib/improver/tests/lapse_rate/Test_LapseRate.py
@@ -310,6 +310,16 @@ class Test_process(IrisTest):
                                                 self.orography,
                                                 self.land_sea_mask)
 
+    def test_fails_if_max_height_diff_less_than_zero(self):
+        """Test code raises a Value Error if input neighbourhood radius
+        is less than zero"""
+        msg = "Maximum height difference is less than zero"
+
+        with self.assertRaisesRegexp(ValueError, msg):
+            LapseRate(max_height_diff=-1).process(self.temperature,
+                                                  self.orography,
+                                                  self.land_sea_mask)
+
     def test_lapse_rate_limits(self):
         """Test that the function limits the lapse rate to +DALR and -3*DALR.
            Where DALR = Dry Adiabatic Lapse Rate.

--- a/lib/improver/tests/lapse_rate/Test_LapseRate.py
+++ b/lib/improver/tests/lapse_rate/Test_LapseRate.py
@@ -407,7 +407,7 @@ class Test_process(IrisTest):
                                  [0.0392, 0.0392, 0.0, -0.0196, -0.0196],
                                  [0.0392, 0.0392, 0.0, -0.0196, -0.0196]])
 
-        # West data points should be -3*DALR and East should be 2*DALR.
+        # West data points should be -4*DALR and East should be 2*DALR.
         self.temperature.data[:, :, 0] = 2
         self.temperature.data[:, :, 1] = 1
         self.temperature.data[:, :, 3] = -1


### PR DESCRIPTION
Addresses #731

Fix temperature lapse rate plugin after a number of issues came to light as a result of #732 

**Plugin:**

- Ensure units of the output lapse rate cube are set to `'K m-1'`.
- Ensure that specifying a maximum lapse rate smaller than minimum lapse rate produces an error.
- Ensure that specifying a neighbourhood radius of less than zero produces an error.
- Ensure that specifying a maximum height difference of less than zero produces an error.

**Additional unittests:**

- Test that the output cube units are `'K m-1'`regardless of wether or not default arguments are used.
- Test that a maximum lapse rate less than the minimum produces an error.
- Test that a maximum height difference of less than zero produces an error.
- Test that a neighbourhood radius less than zero produces an error.
- Test the output for combinations of maximum, minimum and combined lapse rate arguments.
- Test the output for a non-default maximum height difference argument.

A non-default neighbourhood radius argument is already used in some of the existing tests so I haven't added another test for this argument.


Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

