### PR TITLE
Allow PercentileConverter plugin to work for time coordinate

### DIFF
--- a/lib/improver/percentile.py
+++ b/lib/improver/percentile.py
@@ -116,7 +116,7 @@ class PercentileConverter(object):
         data_type = cube.dtype
         # Test that collapse coords are present in cube before proceding.
         n_collapse_coords = len(self.collapse_coord)
-        n_valid_coords = sum([test_coord in coord.name()
+        n_valid_coords = sum([test_coord == coord.name()
                               for coord in cube.coords()
                               for test_coord in self.collapse_coord])
 


### PR DESCRIPTION
Related to #69, #109  

Description
The main aim of this PR is the one line correction in `percentile.py`. I accidentally came across this bug, for the case where you're trying to calculate percentiles over the time coordinate. In the current code, using the `time` coordinate will also result in the `forecast_reference_time` coordinate being matched. This results in `n_collapse_coords` not being able to equal `n_valid_coords`, so I've fixed this. Subsequently, a unit test has been added, that would be previously failed, and other unit tests have been updated to use the `set_up_variable_cube` helper function.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

