### PR TITLE
Unit test cube setup: add StaGE metadata

### DIFF
--- a/bin/improver-update-grid-metadata
+++ b/bin/improver-update-grid-metadata
@@ -40,7 +40,7 @@ import iris
 from improver.argparser import ArgParser
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
-from improver.utilities.cube_metadata import stage_v110_to_v120
+from improver.utilities.cube_metadata import update_stage_v110_metadata
 
 
 def main():
@@ -64,7 +64,7 @@ def main():
     args = ArgParser(**cli_definition).parse_args()
 
     cube = load_cube(args.input_filepath)
-    cube_changed = stage_v110_to_v120(cube)
+    cube_changed = update_stage_v110_metadata(cube)
 
     # Create normalised file paths to make them comparable
     in_file_norm = os.path.normpath(args.input_filepath)

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -184,7 +184,7 @@ def set_up_variable_cube(data, name='air_temperature', units='K',
         attributes (dict):
             Optional cube attributes.
         uk_standard_grid_metadata (bool):
-            Flag to add attributes for the UK standard grid. These will
+            Flag to add attributes for the UK standard grid.  These will
             **overwrite** any explicitly set attributes of the same name.
     """
     # construct spatial dimension coordimates
@@ -280,7 +280,7 @@ def set_up_percentile_cube(data, percentiles, name='air_temperature',
         attributes (dict):
             Optional cube attributes.
         uk_standard_grid_metadata (bool):
-            Flag to include attributes for the UK standard grid
+            Flag to include attributes for the MOGREPS-UK ensemble grid.
     """
     cube = set_up_variable_cube(
         data, name=name, units=units, spatial_grid=spatial_grid,
@@ -340,7 +340,7 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
         attributes (dict):
             Optional cube attributes.
         uk_standard_grid_metadata (bool):
-            Flag to include attributes for the UK standard grid
+            Flag to include attributes for the MOGREPS-UK ensemble grid.
     """
     # create a "relative to threshold" attribute
     if attributes is None:

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -40,7 +40,6 @@ from datetime import datetime
 import numpy as np
 import iris
 from iris.coords import DimCoord
-from iris.exceptions import CoordinateNotFoundError
 
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
 from improver.utilities.cube_metadata import GRID_ID_LOOKUP

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -42,6 +42,7 @@ import iris
 from iris.coords import DimCoord
 
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
+from improver.utilities.cube_metadata import MOSG_GRID_DEFINITION
 from improver.utilities.cube_checker import check_cube_not_float64
 
 TIME_UNIT = "seconds since 1970-01-01 00:00:00"
@@ -218,11 +219,7 @@ def set_up_variable_cube(data, name='air_temperature', units='K',
     # set up attributes
     cube_attrs = {}
     if standard_grid_metadata is not None:
-        cube_attrs['mosg__model_configuration'] = standard_grid_metadata
-        cube_attrs['mosg__grid_type'] = 'standard'
-        cube_attrs['mosg__grid_version'] = '1.3.0'
-        cube_attrs['mosg__grid_domain'] = (
-            'uk_extended' if 'uk' in standard_grid_metadata else 'global')
+        cube_attrs.update(MOSG_GRID_DEFINITION[standard_grid_metadata])
     if attributes is not None:
         cube_attrs.update(attributes)
 

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -42,7 +42,6 @@ import iris
 from iris.coords import DimCoord
 
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
-from improver.utilities.cube_metadata import GRID_ID_LOOKUP
 from improver.utilities.cube_checker import check_cube_not_float64
 
 TIME_UNIT = "seconds since 1970-01-01 00:00:00"

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -192,17 +192,6 @@ def set_up_variable_cube(data, name='air_temperature', units='K',
     xpoints = data.shape[-1]
     y_coord, x_coord = construct_xy_coords(ypoints, xpoints, spatial_grid)
 
-    # set up attributes dict
-    cube_attrs = {}
-
-    # set up StaGE attributes if required
-    if standard_grid_metadata is not None:
-        cube_attrs['mosg__model_configuration'] = standard_grid_metadata
-        cube_attrs['mosg__grid_type'] = 'standard'
-        cube_attrs['mosg__grid_version'] = '1.3.0'
-        cube_attrs['mosg__grid_domain'] = (
-            'uk_extended' if 'uk' in standard_grid_metadata else 'global')
-
     # construct realization dimension for 3D data, and dim_coords list
     ndims = len(data.shape)
     if ndims == 3:
@@ -227,7 +216,14 @@ def set_up_variable_cube(data, name='air_temperature', units='K',
         for coord in include_scalar_coords:
             scalar_coords.append((coord, None))
 
-    # update attributes dict
+    # set up attributes
+    cube_attrs = {}
+    if standard_grid_metadata is not None:
+        cube_attrs['mosg__model_configuration'] = standard_grid_metadata
+        cube_attrs['mosg__grid_type'] = 'standard'
+        cube_attrs['mosg__grid_version'] = '1.3.0'
+        cube_attrs['mosg__grid_domain'] = (
+            'uk_extended' if 'uk' in standard_grid_metadata else 'global')
     if attributes is not None:
         cube_attrs.update(attributes)
 

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -253,6 +253,22 @@ class test_set_up_variable_cube(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             _ = set_up_variable_cube(data_4d)
 
+    def test_standard_grid_metadata(self):
+        """Test standard grid metadata is added if specified"""
+        result_det = set_up_variable_cube(
+            self.data, uk_standard_grid_metadata=True)
+        result_ens = set_up_variable_cube(
+            self.data_3d, uk_standard_grid_metadata=True)
+        for cube in [result_det, result_ens]:
+            self.assertEqual(cube.attributes['mosg__grid_type'], 'standard')
+            self.assertEqual(cube.attributes['mosg__grid_version'], '1.3.0')
+            self.assertEqual(
+                cube.attributes['mosg__grid_domain'], 'uk_extended')
+        self.assertEqual(
+            result_det.attributes['mosg__model_configuration'], 'uk_det')
+        self.assertEqual(
+            result_ens.attributes['mosg__model_configuration'], 'uk_ens')
+
 
 class test_set_up_percentile_cube(IrisTest):
     """Test the set_up_percentile_cube function"""

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -296,6 +296,17 @@ class test_set_up_percentile_cube(IrisTest):
         dim_coords = [coord.name() for coord in result.coords(dim_coords=True)]
         self.assertIn("percentile", dim_coords)
 
+    def test_standard_grid_metadata(self):
+        """Test standard grid metadata"""
+        result = set_up_percentile_cube(self.data, self.percentiles,
+                                        uk_standard_grid_metadata=True)
+        self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
+        self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
+        self.assertEqual(
+            result.attributes['mosg__grid_domain'], 'uk_extended')
+        self.assertEqual(
+            result.attributes['mosg__model_configuration'], 'uk_ens')
+
 
 class test_set_up_probability_cube(IrisTest):
     """Test the set_up_probability_cube function"""
@@ -337,6 +348,16 @@ class test_set_up_probability_cube(IrisTest):
         self.assertEqual(len(result.attributes), 1)
         self.assertEqual(result.attributes['relative_to_threshold'], 'below')
 
+    def test_standard_grid_metadata(self):
+        """Test standard grid metadata"""
+        result = set_up_probability_cube(self.data, self.thresholds,
+                                         uk_standard_grid_metadata=True)
+        self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
+        self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
+        self.assertEqual(
+            result.attributes['mosg__grid_domain'], 'uk_extended')
+        self.assertEqual(
+            result.attributes['mosg__model_configuration'], 'uk_ens')
 
 class test_add_coordinate(IrisTest):
     """Test the add_coordinate utility"""

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -317,7 +317,7 @@ class test_set_up_percentile_cube(IrisTest):
         self.assertEqual(
             result.attributes['mosg__grid_domain'], 'uk_extended')
         self.assertEqual(
-            result.attributes['mosg__model_configuration'], 'uk_det')  
+            result.attributes['mosg__model_configuration'], 'uk_det')
 
 
 class test_set_up_probability_cube(IrisTest):

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -253,21 +253,25 @@ class test_set_up_variable_cube(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             _ = set_up_variable_cube(data_4d)
 
-    def test_standard_grid_metadata(self):
+    def test_standard_grid_metadata_uk(self):
         """Test standard grid metadata is added if specified"""
-        result_det = set_up_variable_cube(
-            self.data, uk_standard_grid_metadata=True)
-        result_ens = set_up_variable_cube(
-            self.data_3d, uk_standard_grid_metadata=True)
-        for cube in [result_det, result_ens]:
-            self.assertEqual(cube.attributes['mosg__grid_type'], 'standard')
-            self.assertEqual(cube.attributes['mosg__grid_version'], '1.3.0')
-            self.assertEqual(
-                cube.attributes['mosg__grid_domain'], 'uk_extended')
+        result = set_up_variable_cube(
+            self.data, standard_grid_metadata='uk_det')
+        self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
+        self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
+        self.assertEqual(result.attributes['mosg__grid_domain'], 'uk_extended')
         self.assertEqual(
-            result_det.attributes['mosg__model_configuration'], 'uk_det')
+            result.attributes['mosg__model_configuration'], 'uk_det')
+
+    def test_standard_grid_metadata_global(self):
+        """Test standard grid metadata is added if specified"""
+        result = set_up_variable_cube(
+            self.data_3d, standard_grid_metadata='gl_ens')
+        self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
+        self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
+        self.assertEqual(result.attributes['mosg__grid_domain'], 'global')
         self.assertEqual(
-            result_ens.attributes['mosg__model_configuration'], 'uk_ens')
+            result.attributes['mosg__model_configuration'], 'gl_ens')
 
 
 class test_set_up_percentile_cube(IrisTest):
@@ -299,25 +303,13 @@ class test_set_up_percentile_cube(IrisTest):
     def test_standard_grid_metadata(self):
         """Test standard grid metadata"""
         result = set_up_percentile_cube(self.data, self.percentiles,
-                                        uk_standard_grid_metadata=True)
+                                        standard_grid_metadata='uk_ens')
         self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
         self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
         self.assertEqual(
             result.attributes['mosg__grid_domain'], 'uk_extended')
         self.assertEqual(
             result.attributes['mosg__model_configuration'], 'uk_ens')
-
-    def test_override_grid_metadata(self):
-        """Test cube can be set up with a deterministic grid identifier"""
-        result = set_up_percentile_cube(
-            self.data, self.percentiles, uk_standard_grid_metadata=True,
-            attributes={'mosg__model_configuration': 'uk_det'})
-        self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
-        self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
-        self.assertEqual(
-            result.attributes['mosg__grid_domain'], 'uk_extended')
-        self.assertEqual(
-            result.attributes['mosg__model_configuration'], 'uk_det')
 
 
 class test_set_up_probability_cube(IrisTest):
@@ -363,7 +355,7 @@ class test_set_up_probability_cube(IrisTest):
     def test_standard_grid_metadata(self):
         """Test standard grid metadata"""
         result = set_up_probability_cube(self.data, self.thresholds,
-                                         uk_standard_grid_metadata=True)
+                                         standard_grid_metadata='uk_ens')
         self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
         self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
         self.assertEqual(

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -307,6 +307,18 @@ class test_set_up_percentile_cube(IrisTest):
         self.assertEqual(
             result.attributes['mosg__model_configuration'], 'uk_ens')
 
+    def test_override_grid_metadata(self):
+        """Test cube can be set up with a deterministic grid identifier"""
+        result = set_up_percentile_cube(
+            self.data, self.percentiles, uk_standard_grid_metadata=True,
+            attributes={'mosg__model_configuration': 'uk_det'})
+        self.assertEqual(result.attributes['mosg__grid_type'], 'standard')
+        self.assertEqual(result.attributes['mosg__grid_version'], '1.3.0')
+        self.assertEqual(
+            result.attributes['mosg__grid_domain'], 'uk_extended')
+        self.assertEqual(
+            result.attributes['mosg__model_configuration'], 'uk_det')  
+
 
 class test_set_up_probability_cube(IrisTest):
     """Test the set_up_probability_cube function"""
@@ -358,6 +370,7 @@ class test_set_up_probability_cube(IrisTest):
             result.attributes['mosg__grid_domain'], 'uk_extended')
         self.assertEqual(
             result.attributes['mosg__model_configuration'], 'uk_ens')
+
 
 class test_add_coordinate(IrisTest):
     """Test the add_coordinate utility"""

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -46,7 +46,7 @@ from improver.utilities.cube_metadata import (
     amend_metadata,
     delete_attributes,
     resolve_metadata_diff,
-    stage_v110_to_v120,
+    update_stage_v110_metadata,
     update_cell_methods,
     update_coord,
     update_attribute)
@@ -93,8 +93,8 @@ def create_cube_with_threshold(data=None,
     return cube
 
 
-class Test_stage_v110_to_v120(IrisTest):
-    """Test the stage_v110_to_v120 function"""
+class Test_update_stage_v110_metadata(IrisTest):
+    """Test the update_stage_v110_metadata function"""
 
     def setUp(self):
         """Set up variables for use in testing."""
@@ -103,7 +103,7 @@ class Test_stage_v110_to_v120(IrisTest):
     def test_basic(self):
         """Test that cube is unchanged and function returns False"""
         result = self.cube.copy()
-        output = stage_v110_to_v120(result)
+        output = update_stage_v110_metadata(result)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayEqual(result.data, self.cube.data)
         self.assertEqual(result.attributes, self.cube.attributes)
@@ -112,7 +112,7 @@ class Test_stage_v110_to_v120(IrisTest):
     def test_update_ukv(self):
         """Test that cube attributes from ukv 1.1.0 are updated"""
         self.cube.attributes['grid_id'] = 'ukvx_standard_v1'
-        output = stage_v110_to_v120(self.cube)
+        output = update_stage_v110_metadata(self.cube)
         self.assertTrue('mosg__grid_type' in self.cube.attributes.keys())
         self.assertTrue('mosg__model_configuration' in
                         self.cube.attributes.keys())

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -71,7 +71,7 @@ GRID_ID_LOOKUP = {'enukx_standard_v1': 'uk_ens',
                   'glm_standard_v1': 'gl_det'}
 
 
-def stage_v110_to_v120(cube):
+def update_stage_v110_metadata(cube):
     """Translates meta-data relating to the grid_id attribute from StaGE
     version 1.1.0 to later StaGE versions.
     Cubes that have no "grid_id" attribute are not recognised as v1.1.0 and

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -40,29 +40,40 @@ import iris
 from improver.utilities.cube_manipulation import compare_coords
 
 
+GRID_TYPE = 'standard'
+STAGE_VERSION = '1.3.0'
+
+# Define current StaGE grid metadata
+MOSG_GRID_DEFINITION = {
+    'uk_ens': {'mosg__grid_type': GRID_TYPE,
+               'mosg__model_configuration': 'uk_ens',
+               'mosg__grid_domain': 'uk_extended',
+               'mosg__grid_version': STAGE_VERSION},
+    'gl_ens': {'mosg__grid_type': GRID_TYPE,
+               'mosg__model_configuration': 'gl_ens',
+               'mosg__grid_domain': 'global',
+               'mosg__grid_version': STAGE_VERSION},
+    'uk_det': {'mosg__grid_type': GRID_TYPE,
+               'mosg__model_configuration': 'uk_det',
+               'mosg__grid_domain': 'uk_extended',
+               'mosg__grid_version': STAGE_VERSION},
+    'gl_det': {'mosg__grid_type': GRID_TYPE,
+               'mosg__model_configuration': 'gl_det',
+               'mosg__grid_domain': 'global',
+               'mosg__grid_version': STAGE_VERSION}
+}
+
+
 # Define correct v1.2.0 meta-data for v1.1.0 data.
-GRID_ID_LOOKUP = {'enukx_standard_v1': {'mosg__grid_type': 'standard',
-                                        'mosg__model_configuration': 'uk_ens',
-                                        'mosg__grid_domain': 'uk_extended',
-                                        'mosg__grid_version': '1.1.0'},
-                  'engl_standard_v1': {'mosg__grid_type': 'standard',
-                                       'mosg__model_configuration': 'gl_ens',
-                                       'mosg__grid_domain': 'global',
-                                       'mosg__grid_version': '1.1.0'},
-                  'ukvx_standard_v1': {'mosg__grid_type': 'standard',
-                                       'mosg__model_configuration': 'uk_det',
-                                       'mosg__grid_domain': 'uk_extended',
-                                       'mosg__grid_version': '1.1.0'},
-                  'glm_standard_v1': {'mosg__grid_type': 'standard',
-                                      'mosg__model_configuration': 'gl_det',
-                                      'mosg__grid_domain': 'global',
-                                      'mosg__grid_version': '1.1.0'},
-                  }
+GRID_ID_LOOKUP = {'enukx_standard_v1': 'uk_ens',
+                  'engl_standard_v1': 'gl_ens',
+                  'ukvx_standard_v1': 'uk_det',
+                  'glm_standard_v1': 'gl_ens'}
 
 
 def stage_v110_to_v120(cube):
     """Translates meta-data relating to the grid_id attribute from StaGE
-    version 1.1.0 to StaGE version 1.2.0.
+    version 1.1.0 to later StaGE versions.
     Cubes that have no "grid_id" attribute are not recognised as v1.1.0 and
     are ignored.
 
@@ -79,7 +90,8 @@ def stage_v110_to_v120(cube):
     except KeyError:
         # Not a version 1.1.0 grid, so exit.
         return False
-    cube.attributes.update(GRID_ID_LOOKUP[grid_id])
+    cube.attributes.update(MOSG_GRID_DEFINITION[GRID_ID_LOOKUP[grid_id]])
+    cube.attributes['mosg__grid_version'] = '1.1.0'
     return True
 
 

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -68,7 +68,7 @@ MOSG_GRID_DEFINITION = {
 GRID_ID_LOOKUP = {'enukx_standard_v1': 'uk_ens',
                   'engl_standard_v1': 'gl_ens',
                   'ukvx_standard_v1': 'uk_det',
-                  'glm_standard_v1': 'gl_ens'}
+                  'glm_standard_v1': 'gl_det'}
 
 
 def stage_v110_to_v120(cube):


### PR DESCRIPTION
Added argument to set up standard grid metadata attributes automatically if required.