### PR TITLE
Add option for ECC bounds exceedence warning

### DIFF
--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -71,6 +71,11 @@ def main():
                         "when converting probabilities to percentiles and may "
                         "be omitted. This coordinate(s) will be removed "
                         "and replaced by a percentile coordinate.")
+    parser.add_argument('--ecc_bounds_warning', default=False,
+                        action='store_true',
+                        help='Option to specify that exceeding ECC bounds '
+                             'will only result in a warning message rather '
+                             'than an exception.')
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument("--percentiles", metavar="PERCENTILES",
                        nargs="+", default=None, type=float,
@@ -96,7 +101,8 @@ def main():
                           "not be used.")
 
         result = GeneratePercentilesFromProbabilities().process(
-            cube, percentiles=percentiles)
+            cube, percentiles=percentiles,
+            ecc_bounds_warning=args.ecc_bounds_warning)
     else:
         if not args.coordinates:
             raise ValueError("To collapse a coordinate to calculate "

--- a/bin/improver-probabilities-to-realizations
+++ b/bin/improver-probabilities-to-realizations
@@ -96,6 +96,11 @@ def main():
              'random numbers used for splitting tied values '
              'within the raw ensemble, so that the values from the input '
              'percentiles can be ordered to match the raw ensemble.')
+    reordering.add_argument(
+        '--ecc_bounds_warning', default=False, action='store_true',
+        help='Option to specify that exceeding ECC bounds will '
+        'only result in a warning message rather than an '
+        'exception.')
 
     args = parser.parse_args()
 
@@ -116,7 +121,7 @@ def main():
     if args.reordering:
         if args.raw_forecast_filepath is None:
             message = ("You must supply a raw forecast filepath if using the "
-                       "reording option.")
+                       "reordering option.")
             raise ValueError(message)
         else:
             raw_forecast = load_cube(args.raw_forecast_filepath)
