### PR TITLE
Add ECC bounds exceedance warning option for percentile data

### DIFF
--- a/bin/improver-percentile
+++ b/bin/improver-percentile
@@ -31,10 +31,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to collapse cube coordinates and calculate percentiled data."""
 
+import warnings
 import numpy as np
 
 from improver.argparser import ArgParser
-import warnings
 
 from improver.percentile import PercentileConverter
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import \
@@ -100,9 +100,9 @@ def main():
                           "provided COORDINATES_TO_COLLAPSE variable will "
                           "not be used.")
 
-        result = GeneratePercentilesFromProbabilities().process(
-            cube, percentiles=percentiles,
-            ecc_bounds_warning=args.ecc_bounds_warning)
+        result = GeneratePercentilesFromProbabilities(
+            ecc_bounds_warning=args.ecc_bounds_warning).process(
+                cube, percentiles=percentiles)
     else:
         if not args.coordinates:
             raise ValueError("To collapse a coordinate to calculate "

--- a/bin/improver-percentiles-to-realizations
+++ b/bin/improver-percentiles-to-realizations
@@ -32,8 +32,6 @@
 
 """Script to run Ensemble Copula Coupling processing."""
 
-import numpy as np
-
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     RebadgePercentilesAsRealizations, ResamplePercentiles, EnsembleReordering)
 from improver.argparser import ArgParser
@@ -148,10 +146,10 @@ def main():
     # Safe to now actually do the work...
     cube = load_cube(args.input_filepath)
 
-    result_cube = ResamplePercentiles().process(
-        cube, no_of_percentiles=args.no_of_percentiles,
-        sampling=args.sampling_method,
-        ecc_bounds_warning=args.ecc_bounds_warning)
+    result_cube = ResamplePercentiles(
+        ecc_bounds_warning=args.ecc_bounds_warning).process(
+            cube, no_of_percentiles=args.no_of_percentiles,
+            sampling=args.sampling_method)
 
     if args.reordering:
         raw_forecast = load_cube(args.raw_forecast_filepath)

--- a/bin/improver-percentiles-to-realizations
+++ b/bin/improver-percentiles-to-realizations
@@ -74,6 +74,11 @@ def main():
                              'percentiles which is the preferred '
                              'option for full Ensemble Copula Coupling with '
                              'reordering enabled.')
+    parser.add_argument(
+        '--ecc_bounds_warning', default=False, action='store_true',
+        help='If True, where percentiles (calculated as an intermediate '
+             'output before realizations) exceed the ECC bounds range, raise '
+             'a warning rather than an exception.')
 
     # Different use cases:
     # (We can either reorder OR rebadge)
@@ -145,7 +150,8 @@ def main():
 
     result_cube = ResamplePercentiles().process(
         cube, no_of_percentiles=args.no_of_percentiles,
-        sampling=args.sampling_method)
+        sampling=args.sampling_method,
+        ecc_bounds_warning=args.ecc_bounds_warning)
 
     if args.reordering:
         raw_forecast = load_cube(args.raw_forecast_filepath)

--- a/bin/improver-probabilities-to-realizations
+++ b/bin/improver-probabilities-to-realizations
@@ -47,14 +47,14 @@ def main():
         (['--no_of_realizations'],
          {'metavar': 'NUMBER_OF_REALIZATIONS', 'default': None, 'type': int,
           'help': (
-            "Optional definition of the number of ensemble realizations to be "
-            "generated. These are generated through an intermediate "
-            "percentile representation. These percentiles will be distributed "
-            "regularly with the aim of dividing into blocks of equal "
-            "probability. If the reordering option is specified and the "
-            "number of realizations is not given then the number of "
-            "realizations is taken from the number of realizations in the "
-            "raw forecast NetCDF file.")
+              "Optional definition of the number of ensemble realizations to "
+              "be generated. These are generated through an intermediate "
+              "percentile representation. These percentiles will be "
+              "distributed regularly with the aim of dividing into blocks of "
+              "equal probability. If the reordering option is specified and "
+              "the number of realizations is not given then the number of "
+              "realizations is taken from the number of realizations in the "
+              "raw forecast NetCDF file.")
           })]
 
     cli_definition = {'central_arguments': ('input_file', 'output_file'),
@@ -138,16 +138,16 @@ def main():
         if args.no_of_realizations is None:
             no_of_realizations = len(raw_forecast.coord("realization").points)
 
-        cube = GeneratePercentilesFromProbabilities().process(
-            cube, no_of_percentiles=no_of_realizations,
-            ecc_bounds_warning=args.ecc_bounds_warning)
+        cube = GeneratePercentilesFromProbabilities(
+            ecc_bounds_warning=args.ecc_bounds_warning).process(
+                cube, no_of_percentiles=no_of_realizations)
         cube = EnsembleReordering().process(
             cube, raw_forecast, random_ordering=False,
             random_seed=args.random_seed)
     elif args.rebadging:
-        cube = GeneratePercentilesFromProbabilities().process(
-                cube, no_of_percentiles=args.no_of_realizations,
-                ecc_bounds_warning=args.ecc_bounds_warning)
+        cube = GeneratePercentilesFromProbabilities(
+            ecc_bounds_warning=args.ecc_bounds_warning).process(
+                cube, no_of_percentiles=args.no_of_realizations)
         cube = RebadgePercentilesAsRealizations().process(cube)
 
     save_netcdf(cube, args.output_filepath)

--- a/bin/improver-probabilities-to-realizations
+++ b/bin/improver-probabilities-to-realizations
@@ -146,7 +146,8 @@ def main():
             random_seed=args.random_seed)
     elif args.rebadging:
         cube = GeneratePercentilesFromProbabilities().process(
-                cube, no_of_percentiles=args.no_of_realizations)
+                cube, no_of_percentiles=args.no_of_realizations,
+                ecc_bounds_warning=args.ecc_bounds_warning)
         cube = RebadgePercentilesAsRealizations().process(cube)
 
     save_netcdf(cube, args.output_filepath)

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -123,16 +123,20 @@ class ResamplePercentiles(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, ecc_bounds_warning=False):
         """
         Initialise the class.
