### PR TITLE
Cell Method Sorting: Consistent ordering for multiple cell methods

### DIFF
--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -85,6 +85,20 @@ def append_metadata_cube(cubelist, global_keys):
     return cubelist
 
 
+def order_cell_methods(cube):
+    """
+    Sorts the cell methods on a cube such that if there are multiple methods
+    they are always written in a consistent order in the output cube. The
+    input cube is modified.
+
+    Args:
+        cube (iris.cube.Cube):
+            The cube on which the cell methods are to be sorted.
+    """
+    cell_methods = tuple(sorted(cube.cell_methods))
+    cube.cell_methods = cell_methods
+
+
 def save_netcdf(cubelist, filename):
     """Save the input Cube or CubeList as a NetCDF file.
 
@@ -103,6 +117,7 @@ def save_netcdf(cubelist, filename):
 
     for cube in cubelist:
         check_cube_not_float64(cube)
+        order_cell_methods(cube)
 
     global_keys = ['title', 'um_version', 'grid_id', 'source', 'Conventions',
                    'mosg__grid_type', 'mosg__model_configuration',


### PR DESCRIPTION
Function added to save.py that orders cell methods before saving for instances where there are multiple cell methods applied. In these situations, iris does not consistently order the cell methods on the cube. This leads to CLI test failures as each time a cube is generated the cell method tuple may be differently ordered.
This change is required by #779.

New acceptance test data is needed for cases with multiple cell methods in which they were previously sorted in reverse, e.g. nbhood, recursive filter. In the nbhood/recursive filter cases the cell methods are:
```
mean: time (1 hour)
mean: forecast_period
```
which is reversed by this new function.

This PR relates to IMPRO-1011 in which a test was created that adds two types of cell method to a single cube, e.g.
```
maximum: time (1 hour)
mean: realization
```

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)