@@ -134,7 +139,8 @@ def main():
             no_of_realizations = len(raw_forecast.coord("realization").points)
 
         cube = GeneratePercentilesFromProbabilities().process(
-            cube, no_of_percentiles=no_of_realizations)
+            cube, no_of_percentiles=no_of_realizations,
+            ecc_bounds_warning=args.ecc_bounds_warning)
         cube = EnsembleReordering().process(
             cube, raw_forecast, random_ordering=False,
             random_seed=args.random_seed)

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -359,19 +359,19 @@ class GeneratePercentilesFromProbabilities(object):
                     each end.
         """
         lower_bound, upper_bound = bounds_pairing
-        threshold_points = insert_lower_and_upper_endpoint_to_1d_array(
-            threshold_points, lower_bound, upper_bound)
+        threshold_points_with_endpoints = \
+            insert_lower_and_upper_endpoint_to_1d_array(
+                threshold_points, lower_bound, upper_bound)
         probabilities_for_cdf = concatenate_2d_array_with_2d_array_endpoints(
             probabilities_for_cdf, 0, 1)
 
-        if np.any(np.diff(threshold_points) < 0):
+        if np.any(np.diff(threshold_points_with_endpoints) < 0):
             msg = ("The end points added to the threshold values for "
                    "constructing the Cumulative Distribution Function (CDF) "
                    "must result in an ascending order. "
                    "In this case, the threshold points {} must be "
                    "outside the allowable range given by the "
-                   "bounds {}".format(
-                       threshold_points, bounds_pairing))
+                   "bounds {}".format(threshold_points, bounds_pairing))
             # If ecc_bounds_warning has been set, generate a warning message
             # rather than raising an exception so that subsequent processing
             # can continue. Then re-apply the upper and lower bounds as
@@ -384,11 +384,12 @@ class GeneratePercentilesFromProbabilities(object):
                     upper_bound = max(threshold_points)
                 if lower_bound > min(threshold_points):
                     lower_bound = min(threshold_points)
-                threshold_points = insert_lower_and_upper_endpoint_to_1d_array(
-                    threshold_points, lower_bound, upper_bound)
+                threshold_points_with_endpoints = \
+                    insert_lower_and_upper_endpoint_to_1d_array(
+                        threshold_points, lower_bound, upper_bound)
             else:
                 raise ValueError(msg)
-        return threshold_points, probabilities_for_cdf
+        return threshold_points_with_endpoints, probabilities_for_cdf
 
     def _probabilities_to_percentiles(
             self, forecast_probabilities, percentiles, bounds_pairing,

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -371,7 +371,8 @@ class GeneratePercentilesFromProbabilities(object):
                    "must result in an ascending order. "
                    "In this case, the threshold points {} must be "
                    "outside the allowable range given by the "
-                   "bounds {}".format(threshold_points, bounds_pairing))
+                   "bounds {}".format(threshold_points_with_endpoints,
+                                      bounds_pairing))
             # If ecc_bounds_warning has been set, generate a warning message
             # rather than raising an exception so that subsequent processing
             # can continue. Then re-apply the upper and lower bounds as
@@ -380,10 +381,10 @@ class GeneratePercentilesFromProbabilities(object):
             # chain.
             if ecc_bounds_warning:
                 warnings.warn(msg)
-                if upper_bound < max(threshold_points):
-                    upper_bound = max(threshold_points)
-                if lower_bound > min(threshold_points):
-                    lower_bound = min(threshold_points)
+                if upper_bound < max(threshold_points_with_endpoints):
+                    upper_bound = max(threshold_points_with_endpoints)
+                if lower_bound > min(threshold_points_with_endpoints):
+                    lower_bound = min(threshold_points_with_endpoints)
                 threshold_points_with_endpoints = \
                     insert_lower_and_upper_endpoint_to_1d_array(
                         threshold_points, lower_bound, upper_bound)

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -372,7 +372,12 @@ class GeneratePercentilesFromProbabilities(object):
                    "outside the allowable range given by the "
                    "bounds {}".format(
                        threshold_points, bounds_pairing))
-
+            # If ecc_bounds_warning has been set, generate a warning message
+            # rather than raising an exception so that subsequent processing
+            # can continue. Then re-apply the upper and lower bounds as
+            # necessary to ensure the threshold values and endpoints are in
+            # ascending order and avoid problems further along the processing
+            # chain.
             if ecc_bounds_warning:
                 warnings.warn(msg)
             else:

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -344,6 +344,8 @@ class GeneratePercentilesFromProbabilities(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
+
+        Keyword Args:
             ecc_bounds_warning (bool):
                 If true and ECC bounds are exceeded, a warning will be
                 generated rather than an exception. Default value is FALSE.
@@ -395,6 +397,8 @@ class GeneratePercentilesFromProbabilities(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
+
+        Keyword Args:
             ecc_bounds_warning (bool):
                 If true and ECC bounds are exceeded, a warning will be
                 generated rather than an exception. Default value is FALSE.
@@ -517,6 +521,8 @@ class GeneratePercentilesFromProbabilities(object):
                           at dividing a Cumulative Distribution Function into
                           blocks of equal probability.
                 * Random: A random set of ordered percentiles.
+
+        Keyword Args:
             ecc_bounds_warning (bool):
                 If True then exceeding ECC bounds will only generate a
                 warning rather than an exception. Default value is FALSE.

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -327,7 +327,8 @@ class GeneratePercentilesFromProbabilities(object):
 
     @staticmethod
     def _add_bounds_to_thresholds_and_probabilities(
-            threshold_points, probabilities_for_cdf, bounds_pairing):
+            threshold_points, probabilities_for_cdf, bounds_pairing,
+            ecc_bounds_warning=False):
         """
         Padding of the lower and upper bounds of the distribution for a
         given phenomenon for the threshold_points, and padding of
@@ -343,6 +344,9 @@ class GeneratePercentilesFromProbabilities(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
+            ecc_bounds_warning (bool):
+                If true and ECC bounds are exceeded, a warning will be
+                generated rather than an exception. Default value is FALSE.
         Returns:
             (tuple) : tuple containing:
                 **threshold_points** (Numpy array):
@@ -357,6 +361,10 @@ class GeneratePercentilesFromProbabilities(object):
             threshold_points, lower_bound, upper_bound)
         probabilities_for_cdf = concatenate_2d_array_with_2d_array_endpoints(
             probabilities_for_cdf, 0, 1)
