### PR TITLE
IMPRO-1082: Global domain checking to allow circular coordinates

### DIFF
--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -456,9 +456,11 @@ class NeighbourSelection(object):
 
         # Exclude any sites falling outside the domain given by the cube and
         # notify the user.
-        sites, site_coords, site_x_coords, site_y_coords = (
-            self.check_sites_are_within_domain(
-                sites, site_coords, site_x_coords, site_y_coords, orography))
+        if not self.geodetic_coordinate_system:
+            sites, site_coords, site_x_coords, site_y_coords = (
+                self.check_sites_are_within_domain(
+                    sites, site_coords, site_x_coords, site_y_coords,
+                    orography))
 
         # Find nearest neighbour point using quick iris method.
         nearest_indices = self.get_nearest_indices(site_coords, orography)

--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -107,9 +107,7 @@ class NeighbourSelection(object):
         self.site_altitude = 'altitude'
         self.grid_metadata_identifier = grid_metadata_identifier
         self.node_limit = node_limit
-        # This is a global flag that will be set to True if the input cubes are
-        # geodetic, which here means they are global grids.
-        self.geodetic_coordinate_system = False
+        self.global_coordinate_system = False
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -168,7 +166,7 @@ class NeighbourSelection(object):
 
     @staticmethod
     def check_sites_are_within_domain(sites, site_coords, site_x_coords,
-                                      site_y_coords, cube):
+                                      site_y_coords, cube, global_grid=False):
         """
         A function to remove sites from consideration if they fall outside the
         domain of the provided model cube. A warning is raised and the details
@@ -194,6 +192,10 @@ class NeighbourSelection(object):
             cube (iris.cube.Cube):
                 A cube that is representative of the model/grid from which spot
                 data will be extracted.
+            global_grid (bool):
+                If true the x-axis is circular, meaning only the y-axis needs
+                to be checked for outliers (points with latitudes outside of
+                -90 to +90).
         Returns:
            sites, site_coords, site_x_coords, site_y_coords (as above):
                The inputs modified to filter out the sites falling outside the
@@ -205,13 +207,20 @@ class NeighbourSelection(object):
         y_min = cube.coord(axis='y').bounds.min()
         y_max = cube.coord(axis='y').bounds.max()
 
-        domain_valid = np.where(
-            (site_coords[:, 0] >= x_min) & (site_coords[:, 0] <= x_max) &
-            (site_coords[:, 1] >= y_min) & (site_coords[:, 1] <= y_max))
+        if global_grid:
+            domain_valid = np.where(
+                (site_coords[:, 1] >= y_min) & (site_coords[:, 1] <= y_max))
 
-        domain_invalid = np.where(
-            (site_coords[:, 0] < x_min) | (site_coords[:, 0] > x_max) |
-            (site_coords[:, 1] < y_min) | (site_coords[:, 1] > y_max))
+            domain_invalid = np.where(
+                (site_coords[:, 1] < y_min) | (site_coords[:, 1] > y_max))
+        else:
+            domain_valid = np.where(
+                (site_coords[:, 0] >= x_min) & (site_coords[:, 0] <= x_max) &
+                (site_coords[:, 1] >= y_min) & (site_coords[:, 1] <= y_max))
+
+            domain_invalid = np.where(
+                (site_coords[:, 0] < x_min) | (site_coords[:, 0] > x_max) |
+                (site_coords[:, 1] < y_min) | (site_coords[:, 1] > y_max))
 
         num_invalid = len(domain_invalid[0])
         if num_invalid > 0:
@@ -256,7 +265,7 @@ class NeighbourSelection(object):
     @staticmethod
     def geocentric_cartesian(cube, x_coords, y_coords):
         """
-        A function to convert a geodetic (lat/lon) coordinate system into a
+        A function to convert a global (lat/lon) coordinate system into a
         geocentric (3D trignonometric) system. This function ignores orographic
         height differences between coordinates, giving a 2D projected
         neighbourhood akin to selecting a neighbourhood of grid points about a
@@ -316,7 +325,7 @@ class NeighbourSelection(object):
         x_coords = land_mask.coord(axis='x').points[x_indices]
         y_coords = land_mask.coord(axis='y').points[y_indices]
 
-        if self.geodetic_coordinate_system:
+        if self.global_coordinate_system:
             nodes = self.geocentric_cartesian(land_mask, x_coords, y_coords)
         else:
             nodes = list(zip(x_coords, y_coords))
@@ -422,11 +431,10 @@ class NeighbourSelection(object):
         """
         index_nodes = []
         # Check if we are dealing with a global grid.
-        self.geodetic_coordinate_system = (
-            orography.coord_system().as_cartopy_crs().is_geodetic())
+        self.global_coordinate_system = orography.coord(axis='x').circular
 
         # Exclude regional grids with spatial dimensions other than metres.
-        if not self.geodetic_coordinate_system:
+        if not self.global_coordinate_system:
             if not orography.coord(axis='x').units == 'metres':
                 msg = ('Cube spatial coordinates for regional grids must be'
                        'in metres to match the defined search_radius.')
@@ -456,11 +464,10 @@ class NeighbourSelection(object):
 
         # Exclude any sites falling outside the domain given by the cube and
         # notify the user.
-        if not self.geodetic_coordinate_system:
-            sites, site_coords, site_x_coords, site_y_coords = (
-                self.check_sites_are_within_domain(
-                    sites, site_coords, site_x_coords, site_y_coords,
-                    orography))
+        sites, site_coords, site_x_coords, site_y_coords = (
+            self.check_sites_are_within_domain(
+                sites, site_coords, site_x_coords, site_y_coords,
+                orography, global_grid=self.global_coordinate_system))
 
         # Find nearest neighbour point using quick iris method.
         nearest_indices = self.get_nearest_indices(site_coords, orography)
@@ -481,7 +488,7 @@ class NeighbourSelection(object):
             tree, index_nodes = self.build_KDTree(land_mask)
 
             # Site coordinates made cartesian for global coordinate system
-            if self.geodetic_coordinate_system:
+            if self.global_coordinate_system:
                 site_coords = self.geocentric_cartesian(
                     orography, site_coords[:, 0], site_coords[:, 1])
 

--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -41,7 +41,7 @@ from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 from improver.spotdata.build_spotdata_cube import build_spotdata_cube
 
 
-class NeighbourSelection(object):
+class NeighbourSelection:
     """
     For the selection of a grid point near an arbitrary coordinate, where the
     selection may be the nearest point, or a point that fulfils other

