### PR TITLE
Changes to check_cube_coordinates to transpose cubes properly

### DIFF
--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -206,6 +206,14 @@ class Test_check_cube_coordinates(IrisTest):
         result = check_cube_coordinates(cube, cube)
         self.assertIsInstance(result, Cube)
 
+    def test_basic_transpose(self):
+        """Test when we only want to transpose the new_cube."""
+        cube = set_up_cube()
+        new_cube = set_up_cube()
+        new_cube.transpose([3, 2, 0, 1])
+        result = check_cube_coordinates(cube, new_cube)
+        self.assertEqual(result.dim_coords, cube.dim_coords)
+
     def test_coord_promotion(self):
         """Test that scalar coordinates in new_cube are promoted to dimension
         coordinates to match the parent cube."""
@@ -254,8 +262,9 @@ class Test_check_cube_coordinates(IrisTest):
         cube = set_up_cube()
         new_cube = cube[0].copy()
         cube = iris.util.squeeze(cube)
-        msg = 'is not within the permitted exceptions'
-        with self.assertRaisesRegex(iris.exceptions.InvalidCubeError, msg):
+        msg = 'The number of dimension coordinates within the new cube'
+        with self.assertRaisesRegex(iris.exceptions.CoordinateNotFoundError,
+                                    msg):
             check_cube_coordinates(
                 cube, new_cube)
 
@@ -267,8 +276,10 @@ class Test_check_cube_coordinates(IrisTest):
         new_cube = cube[0].copy()
         cube = iris.util.squeeze(cube)
         exception_coordinates = ["height"]
-        msg = 'is not within the permitted exceptions'
-        with self.assertRaisesRegex(iris.exceptions.InvalidCubeError, msg):
+        msg = ("The coordinate: height is not new_cube, but is within the"
+               " permitted exceptions")
+        with self.assertRaisesRegex(iris.exceptions.CoordinateNotFoundError,
+                                    msg):
             check_cube_coordinates(
                 cube, new_cube, exception_coordinates=exception_coordinates)
 

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -31,7 +31,7 @@
 """ Provides support utilities for checking cubes."""
 
 import iris
-from iris.exceptions import CoordinateNotFoundError, InvalidCubeError
+from iris.exceptions import CoordinateNotFoundError
 import numpy as np
 
 
@@ -132,9 +132,8 @@ def check_cube_coordinates(cube, new_cube, exception_coordinates=None):
     Raises:
         CoordinateNotFoundError : Raised if the final dimension
             coordinates of the returned cube do not match the input cube.
-        InvalidCubeError : If the coordinate is not within the original cube
-            and it is not within the list of permitted exceptions.
-
+        CoordinateNotFoundError : If a coodinate is within in the permitted
+            exceptions but is not in the new_cube.
     """
     if exception_coordinates is None:
         exception_coordinates = []
@@ -144,48 +143,42 @@ def check_cube_coordinates(cube, new_cube, exception_coordinates=None):
     for coord in new_cube.aux_coords[::-1]:
         if coord.name() in cube_dim_names:
             new_cube = iris.util.new_axis(new_cube, coord)
-
-    # Ensure dimension order matches; if lengths are unequal a coordinate
-    # is missing, so raise an appropriate error.
-    cube_dimension_order = {coord.name(): cube.coord_dims(coord.name())[0]
-                            for coord in cube.dim_coords}
-
-    correct_order = []
-    new_cube_only_dims = []
     new_cube_dim_names = [coord.name() for coord in new_cube.dim_coords]
-    for coord_name in new_cube_dim_names:
-        if coord_name in cube_dim_names:
-            correct_order.append(cube_dimension_order[coord_name])
-        else:
-            if coord_name in exception_coordinates:
-                new_coord_dim = new_cube.coord_dims(coord_name)[0]
-                new_cube_only_dims.append(new_coord_dim)
-            else:
-                msg = ("The coordinate: {0} is within new_cube, "
-                       "however, this is not within the original "
-                       "cube. As {0} is not within the permitted "
-                       "exceptions: {1}, this is not allowed. "
-                       "\nnew_cube: {2}"
-                       "\ncube: {3}").format(
-                           coord_name, exception_coordinates, new_cube,
-                           cube)
-                raise InvalidCubeError(msg)
+    # If we have the wrong number of dimensions then raise an error.
+    if (len(cube.dim_coords)+len(exception_coordinates) !=
+            len(new_cube.dim_coords)):
 
-    correct_order = np.array(correct_order)
-    for dim in new_cube_only_dims:
-        correct_order[correct_order >= dim] += 1
-        correct_order = np.insert(correct_order, dim, dim)
-
-    if (len(cube_dimension_order.keys())+len(exception_coordinates) ==
-            len(correct_order)):
-        new_cube.transpose(correct_order)
-    else:
         msg = ('The number of dimension coordinates within the new cube '
                'do not match the number of dimension coordinates within the '
                'original cube plus the number of exception coordinates. '
-               '\n input cube shape {} returned cube shape {}'.format(
-                   cube.shape, new_cube.shape))
+               '\n input cube dimensions {}, new cube dimensions {}'.format(
+                   cube_dim_names, new_cube_dim_names))
         raise CoordinateNotFoundError(msg)
+
+    # Ensure dimension order matches
+    new_cube_dimension_order = {coord.name(): new_cube.coord_dims(
+        coord.name())[0] for coord in new_cube.dim_coords}
+    correct_order = []
+    new_cube_only_dims = []
+    for coord_name in cube_dim_names:
+        correct_order.append(new_cube_dimension_order[coord_name])
+    for coord_name in exception_coordinates:
+        try:
+            new_coord_dim = new_cube.coord_dims(coord_name)[0]
+            new_cube_only_dims.append(new_coord_dim)
+        except CoordinateNotFoundError:
+            msg = ("The coordinate: {0} is not new_cube, "
+                   "but is within the permitted "
+                   "exceptions: {1}, this is not allowed. ").format(
+                        coord_name, exception_coordinates)
+            raise CoordinateNotFoundError(msg)
+
+    correct_order = np.array(correct_order)
+    for dim in new_cube_only_dims:
+        correct_order[correct_order >= dim]
+        correct_order = np.insert(correct_order, dim, dim)
+
+    new_cube.transpose(correct_order)
 
     return new_cube
 


### PR DESCRIPTION
Addresses #692 

Whilst testing my plugin for IMPRO-913 (#692) I noticed the check_cube_coordinates does not transpose cubes correctly if this is the only thing it needs to do. This PR fixes this.

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)


