### PR TITLE
Migrating unit tests to new cube setup utilities: PR 1

### DIFF
--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -40,6 +40,7 @@ from datetime import datetime
 import numpy as np
 import iris
 from iris.coords import DimCoord
+from iris.exceptions import CoordinateNotFoundError
 
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
 from improver.utilities.cube_metadata import MOSG_GRID_DEFINITION
@@ -397,8 +398,10 @@ def add_coordinate(incube, coord_points, coord_name, coord_units=None,
     """
     # if the coordinate already exists as a scalar coordinate, remove it
     cube = incube.copy()
-    if coord_name in [crd.name() for crd in cube.coords(dim_coords=False)]:
+    try:
         cube.remove_coord(coord_name)
+    except CoordinateNotFoundError:
+        pass
 
     cubes = iris.cube.CubeList([])
     for val in coord_points:

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -364,7 +364,7 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
     return cube
 
 
-def add_coordinate(cube, coord_points, coord_name, coord_units=None,
+def add_coordinate(incube, coord_points, coord_name, coord_units=None,
                    dtype=np.float32, order=None):
     """
     Function to duplicate a sample cube with an additional coordinate to create
@@ -372,7 +372,7 @@ def add_coordinate(cube, coord_points, coord_name, coord_units=None,
     reordered to place the new coordinate in the required position.
 
     Args:
-        cube (iris.cube.Cube):
+        incube (iris.cube.Cube):
             Cube to be duplicated.
         coord_points (list):
             Values for the coordinate.
@@ -395,6 +395,11 @@ def add_coordinate(cube, coord_points, coord_name, coord_units=None,
         iris.cube.Cube:
             Cube containing an additional dimension coordinate.
     """
+    # if the coordinate already exists as a scalar coordinate, remove it
+    cube = incube.copy()
+    if coord_name in [crd.name() for crd in cube.coords(dim_coords=False)]:
+        cube.remove_coord(coord_name)
+
     cubes = iris.cube.CubeList([])
     for val in coord_points:
         temp_cube = cube.copy()

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -51,9 +51,9 @@ from improver.utilities.cube_metadata import (
     update_coord,
     update_attribute)
 from improver.utilities.warnings_handler import ManageWarnings
-from improver.tests.ensemble_calibration.ensemble_calibration.\
-    helper_functions import set_up_temperature_cube
 from improver.utilities.temporal import forecast_period_coord
+
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 
 
 def create_cube_with_threshold(data=None,
@@ -77,15 +77,15 @@ def create_cube_with_threshold(data=None,
                                 units='degrees'), 2)
     cube.add_dim_coord(DimCoord(np.linspace(120, 180, 2), 'longitude',
                                 units='degrees'), 3)
-    time_origin = "hours since 1970-01-01 00:00:00"
+    time_origin = "seconds since 1970-01-01 00:00:00"
     calendar = "gregorian"
     tunit = Unit(time_origin, calendar)
-    cube.add_dim_coord(DimCoord([402192.5, 402193.5],
+    cube.add_dim_coord(DimCoord([1447893000, 1447896600],
                                 "time", units=tunit), 1)
     cube.add_dim_coord(DimCoord(threshold_values,
                                 long_name='threshold',
                                 units=units), 0)
-    cube.add_aux_coord(AuxCoord([402190.],
+    cube.add_aux_coord(AuxCoord([1447884000],
                                 standard_name='forecast_reference_time',
                                 units=tunit), None)
     cube.add_aux_coord(forecast_period_coord(cube), 1)
@@ -98,7 +98,8 @@ class Test_update_stage_v110_metadata(IrisTest):
 
     def setUp(self):
         """Set up variables for use in testing."""
-        self.cube = set_up_temperature_cube()
+        data = 275.*np.ones((3, 3), dtype=np.float32)
+        self.cube = set_up_variable_cube(data)
 
     def test_basic(self):
         """Test that cube is unchanged and function returns False"""
@@ -565,7 +566,8 @@ class Test_amend_metadata(IrisTest):
 
     def test_convert_units(self):
         """Test amend_metadata updates attributes OK. """
-        cube = set_up_temperature_cube()
+        cube = set_up_variable_cube(
+            np.ones((3, 3), dtype=np.float32), units='K')
         result = amend_metadata(cube, units="Celsius")
         self.assertEqual(result.units, "Celsius")
 
@@ -779,7 +781,7 @@ class Test_add_history_attribute(IrisTest):
 
     def test_add_history(self):
         """Test that a history attribute has been added."""
-        cube = set_up_temperature_cube()
+        cube = set_up_variable_cube(np.ones((3, 3), dtype=np.float32))
         add_history_attribute(cube, ["add", "Nowcast"])
         self.assertTrue("history" in cube.attributes)
         self.assertTrue("Nowcast" in cube.attributes["history"])
@@ -787,7 +789,7 @@ class Test_add_history_attribute(IrisTest):
     def test_history_already_exists(self):
         """Test that the history attribute is overwritten, if it
         already exists."""
-        cube = set_up_temperature_cube()
+        cube = set_up_variable_cube(np.ones((3, 3), dtype=np.float32))
         expected_history = "2018-09-13T11:28:29"
         cube.attributes["history"] = expected_history
         add_history_attribute(cube, ["Nowcast", "add"])

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -58,13 +58,10 @@ class Test_load_cube(IrisTest):
         self.filepath = os.path.join(self.directory, "temp.nc")
         self.cube = set_up_variable_cube(np.ones((3, 3, 3), dtype=np.float32))
         save_netcdf(self.cube, self.filepath)
-        self.realization_points = (
-            self.cube.coord("realization").points.astype(np.float32))
-        self.time_points = self.cube.coord("time").points.astype(np.int64)
-        self.latitude_points = (
-            self.cube.coord("latitude").points.astype(np.float32))
-        self.longitude_points = (
-            self.cube.coord("longitude").points.astype(np.float32))
+        self.realization_points = self.cube.coord("realization").points
+        self.time_points = self.cube.coord("time").points
+        self.latitude_points = self.cube.coord("latitude").points
+        self.longitude_points = self.cube.coord("longitude").points
 
     def tearDown(self):
         """Remove temporary directories created for testing."""
@@ -230,13 +227,10 @@ class Test_load_cubelist(IrisTest):
         self.filepath = os.path.join(self.directory, "temp.nc")
         self.cube = set_up_variable_cube(np.ones((3, 3, 3), dtype=np.float32))
         save_netcdf(self.cube, self.filepath)
-        self.realization_points = (
-            self.cube.coord("realization").points.astype(np.float32))
-        self.time_points = self.cube.coord("time").points.astype(np.int64)
-        self.latitude_points = (
-            self.cube.coord("latitude").points.astype(np.float32))
-        self.longitude_points = (
-            self.cube.coord("longitude").points.astype(np.float32))
+        self.realization_points = self.cube.coord("realization").points
+        self.time_points = self.cube.coord("time").points
+        self.latitude_points = self.cube.coord("latitude").points
+        self.longitude_points = self.cube.coord("longitude").points
         self.low_cloud_filepath = os.path.join(self.directory, "low_cloud.nc")
         self.med_cloud_filepath = os.path.join(self.directory,
                                                "medium_cloud.nc")

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -44,39 +44,9 @@ import numpy as np
 from improver.utilities.load import load_cube, load_cubelist
 from improver.utilities.save import save_netcdf
 
-from improver.tests.ensemble_calibration.ensemble_calibration.\
-    helper_functions import (
-        set_up_probability_above_threshold_temperature_cube,
-        set_up_temperature_cube)
-from improver.tests.set_up_test_cubes import set_up_percentile_cube
-
-
-def create_sample_cube_with_additional_coordinate(
-        cube, coord_name, coord_points):
-    """
-    Function to duplicate a sample cube with an additional coordinate to
-    create a cubelist. The cubelist is merged to create a single cube.
-
-    Args:
-        cube (iris.cube.Cube):
-            Create a cube to be duplicated.
-        coord_name (str):
-            Long name of the coordinate that you would like to add.
-        coord_points (list):
-            Values for the coordinate.
-
-    Returns:
-        iris.cube.Cube:
-            Cube containing an additional dimension coordinate.
-
-    """
-    cubes = iris.cube.CubeList([])
-    for val in coord_points:
-        temp_cube = cube.copy()
-        temp_cube.add_aux_coord(
-            DimCoord(np.array([val]), long_name=coord_name))
-        cubes.append(temp_cube)
-    return cubes.merge_cube()
+from improver.tests.set_up_test_cubes import (
+    set_up_variable_cube, set_up_percentile_cube, set_up_probability_cube,
+    add_coordinate)
 
 
 class Test_load_cube(IrisTest):
@@ -86,12 +56,15 @@ class Test_load_cube(IrisTest):
         """Set up variables for use in testing."""
         self.directory = mkdtemp()
         self.filepath = os.path.join(self.directory, "temp.nc")
-        self.cube = set_up_temperature_cube()
+        self.cube = set_up_variable_cube(np.ones((3, 3, 3), dtype=np.float32))
         save_netcdf(self.cube, self.filepath)
-        self.realization_points = np.array([0, 1, 2], dtype=np.float32)
-        self.time_points = np.array([412227], dtype=np.float64)
-        self.latitude_points = np.array([-45., 0., 45.], dtype=np.float32)
-        self.longitude_points = np.array([120., 150., 180.], dtype=np.float32)
+        self.realization_points = (
+            self.cube.coord("realization").points.astype(np.float32))
+        self.time_points = self.cube.coord("time").points.astype(np.int64)
+        self.latitude_points = (
+            self.cube.coord("latitude").points.astype(np.float32))
+        self.longitude_points = (
+            self.cube.coord("longitude").points.astype(np.float32))
 
     def tearDown(self):
         """Remove temporary directories created for testing."""
@@ -169,14 +142,13 @@ class Test_load_cube(IrisTest):
     def test_ordering_for_realization_coordinate(self):
         """Test that the cube has been reordered, if it is originally in an
         undesirable order and the cube contains a "realization" coordinate."""
-        cube = set_up_temperature_cube()
-        cube.transpose([3, 2, 1, 0])
+        cube = set_up_variable_cube(np.ones((3, 3, 3), dtype=np.float32))
+        cube.transpose([2, 1, 0])
         save_netcdf(cube, self.filepath)
         result = load_cube(self.filepath)
         self.assertEqual(result.coord_dims("realization")[0], 0)
-        self.assertEqual(result.coord_dims("time")[0], 1)
-        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
-        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 3)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 1)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 2)
 
     def test_ordering_for_percentile_over_coordinate(self):
         """Test that the cube has been reordered, if it is originally in an
@@ -195,35 +167,36 @@ class Test_load_cube(IrisTest):
     def test_ordering_for_threshold_coordinate(self):
         """Test that the cube has been reordered, if it is originally in an
         undesirable order and the cube contains a "threshold" coordinate."""
-        cube = set_up_probability_above_threshold_temperature_cube()
-        cube.transpose([3, 2, 1, 0])
+        cube = set_up_probability_cube(
+            np.zeros((3, 4, 5), dtype=np.float32),
+            np.array([273., 274., 275.], dtype=np.float32))
+        cube.transpose([2, 1, 0])
         save_netcdf(cube, self.filepath)
         result = load_cube(self.filepath)
         self.assertEqual(result.coord_dims("threshold")[0], 0)
-        self.assertEqual(result.coord_dims("time")[0], 1)
-        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 2)
-        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 3)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 1)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 2)
 
     def test_ordering_for_realization_threshold_percentile_over_coordinate(
             self):
         """Test that the cube has been reordered, if it is originally in an
         undesirable order and the cube contains a "threshold" coordinate,
         a "realization" coordinate and a "percentile_over" coordinate."""