-        """
-        pass
 
-    @staticmethod
+        Keyword Args:
+            ecc_bounds_warning (bool):
+                If true and ECC bounds are exceeded by the percentile values,
+                a warning will be generated rather than an exception.
+                Default value is FALSE.
+        """
+        self.ecc_bounds_warning = ecc_bounds_warning
+
     def _add_bounds_to_percentiles_and_forecast_at_percentiles(
-            percentiles, forecast_at_percentiles, bounds_pairing,
-            ecc_bounds_warning=False):
+            self, percentiles, forecast_at_percentiles, bounds_pairing):
         """
         Padding of the lower and upper bounds of the percentiles for a
         given phenomenon, and padding of forecast values using the
@@ -146,10 +150,6 @@ class ResamplePercentiles(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
-            ecc_bounds_warning (bool):
-                If true and ECC bounds are exceeded by the percentile values,
-                a warning will be generated rather than an exception.
-                Default value is FALSE.
         Returns:
             (tuple) : tuple containing:
                 **percentiles** (Numpy array):
@@ -173,7 +173,7 @@ class ResamplePercentiles(object):
                    "is outside the allowable range given by the "
                    "bounds {}".format(forecast_at_percentiles, bounds_pairing))
 
-            if ecc_bounds_warning:
+            if self.ecc_bounds_warning:
                 warn_msg = msg + (" The percentile values that have "
                                   "exceeded the existing bounds will be used "
                                   "as new bounds.")
@@ -195,7 +195,7 @@ class ResamplePercentiles(object):
 
     def _interpolate_percentiles(
             self, forecast_at_percentiles, desired_percentiles,
-            bounds_pairing, percentile_coord, ecc_bounds_warning=False):
+            bounds_pairing, percentile_coord):
         """
         Interpolation of forecast for a set of percentiles from an initial
         set of percentiles to a new set of percentiles. This is constructed