+
+        if ecc_bounds_warning:
+            pass
+
         if np.any(np.diff(threshold_points) < 0):
             msg = ("The end points added to the threshold values for "
                    "constructing the Cumulative Distribution Function (CDF) "
@@ -369,7 +377,8 @@ class GeneratePercentilesFromProbabilities(object):
         return threshold_points, probabilities_for_cdf
 
     def _probabilities_to_percentiles(
-            self, forecast_probabilities, percentiles, bounds_pairing):
+            self, forecast_probabilities, percentiles, bounds_pairing,
+            ecc_bounds_warning=False):
         """
         Conversion of probabilities to percentiles through the construction
         of an cumulative distribution function. This is effectively
@@ -385,6 +394,9 @@ class GeneratePercentilesFromProbabilities(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
+            ecc_bounds_warning (bool):
+                If true and ECC bounds are exceeded, a warning will be
+                generated rather than an exception. Default value is FALSE.
 
         Returns:
             percentile_cube (Iris cube):
@@ -423,7 +435,8 @@ class GeneratePercentilesFromProbabilities(object):
 
         threshold_points, probabilities_for_cdf = (
             self._add_bounds_to_thresholds_and_probabilities(
-                threshold_points, probabilities_for_cdf, bounds_pairing))
+                threshold_points, probabilities_for_cdf, bounds_pairing,
+                ecc_bounds_warning))
 
         if np.any(np.diff(probabilities_for_cdf) < 0):
             msg = ("The probability values used to construct the "
@@ -505,7 +518,7 @@ class GeneratePercentilesFromProbabilities(object):
                 * Random: A random set of ordered percentiles.
             ecc_bounds_warning (bool):
                 If True then exceeding ECC bounds will only generate a
-                warning rather than an exception.
+                warning rather than an exception. Default value is FALSE.
 
         Returns:
             forecast_at_percentiles (Iris cube):
@@ -556,7 +569,8 @@ class GeneratePercentilesFromProbabilities(object):
         cubelist = iris.cube.CubeList([])
         for cube_realization in slices_over_realization:
             cubelist.append(self._probabilities_to_percentiles(
-                cube_realization, percentiles, bounds_pairing))
+                cube_realization, percentiles, bounds_pairing,
+                ecc_bounds_warning))
 
         forecast_at_percentiles = cubelist.merge_cube()
         return forecast_at_percentiles

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -362,10 +362,9 @@ class GeneratePercentilesFromProbabilities(object):
         probabilities_for_cdf = concatenate_2d_array_with_2d_array_endpoints(
             probabilities_for_cdf, 0, 1)
 
-        if ecc_bounds_warning:
-            pass
-
         if np.any(np.diff(threshold_points) < 0):
+            if ecc_bounds_warning:
+                pass
             msg = ("The end points added to the threshold values for "
                    "constructing the Cumulative Distribution Function (CDF) "
                    "must result in an ascending order. "

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -363,8 +363,6 @@ class GeneratePercentilesFromProbabilities(object):
             probabilities_for_cdf, 0, 1)
 
         if np.any(np.diff(threshold_points) < 0):
-            if ecc_bounds_warning:
-                pass
             msg = ("The end points added to the threshold values for "
                    "constructing the Cumulative Distribution Function (CDF) "
                    "must result in an ascending order. "
@@ -372,7 +370,11 @@ class GeneratePercentilesFromProbabilities(object):
                    "outside the allowable range given by the "
                    "bounds {}".format(
                        threshold_points, bounds_pairing))
-            raise ValueError(msg)
+
+            if ecc_bounds_warning:
+                warnings.warn(msg)
+            else:
+                raise ValueError(msg)
         return threshold_points, probabilities_for_cdf
 
     def _probabilities_to_percentiles(

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -359,6 +359,9 @@ class GeneratePercentilesFromProbabilities(object):
                     each end.
         """
         lower_bound, upper_bound = bounds_pairing