-        cube = set_up_probability_above_threshold_temperature_cube()
-        cube = create_sample_cube_with_additional_coordinate(
-            cube, "realization", [0, 1, 2])
-        cube = create_sample_cube_with_additional_coordinate(
-            cube, "percentile_over_neighbourhood", [10, 50, 90])
-        cube.transpose([5, 4, 3, 2, 1, 0])
+        cube = set_up_probability_cube(
+            np.zeros((3, 4, 5), dtype=np.float32),
+            np.array([273., 274., 275.], dtype=np.float32))
+        cube = add_coordinate(cube, [0, 1, 2], "realization")
+        cube = add_coordinate(
+            cube, [10, 50, 90], "percentile_over_neighbourhood")
+        cube.transpose([4, 3, 2, 1, 0])
         save_netcdf(cube, self.filepath)
         result = load_cube(self.filepath)
         self.assertEqual(result.coord_dims("realization")[0], 0)
         self.assertEqual(
             result.coord_dims("percentile_over_neighbourhood")[0], 1)
         self.assertEqual(result.coord_dims("threshold")[0], 2)
-        self.assertEqual(result.coord_dims("time")[0], 3)
-        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 4)
-        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 5)
+        self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 3)
+        self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 4)
 
     def test_attributes(self):
         """Test that metadata attributes are successfully stripped out."""