@@ -212,11 +212,6 @@ class ResamplePercentiles(object):
                 cumulative distribution function.
             percentile_coord (String):
                 Name of required percentile coordinate.
-            ecc_bounds_warning (bool):
-                If true and ECC bounds are exceeded by the percentile values,
-                a warning will be generated rather than an exception.
-                Default value is FALSE.
-
         Returns:
             percentile_cube (iris cube.Cube):
                 Cube containing values for the required diagnostic e.g.
@@ -238,7 +233,7 @@ class ResamplePercentiles(object):
         original_percentiles, forecast_at_reshaped_percentiles = (
             self._add_bounds_to_percentiles_and_forecast_at_percentiles(
                 original_percentiles, forecast_at_reshaped_percentiles,
-                bounds_pairing, ecc_bounds_warning))
+                bounds_pairing))
 
         forecast_at_interpolated_percentiles = (
             np.empty(
@@ -269,7 +264,7 @@ class ResamplePercentiles(object):
         return percentile_cube
 
     def process(self, forecast_at_percentiles, no_of_percentiles=None,
-                sampling="quantile", ecc_bounds_warning=False):
+                sampling="quantile"):
         """
         1. Creates a list of percentiles.
         2. Accesses the lower and upper bound pair of the forecast values,
@@ -295,11 +290,6 @@ class ResamplePercentiles(object):
                      at dividing a Cumulative Distribution Function into
                      blocks of equal probability.
                 * Random: A random set of ordered percentiles.
-            ecc_bounds_warning (bool):
-                If true and ECC bounds are exceeded by the percentile values,
-                a warning will be generated rather than an exception.
-                Default value is FALSE.
-
         Returns:
             forecast_at_percentiles (iris.cube.Cube):
                 Cube with forecast values at the desired set of percentiles.
@@ -324,7 +314,7 @@ class ResamplePercentiles(object):
 
         forecast_at_percentiles = self._interpolate_percentiles(
             forecast_at_percentiles, percentiles, bounds_pairing,
-            percentile_coord, ecc_bounds_warning)
+            percentile_coord)
         return forecast_at_percentiles
 
 
@@ -345,16 +335,20 @@ class GeneratePercentilesFromProbabilities(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, ecc_bounds_warning=False):
         """
         Initialise the class.
-        """
-        pass
 
-    @staticmethod
+        Keyword Args:
+            ecc_bounds_warning (bool):
+                If true and ECC bounds are exceeded by the percentile values,
+                a warning will be generated rather than an exception.
+                Default value is FALSE.
+        """
+        self.ecc_bounds_warning = ecc_bounds_warning
+
     def _add_bounds_to_thresholds_and_probabilities(
-            threshold_points, probabilities_for_cdf, bounds_pairing,
-            ecc_bounds_warning=False):
+            self, threshold_points, probabilities_for_cdf, bounds_pairing):
         """
         Padding of the lower and upper bounds of the distribution for a
         given phenomenon for the threshold_points, and padding of
@@ -370,12 +364,6 @@ class GeneratePercentilesFromProbabilities(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
-
-        Keyword Args:
-            ecc_bounds_warning (bool):
-                If true and ECC bounds are exceeded by the threshold values,
-                a warning will be generated rather than an exception.
-                Default value is FALSE.
         Returns:
             (tuple) : tuple containing:
                 **threshold_points** (Numpy array):
@@ -403,7 +391,7 @@ class GeneratePercentilesFromProbabilities(object):
             # can continue. Then apply the new bounds as necessary to
             # ensure the threshold values and endpoints are in ascending
             # order and avoid problems further along the processing chain.
-            if ecc_bounds_warning:
+            if self.ecc_bounds_warning:
                 warn_msg = msg + (" The threshold points that have "
                                   "exceeded the existing bounds will be used "
                                   "as new bounds.")
@@ -420,8 +408,7 @@ class GeneratePercentilesFromProbabilities(object):
         return threshold_points_with_endpoints, probabilities_for_cdf
 
     def _probabilities_to_percentiles(
-            self, forecast_probabilities, percentiles, bounds_pairing,
-            ecc_bounds_warning=False):
+            self, forecast_probabilities, percentiles, bounds_pairing):
         """
         Conversion of probabilities to percentiles through the construction
         of an cumulative distribution function. This is effectively
