### PR TITLE
Created CLI for time-lagged ensemble plugin and added CLI tests.

### DIFF
--- a/bin/improver-time-lagged-ensembles
+++ b/bin/improver-time-lagged-ensembles
@@ -62,10 +62,6 @@ def main():
     for filename in args.input_filenames:
         new_cube = load_cube(filename)
         cubes.append(new_cube)
-    
-    # Warns if a single file is input
-    if len(cubes) == 1:
-        warnings.warn('Only a single cube so no differences will be found')
 
     # Raises an error if the validity times do not match
     for i, this_cube in enumerate(cubes):
@@ -77,8 +73,14 @@ def main():
                        "compatible.")
                 raise ValueError(msg)
 
-    result = GenerateTimeLaggedEnsemble().process(cubes)
-    save_netcdf(result, args.output_file)
+    # Warns if a single file is input
+    if len(cubes) == 1:
+        warnings.warn('Only a single cube input, so time lagging will have '
+                      'no effect.')
+        save_netcdf(cubes, args.output_file)
+    else:
+        result = GenerateTimeLaggedEnsemble().process(cubes)
+        save_netcdf(result, args.output_file)
 
 
 if __name__ == "__main__":

--- a/bin/improver-time-lagged-ensembles
+++ b/bin/improver-time-lagged-ensembles
@@ -77,7 +77,7 @@ def main():
     if len(cubes) == 1:
         warnings.warn('Only a single cube input, so time lagging will have '
                       'no effect.')
-        save_netcdf(cubes, args.output_file)
+        save_netcdf(cubes[0], args.output_file)
     else:
         result = GenerateTimeLaggedEnsemble().process(cubes)
         save_netcdf(result, args.output_file)

--- a/bin/improver-time-lagged-ensembles
+++ b/bin/improver-time-lagged-ensembles
@@ -63,22 +63,21 @@ def main():
         new_cube = load_cube(filename)
         cubes.append(new_cube)
 
-    # Raises an error if the validity times do not match
-    for i, this_cube in enumerate(cubes):
-        for later_cube in cubes[i+1:]:
-            if this_cube.coord('time') == later_cube.coord('time'):
-                continue
-            else:
-                msg = ("Cubes with mismatched validity times are not "
-                       "compatible.")
-                raise ValueError(msg)
-
     # Warns if a single file is input
     if len(cubes) == 1:
         warnings.warn('Only a single cube input, so time lagging will have '
                       'no effect.')
         save_netcdf(cubes[0], args.output_file)
+    # Raises an error if the validity times do not match
     else:
+        for i, this_cube in enumerate(cubes):
+            for later_cube in cubes[i+1:]:
+                if this_cube.coord('time') == later_cube.coord('time'):
+                    continue
+                else:
+                    msg = ("Cubes with mismatched validity times are not "
+                           "compatible.")
+                    raise ValueError(msg)
         result = GenerateTimeLaggedEnsemble().process(cubes)
         save_netcdf(result, args.output_file)
 

--- a/bin/improver-time-lagged-ensembles
+++ b/bin/improver-time-lagged-ensembles
@@ -32,6 +32,7 @@
 """Script to run time-lagged ensembles."""
 
 import iris
+import warnings
 
 from improver.argparser import ArgParser
 from improver.utilities.load import load_cube
@@ -61,6 +62,10 @@ def main():
     for filename in args.input_filenames:
         new_cube = load_cube(filename)
         cubes.append(new_cube)
+    
+    # Warns if a single file is input
+    if len(cubes) == 1:
+        warnings.warn('Only a single cube so no differences will be found')
 
     # Raises an error if the validity times do not match
     for i, this_cube in enumerate(cubes):