@@ -255,12 +228,15 @@ class Test_load_cubelist(IrisTest):
         """Set up variables for use in testing."""
         self.directory = mkdtemp()
         self.filepath = os.path.join(self.directory, "temp.nc")
-        self.cube = set_up_temperature_cube()
+        self.cube = set_up_variable_cube(np.ones((3, 3, 3), dtype=np.float32))
         save_netcdf(self.cube, self.filepath)
-        self.realization_points = np.array([0, 1, 2])
-        self.time_points = np.array(412227, dtype=np.float64)
-        self.latitude_points = np.array([-45., 0., 45.], dtype=np.float32)
-        self.longitude_points = np.array([120., 150., 180.], dtype=np.float32)
+        self.realization_points = (
+            self.cube.coord("realization").points.astype(np.float32))
+        self.time_points = self.cube.coord("time").points.astype(np.int64)
+        self.latitude_points = (
+            self.cube.coord("latitude").points.astype(np.float32))
+        self.longitude_points = (
+            self.cube.coord("longitude").points.astype(np.float32))
         self.low_cloud_filepath = os.path.join(self.directory, "low_cloud.nc")
         self.med_cloud_filepath = os.path.join(self.directory,
                                                "medium_cloud.nc")

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -32,14 +32,12 @@
 
 import unittest
 import numpy as np