@@ -437,13 +424,6 @@ class GeneratePercentilesFromProbabilities(object):
             bounds_pairing (Tuple):
                 Lower and upper bound to be used as the ends of the
                 cumulative distribution function.
-
-        Keyword Args:
-            ecc_bounds_warning (bool):
-                If true and ECC bounds are exceeded by the threshold values
-                from the forecast_probabilities, then a warning will be
-                generated rather than an exception. Default value is FALSE.
-
         Returns:
             percentile_cube (Iris cube):
                 Cube containing values for the required diagnostic e.g.
@@ -481,8 +461,7 @@ class GeneratePercentilesFromProbabilities(object):
 
         threshold_points, probabilities_for_cdf = (
             self._add_bounds_to_thresholds_and_probabilities(
-                threshold_points, probabilities_for_cdf, bounds_pairing,
-                ecc_bounds_warning))
+                threshold_points, probabilities_for_cdf, bounds_pairing))
 
         if np.any(np.diff(probabilities_for_cdf) < 0):
             msg = ("The probability values used to construct the "
@@ -529,8 +508,7 @@ class GeneratePercentilesFromProbabilities(object):
         return percentile_cube
 
     def process(self, forecast_probabilities, no_of_percentiles=None,
-                percentiles=None, sampling="quantile",
-                ecc_bounds_warning=False):
+                percentiles=None, sampling="quantile"):
         """
         1. Concatenates cubes with a threshold coordinate.
         2. Creates a list of percentiles.
@@ -562,11 +540,6 @@ class GeneratePercentilesFromProbabilities(object):
                           at dividing a Cumulative Distribution Function into
                           blocks of equal probability.
                 * Random: A random set of ordered percentiles.
-
-        Keyword Args:
-            ecc_bounds_warning (bool):
-                If True then exceeding ECC bounds will only generate a
-                warning rather than an exception. Default value is FALSE.
 
         Returns:
             forecast_at_percentiles (Iris cube):
@@ -617,8 +590,7 @@ class GeneratePercentilesFromProbabilities(object):
         cubelist = iris.cube.CubeList([])
         for cube_realization in slices_over_realization:
             cubelist.append(self._probabilities_to_percentiles(
-                cube_realization, percentiles, bounds_pairing,
-                ecc_bounds_warning))
+                cube_realization, percentiles, bounds_pairing))
 
         forecast_at_percentiles = cubelist.merge_cube()
         return forecast_at_percentiles

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -33,9 +33,8 @@ Unit tests for the
 `ensemble_copula_coupling.GeneratePercentilesFromProbabilities` class.
 
 """
-import numpy as np
 import unittest
-
+import numpy as np
 
 import cf_units as unit
 from iris.cube import Cube
@@ -139,11 +138,10 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
         threshold_points = np.array([8, 10, 60])
         bounds_pairing = (-40, 50)
-        plugin = Plugin()
+        plugin = Plugin(ecc_bounds_warning=True)
         warning_msg = "The calculated threshold values"
         plugin._add_bounds_to_thresholds_and_probabilities(
-            threshold_points, probabilities_for_cdf, bounds_pairing,
-            ecc_bounds_warning=True)
+            threshold_points, probabilities_for_cdf, bounds_pairing)
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
 
