### PR TITLE
IMPRO-880: Compare attributes and missing kwarg fix

### DIFF
--- a/lib/improver/spotdata_new/apply_lapse_rate.py
+++ b/lib/improver/spotdata_new/apply_lapse_rate.py
@@ -120,7 +120,8 @@ class SpotLapseRateAdjust:
 
         # Extract the lapse rates that correspond to the spot sites.
         extraction_plugin = SpotExtraction(
-            neighbour_selection_method=self.neighbour_selection_method)
+            neighbour_selection_method=self.neighbour_selection_method,
+            grid_metadata_identifier=self.grid_metadata_identifier)
         spot_lapse_rate = extraction_plugin.process(neighbour_cube,
                                                     gridded_lapse_rate_cube)
 

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -575,21 +575,21 @@ def compare_attributes(cubes, attribute_filter=None):
         reference_attributes = get_filtered_attributes(
             cubes[0], attribute_filter=attribute_filter)
 
+        common_keys = reference_attributes.keys()
+        for cube in cubes[1:]:
+            cube_attributes = get_filtered_attributes(
+                cube, attribute_filter=attribute_filter)
+            common_keys = {
+                key for key in cube_attributes.keys()
+                if key in common_keys and
+                np.all(cube_attributes[key] == reference_attributes[key])}
+
         for cube in cubes:
             cube_attributes = get_filtered_attributes(
                 cube, attribute_filter=attribute_filter)
-
-            common_keys = list(
-                cube_attributes.keys() & reference_attributes.keys())
-            unique_keys = list(
-                cube_attributes.keys() - reference_attributes.keys())
-            for key in common_keys:
-                if not np.all(
-                        cube_attributes[key] == reference_attributes[key]):
-                    unique_keys.append(key)
-                    common_keys.remove(key)
-
-            unique_attributes = {k: cube_attributes[k] for k in unique_keys}
+            unique_attributes = {
+                key: value for (key, value) in cube_attributes.items()
+                if key not in common_keys}
             unmatching_attributes.append(unique_attributes)
 
     return unmatching_attributes

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -574,13 +574,23 @@ def compare_attributes(cubes, attribute_filter=None):
     else:
         reference_attributes = get_filtered_attributes(
             cubes[0], attribute_filter=attribute_filter)
-        for cube in cubes[1:]:
+
+        for cube in cubes:
             cube_attributes = get_filtered_attributes(
                 cube, attribute_filter=attribute_filter)
-            unmatching_attributes.append(
-                dict(reference_attributes.items() - cube_attributes.items()))
-            unmatching_attributes.append(
-                dict(cube_attributes.items() - reference_attributes.items()))
+
+            common_keys = list(
+                cube_attributes.keys() & reference_attributes.keys())
+            unique_keys = list(
+                cube_attributes.keys() - reference_attributes.keys())
+            for key in common_keys:
+                if not np.all(
+                        cube_attributes[key] == reference_attributes[key]):
+                    unique_keys.append(key)
+                    common_keys.remove(key)
+
+            unique_attributes = {k: cube_attributes[k] for k in unique_keys}
+            unmatching_attributes.append(unique_attributes)
 
     return unmatching_attributes
 


### PR DESCRIPTION
- Modified compare_attributes function to look more like it once did, though now with attribute filtering. The use of python 3 dictionary comparison methods failed when the dictionaries contained unhashable values (e.g. arrays, lists) as is the case for source_realizations. As such the code has been reverted to something more robust.
- Added missing kwarg (grid_metadata_identifier) in call to SpotExtraction from within SpotLapseRateAdjust.

Testing:
 - [x] Ran tests and they passed OK