### PR TITLE
Update amend_metadata functionality to convert coordinate units

### DIFF
--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -239,7 +239,7 @@ class Test_process(IrisTest):
         """Test that the plugin does not change the origonal input cube."""
 
         # Add threshold axis to standard input cube.
-        changes = {'points': [0.5], 'units': {'action': 'set', 'units': '1'}}
+        changes = {'points': [0.5], 'units': '1'}
         cube_with_thresh = add_coord(self.cube.copy(), 'threshold', changes)
         original_cube = cube_with_thresh.copy()
 
@@ -266,7 +266,7 @@ class Test_process(IrisTest):
         expected_cube = self.cube[0].copy(data.astype(np.float32))
 
         # Add threshold axis to expected output cube.
-        changes = {'points': [0.5], 'units': {'action': 'set', 'units': '1'}}
+        changes = {'points': [0.5], 'units': '1'}
         expected_cube = add_coord(expected_cube, 'threshold', changes)
 
         # Add threshold axis to standard input cube.
@@ -295,13 +295,13 @@ class Test_process(IrisTest):
         thresh_cube = self.cube.copy()
         thresh_cube.remove_coord("forecast_reference_time")
 
-        changes = {'points': [0.25], 'units': {'action': 'set', 'units': '1'}}
+        changes = {'points': [0.25], 'units': '1'}
         cube_with_thresh1 = add_coord(thresh_cube.copy(), 'threshold', changes)
 
-        changes = {'points': [0.5], 'units': {'action': 'set', 'units': '1'}}
+        changes = {'points': [0.5], 'units': '1'}
         cube_with_thresh2 = add_coord(thresh_cube.copy(), 'threshold', changes)
 
-        changes = {'points': [0.75], 'units': {'action': 'set', 'units': '1'}}
+        changes = {'points': [0.75], 'units': '1'}
         cube_with_thresh3 = add_coord(thresh_cube.copy(), 'threshold', changes)
 
         cubelist = iris.cube.CubeList([cube_with_thresh1, cube_with_thresh2,

--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -239,7 +239,7 @@ class Test_process(IrisTest):
         """Test that the plugin does not change the origonal input cube."""
 
         # Add threshold axis to standard input cube.
-        changes = {'points': [0.5], 'units': '1'}
+        changes = {'points': [0.5], 'units': {'action': 'set', 'units': '1'}}
         cube_with_thresh = add_coord(self.cube.copy(), 'threshold', changes)
         original_cube = cube_with_thresh.copy()
 
@@ -266,7 +266,7 @@ class Test_process(IrisTest):
         expected_cube = self.cube[0].copy(data.astype(np.float32))
 
         # Add threshold axis to expected output cube.
-        changes = {'points': [0.5], 'units': '1'}
+        changes = {'points': [0.5], 'units': {'action': 'set', 'units': '1'}}
         expected_cube = add_coord(expected_cube, 'threshold', changes)
 
         # Add threshold axis to standard input cube.
@@ -295,13 +295,13 @@ class Test_process(IrisTest):
         thresh_cube = self.cube.copy()
         thresh_cube.remove_coord("forecast_reference_time")
 
-        changes = {'points': [0.25], 'units': '1'}
+        changes = {'points': [0.25], 'units': {'action': 'set', 'units': '1'}}
         cube_with_thresh1 = add_coord(thresh_cube.copy(), 'threshold', changes)
 
-        changes = {'points': [0.5], 'units': '1'}
+        changes = {'points': [0.5], 'units': {'action': 'set', 'units': '1'}}
         cube_with_thresh2 = add_coord(thresh_cube.copy(), 'threshold', changes)
 
-        changes = {'points': [0.75], 'units': '1'}
+        changes = {'points': [0.75], 'units': {'action': 'set', 'units': '1'}}
         cube_with_thresh3 = add_coord(thresh_cube.copy(), 'threshold', changes)
 
         cubelist = iris.cube.CubeList([cube_with_thresh1, cube_with_thresh2,

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -140,7 +140,7 @@ class Test_add_coord(IrisTest):
             'points': [2.0],
             'bounds': [0.1, 2.0],
             'units': 'mm'
-             }
+            }
 
     def test_basic(self):
         """Test that add_coord returns a Cube and adds coord correctly. """
@@ -206,7 +206,7 @@ class Test_update_coord(IrisTest):
         changes = {
             'points': [2.0],
             'bounds': [0.1, 2.0],
-             }
+            }
         result = update_coord(cube, 'threshold', changes)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.coord('threshold').points,

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -214,12 +214,13 @@ class Test_update_coord(IrisTest):
         self.assertArrayAlmostEqual(result.coord('threshold').bounds,
                                     np.array([[0.1, 2.0]], dtype=np.float32))
 
-    def test_update_units(self):
-        """Test update_coord returns a Cube and updates units correctly. """
+    def test_convert_units(self):
+        """Test update_coord returns a Cube and converts units correctly. """
         cube = create_cube_with_threshold()
         changes = {'units': 'km s-1'}
         result = update_coord(cube, 'threshold', changes)
         self.assertIsInstance(result, Cube)
+        self.assertEqual(result.coord('threshold').points, np.array([0.001]))
         self.assertEqual(str(result.coord('threshold').units), 'km s-1')
 
     def test_coords_deleted(self):

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -200,12 +200,12 @@ class Test_update_coord(IrisTest):
     """Test the update_coord method."""
 
     def test_basic(self):
-        """Test update_coord returns a Cube and updates coord correctly. """
+        """Test update_coord returns a Cube and updates coordinate points and
+        bounds correctly. """
         cube = create_cube_with_threshold()
         changes = {
             'points': [2.0],
             'bounds': [0.1, 2.0],
-            'units': 'km s-1'
              }
         result = update_coord(cube, 'threshold', changes)
         self.assertIsInstance(result, Cube)
@@ -213,8 +213,14 @@ class Test_update_coord(IrisTest):
                                     np.array([2.0], dtype=np.float32))
         self.assertArrayAlmostEqual(result.coord('threshold').bounds,
                                     np.array([[0.1, 2.0]], dtype=np.float32))
