### PR TITLE
IMPRO-893-UVIndex_global - Changes for uv_index

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -73,5 +73,6 @@ BOUNDS_FOR_ECDF = {
     "temperature_at_screen_level_nighttime_min": (
         Bounds((-90-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
     "temperature_at_screen_level_daytime_max": (
-        Bounds((-60-ABSOLUTE_ZERO, 65-ABSOLUTE_ZERO), "Kelvin"))
+        Bounds((-60-ABSOLUTE_ZERO, 65-ABSOLUTE_ZERO), "Kelvin")),
+    "ultraviolet_index": Bounds((0, 25.0), "1")
 }


### PR DESCRIPTION
Description

Changes to ensemble_copula_coupling_constants.py to cope with ultraviolet_index
Required to run percentile_extract for this data.
