### PR TITLE
Update CubeCombiner unit tests to use integer seconds and fix bug

### DIFF
--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -136,9 +136,8 @@ class CubeCombiner(object):
             result_coord.bounds = result_coord.bounds.astype(np.float32)
 
         if point == 'mid':
-            if 'seconds' in str(result_coord.units):
-                # integer division of seconds required to retain floating
-                # point precision
+            if 'seconds since' in str(result_coord.units):
+                # integer division of seconds required to retain precision
                 result_coord.points = [
                     (new_top_bound - new_low_bound) // 2 + new_low_bound]
             else:

--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -105,7 +105,8 @@ class CubeCombiner(object):
                 Cube with coord expanded.
 
                 n.b. If argument point == 'mid' then python will convert
-                result.coord('coord').points[0] to a float.
+                result.coord('coord').points[0] to a float UNLESS the coord
+                units contain 'seconds'.
 
                 This is to ensure that midpoints are not accidentally
                 rounded down by Python's default integer divide behavour:
@@ -136,10 +137,13 @@ class CubeCombiner(object):
             result_coord.bounds = result_coord.bounds.astype(np.float32)
 
         if point == 'mid':
-            if 'seconds since' in str(result_coord.units):
+            if 'seconds' in str(result_coord.units):
                 # integer division of seconds required to retain precision
+                dtype_orig = result_coord.dtype
                 result_coord.points = [
                     (new_top_bound - new_low_bound) // 2 + new_low_bound]
+                # re-cast to original precision to avoid escalating int32s
+                result_coord.points = result_coord.points.astype(dtype_orig)
             else:
                 # float division of hours required for accuracy
                 result_coord.points = [

--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -106,13 +106,8 @@ class CubeCombiner(object):
 
                 n.b. If argument point == 'mid' then python will convert
                 result.coord('coord').points[0] to a float UNLESS the coord
-                units contain 'seconds'.
-
-                This is to ensure that midpoints are not accidentally
-                rounded down by Python's default integer divide behavour:
-                For example if you combined cubes for accumulation for three
-                hours the midpoint should be 1.5 hours into the period.
-                Integer behaviour would give 3 / 2 = 1
+                units contain 'seconds'.  This is to ensure that midpoints are
+                not rounded down, for example when times are in hours.
         """
         if len(result_cube.coord(coord).points) != 1:
             emsg = ('the expand bounds function should only be used on a'

--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -136,8 +136,15 @@ class CubeCombiner(object):
             result_coord.bounds = result_coord.bounds.astype(np.float32)
 
         if point == 'mid':
-            result_coord.points = [((new_top_bound - new_low_bound) / 2.) +
-                                   new_low_bound]
+            if 'seconds' in str(result_coord.units):
+                # integer division of seconds required to retain floating
+                # point precision
+                result_coord.points = [
+                    (new_top_bound - new_low_bound) // 2 + new_low_bound]
+            else:
+                # float division of hours required for accuracy
+                result_coord.points = [
+                    (new_top_bound - new_low_bound) / 2. + new_low_bound]
         elif point == 'upper':
             result_coord.points = [new_top_bound]
 

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -145,6 +145,7 @@ class Test_expand_bounds(IrisTest):
         result = CubeCombiner.expand_bounds(
             self.cubelist[0], self.cubelist, 'time', 'mid')
         self.assertEqual(result.coord('time'), expected_result)
+        self.assertEqual(result.coord('time').dtype, np.float32)
 
     def test_basic_time_upper(self):
         """Test that expand_bound produces sensible bounds

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -118,6 +118,19 @@ class Test_expand_bounds(IrisTest):
         result = CubeCombiner.expand_bounds(
             self.cubelist[0], self.cubelist, 'time', 'mid')
         self.assertEqual(result.coord('time'), expected_result)
+        self.assertEqual(result.coord('time').dtype, np.int64)
+
+    def test_time_mid_data_precision(self):
+        """Test that expand_bound does not escalate precision when input is
+        of dtype int32"""
+        expected_result = iris.coords.DimCoord(
+            np.array([5400], dtype=np.int32),
+            bounds=np.array([0, 10800], dtype=np.int32),
+            standard_name='forecast_period', units='seconds')
+        result = CubeCombiner.expand_bounds(
+            self.cubelist[0], self.cubelist, 'forecast_period', 'mid')
+        self.assertEqual(result.coord('forecast_period'), expected_result)
+        self.assertEqual(result.coord('forecast_period').dtype, np.int32)
 
     def test_float_time_mid(self):
         """Test that expand_bound produces sensible bounds

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -32,7 +32,7 @@
 import unittest
 
 import numpy as np
-from cf_units import Unit, date2num
+from cf_units import date2num
 from datetime import datetime as dt
 
 import iris
@@ -152,8 +152,7 @@ class Test_expand_bounds(IrisTest):
         time_point = np.around(date2num(dt(2015, 11, 19, 3), TIME_UNIT,
                                         CALENDAR)).astype(np.int64)
         expected_result = iris.coords.DimCoord(
-            [date2num(dt(2015, 11, 19, 3), TIME_UNIT, CALENDAR)],
-            bounds=self.expected_bounds_seconds,
+            [time_point], bounds=self.expected_bounds_seconds,
             standard_name='time', units=TIME_UNIT)
         result = CubeCombiner.expand_bounds(
             self.cubelist[0], self.cubelist, 'time', 'upper')

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -115,7 +115,8 @@ def construct_scalar_time_coords(time, time_bounds, frt):
 
     if time_point_seconds < frt_point_seconds:
         raise ValueError('Cannot set up cube with negative forecast period')
-    fp_point_seconds = np.int32(time_point_seconds - frt_point_seconds)
+    fp_point_seconds = (
+        time_point_seconds - frt_point_seconds).astype(np.int32)
 
     # parse bounds if required
     if time_bounds is not None:
@@ -129,8 +130,9 @@ def construct_scalar_time_coords(time, time_bounds, frt):
             raise ValueError(
                 'Time point {} not within bounds {}-{}'.format(
                     time, time_bounds[0], time_bounds[1]))
-        fp_bounds = (bounds[0] - frt_point_seconds,
-                     bounds[1] - frt_point_seconds)
+        fp_bounds = np.array([
+            [bounds[0] - frt_point_seconds,
+             bounds[1] - frt_point_seconds]]).astype(np.int32)
     else:
         bounds = None
         fp_bounds = None

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -115,7 +115,7 @@ def construct_scalar_time_coords(time, time_bounds, frt):
 
     if time_point_seconds < frt_point_seconds:
         raise ValueError('Cannot set up cube with negative forecast period')
-    fp_point_seconds = time_point_seconds - frt_point_seconds
+    fp_point_seconds = np.int32(time_point_seconds - frt_point_seconds)
 
     # parse bounds if required
     if time_bounds is not None:

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -85,7 +85,6 @@ class test_construct_scalar_time_coords(IrisTest):
 
         for crd in time_coords:
             self.assertIsInstance(crd, iris.coords.DimCoord)
-            self.assertEqual(crd.dtype, np.int64)
 
         self.assertEqual(time_coords[0].name(), "time")
         self.assertEqual(iris_time_to_datetime(time_coords[0])[0],
@@ -97,9 +96,11 @@ class test_construct_scalar_time_coords(IrisTest):
         self.assertEqual(time_coords[2].points[0], 3600*5)
 
         for crd in time_coords[:2]:
+            self.assertEqual(crd.dtype, np.int64)
             self.assertEqual(
                 crd.units, "seconds since 1970-01-01 00:00:00")
         self.assertEqual(time_coords[2].units, "seconds")
+        self.assertEqual(time_coords[2].dtype, np.int32)
 
     def test_error_negative_fp(self):
         """Test an error is raised if the calculated forecast period is
@@ -172,9 +173,9 @@ class test_set_up_variable_cube(IrisTest):
         self.assertEqual(result.coord_dims("longitude"), (1,))
 
         # check scalar time coordinates
-        for time_coord in ["time", "forecast_reference_time",
-                           "forecast_period"]:
+        for time_coord in ["time", "forecast_reference_time"]:
             self.assertEqual(result.coord(time_coord).dtype, np.int64)
+        self.assertEqual(result.coord("forecast_period").dtype, np.int32)
 
         expected_time = datetime(2017, 11, 10, 4, 0)
         time_point = iris_time_to_datetime(result.coord("time"))[0]


### PR DESCRIPTION
Addresses #792 .  In working on #782 , found CubeCombiner cannot generate accurate time points when given int64 seconds.  This PR fixes the underlying bug where datatypes were being escalated in CubeCombiner.expand_bounds, and updates CubeCombiner unit tests to use the centralised cube setup utilities (apart from those served by create_cube_with_threshold() which is dealt with in a separate PR).
