### PR TITLE
IMPRO-814: ECC bounds for feels like temperature.

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -52,6 +52,8 @@ Bounds = namedtuple("bounds", "value units")
 BOUNDS_FOR_ECDF = {
     "air_temperature": (
         Bounds((-140-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
+    "feels_like_temperature": (
+        Bounds((-140-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "wind_speed": Bounds((0, 50), "m s^-1"),
     "wind_speed_of_gust": Bounds((0, 200), "m s^-1"),
     "air_pressure_at_sea_level": Bounds((86000, 108000), "Pa"),


### PR DESCRIPTION
Added ecc bounds for feels like temperature, where these are used for percentile extract in the global processing chain.

Testing:
 - [x] Ran tests and they passed OK
