### PR TITLE
IMPRO-881: Spot-extract and lapse rate adjust CLI

### DIFF
--- a/bin/improver-spot-extract-new
+++ b/bin/improver-spot-extract-new
@@ -153,7 +153,6 @@ def main():
             metadata_dict = json.load(input_file)
         result = amend_metadata(result, **metadata_dict)
 
-
     # Save the spot data cube
     save_netcdf(result, args.output_filepath)
 

--- a/bin/improver-spot-extract-new
+++ b/bin/improver-spot-extract-new
@@ -31,13 +31,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to run spotdata extraction."""
 
+import json
+import warnings
 import numpy as np
 
-from improver.argparser import ArgParser
+from iris.exceptions import CoordinateNotFoundError
 
+from improver.argparser import ArgParser
 from improver.spotdata_new.apply_lapse_rate import SpotLapseRateAdjust
 from improver.spotdata_new.spot_extraction import SpotExtraction
 from improver.spotdata_new.neighbour_finding import NeighbourSelection
+from improver.utilities.cube_metadata import amend_metadata
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
@@ -88,12 +92,17 @@ def main():
 
     meta_group = parser.add_argument_group("Metadata")
     meta_group.add_argument(
-        "--grid_metadata_identifier", default="mosg",
+        "--grid_metadata_identifier", default="mosg__grid",
         help="A string to identify attributes from the input netCDF files that"
         " should be compared to ensure that the data is compatible. Spot"
         " data works using grid indices, so it is important that the grids"
         " are matching or the data extracted may not match the location of the"
         " spot data sites.")
+
+    meta_group.add_argument(
+        "--json_file", metavar="JSON_FILE", default=None,
+        help="If provided, this JSON file can be used to modify the metadata "
+        "of the returned netCDF file. Defaults to None.")
 
     args = parser.parse_args()
     neighbour_cube = load_cube(args.neighbour_filepath)
@@ -108,19 +117,42 @@ def main():
         grid_metadata_identifier=args.grid_metadata_identifier)
     result = plugin.process(neighbour_cube, diagnostic_cube)
 
-    # Check whether the diagnostic is screen temperature and a lapse rate cube
-    # has been provided.
-    screen_temperature = (
-        diagnostic_cube.name() == "air_temperature" and
-        np.isclose(diagnostic_cube.coord("height").points, 1.5) and
-        args.temperature_lapse_rate_filepath)
+    # Check whether a lapse rate cube has been provided and we are dealing with
+    # temperature data.
+    if (args.temperature_lapse_rate_filepath and
+            diagnostic_cube.name() == "air_temperature"):
 
-    if screen_temperature:
         lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath)
-        plugin = SpotLapseRateAdjust(
-            args.grid_metadata_identifier,
-            neighbour_selection_method=neighbour_selection_method)
-        result = plugin.process(result, neighbour_cube, lapse_rate_cube)
+        try:
+            lapse_rate_height_coord = lapse_rate_cube.coord("height")
+            lapse_rate_height, = lapse_rate_height_coord.points
+        except (ValueError, CoordinateNotFoundError):
+            msg = ("Lapse rate cube does not contain a single valued height "
+                   "coordinate. This is required to ensure it is applied to "
+                   "equivalent temperature data.")
+            raise ValueError(msg)
+
+        # Check the height of the temperature data  matches that used to
+        # calculate the lapse rates. If so, adjust temperatures using the lapse
+        # rate values.
+        if diagnostic_cube.coord("height") == lapse_rate_height_coord:
+            plugin = SpotLapseRateAdjust(
+                args.grid_metadata_identifier,
+                neighbour_selection_method=neighbour_selection_method)
+            result = plugin.process(result, neighbour_cube, lapse_rate_cube)
+        else:
+            msg = ("A lapse rate cube was provided, but the height of "
+                   "the temperature data does not match that of the data used "
+                   "to calculate the lapse rates. As such the temperatures "
+                   "were not adjusted with the lapse rates.")
+            warnings.warn(msg)
+
+    # Modify final metadata as described by provided JSON file.
+    if args.json_file:
+        with open(args.json_file, 'r') as input_file:
+            metadata_dict = json.load(input_file)
+        result = amend_metadata(result, **metadata_dict)
+
 
     # Save the spot data cube
     save_netcdf(result, args.output_filepath)

--- a/bin/improver-spot-extract-new
+++ b/bin/improver-spot-extract-new
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to run spotdata extraction."""
+
+import numpy as np
+
+from improver.argparser import ArgParser
+
+from improver.spotdata_new.apply_lapse_rate import SpotLapseRateAdjust
+from improver.spotdata_new.spot_extraction import SpotExtraction
+from improver.spotdata_new.neighbour_finding import NeighbourSelection
+from improver.utilities.load import load_cube
+from improver.utilities.save import save_netcdf
+
+
+def main():
+    """Load in arguments and start spotdata extraction process."""
+    parser = ArgParser(
+        description="Extract diagnostic data from gridded fields for spot data"
+        " sites. It is possible to apply a temperature lapse rate adjustment"
+        " to temperature data that helps to account for differences between"
+        " the spot sites real altitude and that of the grid point from which"
+        " the temperature data is extracted.")
+
+    # Input and output files required.
+    parser.add_argument("neighbour_filepath", metavar="NEIGHBOUR_FILEPATH",
+                        help="Path to a NetCDF file of spot-data neighbours. "
+                        "This file also contains the spot site information.")
+    parser.add_argument("diagnostic_filepath", metavar="DIAGNOSTIC_FILEPATH",
+                        help="Path to a NetCDF file containing the diagnostic "
+                             "data to be extracted.")
+    parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
+                        help="The output path for the resulting NetCDF")
+
+    method_group = parser.add_argument_group("Neighbour finding method")
+    method_group.add_argument(
+        "--land_constraint", default=False, action='store_true',
+        help="If set the neighbour cube will be interogated for grid point"
+        " neighbours that were identified using a land constraint. This means"
+        " that the grid points should be land points except for sites where"
+        " none was found within the search radius when the neighbour cube was"
+        " created. May be used with minimum_dz.")
+    method_group.add_argument(
+        "--minimum_dz", default=False, action='store_true',
+        help="If set the neighbour cube will be interogated for grid point"
+        " neighbours that were identified using a minimum height difference"
+        " constraint. These are grid points that were found to be the closest"
+        " in altitude to the spot site within the search radius defined when"
+        " the neighbour cube was created. May be used with land_constraint.")
+
+    lapse_group = parser.add_argument_group(
+        "Temperature lapse rate adjustment")
+    lapse_group.add_argument(
+        "--temperature_lapse_rate_filepath",
+        help="Filepath to a NetCDF file containing temperature lapse rates. "
+        "If this cube is provided, and a screen temperature cube is being "
+        "processed, the lapse rates will be used to adjust the temperatures "
+        "to better represent each spot site's altitude.")
+
+    meta_group = parser.add_argument_group("Metadata")
+    meta_group.add_argument(
+        "--grid_metadata_identifier", default="mosg",
+        help="A string to identify attributes from the input netCDF files that"
+        " should be compared to ensure that the data is compatible. Spot"
+        " data works using grid indices, so it is important that the grids"
+        " are matching or the data extracted may not match the location of the"
+        " spot data sites.")
+
+    args = parser.parse_args()
+    neighbour_cube = load_cube(args.neighbour_filepath)
+    diagnostic_cube = load_cube(args.diagnostic_filepath)
+
+    neighbour_selection_method = NeighbourSelection(
+        land_constraint=args.land_constraint,
+        minimum_dz=args.minimum_dz).neighbour_finding_method_name()
+
+    plugin = SpotExtraction(
+        neighbour_selection_method=neighbour_selection_method,
+        grid_metadata_identifier=args.grid_metadata_identifier)
+    result = plugin.process(neighbour_cube, diagnostic_cube)
+
+    # Check whether the diagnostic is screen temperature and a lapse rate cube
+    # has been provided.
+    screen_temperature = (
+        diagnostic_cube.name() == "air_temperature" and
+        np.isclose(diagnostic_cube.coord("height").points, 1.5) and
+        args.temperature_lapse_rate_filepath)
+
+    if screen_temperature:
+        lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath)
+        plugin = SpotLapseRateAdjust(
+            args.grid_metadata_identifier,
+            neighbour_selection_method=neighbour_selection_method)
+        result = plugin.process(result, neighbour_cube, lapse_rate_cube)
+
+    # Save the spot data cube
+    save_netcdf(result, args.output_filepath)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/improver-spot-extract-new
+++ b/bin/improver-spot-extract-new
@@ -65,17 +65,20 @@ def main():
     parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
                         help="The output path for the resulting NetCDF")
 