-        self.assertEqual(str(result.coord('threshold').units),
-                         'km s-1')
+
+    def test_update_units(self):
+        """Test update_coord returns a Cube and updates units correctly. """
+        cube = create_cube_with_threshold()
+        changes = {'units': 'km s-1'}
+        result = update_coord(cube, 'threshold', changes)
+        self.assertIsInstance(result, Cube)
+        self.assertEqual(str(result.coord('threshold').units), 'km s-1')
 
     def test_coords_deleted(self):
         """Test update_coord deletes coordinate. """
@@ -289,7 +295,6 @@ class Test_update_coord(IrisTest):
         changes = {
             'points': [2.0],
             'bounds': [0.1, 2.0],
-            'units': 'mm/hr'
             }
         warning_msg = "Updated coordinate"
         update_coord(cube, coord_name, changes, warnings_on=True)
@@ -297,6 +302,24 @@ class Test_update_coord(IrisTest):
                             for item in warning_list))
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
+
+    def test_incompatible_changes_requested(self):
+        """Test that update_coord raises an exception if 'points' and 'units'
+        are requested to be changed."""
+        cube = create_cube_with_threshold()
+        changes = {'points': [2.0, 3.0], 'units': 'mm/hr'}
+        msg = "When updating a coordinate"
+        with self.assertRaisesRegex(ValueError, msg):
+            update_coord(cube, 'threshold', changes)
+
+    def test_alternative_incompatible_changes_requested(self):
+        """Test that update_coord raises an exception if 'bounds' and 'units'
+        are requested to be changed."""
+        cube = create_cube_with_threshold()
+        changes = {'bounds': [0.1, 2.0], 'units': 'mm/hr'}
+        msg = "When updating a coordinate"
+        with self.assertRaisesRegex(ValueError, msg):
+            update_coord(cube, 'threshold', changes)
 
 
 class Test_update_attribute(IrisTest):

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -207,11 +207,11 @@ def update_coord(cube, coord_name, changes, warnings_on=False):
                    "{}".format(coord_name))
             warnings.warn(msg)
     else:
