### PR TITLE
Impro1001 radar coverage mask

### DIFF
--- a/bin/improver-extend-radar-mask
+++ b/bin/improver-extend-radar-mask
@@ -40,6 +40,7 @@ from improver.nowcasting.utilities import ExtendRadarMask
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
+
 def main():
     """Extend radar mask based on coverage data."""
     parser = ArgParser(description="Extend radar mask based on coverage "

--- a/bin/improver-extend-radar-mask
+++ b/bin/improver-extend-radar-mask
@@ -31,10 +31,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to extend a radar mask based on coverage data."""
 
-import datetime
-import os
-import numpy as np
-
 from improver.argparser import ArgParser
 from improver.nowcasting.utilities import ExtendRadarMask
 from improver.utilities.load import load_cube
@@ -52,7 +48,7 @@ def main():
                         type=str, help="Full path to input NetCDF file "
                         "containing radar coverage data.")
     parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
-                        type=str, help="Full path save remasked rainrate "
+                        type=str, help="Full path to save remasked rainrate "
                         "NetCDF file.")
     args = parser.parse_args()
 

--- a/bin/improver-extend-radar-mask
+++ b/bin/improver-extend-radar-mask
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to extend a radar mask based on coverage data."""
+
+import datetime
+import os
+import numpy as np
+
+from improver.argparser import ArgParser
+from improver.nowcasting.utilities import ExtendRadarMask
+from improver.utilities.load import load_cube
+from improver.utilities.save import save_netcdf
+
+def main():
+    """Extend radar mask based on coverage data."""
+    parser = ArgParser(description="Extend radar mask based on coverage "
+                       "data.")
+    parser.add_argument("rainrate_filepath", metavar="RAINRATE_FILEPATH",
+                        type=str, help="Full path to input NetCDF file "
+                        "containing radar rain rates.")
+    parser.add_argument("coverage_filepath", metavar="COVERAGE_FILEPATH",
+                        type=str, help="Full path to input NetCDF file "
+                        "containing radar coverage data.")
+    parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
+                        type=str, help="Full path save remasked rainrate "
+                        "NetCDF file.")
+    args = parser.parse_args()
+
+    # load data
+    rainrate = load_cube(args.rainrate_filepath)
+    coverage = load_cube(args.rainrate_filepath)
+
+    # extend mask
+    remasked_rainrate = ExtendRadarMask().process(rainrate, coverage)
+
+    # save output file
+    save_netcdf(remasked_rainrate, args.output_filepath)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/improver-extend-radar-mask
+++ b/bin/improver-extend-radar-mask
@@ -41,26 +41,26 @@ def main():
     """Extend radar mask based on coverage data."""
     parser = ArgParser(description="Extend radar mask based on coverage "
                        "data.")
-    parser.add_argument("rainrate_filepath", metavar="RAINRATE_FILEPATH",
+    parser.add_argument("radar_data_filepath", metavar="RADAR_DATA_FILEPATH",
                         type=str, help="Full path to input NetCDF file "
-                        "containing radar rain rates.")
+                        "containing the radar variable to remask.")
     parser.add_argument("coverage_filepath", metavar="COVERAGE_FILEPATH",
                         type=str, help="Full path to input NetCDF file "
                         "containing radar coverage data.")
     parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
-                        type=str, help="Full path to save remasked rainrate "
+                        type=str, help="Full path to save remasked radar data "
                         "NetCDF file.")
     args = parser.parse_args()
 
     # load data
-    rainrate = load_cube(args.rainrate_filepath)
+    radar_data = load_cube(args.radar_data_filepath)
     coverage = load_cube(args.coverage_filepath)
 
     # extend mask
-    remasked_rainrate = ExtendRadarMask().process(rainrate, coverage)
+    remasked_data = ExtendRadarMask().process(radar_data, coverage)
 
     # save output file
-    save_netcdf(remasked_rainrate, args.output_filepath)
+    save_netcdf(remasked_data, args.output_filepath)
 
 
 if __name__ == "__main__":

--- a/bin/improver-extend-radar-mask
+++ b/bin/improver-extend-radar-mask
@@ -57,7 +57,7 @@ def main():
 
     # load data
     rainrate = load_cube(args.rainrate_filepath)