-    method_group = parser.add_argument_group("Neighbour finding method")
+    method_group = parser.add_argument_group(
+        title="Neighbour finding method",
+        description="If none of these options are set, the nearest grid point "
+        "to a spot site will be used without any other constraints.")
     method_group.add_argument(
         "--land_constraint", default=False, action='store_true',
-        help="If set the neighbour cube will be interogated for grid point"
+        help="If set the neighbour cube will be interrogated for grid point"
         " neighbours that were identified using a land constraint. This means"
         " that the grid points should be land points except for sites where"
-        " none was found within the search radius when the neighbour cube was"
+        " none were found within the search radius when the neighbour cube was"
         " created. May be used with minimum_dz.")
     method_group.add_argument(
         "--minimum_dz", default=False, action='store_true',
-        help="If set the neighbour cube will be interogated for grid point"
+        help="If set the neighbour cube will be interrogated for grid point"
         " neighbours that were identified using a minimum height difference"
         " constraint. These are grid points that were found to be the closest"
         " in altitude to the spot site within the search radius defined when"
@@ -88,7 +91,7 @@ def main():
         help="Filepath to a NetCDF file containing temperature lapse rates. "
         "If this cube is provided, and a screen temperature cube is being "
         "processed, the lapse rates will be used to adjust the temperatures "
-        "to better represent each spot site's altitude.")
+        "to better represent each spot's site-altitude.")
 
     meta_group = parser.add_argument_group("Metadata")
     meta_group.add_argument(
@@ -97,7 +100,7 @@ def main():
         " should be compared to ensure that the data is compatible. Spot"
         " data works using grid indices, so it is important that the grids"
         " are matching or the data extracted may not match the location of the"
-        " spot data sites.")
+        " spot data sites. The default is 'mosg__grid'.")
 
     meta_group.add_argument(
         "--json_file", metavar="JSON_FILE", default=None,
@@ -132,7 +135,7 @@ def main():
                    "equivalent temperature data.")
             raise ValueError(msg)
 