--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -164,9 +164,8 @@ class NeighbourSelection(object):
         return target_coordinate_system.transform_points(
             self.site_coordinate_system, x_points, y_points)[:, 0:2]
 
-    @staticmethod
-    def check_sites_are_within_domain(sites, site_coords, site_x_coords,
-                                      site_y_coords, cube, global_grid=False):
+    def check_sites_are_within_domain(self, sites, site_coords, site_x_coords,
+                                      site_y_coords, cube):
         """
         A function to remove sites from consideration if they fall outside the
         domain of the provided model cube. A warning is raised and the details
@@ -192,10 +191,6 @@ class NeighbourSelection(object):
             cube (iris.cube.Cube):
                 A cube that is representative of the model/grid from which spot
                 data will be extracted.
-            global_grid (bool):
-                If true the x-axis is circular, meaning only the y-axis needs
-                to be checked for outliers (points with latitudes outside of
-                -90 to +90).
         Returns:
            sites, site_coords, site_x_coords, site_y_coords (as above):
                The inputs modified to filter out the sites falling outside the
@@ -207,7 +202,7 @@ class NeighbourSelection(object):
         y_min = cube.coord(axis='y').bounds.min()
         y_max = cube.coord(axis='y').bounds.max()
 
-        if global_grid:
+        if self.global_coordinate_system:
             domain_valid = np.where(
                 (site_coords[:, 1] >= y_min) & (site_coords[:, 1] <= y_max))
 
@@ -467,7 +462,7 @@ class NeighbourSelection(object):
         sites, site_coords, site_x_coords, site_y_coords = (
             self.check_sites_are_within_domain(
                 sites, site_coords, site_x_coords, site_y_coords,
-                orography, global_grid=self.global_coordinate_system))
+                orography))
 
         # Find nearest neighbour point using quick iris method.
         nearest_indices = self.get_nearest_indices(site_coords, orography)

--- a/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
@@ -342,8 +342,7 @@ class Test_check_sites_are_within_domain(Test_NeighbourSelection):
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
 
-    @ManageWarnings(record=True)
-    def test_global_circular_valid(self, warning_list=None):
+    def test_global_circular_valid(self):
         """Test case with a site defined using a longitide exceeding 180
         degrees (e.g. with longitudes that run 0 to 360) is still included
         as the circular x-coordinate means it will still be used correctly."""

--- a/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
@@ -325,10 +325,12 @@ class Test_check_sites_are_within_domain(Test_NeighbourSelection):
             [site['latitude'] for site in sites])
         site_coords = np.stack((x_points, y_points), axis=1)
 
+        plugin.global_coordinate_system = True
+
         sites_out, site_coords_out, out_x, out_y = (
             plugin.check_sites_are_within_domain(
                 sites, site_coords, x_points, y_points,
-                self.global_orography, global_grid=True))
+                self.global_orography))
 
         self.assertArrayEqual(sites_out, sites[0:2])
         self.assertArrayEqual(site_coords_out[0:2], site_coords[0:2])
@@ -357,10 +359,12 @@ class Test_check_sites_are_within_domain(Test_NeighbourSelection):
             [site['latitude'] for site in sites])
         site_coords = np.stack((x_points, y_points), axis=1)
 
+        plugin.global_coordinate_system = True
+
         sites_out, site_coords_out, out_x, out_y = (
             plugin.check_sites_are_within_domain(
                 sites, site_coords, x_points, y_points,
-                self.global_orography, global_grid=True))
+                self.global_orography))
 
         self.assertArrayEqual(sites_out, sites)
         self.assertArrayEqual(site_coords_out, site_coords)

--- a/tests/improver-neighbour-finding/15-invalid-global-site.bats
+++ b/tests/improver-neighbour-finding/15-invalid-global-site.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding with invalid global site" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_global_invalid_site_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites_invalid.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+UserWarning: 1 spot sites fall outside the grid domain and will not be processed. These sites are:
+{'altitude': 0.0, 'latitude': 125.0, 'longitude': 0.0}
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-neighbour-finding/16-circular-coord-beyond-bounds.bats
+++ b/tests/improver-neighbour-finding/16-circular-coord-beyond-bounds.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding with site longitudes up to 360 degrees" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_global_kgo.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_sites_360.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/global_landmask.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo. In this case we are excluding the
+  # longitude coordinate from comparison as we know that will differ, but the
+  # data at any given point should be identical. As such we can compare against
+  # the KGO for the test using sites with longitudes -180 to 180.
+  nccmp -dmNsg -x longitude "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
This PR addresses an issue of longitudes defined variously 0 to 360 degrees of -180 to 180 degrees and their interoperability. No longer will sites on a circular longitude coordinate by removed by the bounds checking code because they do no fall into the correct longitudinal bracket, instead they will persist. The spot data code is already able to handle this, it was just the check getting in the way. Domain checking still works for the non-circular latitudinal coordinate.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