--- a/bin/improver-time-lagged-ensembles
+++ b/bin/improver-time-lagged-ensembles
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to run time-lagged ensembles."""
+
+import iris
+
+from improver.argparser import ArgParser
+from improver.utilities.load import load_cube
+from improver.utilities.save import save_netcdf
+from improver.utilities.time_lagging import GenerateTimeLaggedEnsemble
+
+
+def main():
+    """Load in the arguments and ensure they are set correctly. Then run
+    the time-lagged ensembles on the input cubes."""
+    parser = ArgParser(
+        description='This combines the realizations from different forecast '
+                    'cycles into one cube. It does this by taking an input '
+                    'CubeList containing forecasts from different cycles and '
+                    'merges them into a single cube, removing any metadata '
+                    'that does not match.')
+    parser.add_argument('input_filenames', metavar='INPUT_FILENAMES',
+                        nargs="+", type=str,
+                        help='Paths to input NetCDF files for the time-lagged '
+                        'ensemble to combine the realizations.')
+    parser.add_argument('output_file', metavar='OUTPUT_FILE',
+                        help='The output file for the processed NetCDF.')
+    args = parser.parse_args()
+
+    # Load the cubes
+    cubes = iris.cube.CubeList([])
+    for filename in args.input_filenames:
+        new_cube = load_cube(filename)
+        cubes.append(new_cube)
+
+    # Raises an error if the validity times do not match
+    for i, this_cube in enumerate(cubes):
+        for later_cube in cubes[i+1:]:
+            if this_cube.coord('time') == later_cube.coord('time'):
+                continue
+            else:
+                msg = ("Cubes with mismatched validity times are not "
+                       "compatible.")
+                raise ValueError(msg)
+
+    result = GenerateTimeLaggedEnsemble().process(cubes)
+    save_netcdf(result, args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/improver-time-lagged-ensembles/00-null.bats
+++ b/tests/improver-time-lagged-ensembles/00-null.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "time-lagged-ensembles no arguments" {
+  run improver time-lagged-ensembles
+  [[ "$status" -eq 2 ]]
+  read -d '' expected <<'__TEXT__' || true
+usage: improver-time-lagged-ensembles [-h] [--profile]
+                                      [--profile_file PROFILE_FILE]
+                                      INPUT_FILENAMES [INPUT_FILENAMES ...]
+                                      OUTPUT_FILE
+improver-time-lagged-ensembles: error: the following arguments are required: INPUT_FILENAMES, OUTPUT_FILE
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-time-lagged-ensembles/01-help.bats
+++ b/tests/improver-time-lagged-ensembles/01-help.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "time-lagged-ensembles -h" {
+  run improver time-lagged-ensembles -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__HELP__' || true
+usage: improver-time-lagged-ensembles [-h] [--profile]
+                                      [--profile_file PROFILE_FILE]
+                                      INPUT_FILENAMES [INPUT_FILENAMES ...]
+                                      OUTPUT_FILE
+
+This combines the realizations from different forecast cycles into one cube.
+It does this by taking an input CubeList containing forecasts from different
+cycles and merges them into a single cube, removing any metadata that does not
+match.
+
+positional arguments:
+  INPUT_FILENAMES       Paths to input NetCDF files for the time-lagged
+                        ensemble to combine the realizations.
+  OUTPUT_FILE           The output file for the processed NetCDF.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --profile             Switch on profiling information.
+  --profile_file PROFILE_FILE
+                        Dump profiling info to a file. Implies --profile.
+__HELP__
+  [[ "$output" == "$expected" ]]
+}

--- a/tests/improver-time-lagged-ensembles/02-basic.bats
+++ b/tests/improver-time-lagged-ensembles/02-basic.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "time-lagged-ensembles" {
+  improver_check_skip_acceptance
+  KGO="1300_validity/kgo.nc"
+
+  # Run time-lagged-ensemble processing and check it passes.
+  run improver time-lagged-ensembles \
+      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0005H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0006H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0007H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0008H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0009H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0010H00M-temperature_at_surface.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-time-lagged-ensembles/02-basic.bats
+++ b/tests/improver-time-lagged-ensembles/02-basic.bats
@@ -33,16 +33,16 @@
 
 @test "time-lagged-ensembles" {
   improver_check_skip_acceptance
-  KGO="1300_validity/kgo.nc"
+  KGO="time-lagged-ens/same_validity/kgo.nc"
 
   # Run time-lagged-ensemble processing and check it passes.
   run improver time-lagged-ensembles \
-      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0005H00M-temperature_at_surface.nc" \
-      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0006H00M-temperature_at_surface.nc" \
-      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0007H00M-temperature_at_surface.nc" \
-      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0008H00M-temperature_at_surface.nc" \
-      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0009H00M-temperature_at_surface.nc" \
-      "$IMPROVER_ACC_TEST_DIR/1300_validity/20180924T1300Z-PT0010H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0005H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0006H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0007H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0008H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0009H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0010H00M-temperature_at_surface.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-time-lagged-ensembles/03-validity-error.bats
+++ b/tests/improver-time-lagged-ensembles/03-validity-error.bats
@@ -36,8 +36,8 @@
 
   # Run with different validity times and check it fails.
   run improver time-lagged-ensembles \
-      "$IMPROVER_ACC_TEST_DIR/mixed_validity/20180924T1300Z-PT0001H00M-temperature_at_surface.nc" \
-      "$IMPROVER_ACC_TEST_DIR/mixed_validity/20180924T1900Z-PT0006H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/mixed_validity/20180924T1300Z-PT0001H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/mixed_validity/20180924T1900Z-PT0006H00M-temperature_at_surface.nc" \
       "NO_OUTPUT_FILE"
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]

--- a/tests/improver-time-lagged-ensembles/03-validity-error.bats
+++ b/tests/improver-time-lagged-ensembles/03-validity-error.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "different validity error" {
+  improver_check_skip_acceptance
+
+  # Run with different validity times and check it fails.
+  run improver time-lagged-ensembles \
+      "$IMPROVER_ACC_TEST_DIR/mixed_validity/20180924T1300Z-PT0001H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/mixed_validity/20180924T1900Z-PT0006H00M-temperature_at_surface.nc" \
+      "NO_OUTPUT_FILE"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Cubes with mismatched validity times are not compatible.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+
+}

--- a/tests/improver-time-lagged-ensembles/04-single-cube.bats
+++ b/tests/improver-time-lagged-ensembles/04-single-cube.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "time-lagged-ensembles" {
+  improver_check_skip_acceptance
+  KGO="time-lagged-ens/same_validity/kgo_single_cube.nc"
+
+  # Run time-lagged-ensemble processing and check it passes.
+  run improver time-lagged-ensembles \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0005H00M-temperature_at_surface.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Addresses #711 

Description

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

I have created a CLI to make use of the time-lagged ensemble plugin that had already been created in a previous ticket. It should:

- Call the GenerateTimeLaggedEnsemble from improver.utilities.time_lagging

- Use this plugin on a list of files that have the same validity time, but can be from different cycles

-  If it is used on files with different validity times an Error will occur

I have also written some basic CLI tests for this to check it is working properly. I created the CLI data, but using the plugin, generating a cube from this and then saving it to a NetCDF file. I was then able to compare this file to one created by using my new CLI, which I have documented in a jupyter notebook.