+        print(bounds_pairing)
+        print(max(threshold_points))
+        print(min(threshold_points))
         threshold_points = insert_lower_and_upper_endpoint_to_1d_array(
             threshold_points, lower_bound, upper_bound)
         probabilities_for_cdf = concatenate_2d_array_with_2d_array_endpoints(
@@ -380,6 +383,15 @@ class GeneratePercentilesFromProbabilities(object):
             # chain.
             if ecc_bounds_warning:
                 warnings.warn(msg)
+                if upper_bound < max(threshold_points):
+                    upper_bound = max(threshold_points)
+                if lower_bound > min(threshold_points):
+                    lower_bound = min(threshold_points)
+                threshold_points = insert_lower_and_upper_endpoint_to_1d_array(
+                    threshold_points, lower_bound, upper_bound)
+                probabilities_for_cdf = \
+                    concatenate_2d_array_with_2d_array_endpoints(
+                        probabilities_for_cdf, 0, 1)
             else:
                 raise ValueError(msg)
         return threshold_points, probabilities_for_cdf

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -386,9 +386,6 @@ class GeneratePercentilesFromProbabilities(object):
                     lower_bound = min(threshold_points)
                 threshold_points = insert_lower_and_upper_endpoint_to_1d_array(
                     threshold_points, lower_bound, upper_bound)
-                probabilities_for_cdf = \
-                    concatenate_2d_array_with_2d_array_endpoints(
-                        probabilities_for_cdf, 0, 1)
             else:
                 raise ValueError(msg)
         return threshold_points, probabilities_for_cdf

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -371,8 +371,8 @@ class GeneratePercentilesFromProbabilities(object):
                    "must result in an ascending order. "
                    "In this case, the threshold points {} must be "
                    "outside the allowable range given by the "
-                   "bounds {}".format(threshold_points_with_endpoints,
-                                      bounds_pairing))
+                   "bounds {}. ".format(threshold_points_with_endpoints,
+                                        bounds_pairing))
             # If ecc_bounds_warning has been set, generate a warning message
             # rather than raising an exception so that subsequent processing
             # can continue. Then re-apply the upper and lower bounds as
@@ -380,7 +380,10 @@ class GeneratePercentilesFromProbabilities(object):
             # ascending order and avoid problems further along the processing
             # chain.
             if ecc_bounds_warning:
-                warnings.warn(msg)
+                warn_msg = msg + ("The threshold points that have exceeded "
+                                  "the existing bounds will be used as "
+                                  "new bounds.")
+                warnings.warn(warn_msg)
                 if upper_bound < max(threshold_points_with_endpoints):
                     upper_bound = max(threshold_points_with_endpoints)
                 if lower_bound > min(threshold_points_with_endpoints):

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -359,9 +359,6 @@ class GeneratePercentilesFromProbabilities(object):
                     each end.
         """
         lower_bound, upper_bound = bounds_pairing
-        print(bounds_pairing)
-        print(max(threshold_points))
-        print(min(threshold_points))
         threshold_points = insert_lower_and_upper_endpoint_to_1d_array(
             threshold_points, lower_bound, upper_bound)
         probabilities_for_cdf = concatenate_2d_array_with_2d_array_endpoints(

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -470,7 +470,8 @@ class GeneratePercentilesFromProbabilities(object):
         return percentile_cube
 
     def process(self, forecast_probabilities, no_of_percentiles=None,
-                percentiles=None, sampling="quantile"):
+                percentiles=None, sampling="quantile",
+                ecc_bounds_warning=False):
         """
         1. Concatenates cubes with a threshold coordinate.
         2. Creates a list of percentiles.
@@ -502,6 +503,9 @@ class GeneratePercentilesFromProbabilities(object):
                           at dividing a Cumulative Distribution Function into
                           blocks of equal probability.
                 * Random: A random set of ordered percentiles.
+            ecc_bounds_warning (bool):
+                If True then exceeding ECC bounds will only generate a
+                warning rather than an exception.
 
         Returns:
             forecast_at_percentiles (Iris cube):

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -127,6 +127,27 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
             plugin._add_bounds_to_thresholds_and_probabilities(
                 threshold_points, probabilities_for_cdf, bounds_pairing)
 