-        # Unit conversion must take place prior to potentially setting
-        # points and bounds, so that unit conversion does not conflict with
-        # setting points and bounds.
-        if 'units' in changes:
-            new_coord.convert_units(changes["units"])
+        if 'units' in changes and ('points' in changes or 'bounds' in changes):
+            msg = ("When updating a coordinate, the 'units' and "
+                   "'points'/'bounds' can only be updated independently. "
+                   "The changes requested were {}".format(changes))
+            raise ValueError(msg)
         if 'points' in changes:
             new_points = np.array(changes['points'])
             if new_points.dtype == np.float64:
@@ -247,6 +247,8 @@ def update_coord(cube, coord_name, changes, warnings_on=False):
                            " be points.shape + (n_bounds,)"
                            "for coord= {}".format(coord_name))
                     raise ValueError(msg)
+        if 'units' in changes:
+            new_coord.convert_units(changes["units"])
         if warnings_on:
             msg = ("Updated coordinate "
                    "{}".format(coord_name) +

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -95,6 +95,43 @@ def update_stage_v110_metadata(cube):
     return True
 
 
+def update_units(item, changes):
+    """Update the units on the item supplied. Options are to either
+    'set' or 'convert' the units
+
+    Args:
+        item (iris.cube.Cube, iris.coords.DimCoord or iris.coords.AuxCoord):
+            Item that will have its units modified.
+        changes (dict):
+            Dictionary of the formats shown below for specifying whether the
+            units will be set or converted::
+            "units": {
+                "action": "set",
+                "units": "K"
+            }
+            "units": {
+                "action": "convert",
+                "units": "seconds since 1970-01-01 00:00:00"
+            }
+
+    Return:
+        item (iris.cube.Cube, iris.coords.DimCoord or iris.coords.AuxCoord):
+            Item that has had its units modified.
+    """
+
+    if changes["units"]["action"] == "set":
+        item.units = changes['units']["units"]
+    elif changes["units"]["action"] == "convert":
+        item.convert_units(changes["units"]["units"])
+    else:
+        msg = ("The specified action is not known. "
+               "The specified action was '{}'. "
+               "Possible actions are: 'set' or 'convert'.").format(
+                   changes["units"]["action"])
+        raise KeyError(msg)
+    return item
+
+
 def add_coord(cube, coord_name, changes, warnings_on=False):
     """Add coord to the cube.
 
@@ -145,7 +182,7 @@ def add_coord(cube, coord_name, changes, warnings_on=False):
         bounds = changes['bounds']
     units = None
     if 'units' in changes:
-        units = changes['units']
+        units = changes["units"]["units"]
     new_coord = new_coord_method(long_name=coord_name,
                                  points=points,
                                  bounds=bounds,
@@ -243,7 +280,7 @@ def update_coord(cube, coord_name, changes, warnings_on=False):
                            "for coord= {}".format(coord_name))
                     raise ValueError(msg)
         if 'units' in changes:
-            new_coord.units = changes['units']
+            new_coord = update_units(new_coord, changes)
         if warnings_on:
             msg = ("Updated coordinate "
                    "{}".format(coord_name) +
@@ -491,7 +528,7 @@ def amend_metadata(cube,
             update_cell_methods(result, cell_methods[key])
 
     if units is not None:
-        result.convert_units(units)
+        result = update_units(result, units)
 
     return result
 
@@ -534,7 +571,10 @@ def resolve_metadata_diff(cube1, cube2, warnings_on=False):
                     coord_dict = dict()
                     coord_dict['points'] = result1.coord(coord).points
                     coord_dict['bounds'] = result1.coord(coord).bounds
-                    coord_dict['units'] = result1.coord(coord).units
+                    coord_dict['units'] = {
+                        'action': 'set',
+                        'units': result1.coord(coord).units
+                    }
                     coord_dict['metatype'] = 'DimCoord'
                     result2 = add_coord(result2, coord, coord_dict,
                                         warnings_on=warnings_on)


### PR DESCRIPTION
Description
~~This PR extends the existing functionality for modifying units using the amend_metadata function and, in turn, the standardise CLI. This is done by adding an `update_units` function, primarily to handle instances where the user wants the units to be set directly or where the user wants to convert the units.~~
This PR updates the amend_metadata functionality, so that if a units are specified when a coordinate is being updated then a unit conversion takes place. 
 
Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