+from datetime import datetime
 
 from iris.tests import IrisTest
 
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.rescale import rescale, apply_double_scaling
-from improver.tests.nbhood.nbhood.test_BaseNeighbourhoodProcessing import (
-    set_up_cube, set_up_cube_with_no_realizations)
-from improver.tests.ensemble_calibration.ensemble_calibration.helper_functions\
-    import add_forecast_reference_time_and_forecast_period
 
 
 class Test_rescale(IrisTest):
@@ -47,12 +45,10 @@ class Test_rescale(IrisTest):
     """Test the utilities.rescale rescale function."""
 
     def setUp(self):
-        """
-        Create a cube with a single non-zero point.
-        Trap standard output
-        """
-        self.cube = add_forecast_reference_time_and_forecast_period(
-            set_up_cube())
+        """Create a cube with a single non-zero point."""
+        self.cube = set_up_variable_cube(
+            np.ones((1, 16, 16), dtype=np.float32))
+        self.cube.data[0, 7, 7] = 0.
 
     def test_basic(self):
         """Test that the method returns the expected array type"""
@@ -75,7 +71,7 @@ class Test_rescale(IrisTest):
         """Test that the method returns the expected values when in range"""
         expected = self.cube.data.copy()
         expected[...] = 110.
-        expected[0, 0, 7, 7] = 100.
+        expected[0, 7, 7] = 100.
         result = rescale(self.cube.data, data_range=(0., 1.),
                          scale_range=(100., 110.))
         self.assertArrayAlmostEqual(result, expected)