-    coverage = load_cube(args.rainrate_filepath)
+    coverage = load_cube(args.coverage_filepath)
 
     # extend mask
     remasked_rainrate = ExtendRadarMask().process(rainrate, coverage)

--- a/lib/improver/nowcasting/utilities.py
+++ b/lib/improver/nowcasting/utilities.py
@@ -51,50 +51,50 @@ class ExtendRadarMask(object):
     def __init__(self):
         """
         Initialise with known values of the coverage composite for which radar
-        rain rate data is valid.  All other areas will be masked.
+        data is valid.  All other areas will be masked.
         """
         self.coverage_valid = [1, 2]
 
-    def process(self, rainrate, coverage):
+    def process(self, radar_data, coverage):
         """
         Update the mask on the input rainrate cube to reflect where coverage
         is valid
 
         Args:
-            rainrate (iris.cube.Cube):
-                Radar rain rate data with mask corresponding to radar domains
+            radar_data (iris.cube.Cube):
+                Radar data with mask corresponding to radar domains
             coverage (iris.cube.Cube):
                 Radar coverage data containing values:
                     0: outside composite
-                    1: rain detected
-                    2: rain not detected and 1/32 mm/h detectable at this range
-                    3: rain not detected and 1/32 mm/h NOT detectable
+                    1: precip detected
+                    2: precip not detected & 1/32 mm/h detectable at this range
+                    3: precip not detected & 1/32 mm/h NOT detectable
 
         Returns:
             (iris.cube.Cube):
-                Radar rain rate data with mask extended to mask out regions
-                where 1/32 mm/h are not detectable
+                Radar data with mask extended to mask out regions where
+                1/32 mm/h are not detectable
         """
         # check cube coordinates match
-        for crd in rainrate.coords():
+        for crd in radar_data.coords():
             if coverage.coord(crd.name()) != crd:
                 raise ValueError('Rain rate and coverage composites unmatched '
                                  '- coord {}'.format(crd.name()))
 
         # accomodate data from multiple times
-        rainrate_slices = rainrate.slices([rainrate.coord(axis='y'),
-                                           rainrate.coord(axis='x')])
+        radar_data_slices = radar_data.slices([radar_data.coord(axis='y'),
+                                               radar_data.coord(axis='x')])
         coverage_slices = coverage.slices([coverage.coord(axis='y'),
                                            coverage.coord(axis='x')])
 
         cube_list = iris.cube.CubeList()
-        for rain, cov in zip(rainrate_slices, coverage_slices):
+        for rad, cov in zip(radar_data_slices, coverage_slices):
             # create a new mask that is False wherever coverage is valid
             new_mask = ~np.isin(cov.data, self.coverage_valid)
 
             # remask rainrate data
-            remasked_data = np.ma.MaskedArray(rain.data.data, mask=new_mask)
-            cube_list.append(rain.copy(remasked_data))
+            remasked_data = np.ma.MaskedArray(rad.data.data, mask=new_mask)
+            cube_list.append(rad.copy(remasked_data))
 
         return cube_list.merge_cube()
 