@@ -154,10 +152,9 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
         threshold_points = np.array([-50, 10, 60])
         bounds_pairing = (-40, 50)
-        plugin = Plugin()
+        plugin = Plugin(ecc_bounds_warning=True)
         result = plugin._add_bounds_to_thresholds_and_probabilities(
-            threshold_points, probabilities_for_cdf, bounds_pairing,
-            ecc_bounds_warning=True)
+            threshold_points, probabilities_for_cdf, bounds_pairing)
         self.assertEqual(max(result[0]), max(threshold_points))
         self.assertEqual(min(result[0]), min(threshold_points))
 

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -31,8 +31,8 @@
 """
 Unit tests for the `ensemble_copula_coupling.ResamplePercentiles` class.
 """
-import numpy as np
 import unittest
+import numpy as np
 
 from iris.cube import Cube
 from iris.tests import IrisTest
@@ -144,14 +144,15 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         forecast_at_percentiles = np.array([[8, 10, 60]])
         percentiles = np.array([5, 70, 95])
         bounds_pairing = (-40, 50)
-        plugin = Plugin()
+        plugin = Plugin(ecc_bounds_warning=True)
         warning_msg = "The end points added to the forecast at percentile "
         plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
-            percentiles, forecast_at_percentiles, bounds_pairing,
-            ecc_bounds_warning=True)
+            percentiles, forecast_at_percentiles, bounds_pairing)
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
 
+    @ManageWarnings(
+        ignored_messages=["The end points added to the forecast at"])
     def test_new_endpoints_generation(self):
         """Test that the plugin re-applies the percentile bounds using the
         maximum and minimum percentile values when the original bounds have
@@ -159,10 +160,9 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         forecast_at_percentiles = np.array([[8, 10, 60]])
         percentiles = np.array([5, 70, 95])
         bounds_pairing = (-40, 50)
-        plugin = Plugin()
+        plugin = Plugin(ecc_bounds_warning=True)
         result = plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
-            percentiles, forecast_at_percentiles, bounds_pairing,
-            ecc_bounds_warning=True)
+            percentiles, forecast_at_percentiles, bounds_pairing)
         self.assertEqual(
             np.max(result[1]),
             max([forecast_at_percentiles.max(), max(bounds_pairing)]))

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -127,10 +127,48 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         percentiles = np.array([5, 70, 95])
         bounds_pairing = (-40, 50)
         plugin = Plugin()
-        msg = "The end points added to the forecast at percentiles"
+        msg = "The end points added to the forecast at percentile"
         with self.assertRaisesRegex(ValueError, msg):
             plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
                 percentiles, forecast_at_percentiles, bounds_pairing)
+
+    @ManageWarnings(record=True)
+    def test_endpoints_of_distribution_exceeded_warning(
+            self, warning_list=None):
+        """
+        Test that the plugin raises a warning message when the constant
+        end points of the distribution are exceeded by a percentile value
+        used in the forecast and the ecc_bounds_warning keyword argument
+        has been specified.
+        """
+        forecast_at_percentiles = np.array([[8, 10, 60]])
+        percentiles = np.array([5, 70, 95])
+        bounds_pairing = (-40, 50)
+        plugin = Plugin()
+        warning_msg = "The end points added to the forecast at percentile "
+        plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
+            percentiles, forecast_at_percentiles, bounds_pairing,
+            ecc_bounds_warning=True)
+        self.assertTrue(any(warning_msg in str(item)
+                            for item in warning_list))
+
+    def test_new_endpoints_generation(self):
+        """Test that the plugin re-applies the percentile bounds using the
+        maximum and minimum percentile values when the original bounds have
+        been exceeded and ecc_bounds_warning has been set."""
+        forecast_at_percentiles = np.array([[8, 10, 60]])
+        percentiles = np.array([5, 70, 95])
+        bounds_pairing = (-40, 50)
+        plugin = Plugin()
+        result = plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
+            percentiles, forecast_at_percentiles, bounds_pairing,
+            ecc_bounds_warning=True)
+        self.assertEqual(
+            np.max(result[1]),
+            max([forecast_at_percentiles.max(), max(bounds_pairing)]))
+        self.assertEqual(
+            np.min(result[1]),
+            min([forecast_at_percentiles.min(), min(bounds_pairing)]))
 
     def test_percentiles_not_ascending(self):
         """

