### PR TITLE
Allow sphinx-build to be supplied via site-init

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -111,7 +111,7 @@ function improver_test_pylintE {
 function improver_test_doc {
     # Build documentation as test.
     cd $IMPROVER_DIR/doc
-    make html 1>/dev/null
+    make SPHINXBUILD=${SPHINXBUILD:-sphinx-build} html 1>/dev/null
     echo_ok "sphinx-build -b html"
     cd -
 }


### PR DESCRIPTION
This allows `sphinx-build` to be configured in the site-init, for situations where the normally desired Python deployment doesn't have it.