--- a/lib/improver/nowcasting/utilities.py
+++ b/lib/improver/nowcasting/utilities.py
@@ -75,15 +75,6 @@ class ExtendRadarMask(object):
                 Radar rain rate data with mask extended to mask out regions
                 where 1/32 mm/h are not detectable
         """
-        # check cube names
-        if 'lwe_precipitation_rate' not in rainrate.name():
-            raise ValueError('Rainrate cube name "lwe_precipitation_rate" '
-                             'expected, got {}'.format(rainrate.name()))
-
-        if 'coverage' not in coverage.name():
-            raise ValueError('Coverage cube "coverage" expected, got '
-                             '{}'.format(coverage.name()))
-
         # check cube coordinates match
         for crd in rainrate.coords():
             if coverage.coord(crd.name()) != crd:

--- a/lib/improver/nowcasting/utilities.py
+++ b/lib/improver/nowcasting/utilities.py
@@ -87,7 +87,7 @@ class ExtendRadarMask(object):
         coverage_slices = coverage.slices([coverage.coord(axis='y'),
                                            coverage.coord(axis='x')])
 
-        cube_list = []
+        cube_list = iris.cube.CubeList()
         for rain, cov in zip(rainrate_slices, coverage_slices):
             # create a new mask that is False wherever coverage is valid
             new_mask = ~np.isin(cov.data, self.coverage_valid)
@@ -96,7 +96,7 @@ class ExtendRadarMask(object):
             remasked_data = np.ma.MaskedArray(rain.data.data, mask=new_mask)
             cube_list.append(rain.copy(remasked_data))
 
-        return iris.cube.CubeList(cube_list).merge_cube()
+        return cube_list.merge_cube()
 
 
 class ApplyOrographicEnhancement(object):

--- a/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
+++ b/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
@@ -99,7 +99,7 @@ class Test_process(IrisTest):
     def test_values(self):
         """Test output cube has expected mask and underlying data is
         unchanged"""
-        result = ExtendRadarMask().process(self.rainrate, self.coverage)        
+        result = ExtendRadarMask().process(self.rainrate, self.coverage)
         self.assertArrayEqual(result.data.mask, self.expected_mask)
         self.assertArrayEqual(result.data.data, self.rainrate.data.data)
 

--- a/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
+++ b/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
@@ -72,7 +72,8 @@ class Test_process(IrisTest):
         rainrate_data = np.ma.MaskedArray(rainrate_data, mask=rainrate_mask)
 
         self.rainrate = set_up_variable_cube(
-            rainrate_data, name='lwe_precipitation_rate', units='mm h-1')
+            rainrate_data, name='lwe_precipitation_rate', units='mm h-1',
+            spatial_grid='equalarea')
 
         coverage_data = np.array([[0, 0, 0, 0, 0],
                                   [0, 2, 1, 1, 3],
@@ -81,7 +82,8 @@ class Test_process(IrisTest):
                                   [0, 3, 1, 1, 1]])
 
         self.coverage = set_up_variable_cube(
-            coverage_data, name='radar_coverage', units='1')
+            coverage_data, name='radar_coverage', units='1',
+            spatial_grid='equalarea')
 
         self.expected_mask = np.array([
             [True, True, True, True, True],

--- a/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
+++ b/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
@@ -109,6 +109,14 @@ class Test_process(IrisTest):
         _ = ExtendRadarMask().process(self.rainrate, self.coverage)
         self.assertEqual(reference, self.rainrate)
 
+    def test_coords_unmatched_error(self):
+        """Test error is raised if coordinates do not match"""
+        x_points = self.rainrate.coord(axis='x').points
+        self.rainrate.coord(axis='x').points = x_points + 100.
+        msg = 'Rain rate and coverage composites unmatched'
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = ExtendRadarMask().process(self.rainrate, self.coverage)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
+++ b/lib/improver/tests/nowcasting/utilities/test_ExtendRadarMask.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module with tests for the ExtendRadarMask plugin."""
+
+import unittest
+import numpy as np
+
+import iris
+from iris.tests import IrisTest
+
+from improver.nowcasting.utilities import ExtendRadarMask
+from improver.tests.set_up_test_cubes import set_up_variable_cube
+
+
+class Test__init_(IrisTest):
+    """Test the _init_ method"""
+
+    def test_basic(self):
+        """Test initialisation of class"""
+        plugin = ExtendRadarMask()
+        self.assertSequenceEqual(plugin.coverage_valid, [1, 2])
+
+
+class Test_process(IrisTest):
+    """Test the process method"""
+
+    def setUp(self):
+        """Set up some input cubes"""
+        rainrate_data = np.array([
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.4, 0.3, 0.0],
+            [0.0, 0.2, 0.6, 0.7, 0.6],
+            [0.0, 0.0, 0.4, 0.5, 0.4],
+            [0.0, 0.0, 0.1, 0.2, 0.3]], dtype=np.float32)
+
+        rainrate_mask = np.array([
+            [True, True, True, True, True],
+            [True, False, False, False, False],
+            [True, False, False, False, False],
+            [True, False, False, False, False],
+            [True, False, False, False, False]], dtype=bool)
+
+        rainrate_data = np.ma.MaskedArray(rainrate_data, mask=rainrate_mask)
+
+        self.rainrate = set_up_variable_cube(
+            rainrate_data, name='lwe_precipitation_rate', units='mm h-1')
+
+        coverage_data = np.array([[0, 0, 0, 0, 0],
+                                  [0, 2, 1, 1, 3],
+                                  [0, 1, 1, 1, 1],
+                                  [0, 2, 1, 1, 1],
+                                  [0, 3, 1, 1, 1]])
+
+        self.coverage = set_up_variable_cube(
+            coverage_data, name='radar_coverage', units='1')
+
+        self.expected_mask = np.array([
+            [True, True, True, True, True],
+            [True, False, False, False, True],
+            [True, False, False, False, False],
+            [True, False, False, False, False],
+            [True, True, False, False, False]], dtype=bool)
+
+    def test_basic(self):
+        """Test processing outputs a cube of precipitation rates"""
+        result = ExtendRadarMask().process(self.rainrate, self.coverage)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertEqual(result.name(), self.rainrate.name())
+
+    def test_values(self):
+        """Test output cube has expected mask and underlying data is
+        unchanged"""
+        result = ExtendRadarMask().process(self.rainrate, self.coverage)        
+        self.assertArrayEqual(result.data.mask, self.expected_mask)
+        self.assertArrayEqual(result.data.data, self.rainrate.data.data)
+
+    def test_inputs_unmodified(self):
+        """Test the rainrate cube is not modified in place"""
+        reference = self.rainrate.copy()
+        _ = ExtendRadarMask().process(self.rainrate, self.coverage)
+        self.assertEqual(reference, self.rainrate)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/improver-extend-radar-mask/00-null.bats
+++ b/tests/improver-extend-radar-mask/00-null.bats
@@ -35,7 +35,7 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-extend-radar-mask [-h] [--profile]
                                   [--profile_file PROFILE_FILE]
