### PR TITLE
Impro1059 ecc thresholds

### DIFF
--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -67,13 +67,14 @@ def main():
     parser.add_argument("--threshold_config", metavar="THRESHOLD_CONFIG",
                         type=str,
                         help="Threshold configuration JSON file containing "
-                        "thresholds and fuzzy bounds. Best used in "
-                        "combination  with --threshold_units. "
+                        "thresholds and (optionally) fuzzy bounds. Best used "
+                        "in combination  with --threshold_units. "
                         "It should contain a dictionary of strings that can "
                         "be interpreted as floats with the structure: "
                         " \"THRESHOLD_VALUE\": [LOWER_BOUND, UPPER_BOUND] "
                         "e.g: {\"280.0\": [278.0, 282.0], "
-                        "\"290.0\": [288.0, 292.0]}. "
+                        "\"290.0\": [288.0, 292.0]}, or with structure "
+                        " \"THRESHOLD_VALUE\": \"None\" (no fuzzy bounds). "
                         "Repeated thresholds with different bounds are not "
                         "handled well. Only the last duplicate will be used.")
     parser.add_argument("--threshold_units", metavar="THRESHOLD_UNITS",
@@ -128,9 +129,15 @@ def main():
                 thresholds_from_file = json.load(input_file)
             thresholds = []
             fuzzy_bounds = []
+            is_fuzzy = True
             for key in thresholds_from_file.keys():
                 thresholds.append(float(key))
-                fuzzy_bounds.append(tuple(thresholds_from_file[key]))
+                if is_fuzzy:
+                    if thresholds_from_file[key] == "None":
+                        is_fuzzy = False
+                        fuzzy_bounds = None
+                    else:
+                        fuzzy_bounds.append(tuple(thresholds_from_file[key]))
         except ValueError as err:
             # Extend error message with hint for common JSON error.
             raise type(err)(err + " in JSON file {}. \nHINT: Try "

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -133,6 +133,8 @@ def main():
             for key in thresholds_from_file.keys():
                 thresholds.append(float(key))
                 if is_fuzzy:
+                    # If the first threshold has no bounds, fuzzy_bounds is
+                    # set to None and subsequent bounds checks are skipped
                     if thresholds_from_file[key] == "None":
                         is_fuzzy = False
                         fuzzy_bounds = None

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -51,9 +51,9 @@ Bounds = namedtuple("bounds", "value units")
 
 BOUNDS_FOR_ECDF = {
     "air_temperature": (
-        Bounds((-140-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
+        Bounds((-100-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "feels_like_temperature": (
-        Bounds((-140-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
+        Bounds((-100-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "wind_speed": Bounds((0, 50), "m s^-1"),
     "wind_speed_of_gust": Bounds((0, 200), "m s^-1"),
     "air_pressure_at_sea_level": Bounds((86000, 108000), "Pa"),
@@ -74,8 +74,8 @@ BOUNDS_FOR_ECDF = {
     "lwe_snowfall_rate_in_vicinity": Bounds((0, 0.00001), "m s-1"),
     "visibility_in_air": Bounds((0, 100000), "m"),
     "temperature_at_screen_level_nighttime_min": (
-        Bounds((-90-ABSOLUTE_ZERO, 50-ABSOLUTE_ZERO), "Kelvin")),
+        Bounds((-100-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "temperature_at_screen_level_daytime_max": (
-        Bounds((-60-ABSOLUTE_ZERO, 65-ABSOLUTE_ZERO), "Kelvin")),
+        Bounds((-100-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),
     "ultraviolet_index": Bounds((0, 25.0), "1")
 }

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling_constants.py
@@ -41,13 +41,12 @@ Bounds = namedtuple("bounds", "value units")
 # the following dictionary specifies the end points of the distribution,
 # as a first approximation of likely climatological lower and upper bounds.
 # The units for the end points of the distribution are specified for each
-# phenomenon. SI units are used exclusively.
+# phenomenon. SI units are used throughout with the exception of precipitation
+# rates, where mm/h provides more human-readable values.
 # Scientific Reference:
 # Flowerdew, J., 2014.
 # Calibrated ensemble reliability whilst preserving spatial structure.
 # Tellus Series A, Dynamic Meteorology and Oceanography, 66, 22662.
-
-# 0.00003 ms-1 ~ 100 mm hr-1 for rainfall. Divided by 3 as a guess for snow!
 
 BOUNDS_FOR_ECDF = {
     "air_temperature": (
@@ -63,15 +62,15 @@ BOUNDS_FOR_ECDF = {
     ("cloud_area_fraction_assuming_only_consider_surface_to_1000_" +
      "feet_asl"): Bounds((0, 1.0), "1"),
     "low_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
-    "precipitation_rate": Bounds((0, 0.00003), "m s-1"),
-    "rainfall_rate": Bounds((0, 0.00003), "m s-1"),
-    "rainfall_rate_in_vicinity": Bounds((0, 0.00003), "m s-1"),
+    "precipitation_rate": Bounds((0, 128.0), "mm h-1"),
+    "rainfall_rate": Bounds((0, 128.0), "mm h-1"),
+    "rainfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
     "relative_humidity": Bounds((0, 1.2), "1"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.2), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.2), "m"),
     "lwe_thickness_of_snowfall_amount": Bounds((0, 0.2), "m"),
-    "lwe_snowfall_rate": Bounds((0, 0.00001), "m s-1"),
-    "lwe_snowfall_rate_in_vicinity": Bounds((0, 0.00001), "m s-1"),
+    "lwe_snowfall_rate": Bounds((0, 128.0), "mm h-1"),
+    "lwe_snowfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
     "visibility_in_air": Bounds((0, 100000), "m"),
     "temperature_at_screen_level_nighttime_min": (
         Bounds((-100-ABSOLUTE_ZERO, 60-ABSOLUTE_ZERO), "Kelvin")),

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromProbabilities.py
@@ -145,6 +145,7 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
 
+    @ManageWarnings(ignored_messages=['The calculated threshold values'])
     def test_new_endpoints_generation(self):
         """Test that the plugin re-applies the threshold bounds using the
         maximum and minimum threshold points values when the original bounds
@@ -558,6 +559,19 @@ class Test_process(IrisTest):
             add_forecast_reference_time_and_forecast_period(
                 set_up_probability_above_threshold_temperature_cube()))
 
+        self.percentile_25 = np.array(
+            [[[24., 8.75, 11.],
+              [8.33333333, 8.75, -46.],
+              [-46., -66.25, -73.]]], dtype=np.float32)
+        self.percentile_50 = np.array(
+            [[[36., 10., 12.],
+              [10., 10., 8.],
+              [8., -32.5, -46.]]], dtype=np.float32)
+        self.percentile_75 = np.array(
+            [[[48., 11.66666667, 36.],
+              [11.66666667, 11., 10.5],
+              [9.66666667, 1.25, -19.]]], dtype=np.float32)
+
     @ManageWarnings(
         ignored_messages=["Only a single cube so no differences"])
     def test_check_data_specifying_no_of_percentiles(self):
@@ -565,22 +579,12 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific number of percentiles.
         """
-        data = np.array([[[[24., 8.75, 11.],
-                           [8.33333333, 8.75, -66.],
-                           [-66., -93.75, -103.]]],
-                         [[[36., 10., 12.],
-                           [10., 10., 8.],
-                           [8., -47.5, -66.]]],
-                         [[[48., 11.66666667, 36.],
-                           [11.66666667, 11., 10.5],
-                           [9.66666667, -1.25, -29.]]]])
-
+        expected_data = np.array(
+            [self.percentile_25, self.percentile_50, self.percentile_75])
         cube = self.current_temperature_forecast_cube
-        no_of_percentiles = 3
         plugin = Plugin()
-        result = plugin.process(
-            cube, no_of_percentiles=no_of_percentiles)
-        self.assertArrayAlmostEqual(result.data, data, decimal=5)
+        result = plugin.process(cube, no_of_percentiles=3)
+        self.assertArrayAlmostEqual(result.data, expected_data, decimal=5)
 
     @ManageWarnings(
         ignored_messages=["Only a single cube so no differences"])
@@ -590,16 +594,11 @@ class Test_process(IrisTest):
         data values for a specific percentile passes in as a single realization
         list.
         """
-        data = np.array([[[[24., 8.75, 11.],
-                           [8.33333333, 8.75, -66.],
-                           [-66., -93.75, -103.]]]])
-
+        expected_data = np.array([self.percentile_25])
         cube = self.current_temperature_forecast_cube
-        percentiles = [25]
         plugin = Plugin()
-        result = plugin.process(
-            cube, percentiles=percentiles)
-        self.assertArrayAlmostEqual(result.data, data, decimal=5)
+        result = plugin.process(cube, percentiles=[25])
+        self.assertArrayAlmostEqual(result.data, expected_data, decimal=5)
 
     @ManageWarnings(
         ignored_messages=["Only a single cube so no differences"])
@@ -608,16 +607,11 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific percentile passed in as a value.
         """
-        data = np.array([[[[24., 8.75, 11.],
-                           [8.33333333, 8.75, -66.],
-                           [-66., -93.75, -103.]]]])
-
+        expected_data = np.array([self.percentile_25])
         cube = self.current_temperature_forecast_cube
-        percentiles = 25
         plugin = Plugin()
-        result = plugin.process(
-            cube, percentiles=percentiles)
-        self.assertArrayAlmostEqual(result.data, data, decimal=5)
+        result = plugin.process(cube, percentiles=25)
+        self.assertArrayAlmostEqual(result.data, expected_data, decimal=5)
 
     @ManageWarnings(
         ignored_messages=["Only a single cube so no differences"])
@@ -626,22 +620,14 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values for a specific set of percentiles.
         """
-        data = np.array([[[[24., 8.75, 11.],
-                           [8.33333333, 8.75, -66.],
-                           [-66., -93.75, -103.]]],
-                         [[[36., 10., 12.],
-                           [10., 10., 8.],
-                           [8., -47.5, -66.]]],
-                         [[[48., 11.66666667, 36.],
-                           [11.66666667, 11., 10.5],
-                           [9.66666667, -1.25, -29.]]]])
-
+        expected_data = np.array(
+            [self.percentile_25, self.percentile_50, self.percentile_75])
         cube = self.current_temperature_forecast_cube
         percentiles = [25, 50, 75]
         plugin = Plugin()
         result = plugin.process(
             cube, percentiles=percentiles)
-        self.assertArrayAlmostEqual(result.data, data, decimal=5)
+        self.assertArrayAlmostEqual(result.data, expected_data, decimal=5)
 
     @ManageWarnings(
         ignored_messages=["Only a single cube so no differences"])
@@ -650,20 +636,12 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values without specifying the number of percentiles.
         """
-        data = np.array([[[[24., 8.75, 11.],
-                           [8.33333333, 8.75, -66.],
-                           [-66., -93.75, -103.]]],
-                         [[[36., 10., 12.],
-                           [10., 10., 8.],
-                           [8., -47.5, -66.]]],
-                         [[[48., 11.66666667, 36.],
-                           [11.66666667, 11., 10.5],
-                           [9.66666667, -1.25, -29.]]]])
-
+        expected_data = np.array(
+            [self.percentile_25, self.percentile_50, self.percentile_75])
         cube = self.current_temperature_forecast_cube
         plugin = Plugin()
         result = plugin.process(cube)
-        self.assertArrayAlmostEqual(result.data, data, decimal=5)
+        self.assertArrayAlmostEqual(result.data, expected_data, decimal=5)
 
     def test_check_data_over_specifying_percentiles(self):
         """

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ensemble_copula_coupling_utilities.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ensemble_copula_coupling_utilities.py
@@ -352,7 +352,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         """
         cube_name = "air_temperature"
         cube_units = Unit("degreesC")
-        bounds_pairing = (-140, 60)
+        bounds_pairing = (-100, 60)
         result = (
             get_bounds_of_distribution(cube_name, cube_units))
         self.assertArrayAlmostEqual(result, bounds_pairing)
@@ -365,7 +365,7 @@ class Test_get_bounds_of_distribution(IrisTest):
         """
         cube_name = "air_temperature"
         cube_units = Unit("fahrenheit")
-        bounds_pairing = (-220, 140)  # In fahrenheit
+        bounds_pairing = (-148, 140)  # In fahrenheit
         result = (
             get_bounds_of_distribution(cube_name, cube_units))
         self.assertArrayAlmostEqual(result, bounds_pairing)

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -61,14 +61,15 @@ optional arguments:
                         Dump profiling info to a file. Implies --profile.
   --threshold_config THRESHOLD_CONFIG
                         Threshold configuration JSON file containing
-                        thresholds and fuzzy bounds. Best used in combination
-                        with --threshold_units. It should contain a dictionary
-                        of strings that can be interpreted as floats with the
-                        structure: "THRESHOLD_VALUE": [LOWER_BOUND,
-                        UPPER_BOUND] e.g: {"280.0": [278.0, 282.0], "290.0":
-                        [288.0, 292.0]}. Repeated thresholds with different
-                        bounds are not handled well. Only the last duplicate
-                        will be used.
+                        thresholds and (optionally) fuzzy bounds. Best used in
+                        combination with --threshold_units. It should contain
+                        a dictionary of strings that can be interpreted as
+                        floats with the structure: "THRESHOLD_VALUE":
+                        [LOWER_BOUND, UPPER_BOUND] e.g: {"280.0": [278.0,
+                        282.0], "290.0": [288.0, 292.0]}, or with structure
+                        "THRESHOLD_VALUE": "None" (no fuzzy bounds). Repeated
+                        thresholds with different bounds are not handled well.
+                        Only the last duplicate will be used.
   --threshold_units THRESHOLD_UNITS
                         Units of the threshold values. If not provided the
                         units are assumed to be the same as those of the input

--- a/tests/improver-threshold/13-threshold_json.bats
+++ b/tests/improver-threshold/13-threshold_json.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "threshold input output json" {
+  improver_check_skip_acceptance
+  KGO="threshold/basic/kgo.nc"
+
+  # Run threshold processing and check it passes.
+  run improver threshold \
+      "$IMPROVER_ACC_TEST_DIR/threshold/basic/input.nc" "$TEST_DIR/output.nc" \
+      --threshold_config $IMPROVER_ACC_TEST_DIR/threshold/json/threshold_config.json
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Changed ECC bounds for all temperature diagnostics to be the same (-100C to 60C).  Updated threshold CLI to read a json file with no bounds (so that we don't have to repeat the same list of 50 thresholds in multiple calls).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
