### PR TITLE
Add /usr/bin/time to IMPROVER apps to give diagnostic info

### DIFF
--- a/bin/improver
+++ b/bin/improver
@@ -77,4 +77,5 @@ fi
 export PYTHONPATH="$IMPROVER_DIR/lib/:${PYTHONPATH:-}"
 export PATH="$IMPROVER_DIR/bin/:$PATH"
 
-exec improver-$OPER "$@"
+# Run the IMPROVER app, wrapped with time to give resource usage information.
+exec /usr/bin/time -v improver-$OPER "$@"


### PR DESCRIPTION
Addresses IMPRO-945: Suite-wide profiling for improver executions

This will give us memory and better CPU usage info for all executions, allowing a grep of the logfiles after a trail run to see how well we are saturating the allocated resource