-                                  RAINRATE_FILEPATH COVERAGE_FILEPATH
+                                  RADAR_DATA_FILEPATH COVERAGE_FILEPATH
                                   OUTPUT_FILEPATH
 __TEXT__
   [[ "$output" =~ "$expected" ]]

--- a/tests/improver-extend-radar-mask/00-null.bats
+++ b/tests/improver-extend-radar-mask/00-null.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "extend-radar-mask no arguments" {
+  run improver extend-radar-mask
+  [[ "$status" -eq 2 ]]
+  read -d '' expected <<'__TEXT__' || true
+usage: improver-extend-radar-mask [-h] [--profile]
+                                  [--profile_file PROFILE_FILE]
+                                  RAINRATE_FILEPATH COVERAGE_FILEPATH
+                                  OUTPUT_FILEPATH
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}
+

--- a/tests/improver-extend-radar-mask/01-help.bats
+++ b/tests/improver-extend-radar-mask/01-help.bats
@@ -45,7 +45,7 @@ positional arguments:
                         rates.
   COVERAGE_FILEPATH     Full path to input NetCDF file containing radar
                         coverage data.
-  OUTPUT_FILEPATH       Full path save remasked rainrate NetCDF file.
+  OUTPUT_FILEPATH       Full path to save remasked rainrate NetCDF file.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/tests/improver-extend-radar-mask/01-help.bats
+++ b/tests/improver-extend-radar-mask/01-help.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "extend-radar-mask -h" {
+  run improver extend-radar-mask -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+usage: improver-extend-radar-mask [-h] [--profile]
+                                  [--profile_file PROFILE_FILE]
+                                  RAINRATE_FILEPATH COVERAGE_FILEPATH
+                                  OUTPUT_FILEPATH
+
+Extend radar mask based on coverage data.
+
+positional arguments:
+  RAINRATE_FILEPATH     Full path to input NetCDF file containing radar rain
+                        rates.
+  COVERAGE_FILEPATH     Full path to input NetCDF file containing radar
+                        coverage data.
+  OUTPUT_FILEPATH       Full path save remasked rainrate NetCDF file.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --profile             Switch on profiling information.
+  --profile_file PROFILE_FILE
+                        Dump profiling info to a file. Implies --profile.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}
+

