### PR TITLE
IMPRO-263 (defunct): nccmp replaces temporary use of cmp for masked arrays with nans

### DIFF
--- a/tests/improver-nbhood/05-mask-square.bats
+++ b/tests/improver-nbhood/05-mask-square.bats
@@ -43,8 +43,7 @@
 
   improver_check_recreate_kgo "output.nc" $KGO
 
-  # Run cmp -b to compare the output and kgo.
-  cmp -b "$TEST_DIR/output.nc" \
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
-  [[ "$status" -eq 0 ]]
 }


### PR DESCRIPTION
nccmp no longer has an issue with masked arrays using nan fill values. This test has been updated to use the standard means of testing using nccmp. Ticket IMPRO-263 can be closed as the issue no longer exists.

Testing:
 - [x] Ran tests and they passed OK