-        # Check the height of the temperature data  matches that used to
+        # Check the height of the temperature data matches that used to
         # calculate the lapse rates. If so, adjust temperatures using the lapse
         # rate values.
         if diagnostic_cube.coord("height") == lapse_rate_height_coord:
@@ -146,6 +149,11 @@ def main():
                    "to calculate the lapse rates. As such the temperatures "
                    "were not adjusted with the lapse rates.")
             warnings.warn(msg)
+    elif args.temperature_lapse_rate_filepath:
+        msg = ("A lapse rate cube was provided, but the diagnostic being "
+               "processed is not air temperature. The lapse rate cube was "
+               "not used.")
+        warnings.warn(msg)
 
     # Modify final metadata as described by provided JSON file.
     if args.json_file:

--- a/tests/improver-spot-extract-new/00-null.bats
+++ b/tests/improver-spot-extract-new/00-null.bats
@@ -38,6 +38,7 @@ usage: improver-spot-extract-new [-h] [--profile]
                                  [--land_constraint] [--minimum_dz]
                                  [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                                  [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
+                                 [--json_file JSON_FILE]
                                  NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
                                  OUTPUT_FILEPATH
 __TEXT__

--- a/tests/improver-spot-extract-new/00-null.bats
+++ b/tests/improver-spot-extract-new/00-null.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+@test "spot-extract no arguments" {
+  run improver spot-extract-new
+  [[ "$status" -eq 2 ]]
+  read -d '' expected <<'__TEXT__' || true
+usage: improver-spot-extract-new [-h] [--profile]
+                                 [--profile_file PROFILE_FILE]
+                                 [--land_constraint] [--minimum_dz]
+                                 [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
+                                 [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
+                                 NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
+                                 OUTPUT_FILEPATH
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract-new/01-help.bats
+++ b/tests/improver-spot-extract-new/01-help.bats
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-@test "spot-extract-new -h" {
+@test "spot-extract -h" {
   run improver spot-extract-new -h
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
@@ -39,6 +39,7 @@ usage: improver-spot-extract-new [-h] [--profile]
                                  [--land_constraint] [--minimum_dz]
                                  [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                                  [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
+                                 [--json_file JSON_FILE]
                                  NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
                                  OUTPUT_FILEPATH
 
@@ -91,6 +92,10 @@ Metadata:
                         it is important that the grids are matching or the
                         data extracted may not match the location of the spot
                         data sites.
+  --json_file JSON_FILE
+                        If provided, this JSON file can be used to modify the
+                        metadata of the returned netCDF file. Defaults to
+                        None.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-spot-extract-new/01-help.bats
+++ b/tests/improver-spot-extract-new/01-help.bats
@@ -62,18 +62,21 @@ optional arguments:
                         Dump profiling info to a file. Implies --profile.
 
 Neighbour finding method:
-  --land_constraint     If set the neighbour cube will be interogated for grid
-                        point neighbours that were identified using a land
-                        constraint. This means that the grid points should be
-                        land points except for sites where none was found
-                        within the search radius when the neighbour cube was
-                        created. May be used with minimum_dz.
-  --minimum_dz          If set the neighbour cube will be interogated for grid
-                        point neighbours that were identified using a minimum
-                        height difference constraint. These are grid points
-                        that were found to be the closest in altitude to the
-                        spot site within the search radius defined when the
-                        neighbour cube was created. May be used with
+  If none of these options are set, the nearest grid point to a spot site
+  will be used without any other constraints.
+
+  --land_constraint     If set the neighbour cube will be interrogated for
+                        grid point neighbours that were identified using a
+                        land constraint. This means that the grid points
+                        should be land points except for sites where none were
+                        found within the search radius when the neighbour cube
+                        was created. May be used with minimum_dz.
+  --minimum_dz          If set the neighbour cube will be interrogated for
+                        grid point neighbours that were identified using a
+                        minimum height difference constraint. These are grid
+                        points that were found to be the closest in altitude
+                        to the spot site within the search radius defined when
+                        the neighbour cube was created. May be used with
                         land_constraint.
 
 Temperature lapse rate adjustment:
@@ -82,7 +85,7 @@ Temperature lapse rate adjustment:
                         rates. If this cube is provided, and a screen
                         temperature cube is being processed, the lapse rates
                         will be used to adjust the temperatures to better
-                        represent each spot site's altitude.
+                        represent each spot's site-altitude.
 
 Metadata:
   --grid_metadata_identifier GRID_METADATA_IDENTIFIER
@@ -91,7 +94,7 @@ Metadata:
                         is compatible. Spot data works using grid indices, so
                         it is important that the grids are matching or the
                         data extracted may not match the location of the spot
-                        data sites.
+                        data sites. The default is 'mosg__grid'.
   --json_file JSON_FILE
                         If provided, this JSON file can be used to modify the
                         metadata of the returned netCDF file. Defaults to

--- a/tests/improver-spot-extract-new/01-help.bats
+++ b/tests/improver-spot-extract-new/01-help.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+@test "spot-extract-new -h" {
+  run improver spot-extract-new -h
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__HELP__' || true
+usage: improver-spot-extract-new [-h] [--profile]
+                                 [--profile_file PROFILE_FILE]
+                                 [--land_constraint] [--minimum_dz]
+                                 [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
+                                 [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
+                                 NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
+                                 OUTPUT_FILEPATH
+
+Extract diagnostic data from gridded fields for spot data sites. It is
+possible to apply a temperature lapse rate adjustment to temperature data that
+helps to account for differences between the spot sites real altitude and that
+of the grid point from which the temperature data is extracted.
+
+positional arguments:
+  NEIGHBOUR_FILEPATH    Path to a NetCDF file of spot-data neighbours. This
+                        file also contains the spot site information.
+  DIAGNOSTIC_FILEPATH   Path to a NetCDF file containing the diagnostic data
+                        to be extracted.
+  OUTPUT_FILEPATH       The output path for the resulting NetCDF
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --profile             Switch on profiling information.
+  --profile_file PROFILE_FILE
+                        Dump profiling info to a file. Implies --profile.
+
+Neighbour finding method:
+  --land_constraint     If set the neighbour cube will be interogated for grid
+                        point neighbours that were identified using a land
+                        constraint. This means that the grid points should be
+                        land points except for sites where none was found
+                        within the search radius when the neighbour cube was
+                        created. May be used with minimum_dz.
+  --minimum_dz          If set the neighbour cube will be interogated for grid
+                        point neighbours that were identified using a minimum
+                        height difference constraint. These are grid points
+                        that were found to be the closest in altitude to the
+                        spot site within the search radius defined when the
+                        neighbour cube was created. May be used with
+                        land_constraint.
+
+Temperature lapse rate adjustment:
+  --temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH
+                        Filepath to a NetCDF file containing temperature lapse
+                        rates. If this cube is provided, and a screen
+                        temperature cube is being processed, the lapse rates
+                        will be used to adjust the temperatures to better
+                        represent each spot site's altitude.
+
+Metadata:
+  --grid_metadata_identifier GRID_METADATA_IDENTIFIER
+                        A string to identify attributes from the input netCDF
+                        files that should be compared to ensure that the data
+                        is compatible. Spot data works using grid indices, so
+                        it is important that the grids are matching or the
+                        data extracted may not match the location of the spot
+                        data sites.
+__HELP__
+  [[ "$output" == "$expected" ]]
+}

--- a/tests/improver-spot-extract-new/02-nearest-uk.bats
+++ b/tests/improver-spot-extract-new/02-nearest-uk.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+  KGO="spot-extract-new/outputs/nearest_uk_temperatures.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract-new/02-nearest-uk.bats
+++ b/tests/improver-spot-extract-new/02-nearest-uk.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract nearest temperatures" {
   improver_check_skip_acceptance
   KGO="spot-extract-new/outputs/nearest_uk_temperatures.nc"
 

--- a/tests/improver-spot-extract-new/03-nearest_uk_min_dz.bats
+++ b/tests/improver-spot-extract-new/03-nearest_uk_min_dz.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract nearest minimum dz temperatures" {
   improver_check_skip_acceptance
   KGO="spot-extract-new/outputs/mindz_uk_temperatures.nc"
 

--- a/tests/improver-spot-extract-new/03-nearest_uk_min_dz.bats
+++ b/tests/improver-spot-extract-new/03-nearest_uk_min_dz.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+  KGO="spot-extract-new/outputs/mindz_uk_temperatures.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      --minimum_dz \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract-new/04-lapse_rate_adjusted_uk.bats
+++ b/tests/improver-spot-extract-new/04-lapse_rate_adjusted_uk.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract lapse rate adjusted temperatures" {
   improver_check_skip_acceptance
   KGO="spot-extract-new/outputs/lapse_rate_adjusted_uk_temperatures.nc"
 

--- a/tests/improver-spot-extract-new/04-lapse_rate_adjusted_uk.bats
+++ b/tests/improver-spot-extract-new/04-lapse_rate_adjusted_uk.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+  KGO="spot-extract-new/outputs/lapse_rate_adjusted_uk_temperatures.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      --temperature_lapse_rate_filepath "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_lapse_rate.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract-new/05-global_site_list_uk_data.bats
+++ b/tests/improver-spot-extract-new/05-global_site_list_uk_data.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract global sites with UK data" {
   improver_check_skip_acceptance
 
   # Run spot extract processing and check it passes.
@@ -42,7 +42,7 @@
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-ValueError: Cubes do not share the metadata identified by the grid_metadata_identifier (mosg)
+ValueError: Cubes do not share the metadata identified by the grid_metadata_identifier (mosg__grid)
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-spot-extract-new/05-global_site_list_uk_data.bats
+++ b/tests/improver-spot-extract-new/05-global_site_list_uk_data.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_global.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Cubes do not share the metadata identified by the grid_metadata_identifier (mosg)
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract-new/06-mismatched_metadata.bats
+++ b/tests/improver-spot-extract-new/06-mismatched_metadata.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature_alternate_metadata.nc" \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Cubes do not share the metadata identified by the grid_metadata_identifier (mosg)
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract-new/06-mismatched_metadata.bats
+++ b/tests/improver-spot-extract-new/06-mismatched_metadata.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract required metadata does not match" {
   improver_check_skip_acceptance
 
   # Run spot extract processing and check it passes.
@@ -42,7 +42,7 @@
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-ValueError: Cubes do not share the metadata identified by the grid_metadata_identifier (mosg)
+ValueError: Cubes do not share the metadata identified by the grid_metadata_identifier (mosg__grid)
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-spot-extract-new/07-alternate_metadata.bats
+++ b/tests/improver-spot-extract-new/07-alternate_metadata.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract test non-default metadata can be used" {
   improver_check_skip_acceptance
   KGO="spot-extract-new/outputs/nearest_uk_temperatures_alternate_metadata.nc"
 

--- a/tests/improver-spot-extract-new/07-alternate_metadata.bats
+++ b/tests/improver-spot-extract-new/07-alternate_metadata.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+  KGO="spot-extract-new/outputs/nearest_uk_temperatures_alternate_metadata.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk_alternate_metadata.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature_alternate_metadata.nc" \
+      --temperature_lapse_rate_filepath \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_lapse_rate_alternate_metadata.nc" \
+      --grid_metadata_identifier my_grid_metadata \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract-new/08-unavailable_neighbour_method.bats
+++ b/tests/improver-spot-extract-new/08-unavailable_neighbour_method.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract" {
+  improver_check_skip_acceptance
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/nearest_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      --minimum_dz \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: The requested neighbour_selection_method "nearest_minimum_dz" is not available
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract-new/08-unavailable_neighbour_method.bats
+++ b/tests/improver-spot-extract-new/08-unavailable_neighbour_method.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract" {
+@test "spot-extract unavailable neighbour method requested" {
   improver_check_skip_acceptance
 
   # Run spot extract processing and check it passes.

--- a/tests/improver-spot-extract-new/09-unmatched_lapse_rate_height.bats
+++ b/tests/improver-spot-extract-new/09-unmatched_lapse_rate_height.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract lapse rate heights do not match temperature heights" {
+  improver_check_skip_acceptance
+  KGO="spot-extract-new/outputs/nearest_uk_temperatures.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      --temperature_lapse_rate_filepath "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_lapse_rate_2m.nc" \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+UserWarning: A lapse rate cube was provided, but the height of the temperature data does not match that of the data used to calculate the lapse rates. As such the temperatures were not adjusted with the lapse rates
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract-new/10-missing_lapse_rate_height.bats
+++ b/tests/improver-spot-extract-new/10-missing_lapse_rate_height.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract lapse rate cube has no height coordinate" {
+  improver_check_skip_acceptance
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      --temperature_lapse_rate_filepath \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_lapse_rate_no_height.nc" \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: Lapse rate cube does not contain a single valued height coordinate. This is required to ensure it is applied to equivalent temperature data.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract-new/11-modified_metadata_with_json.bats
+++ b/tests/improver-spot-extract-new/11-modified_metadata_with_json.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract modifying output metadata with JSON file" {
+  improver_check_skip_acceptance
+  KGO="spot-extract-new/outputs/nearest_uk_temperatures_amended_metadata.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract-new \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
+      --json_file "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/metadata.json" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract-new/12-lapse_rate_for_non_temperature_data.bats
+++ b/tests/improver-spot-extract-new/12-lapse_rate_for_non_temperature_data.bats
@@ -31,17 +31,22 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest minimum_dz temperatures" {
+@test "spot-extract lapse rates provided for non-temperature diagnostic" {
   improver_check_skip_acceptance
-  KGO="spot-extract-new/outputs/mindz_uk_temperatures.nc"
+  KGO="spot-extract-new/outputs/nearest_uk_pmsl.nc"
 
   # Run spot extract processing and check it passes.
   run improver spot-extract-new \
       "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
-      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
-      --minimum_dz \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_pmsl.nc" \
+      --temperature_lapse_rate_filepath "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_lapse_rate.nc" \
       "$TEST_DIR/output.nc"
+  echo "status = ${status}"
   [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+UserWarning: A lapse rate cube was provided, but the diagnostic being processed is not air temperature. The lapse rate cube was not used.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
 
   improver_check_recreate_kgo "output.nc" $KGO
 

--- a/tests/improver-spot-extract-new/13-multiple_constraints.bats
+++ b/tests/improver-spot-extract-new/13-multiple_constraints.bats
@@ -31,15 +31,15 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest minimum_dz temperatures" {
+@test "spot-extract nearest minimum_dz land_constraint temperatures" {
   improver_check_skip_acceptance
-  KGO="spot-extract-new/outputs/mindz_uk_temperatures.nc"
+  KGO="spot-extract-new/outputs/mindz_land_constraint_uk_temperatures.nc"
 
   # Run spot extract processing and check it passes.
   run improver spot-extract-new \
       "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract-new/inputs/ukvx_temperature.nc" \
-      --minimum_dz \
+      --minimum_dz --land_constraint \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 


### PR DESCRIPTION
This PR adds a CLI for using the new spot-extract and lapse rate adjustment plugins. Additional bats tests are also added.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)