--- a/tests/improver-percentiles-to-realizations/00-null.bats
+++ b/tests/improver-percentiles-to-realizations/00-null.bats
@@ -37,12 +37,15 @@ usage: improver-percentiles-to-realizations [-h] [--profile]
                                             [--profile_file PROFILE_FILE]
                                             [--no_of_percentiles NUMBER_OF_PERCENTILES]
                                             [--sampling_method [PERCENTILE_SAMPLING_METHOD]]
+                                            [--ecc_bounds_warning]
                                             (--reordering | --rebadging)
                                             [--raw_forecast_filepath RAW_FORECAST_FILE]
                                             [--random_ordering]
                                             [--random_seed RANDOM_SEED]
                                             [--realization_numbers REALIZATION_NUMBERS [REALIZATION_NUMBERS ...]]
                                             INPUT_FILE OUTPUT_FILE
+improver-percentiles-to-realizations: error: the following arguments are required: INPUT_FILE, OUTPUT_FILE
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }
+

--- a/tests/improver-percentiles-to-realizations/01-help.bats
+++ b/tests/improver-percentiles-to-realizations/01-help.bats
@@ -37,6 +37,7 @@ usage: improver-percentiles-to-realizations [-h] [--profile]
                                             [--profile_file PROFILE_FILE]
                                             [--no_of_percentiles NUMBER_OF_PERCENTILES]
                                             [--sampling_method [PERCENTILE_SAMPLING_METHOD]]
+                                            [--ecc_bounds_warning]
                                             (--reordering | --rebadging)
                                             [--raw_forecast_filepath RAW_FORECAST_FILE]
                                             [--random_ordering]
@@ -69,6 +70,10 @@ optional arguments:
                         option produces equally spaced percentiles which is
                         the preferred option for full Ensemble Copula Coupling
                         with reordering enabled.
+  --ecc_bounds_warning  If True, where percentiles (calculated as an
+                        intermediate output before realizations) exceed the
+                        ECC bounds range, raise a warning rather than an
+                        exception.
   --reordering          The option used to create ensemble realizations from
                         percentiles by reordering the input percentiles based
                         on the order of the raw ensemble forecast.

--- a/tests/improver-percentiles-to-realizations/05-reordering_wrong_options.bats
+++ b/tests/improver-percentiles-to-realizations/05-reordering_wrong_options.bats
@@ -45,6 +45,7 @@ usage: improver-percentiles-to-realizations [-h] [--profile]
                                             [--profile_file PROFILE_FILE]
                                             [--no_of_percentiles NUMBER_OF_PERCENTILES]
                                             [--sampling_method [PERCENTILE_SAMPLING_METHOD]]
+                                            [--ecc_bounds_warning]
                                             (--reordering | --rebadging)
                                             [--raw_forecast_filepath RAW_FORECAST_FILE]
                                             [--random_ordering]

--- a/tests/improver-percentiles-to-realizations/06-rebading_wrong_option1.bats
+++ b/tests/improver-percentiles-to-realizations/06-rebading_wrong_option1.bats
@@ -45,6 +45,7 @@ usage: improver-percentiles-to-realizations [-h] [--profile]
                                             [--profile_file PROFILE_FILE]
                                             [--no_of_percentiles NUMBER_OF_PERCENTILES]
                                             [--sampling_method [PERCENTILE_SAMPLING_METHOD]]