+    @ManageWarnings(record=True)
+    def test_endpoints_of_distribution_exceeded_warning(
+            self, warning_list=None):
+        """
+        Test that the plugin raises a warning message when the constant
+        end points of the distribution are exceeded by a threshold value
+        used in the forecast and the ecc_bounds_warning keyword argument
+        has been specified.
+        """
+        probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
+        threshold_points = np.array([8, 10, 60])
+        bounds_pairing = (-40, 50)
+        plugin = Plugin()
+
+        warning_msg = "The end points added to the threshold values for"
+        plugin._add_bounds_to_thresholds_and_probabilities(
+            threshold_points, probabilities_for_cdf, bounds_pairing,
+            ecc_bounds_warning=True)
+        self.assertTrue(any(warning_msg in str(item)
+                            for item in warning_list))
+
 
 class Test__probabilities_to_percentiles(IrisTest):
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -137,7 +137,7 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         has been specified.
         """
         probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
-        threshold_points = np.array([-50, 10, 60])
+        threshold_points = np.array([8, 10, 60])
         bounds_pairing = (-40, 50)
         plugin = Plugin()
         warning_msg = "The end points added to the threshold values for"
@@ -146,6 +146,22 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
             ecc_bounds_warning=True)
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
+
+    def test_new_endpoints_generation(self):
+        """
+        Test that the plugin re-applies the threshold bounds using the maximum
+        and minimum threshold points values when the original bounds have been
+        exceeded and ecc_bounds_warning has been set.
+        """
+        probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
+        threshold_points = np.array([-50, 10, 60])
+        bounds_pairing = (-40, 50)
+        plugin = Plugin()
+        result = plugin._add_bounds_to_thresholds_and_probabilities(
+            threshold_points, probabilities_for_cdf, bounds_pairing,
+            ecc_bounds_warning=True)
+        self.assertEqual(max(result[0]), max(threshold_points))
+        self.assertEqual(min(result[0]), min(threshold_points))
 
 
 class Test__probabilities_to_percentiles(IrisTest):

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -137,7 +137,7 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         has been specified.
         """
         probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
-        threshold_points = np.array([8, 10, 60])
+        threshold_points = np.array([-50, 10, 60])
         bounds_pairing = (-40, 50)
         plugin = Plugin()
         warning_msg = "The end points added to the threshold values for"

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -140,7 +140,6 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         threshold_points = np.array([8, 10, 60])
         bounds_pairing = (-40, 50)
         plugin = Plugin()