@@ -84,7 +80,7 @@ class Test_rescale(IrisTest):
         """Test that the method gives the expected values when out of range"""
         expected = self.cube.data.copy()
         expected[...] = 108.
-        expected[0, 0, 7, 7] = 98.
+        expected[0, 7, 7] = 98.
         result = rescale(self.cube.data, data_range=(0.2, 1.2),
                          scale_range=(100., 110.))
         self.assertArrayAlmostEqual(result, expected)
@@ -93,7 +89,7 @@ class Test_rescale(IrisTest):
         """Test that the method clips values when out of range"""
         expected = self.cube.data.copy()
         expected[...] = 108.
-        expected[0, 0, 7, 7] = 100.
+        expected[0, 7, 7] = 100.
         result = rescale(self.cube.data, data_range=(0.2, 1.2),
                          scale_range=(100., 110.), clip=True)
         self.assertArrayAlmostEqual(result, expected)
@@ -108,27 +104,28 @@ class Test_apply_double_scaling(IrisTest):
         The cubes look like this:
         precipitation_amount / (kg m^-2)
         Dimension coordinates:
-            time: 1;
             projection_y_coordinate: 4;
             projection_x_coordinate: 4;
-        Auxiliary coordinates:
-            forecast_period (on time coord): 0.0 hours
         Scalar coordinates:
+            time: 2015-11-23 03:00:00
             forecast_reference_time: 2015-11-23 03:00:00
+            forecast_period (on time coord): 0.0 hours
         Data:
             self.cube_a:
                 All points contain float(1.)
             self.cube_b:
                 All points contain float(1.)
         """
-        self.cube_a = add_forecast_reference_time_and_forecast_period(
-            set_up_cube_with_no_realizations(zero_point_indices=[],
-                                             num_grid_points=4),
-            fp_point=0.0)
-        self.cube_b = add_forecast_reference_time_and_forecast_period(
-            set_up_cube_with_no_realizations(zero_point_indices=[],
-                                             num_grid_points=4),
-            fp_point=0.0)
+        self.cube_a = set_up_variable_cube(
+            np.ones((4, 4), dtype=np.float32),
+            time=datetime(2015, 11, 23, 3, 0),
+            frt=datetime(2015, 11, 23, 3, 0))
+
+        self.cube_b = set_up_variable_cube(
+            np.ones((4, 4), dtype=np.float32),
+            time=datetime(2015, 11, 23, 3, 0),
+            frt=datetime(2015, 11, 23, 3, 0))
+
         self.thr_a = (0.1, 0.5, 0.8)
         self.thr_b = (0.0, 0.5, 0.9)
 
@@ -157,17 +154,17 @@ class Test_apply_double_scaling(IrisTest):
         # Create an array of correct shape and fill with expected value
         expected = np.full_like(self.cube_a.data, 0.9)
         # Row zero should be changed to all-zeroes
-        expected[0, 0, :] = [0., 0., 0., 0.]
+        expected[0, :] = [0., 0., 0., 0.]
         # Row one should be like cube_a but with most values reduced to 0.5
-        expected[0, 1, :] = [0.0, 0.4, 0.5, 0.5]
+        expected[1, :] = [0.0, 0.4, 0.5, 0.5]
         # Row two should be like cube_a but with late values limited to 0.9
-        expected[0, 2, :] = [0.0, 0.4, 0.8, 0.9]
-        self.cube_a.data[0, 0, :] = [0., 0., 0., 0.]
-        self.cube_a.data[0, 1, :] = [0.5, 0.5, 0.5, 0.5]
-        self.cube_a.data[0, 2, :] = [1., 1., 1., 1.]
-        self.cube_b.data[0, 0, :] = np.arange(0., 1.6, 0.4)
-        self.cube_b.data[0, 1, :] = np.arange(0., 1.6, 0.4)
-        self.cube_b.data[0, 2, :] = np.arange(0., 1.6, 0.4)
+        expected[2, :] = [0.0, 0.4, 0.8, 0.9]
+        self.cube_a.data[0, :] = [0., 0., 0., 0.]
+        self.cube_a.data[1, :] = [0.5, 0.5, 0.5, 0.5]
+        self.cube_a.data[2, :] = [1., 1., 1., 1.]
+        self.cube_b.data[0, :] = np.arange(0., 1.6, 0.4)
+        self.cube_b.data[1, :] = np.arange(0., 1.6, 0.4)
+        self.cube_b.data[2, :] = np.arange(0., 1.6, 0.4)
         result = apply_double_scaling(self.cube_a,
                                       self.cube_b,
                                       self.thr_a,
@@ -179,17 +176,17 @@ class Test_apply_double_scaling(IrisTest):
         function"""
         expected = self.cube_a.data.copy()
         # Row zero should be unchanged from ltng_cube
