### PR TITLE
IMPRO-881: Change to make doc-strings and CLI document additional functionality.

### DIFF
--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -96,11 +96,13 @@ def main():
     meta_group = parser.add_argument_group("Metadata")
     meta_group.add_argument(
         "--grid_metadata_identifier", default="mosg__grid",
-        help="A string to identify attributes from the input netCDF files that"
-        " should be compared to ensure that the data is compatible. Spot"
-        " data works using grid indices, so it is important that the grids"
-        " are matching or the data extracted may not match the location of the"
-        " spot data sites. The default is 'mosg__grid'.")
+        help="A string (or None) to identify attributes from the input netCDF"
+        " files that should be compared to ensure that the data is compatible."
+        " Spot data works using grid indices, so it is important that the"
+        " grids are matching or the data extracted may not match the location"
+        " of the spot data sites. The default is 'mosg__grid'. If set to None"
+        " no check is made; this can be used if the cubes are known to be"
+        " appropriate but lack relevant metadata.")
 
     meta_group.add_argument(
         "--json_file", metavar="JSON_FILE", default=None,

--- a/lib/improver/spotdata/spot_extraction.py
+++ b/lib/improver/spotdata/spot_extraction.py
@@ -55,10 +55,12 @@ class SpotExtraction():
                 coordinates that match a spot site. These are determined by
                 the neighbour finding method employed. This keyword is used to
                 extract the desired set of coordinates from the neighbour cube.
-            grid_metadata_identifier (str):
+            grid_metadata_identifier (str or None):
                 A string to search for in the input cube attributes that
                 can be used to ensure that the neighbour cube being used has
-                been created for the model/grid of the diagnostic cube.
+                been created for the model/grid of the diagnostic cube. If set
+                to None, no such check is made and the cubes are assumed to be
+                suitable for use with one another.
         """
         self.neighbour_selection_method = neighbour_selection_method
         self.grid_metadata_identifier = grid_metadata_identifier
@@ -217,9 +219,11 @@ def check_grid_match(grid_metadata_identifier, cubes):
     identified should match for the cubes to be deemed compatible.
 
     Args:
-        grid_metadata_identifier (str):
+        grid_metadata_identifier (str or None):
             A partial or complete attribute name. Attributes matching this are
-            compared between the two cubes.
+            compared between the two cubes. If set to None, no such check is
+            made and the cubes are assumed to be suitable for use with one
+            another.
         cubes (list of iris.cube.Cube items):
             List of cubes for which the attributes should be tested.
     Raises:

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -88,12 +88,15 @@ Temperature lapse rate adjustment:
 
 Metadata:
   --grid_metadata_identifier GRID_METADATA_IDENTIFIER
-                        A string to identify attributes from the input netCDF
-                        files that should be compared to ensure that the data
-                        is compatible. Spot data works using grid indices, so
-                        it is important that the grids are matching or the
-                        data extracted may not match the location of the spot
-                        data sites. The default is 'mosg__grid'.
+                        A string (or None) to identify attributes from the
+                        input netCDF files that should be compared to ensure
+                        that the data is compatible. Spot data works using
+                        grid indices, so it is important that the grids are
+                        matching or the data extracted may not match the
+                        location of the spot data sites. The default is
+                        'mosg__grid'. If set to None no check is made; this
+                        can be used if the cubes are known to be appropriate
+                        but lack relevant metadata.
   --json_file JSON_FILE
                         If provided, this JSON file can be used to modify the
                         metadata of the returned netCDF file. Defaults to


### PR DESCRIPTION
Making clear that the grid_metadata_identifier can be set to None to avoid making any metadata comparisons.

Changes to doc-strings in code and CLI help.

Testing:
 - [x] Ran tests and they passed OK