--- a/tests/improver-extend-radar-mask/01-help.bats
+++ b/tests/improver-extend-radar-mask/01-help.bats
@@ -35,17 +35,17 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-extend-radar-mask [-h] [--profile]
                                   [--profile_file PROFILE_FILE]
-                                  RAINRATE_FILEPATH COVERAGE_FILEPATH
+                                  RADAR_DATA_FILEPATH COVERAGE_FILEPATH
                                   OUTPUT_FILEPATH
 
 Extend radar mask based on coverage data.
 
 positional arguments:
-  RAINRATE_FILEPATH     Full path to input NetCDF file containing radar rain
-                        rates.
+  RADAR_DATA_FILEPATH   Full path to input NetCDF file containing the radar
+                        variable to remask.
   COVERAGE_FILEPATH     Full path to input NetCDF file containing radar
                         coverage data.
-  OUTPUT_FILEPATH       Full path to save remasked rainrate NetCDF file.
+  OUTPUT_FILEPATH       Full path to save remasked radar data NetCDF file.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/tests/improver-extend-radar-mask/02-basic.bats
+++ b/tests/improver-extend-radar-mask/02-basic.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "extend-radar-mask" {
+  improver_check_skip_acceptance
+  KGO="extend-radar-mask/basic/kgo.nc"
+
+  # Run radar mask extension and check it passes
+  run improver extend-radar-mask \
+      "$IMPROVER_ACC_TEST_DIR/extend-radar-mask/basic/201811271330_nimrod_ng_radar_rainrate_composite_2km_UK.nc" \
+      "$IMPROVER_ACC_TEST_DIR/extend-radar-mask/basic/201811271330_nimrod_ng_radar_arc_composite_2km_UK.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-nowcast-optical-flow/08-remasked.bats
+++ b/tests/improver-nowcast-optical-flow/08-remasked.bats
@@ -1,3 +1,4 @@
+#!/usr/bin/env bats
 # -----------------------------------------------------------------------------
 # (C) British Crown Copyright 2017-2018 Met Office.
 # All rights reserved.

--- a/tests/improver-nowcast-optical-flow/08-remasked.bats
+++ b/tests/improver-nowcast-optical-flow/08-remasked.bats
@@ -1,0 +1,63 @@
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "optical-flow remasked" {
+
+  improver_check_skip_acceptance
+  KGO1="optical-flow/remasked/ucomp_kgo.nc"
+  KGO2="optical-flow/remasked/vcomp_kgo.nc"
+
+  COMP1="201811271330_radar_rainrate_remasked_composite_2km_UK.nc"
+  COMP2="201811271345_radar_rainrate_remasked_composite_2km_UK.nc"
+  COMP3="201811271400_radar_rainrate_remasked_composite_2km_UK.nc"
+
+  # Run processing with radar data whose masks differ
+  run improver nowcast-optical-flow \
+    "$IMPROVER_ACC_TEST_DIR/optical-flow/remasked/$COMP1" \
+    "$IMPROVER_ACC_TEST_DIR/optical-flow/remasked/$COMP2" \
+    "$IMPROVER_ACC_TEST_DIR/optical-flow/remasked/$COMP3" \
+    --output_dir "$TEST_DIR"
+  [[ "$status" -eq 0 ]]
+
+  UCOMP="20181127T1400Z-PT0000H00M-precipitation_advection_x_velocity.nc"
+  VCOMP="20181127T1400Z-PT0000H00M-precipitation_advection_y_velocity.nc"
+
+  improver_check_recreate_kgo "$UCOMP" $KGO1
+  improver_check_recreate_kgo "$VCOMP" $KGO2
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/$UCOMP" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO1"
+  improver_compare_output "$TEST_DIR/$VCOMP" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO2"
+}
+


### PR DESCRIPTION
Plugin and CLI to update the radar rain rate mask based on a radar coverage composite.  Additional test for the optical-flow CLI with remasked radar data (ie where masks on the three input radar composites are different).