-        expected[0, 0, :] = np.arange(0., 1.6, 0.4)
+        expected[0, :] = np.arange(0., 1.6, 0.4)
         # Row one should be like cube_a but with early values raised to 0.5
-        expected[0, 1, :] = [0.5, 0.5, 0.8, 1.2]
+        expected[1, :] = [0.5, 0.5, 0.8, 1.2]
         # Row two should be like cube_a but with most values raised to 0.9
-        expected[0, 2, :] = [0.9, 0.9, 0.9, 1.2]
-        self.cube_a.data[0, 0, :] = [0., 0., 0., 0.]
-        self.cube_a.data[0, 1, :] = [0.5, 0.5, 0.5, 0.5]
-        self.cube_a.data[0, 2, :] = [1., 1., 1., 1.]
-        self.cube_b.data[0, 0, :] = np.arange(0., 1.6, 0.4)
-        self.cube_b.data[0, 1, :] = np.arange(0., 1.6, 0.4)
-        self.cube_b.data[0, 2, :] = np.arange(0., 1.6, 0.4)
+        expected[2, :] = [0.9, 0.9, 0.9, 1.2]
+        self.cube_a.data[0, :] = [0., 0., 0., 0.]
+        self.cube_a.data[1, :] = [0.5, 0.5, 0.5, 0.5]
+        self.cube_a.data[2, :] = [1., 1., 1., 1.]
+        self.cube_b.data[0, :] = np.arange(0., 1.6, 0.4)
+        self.cube_b.data[1, :] = np.arange(0., 1.6, 0.4)
+        self.cube_b.data[2, :] = np.arange(0., 1.6, 0.4)
         result = apply_double_scaling(self.cube_a,
                                       self.cube_b,
                                       self.thr_a,

--- a/lib/improver/tests/utilities/test_rescale.py
+++ b/lib/improver/tests/utilities/test_rescale.py
@@ -45,7 +45,7 @@ class Test_rescale(IrisTest):
     """Test the utilities.rescale rescale function."""
 
     def setUp(self):
-        """Create a cube with a single non-zero point."""
+        """Create a cube of ones with a single zero point."""
         self.cube = set_up_variable_cube(
             np.ones((1, 16, 16), dtype=np.float32))
         self.cube.data[0, 7, 7] = 0.

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -192,8 +192,6 @@ class Test_forecast_period_coord(IrisTest):
         other than the usual units of seconds since 1970-01-01 00:00:00.
         """
         expected_result = self.cube.coord("forecast_period")
-        fp_coord = self.cube.coord("forecast_period").copy()
-        fp_coord.convert_units("hours")
         self.cube.coord("time").convert_units(
             "hours since 1970-01-01 00:00:00")
         result = forecast_period_coord(


### PR DESCRIPTION
Begins to address #742 

Migrated the following test modules (under lib/improver/tests/utilities/) to use the new cube setup utilities, or local utilities in integer seconds:
- test_cube_metadata
- test_load
- test_rescale
- test_temporal

The test_save module should be migrated after https://github.com/metoppv/improver/pull/748 is merged.