+                                            [--ecc_bounds_warning]
                                             (--reordering | --rebadging)
                                             [--raw_forecast_filepath RAW_FORECAST_FILE]
                                             [--random_ordering]

--- a/tests/improver-percentiles-to-realizations/07-rebading_wrong_option2.bats
+++ b/tests/improver-percentiles-to-realizations/07-rebading_wrong_option2.bats
@@ -45,6 +45,7 @@ usage: improver-percentiles-to-realizations [-h] [--profile]
                                             [--profile_file PROFILE_FILE]
                                             [--no_of_percentiles NUMBER_OF_PERCENTILES]
                                             [--sampling_method [PERCENTILE_SAMPLING_METHOD]]
+                                            [--ecc_bounds_warning]
                                             (--reordering | --rebadging)
                                             [--raw_forecast_filepath RAW_FORECAST_FILE]
                                             [--random_ordering]

--- a/tests/improver-percentiles-to-realizations/08-ecc_bounds_warning.bats
+++ b/tests/improver-percentiles-to-realizations/08-ecc_bounds_warning.bats
@@ -38,11 +38,16 @@
   # Run Ensemble Copula Coupling to convert one set of percentiles to another
   # set of percentiles, and then rebadge the percentiles to be ensemble
   # realizations. Data in this input exceeds the ECC bounds and so tests ecc_bounds_warning functionality.
-  run improver percentiles-to-realizations  --sampling_method 'quantile' --no_of_percentiles 12 \
+  run improver percentiles-to-realizations  --sampling_method 'quantile' --no_of_percentiles 5 \
       --rebadging --ecc_bounds_warning \
       "$IMPROVER_ACC_TEST_DIR/percentiles-to-realizations/ecc_bounds_warning/multiple_percentiles_wind_cube_out_of_bounds.nc" \
       "$TEST_DIR/output.nc"
+  echo "status = ${status}"
   [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+The percentile values that have exceeded the existing bounds will be used as new bounds.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
 
   improver_check_recreate_kgo "output.nc" $KGO
 

--- a/tests/improver-percentiles-to-realizations/08-ecc_bounds_warning.bats
+++ b/tests/improver-percentiles-to-realizations/08-ecc_bounds_warning.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2018 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "percentiles-to-realizations --sampling_method 'quantile' --no_of_percentiles 12 --rebadging  --ecc_bounds_warning input output" {
+  improver_check_skip_acceptance
+  KGO="percentiles-to-realizations/ecc_bounds_warning/kgo.nc"
+
+  # Run Ensemble Copula Coupling to convert one set of percentiles to another
+  # set of percentiles, and then rebadge the percentiles to be ensemble
+  # realizations. Data in this input exceeds the ECC bounds and so tests ecc_bounds_warning functionality.
+  run improver percentiles-to-realizations  --sampling_method 'quantile' --no_of_percentiles 12 \
+      --rebadging --ecc_bounds_warning \
+      "$IMPROVER_ACC_TEST_DIR/percentiles-to-realizations/ecc_bounds_warning/multiple_percentiles_wind_cube_out_of_bounds.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Addresses #GitHubissuenum

Although an ECC bounds exceedance warning option had previously been added for probability data, this had not been implemented for percentile data. 

- Added ECC bounds warning handling to `ensemble-copula-coupling` using a similar method to that used for probabilities. This includes extending the bounds to encompass the exceeded values when the warning option is specified. 

- If the warning option is not specified then an exception will be raised when values exceed ECC bounds.

- Added new unit tests to check that the correct warning is raised and that the new bounds are correctly set.

- Added `--ecc_bounds_warning` option to the `percentiles-to-realizations` CLI. Default option is not to apply the warning functionality.

- Update existing CLI tests to take account of the new option. Add an additional CLI bats test to check the functionality of the ECC bounds warning option.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)