-
         warning_msg = "The end points added to the threshold values for"
         plugin._add_bounds_to_thresholds_and_probabilities(
             threshold_points, probabilities_for_cdf, bounds_pairing,

--- a/tests/improver-percentile/00-null.bats
+++ b/tests/improver-percentile/00-null.bats
@@ -34,6 +34,7 @@
   [[ "$status" -eq 2 ]]
   expected="usage: improver-percentile [-h] [--profile] [--profile_file PROFILE_FILE]
                            [--coordinates COORDINATES_TO_COLLAPSE [COORDINATES_TO_COLLAPSE ...]]
+                           [--ecc_bounds_warning]
                            [--percentiles PERCENTILES [PERCENTILES ...] |
                            --no-of-percentiles NUMBER_OF_PERCENTILES]
                            INPUT_FILE OUTPUT_FILE"

--- a/tests/improver-percentile/01-help.bats
+++ b/tests/improver-percentile/01-help.bats
@@ -35,6 +35,7 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-percentile [-h] [--profile] [--profile_file PROFILE_FILE]
                            [--coordinates COORDINATES_TO_COLLAPSE [COORDINATES_TO_COLLAPSE ...]]
+                           [--ecc_bounds_warning]
                            [--percentiles PERCENTILES [PERCENTILES ...] |
                            --no-of-percentiles NUMBER_OF_PERCENTILES]
                            INPUT_FILE OUTPUT_FILE
@@ -66,6 +67,8 @@ optional arguments:
                         probabilities to percentiles and may be omitted. This
                         coordinate(s) will be removed and replaced by a
                         percentile coordinate.
+  --ecc_bounds_warning  Option to specify that exceeding ECC bounds will only
+                        result in a warning message rather than an exception.
   --percentiles PERCENTILES [PERCENTILES ...]
                         Optional definition of percentiles at which to
                         calculate data, e.g. --percentiles 0 33.3 66.6 100

--- a/tests/improver-percentile/07-ecc_bounds_warning.bats
+++ b/tests/improver-percentile/07-ecc_bounds_warning.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "percentile input output --percentiles 25 50 75 --ecc_bounds_warning" {
+  improver_check_skip_acceptance
+  KGO="percentile/ecc_bounds_warning/kgo.nc"
+
+  # Run percentile processing and check it passes.
+  run improver percentile \
+      "$IMPROVER_ACC_TEST_DIR/percentile/ecc_bounds_warning/input.nc" "$TEST_DIR/output.nc" \
+      --coordinates realization --percentiles 25 50 75 --ecc_bounds_warning
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-probabilities-to-realizations/00-null.bats
+++ b/tests/improver-probabilities-to-realizations/00-null.bats
@@ -39,6 +39,7 @@ usage: improver-probabilities-to-realizations [-h] [--profile]
                                               (--reordering | --rebadging)
                                               [--raw_forecast_filepath RAW_FORECAST_FILE]
                                               [--random_seed RANDOM_SEED]
+                                              [--ecc_bounds_warning]
                                               INPUT_FILE OUTPUT_FILE
 __TEXT__
   [[ "$output" =~ "$expected" ]]

--- a/tests/improver-probabilities-to-realizations/01-help.bats
+++ b/tests/improver-probabilities-to-realizations/01-help.bats
@@ -39,6 +39,7 @@ usage: improver-probabilities-to-realizations [-h] [--profile]
                                               (--reordering | --rebadging)
                                               [--raw_forecast_filepath RAW_FORECAST_FILE]
                                               [--random_seed RANDOM_SEED]
+                                              [--ecc_bounds_warning]
                                               INPUT_FILE OUTPUT_FILE
 
 Convert a dataset containing probabilities into one containing ensemble
@@ -85,6 +86,9 @@ Reordering options:
                         tied values within the raw ensemble, so that the
                         values from the input percentiles can be ordered to
                         match the raw ensemble.
+  --ecc_bounds_warning  Option to specify that exceeding ECC bounds will only
+                        result in a warning message rather than an exception.
+
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-probabilities-to-realizations/04-reordering_no_raw_ens.bats
+++ b/tests/improver-probabilities-to-realizations/04-reordering_no_raw_ens.bats
@@ -39,7 +39,7 @@
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-ValueError: You must supply a raw forecast filepath if using the reording option.
+ValueError: You must supply a raw forecast filepath if using the reordering option.
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-probabilities-to-realizations/10-ecc_bounds_warning.bats
+++ b/tests/improver-probabilities-to-realizations/10-ecc_bounds_warning.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "probabilities-to-realizations --reordering --ecc_bounds_warning raw_ens input output" {
+  improver_check_skip_acceptance
+  KGO="probabilities-to-realizations/ecc_bounds_warning/kgo.nc"
+
+  run improver probabilities-to-realizations --reordering --ecc_bounds_warning --random_seed 0 \
+      --raw_forecast_filepath \
+      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/ecc_bounds_warning/raw_ens.nc" \
+      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/ecc_bounds_warning/input.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Addresses #758

- Optional argument `--ecc_bounds_warning` added to the two CLI's that use `GeneratePercentilesFromProbabilities` within `ensemble_copula_coupling.py` and which currently generate an exception when threshold data exceeds ECC bounds as determined by `ensemble_copula_coupling_constants.py`

- Specifying `--ecc_bounds_warning` will cause a warning to be generated instead of an exception when bounds are exceeded, allowing processing to continue with new bounds set using the threshold points that exceeded the original bounds and maintaining an ascending order through threshold values and endpoints for the Cumulative Distribution Function (CDF) .

- Added new unit tests to check that the correct warning is being generated and that the new endpoints are set correctly.

- Added new CLI bats tests to check this functionality works with 'out-of-bounds' threshold data.


Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
