### PR TITLE
IMPRO-1066: 50th percentile extract in the spot-extract CLI

### DIFF
--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -33,6 +33,7 @@
 
 import json
 import warnings
+import numpy as np
 
 import iris
 from iris.exceptions import CoordinateNotFoundError
@@ -40,6 +41,7 @@ from iris.exceptions import CoordinateNotFoundError
 from improver.argparser import ArgParser
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import \
     GeneratePercentilesFromProbabilities
+from improver.percentile import PercentileConverter
 from improver.spotdata.apply_lapse_rate import SpotLapseRateAdjust
 from improver.spotdata.spot_extraction import SpotExtraction
 from improver.spotdata.neighbour_finding import NeighbourSelection
@@ -91,7 +93,9 @@ def main():
     percentile_group = parser.add_argument_group(
         title="Extract percentiles",
         description="Extract particular percentiles from probabilistic "
-        "data.")
+        "or realization inputs. If deterministic input is provided a warning "
+        "is raised and all leading dimensions are included in the returned "
+        "spot-data cube.")
     percentile_group.add_argument(
         "--extract_percentile", default=None, nargs='+', type=int,
         help="If set to a percentile value or a list of percentile values, "
@@ -162,6 +166,18 @@ def main():
                     ecc_bounds_warning=args.ecc_bounds_warning).process(
                         result, percentiles=args.extract_percentile)
                 result = iris.util.squeeze(result)
+            elif result.coords('realization', dim_coords=True):
+                fast_percentile_method = (
+                    False if np.ma.isMaskedArray(result.data) else True)
+                result = PercentileConverter(
+                    'realization', percentiles=args.extract_percentile,
+                    fast_percentile_method=fast_percentile_method).process(
+                        result)
+                # This ensures the output for percentiles derived from
+                # realization input looks like that derived from other inputs.
+                result.coord('percentile_over_realization').rename(
+                    'percentile')
+                result.coord('percentile').units = '%'
             else:
                 msg = ('Diagnostic cube is not a known probabilistic type. '
                        'The {} percentile could not be extracted. Extracting '
@@ -171,10 +187,8 @@ def main():
                 if not args.suppress_warnings:
                     warnings.warn(msg)
         else:
-            print(args.extract_percentile)
             constraint = ['{}={}'.format(perc_coordinate.name(),
                                          args.extract_percentile)]
-            print(constraint)
             perc_result = extract_subcube(result, constraint)
             if perc_result is not None:
                 result = perc_result

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -35,6 +35,7 @@ import json
 import warnings
 import numpy as np
 
+import iris
 from iris.exceptions import CoordinateNotFoundError
 
 from improver.argparser import ArgParser
@@ -158,9 +159,10 @@ def main():
             perc_coordinate = find_percentile_coordinate(result)
         except CoordinateNotFoundError:
             if 'probability_of_' in result.name():
-                diagnostic_cube = GeneratePercentilesFromProbabilities(
+                result = GeneratePercentilesFromProbabilities(
                     ecc_bounds_warning=args.ecc_bounds_warning).process(
                     result, percentiles=args.extract_percentile)
+                result = iris.util.squeeze(result)
             else:
                 msg = ('Diagnostic cube is not a known probabilistic type. '
                        'The {} percentile could not be extracted. Extracting '

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -136,6 +136,15 @@ def main():
         "of the returned netCDF file. Defaults to None.")
 
     output_group = parser.add_argument_group("Suppress Verbose output")
+    # This CLI may be used to prepare data for verification without knowing the
+    # form of the input, be it deterministic, realizations or probabilistic.
+    # A warning is normally raised when attempting to extract a percentile from
+    # deterministic data as this is not possible; the spot-extraction of the
+    # entire cube is returned. When preparing data for verification we know
+    # that we will produce a large number of these warnings when passing in
+    # deterministic data. This option to suppress warnings is provided to
+    # reduce the amount of unneeded logging information that is written out.
+
     output_group.add_argument(
         "--suppress_warnings", default=False, action="store_true",
         help="Suppress warning output. This option should only be used if "

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -38,10 +38,14 @@ import numpy as np
 from iris.exceptions import CoordinateNotFoundError
 
 from improver.argparser import ArgParser
+from improver.ensemble_copula_coupling.ensemble_copula_coupling import \
+    GeneratePercentilesFromProbabilities
 from improver.spotdata.apply_lapse_rate import SpotLapseRateAdjust
 from improver.spotdata.spot_extraction import SpotExtraction
 from improver.spotdata.neighbour_finding import NeighbourSelection
 from improver.utilities.cube_metadata import amend_metadata
+from improver.utilities.cube_checker import find_percentile_coordinate
+from improver.utilities.cube_extraction import extract_subcube
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
@@ -84,6 +88,22 @@ def main():
         " in altitude to the spot site within the search radius defined when"
         " the neighbour cube was created. May be used with land_constraint.")
 
+    percentile_group = parser.add_argument_group(
+        title="Extract a percentile",
+        description = "Extract a particular percentile from probabilistic "
+        "data.")
+    percentile_group.add_argument(
+        "--extract_percentile", default=None,
+        help="If set to a percentile value, data corresponding to that "
+        "percentile will be returned. For example setting "
+        "'--extract_percentile 50' will result in the 50th percentile "
+        "(median) values being returned from a cube of probabilities or "
+        "percentiles.")
+    parser.add_argument(
+        "--ecc_bounds_warning", default=False, action="store_true",
+        help="If True, where calculated percentiles are outside the ECC "
+        "bounds range, raise a warning rather than an exception.")
+
     lapse_group = parser.add_argument_group(
         "Temperature lapse rate adjustment")
     lapse_group.add_argument(
@@ -109,6 +129,13 @@ def main():
         help="If provided, this JSON file can be used to modify the metadata "
         "of the returned netCDF file. Defaults to None.")
 
+    output_group = parser.add_argument_group("Suppress Verbose output")
+    meta_group.add_argument(
+        "--quiet_mode", default=False, action="store_true",
+        help="Suppress warning output. This option should only be used if "
+        "it is known that warnings will be generated but they are not "
+        "required.")
+
     args = parser.parse_args()
     neighbour_cube = load_cube(args.neighbour_filepath)
     diagnostic_cube = load_cube(args.diagnostic_filepath)
@@ -116,6 +143,37 @@ def main():
     neighbour_selection_method = NeighbourSelection(
         land_constraint=args.land_constraint,
         minimum_dz=args.minimum_dz).neighbour_finding_method_name()
+
+    # If a probability or percentile diagnostic cube is provided, extract
+    # the given percentile if available.
+    if args.extract_percentile:
+        try:
+            perc_coordinate = find_percentile_coordinate(diagnostic_cube)
+        except CoordinateNotFoundError:
+            if 'probability_of_' in diagnostic_cube.name():
+                diagnostic_cube = GeneratePercentilesFromProbabilities(
+                    ecc_bounds_warning=args.ecc_bounds_warning).process(
+                    diagnostic_cube, percentiles=args.extract_percentile)
+            else:
+                msg = ('Diagnostic cube is not a known probabilistic type. '
+                       'The {} percentile could not be extracted. Extracting '
+                       'data from the cube including any leading '
+                       'dimensions.'.format(
+                        args.extract_percentile))
+                if not args.quiet_mode:
+                    warnings.warn(msg)
+        else:
+            constraint = ['{}={}'.format(perc_coordinate.name(),
+                                       args.extract_percentile)]
+            result = extract_subcube(diagnostic_cube, constraint)
+            if result is not None:
+                diagnostic_cube = result
+            else:
+                msg = ('The percentile diagnostic cube does not contain the '
+                       'requested percentile value. Requested {}, available '
+                       '{}'.format(args.extract_percentile,
+                                   perc_coordinate.points))
+                raise ValueError(msg)
 
     plugin = SpotExtraction(
         neighbour_selection_method=neighbour_selection_method,
@@ -150,12 +208,14 @@ def main():
                    "the temperature data does not match that of the data used "
                    "to calculate the lapse rates. As such the temperatures "
                    "were not adjusted with the lapse rates.")
-            warnings.warn(msg)
+            if not args.quiet_mode:
+                warnings.warn(msg)
     elif args.temperature_lapse_rate_filepath:
         msg = ("A lapse rate cube was provided, but the diagnostic being "
                "processed is not air temperature. The lapse rate cube was "
                "not used.")
-        warnings.warn(msg)
+        if not args.quiet_mode:
+            warnings.warn(msg)
 
     # Modify final metadata as described by provided JSON file.
     if args.json_file:

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -33,7 +33,6 @@
 
 import json
 import warnings
-import numpy as np
 
 import iris
 from iris.exceptions import CoordinateNotFoundError
@@ -91,7 +90,7 @@ def main():
 
     percentile_group = parser.add_argument_group(
         title="Extract a percentile",
-        description = "Extract a particular percentile from probabilistic "
+        description="Extract a particular percentile from probabilistic "
         "data.")
     percentile_group.add_argument(
         "--extract_percentile", default=None,
@@ -131,7 +130,7 @@ def main():
         "of the returned netCDF file. Defaults to None.")
 
     output_group = parser.add_argument_group("Suppress Verbose output")
-    meta_group.add_argument(
+    output_group.add_argument(
         "--quiet_mode", default=False, action="store_true",
         help="Suppress warning output. This option should only be used if "
         "it is known that warnings will be generated but they are not "
@@ -161,14 +160,14 @@ def main():
             if 'probability_of_' in result.name():
                 result = GeneratePercentilesFromProbabilities(
                     ecc_bounds_warning=args.ecc_bounds_warning).process(
-                    result, percentiles=args.extract_percentile)
+                        result, percentiles=args.extract_percentile)
                 result = iris.util.squeeze(result)
             else:
                 msg = ('Diagnostic cube is not a known probabilistic type. '
                        'The {} percentile could not be extracted. Extracting '
                        'data from the cube including any leading '
                        'dimensions.'.format(
-                        args.extract_percentile))
+                           args.extract_percentile))
                 if not args.quiet_mode:
                     warnings.warn(msg)
         else:
@@ -192,7 +191,6 @@ def main():
         lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath)
         try:
             lapse_rate_height_coord = lapse_rate_cube.coord("height")
-            lapse_rate_height, = lapse_rate_height_coord.points
         except (ValueError, CoordinateNotFoundError):
             msg = ("Lapse rate cube does not contain a single valued height "
                    "coordinate. This is required to ensure it is applied to "

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -89,16 +89,16 @@ def main():
         " the neighbour cube was created. May be used with land_constraint.")
 
     percentile_group = parser.add_argument_group(
-        title="Extract a percentile",
-        description="Extract a particular percentile from probabilistic "
+        title="Extract percentiles",
+        description="Extract particular percentiles from probabilistic "
         "data.")
     percentile_group.add_argument(
-        "--extract_percentile", default=None,
-        help="If set to a percentile value, data corresponding to that "
-        "percentile will be returned. For example setting "
-        "'--extract_percentile 50' will result in the 50th percentile "
-        "(median) values being returned from a cube of probabilities or "
-        "percentiles.")
+        "--extract_percentile", default=None, nargs='+', type=int,
+        help="If set to a percentile value or a list of percentile values, "
+        "data corresponding to those percentiles will be returned. For "
+        "example setting '--extract_percentile 50' will result in the "
+        "50th percentile (median) values being returned from a cube of "
+        "probabilities or percentiles.")
     parser.add_argument(
         "--ecc_bounds_warning", default=False, action="store_true",
         help="If True, where calculated percentiles are outside the ECC "
@@ -171,8 +171,10 @@ def main():
                 if not args.suppress_warnings:
                     warnings.warn(msg)
         else:
+            print(args.extract_percentile)
             constraint = ['{}={}'.format(perc_coordinate.name(),
                                          args.extract_percentile)]
+            print(constraint)
             perc_result = extract_subcube(result, constraint)
             if perc_result is not None:
                 result = perc_result

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -131,7 +131,7 @@ def main():
 
     output_group = parser.add_argument_group("Suppress Verbose output")
     output_group.add_argument(
-        "--quiet_mode", default=False, action="store_true",
+        "--suppress_warnings", default=False, action="store_true",
         help="Suppress warning output. This option should only be used if "
         "it is known that warnings will be generated but they are not "
         "required.")
@@ -168,7 +168,7 @@ def main():
                        'data from the cube including any leading '
                        'dimensions.'.format(
                            args.extract_percentile))
-                if not args.quiet_mode:
+                if not args.suppress_warnings:
                     warnings.warn(msg)
         else:
             constraint = ['{}={}'.format(perc_coordinate.name(),
@@ -210,13 +210,13 @@ def main():
                    "the temperature data does not match that of the data used "
                    "to calculate the lapse rates. As such the temperatures "
                    "were not adjusted with the lapse rates.")
-            if not args.quiet_mode:
+            if not args.suppress_warnings:
                 warnings.warn(msg)
     elif args.temperature_lapse_rate_filepath:
         msg = ("A lapse rate cube was provided, but the diagnostic being "
                "processed is not air temperature. The lapse rate cube was "
                "not used.")
-        if not args.quiet_mode:
+        if not args.suppress_warnings:
             warnings.warn(msg)
 
     # Modify final metadata as described by provided JSON file.

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -92,17 +92,19 @@ def main():
 
     percentile_group = parser.add_argument_group(
         title="Extract percentiles",
-        description="Extract particular percentiles from probabilistic "
-        "or realization inputs. If deterministic input is provided a warning "
-        "is raised and all leading dimensions are included in the returned "
-        "spot-data cube.")
+        description="Extract particular percentiles from probabilistic, "
+        "percentile, or realization inputs. If deterministic input is "
+        "provided a warning is raised and all leading dimensions are included "
+        "in the returned spot-data cube.")
     percentile_group.add_argument(
-        "--extract_percentile", default=None, nargs='+', type=int,
+        "--extract_percentiles", default=None, nargs='+', type=int,
         help="If set to a percentile value or a list of percentile values, "
         "data corresponding to those percentiles will be returned. For "
-        "example setting '--extract_percentile 50' will result in the "
-        "50th percentile (median) values being returned from a cube of "
-        "probabilities or percentiles.")
+        "example setting '--extract_percentiles 25 50 75' will result in the "
+        "25th, 50th, and 75th percentiles being returned from a cube of "
+        "probabilities, percentiles, or realizations. Note that for "
+        "percentile inputs, the desired percentile(s) must exist in the input "
+        "cube.")
     parser.add_argument(
         "--ecc_bounds_warning", default=False, action="store_true",
         help="If True, where calculated percentiles are outside the ECC "
@@ -157,20 +159,20 @@ def main():
     # the given percentile if available. This is done after the spot-extraction
     # to minimise processing time; usually there are far fewer spot sites than
     # grid points.
-    if args.extract_percentile:
+    if args.extract_percentiles:
         try:
             perc_coordinate = find_percentile_coordinate(result)
         except CoordinateNotFoundError:
             if 'probability_of_' in result.name():
                 result = GeneratePercentilesFromProbabilities(
                     ecc_bounds_warning=args.ecc_bounds_warning).process(
-                        result, percentiles=args.extract_percentile)
+                        result, percentiles=args.extract_percentiles)
                 result = iris.util.squeeze(result)
             elif result.coords('realization', dim_coords=True):
                 fast_percentile_method = (
                     False if np.ma.isMaskedArray(result.data) else True)
                 result = PercentileConverter(
-                    'realization', percentiles=args.extract_percentile,
+                    'realization', percentiles=args.extract_percentiles,
                     fast_percentile_method=fast_percentile_method).process(
                         result)
                 # This ensures the output for percentiles derived from
@@ -183,19 +185,19 @@ def main():
                        'The {} percentile could not be extracted. Extracting '
                        'data from the cube including any leading '
                        'dimensions.'.format(
-                           args.extract_percentile))
+                           args.extract_percentiles))
                 if not args.suppress_warnings:
                     warnings.warn(msg)
         else:
             constraint = ['{}={}'.format(perc_coordinate.name(),
-                                         args.extract_percentile)]
+                                         args.extract_percentiles)]
             perc_result = extract_subcube(result, constraint)
             if perc_result is not None:
                 result = perc_result
             else:
                 msg = ('The percentile diagnostic cube does not contain the '
                        'requested percentile value. Requested {}, available '
-                       '{}'.format(args.extract_percentile,
+                       '{}'.format(args.extract_percentiles,
                                    perc_coordinate.points))
                 raise ValueError(msg)
 

--- a/bin/improver-spot-extract
+++ b/bin/improver-spot-extract
@@ -144,16 +144,23 @@ def main():
         land_constraint=args.land_constraint,
         minimum_dz=args.minimum_dz).neighbour_finding_method_name()
 
+    plugin = SpotExtraction(
+        neighbour_selection_method=neighbour_selection_method,
+        grid_metadata_identifier=args.grid_metadata_identifier)
+    result = plugin.process(neighbour_cube, diagnostic_cube)
+
     # If a probability or percentile diagnostic cube is provided, extract
-    # the given percentile if available.
+    # the given percentile if available. This is done after the spot-extraction
+    # to minimise processing time; usually there are far fewer spot sites than
+    # grid points.
     if args.extract_percentile:
         try:
-            perc_coordinate = find_percentile_coordinate(diagnostic_cube)
+            perc_coordinate = find_percentile_coordinate(result)
         except CoordinateNotFoundError:
-            if 'probability_of_' in diagnostic_cube.name():
+            if 'probability_of_' in result.name():
                 diagnostic_cube = GeneratePercentilesFromProbabilities(
                     ecc_bounds_warning=args.ecc_bounds_warning).process(
-                    diagnostic_cube, percentiles=args.extract_percentile)
+                    result, percentiles=args.extract_percentile)
             else:
                 msg = ('Diagnostic cube is not a known probabilistic type. '
                        'The {} percentile could not be extracted. Extracting '
@@ -164,21 +171,16 @@ def main():
                     warnings.warn(msg)
         else:
             constraint = ['{}={}'.format(perc_coordinate.name(),
-                                       args.extract_percentile)]
-            result = extract_subcube(diagnostic_cube, constraint)
-            if result is not None:
-                diagnostic_cube = result
+                                         args.extract_percentile)]
+            perc_result = extract_subcube(result, constraint)
+            if perc_result is not None:
+                result = perc_result
             else:
                 msg = ('The percentile diagnostic cube does not contain the '
                        'requested percentile value. Requested {}, available '
                        '{}'.format(args.extract_percentile,
                                    perc_coordinate.points))
                 raise ValueError(msg)
-
-    plugin = SpotExtraction(
-        neighbour_selection_method=neighbour_selection_method,
-        grid_metadata_identifier=args.grid_metadata_identifier)
-    result = plugin.process(neighbour_cube, diagnostic_cube)
 
     # Check whether a lapse rate cube has been provided and we are dealing with
     # temperature data.

--- a/lib/improver/spotdata/build_spotdata_cube.py
+++ b/lib/improver/spotdata/build_spotdata_cube.py
@@ -140,5 +140,7 @@ def build_spotdata_cube(data, name, units,
         data, long_name=name, units=units,
         dim_coords_and_dims=dim_coords_and_dims,
         aux_coords_and_dims=aux_coords_and_dims)
+    # rename to force a standard name to be set if name is valid
+    spot_cube.rename(name)
 
     return spot_cube

--- a/lib/improver/tests/spotdata/spotdata/test_build_spotdata_cube.py
+++ b/lib/improver/tests/spotdata/spotdata/test_build_spotdata_cube.py
@@ -175,6 +175,19 @@ class Test_build_spotdata_cube(IrisTest):
             result.coord('forecast_reference_time').points[0], 419805.)
         self.assertEqual(result.coord('forecast_period').points[0], 6)
 
+    def test_renaming_to_set_standard_name(self):
+        """Test that CF standard names are set as such in the returned cube,
+        whilst non-standard names remain as the long_name."""
+        standard_name_cube = build_spotdata_cube(
+            1.6, 'air_temperature', 'degC', 10., 59.5, 1.3, '03854')
+        non_standard_name_cube = build_spotdata_cube(
+            1.6, 'toast_temperature', 'degC', 10., 59.5, 1.3, '03854')
+
+        self.assertEqual(standard_name_cube.standard_name, 'air_temperature')
+        self.assertEqual(standard_name_cube.long_name, None)
+        self.assertEqual(non_standard_name_cube.standard_name, None)
+        self.assertEqual(non_standard_name_cube.long_name, 'toast_temperature')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/improver-spot-extract/00-null.bats
+++ b/tests/improver-spot-extract/00-null.bats
@@ -35,9 +35,11 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
+                             [--extract_percentile EXTRACT_PERCENTILE]
+                             [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
-                             [--json_file JSON_FILE]
+                             [--json_file JSON_FILE] [--quiet_mode]
                              NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
                              OUTPUT_FILEPATH
 __TEXT__

--- a/tests/improver-spot-extract/00-null.bats
+++ b/tests/improver-spot-extract/00-null.bats
@@ -35,7 +35,7 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
-                             [--extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]]
+                             [--extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]]
                              [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]

--- a/tests/improver-spot-extract/00-null.bats
+++ b/tests/improver-spot-extract/00-null.bats
@@ -35,7 +35,7 @@
   read -d '' expected <<'__TEXT__' || true
 usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
-                             [--extract_percentile EXTRACT_PERCENTILE]
+                             [--extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]]
                              [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]

--- a/tests/improver-spot-extract/00-null.bats
+++ b/tests/improver-spot-extract/00-null.bats
@@ -39,7 +39,7 @@ usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
-                             [--json_file JSON_FILE] [--quiet_mode]
+                             [--json_file JSON_FILE] [--suppress_warnings]
                              NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
                              OUTPUT_FILEPATH
 __TEXT__

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -36,7 +36,7 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
-                             [--extract_percentile EXTRACT_PERCENTILE]
+                             [--extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]]
                              [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
@@ -83,15 +83,16 @@ Neighbour finding method:
                         the neighbour cube was created. May be used with
                         land_constraint.
 
-Extract a percentile:
-  Extract a particular percentile from probabilistic data.
+Extract percentiles:
+  Extract particular percentiles from probabilistic data.
 
-  --extract_percentile EXTRACT_PERCENTILE
-                        If set to a percentile value, data corresponding to
-                        that percentile will be returned. For example setting
-                        '--extract_percentile 50' will result in the 50th
-                        percentile (median) values being returned from a cube
-                        of probabilities or percentiles.
+  --extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]
+                        If set to a percentile value or a list of percentile
+                        values, data corresponding to those percentiles will
+                        be returned. For example setting '--extract_percentile
+                        50' will result in the 50th percentile (median) values
+                        being returned from a cube of probabilities or
+                        percentiles.
 
 Temperature lapse rate adjustment:
   --temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -36,9 +36,11 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
+                             [--extract_percentile EXTRACT_PERCENTILE]
+                             [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
-                             [--json_file JSON_FILE]
+                             [--json_file JSON_FILE] [--quiet_mode]
                              NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
                              OUTPUT_FILEPATH
 
@@ -59,6 +61,9 @@ optional arguments:
   --profile             Switch on profiling information.
   --profile_file PROFILE_FILE
                         Dump profiling info to a file. Implies --profile.
+  --ecc_bounds_warning  If True, where calculated percentiles are outside the
+                        ECC bounds range, raise a warning rather than an
+                        exception.
 
 Neighbour finding method:
   If none of these options are set, the nearest grid point to a spot site
@@ -77,6 +82,16 @@ Neighbour finding method:
                         to the spot site within the search radius defined when
                         the neighbour cube was created. May be used with
                         land_constraint.
+
+Extract a percentile:
+  Extract a particular percentile from probabilistic data.
+
+  --extract_percentile EXTRACT_PERCENTILE
+                        If set to a percentile value, data corresponding to
+                        that percentile will be returned. For example setting
+                        '--extract_percentile 50' will result in the 50th
+                        percentile (median) values being returned from a cube
+                        of probabilities or percentiles.
 
 Temperature lapse rate adjustment:
   --temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH
@@ -101,6 +116,11 @@ Metadata:
                         If provided, this JSON file can be used to modify the
                         metadata of the returned netCDF file. Defaults to
                         None.
+
+Suppress Verbose output:
+  --quiet_mode          Suppress warning output. This option should only be
+                        used if it is known that warnings will be generated
+                        but they are not required.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -40,7 +40,7 @@ usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
-                             [--json_file JSON_FILE] [--quiet_mode]
+                             [--json_file JSON_FILE] [--suppress_warnings]
                              NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
                              OUTPUT_FILEPATH
 
@@ -118,7 +118,7 @@ Metadata:
                         None.
 
 Suppress Verbose output:
-  --quiet_mode          Suppress warning output. This option should only be
+  --suppress_warnings   Suppress warning output. This option should only be
                         used if it is known that warnings will be generated
                         but they are not required.
 __HELP__

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -36,7 +36,7 @@
   read -d '' expected <<'__HELP__' || true
 usage: improver-spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
-                             [--extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]]
+                             [--extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]]
                              [--ecc_bounds_warning]
                              [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
@@ -84,17 +84,19 @@ Neighbour finding method:
                         land_constraint.
 
 Extract percentiles:
-  Extract particular percentiles from probabilistic or realization inputs.
-  If deterministic input is provided a warning is raised and all leading
-  dimensions are included in the returned spot-data cube.
+  Extract particular percentiles from probabilistic, percentile, or
+  realization inputs. If deterministic input is provided a warning is raised
+  and all leading dimensions are included in the returned spot-data cube.
 
-  --extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]
+  --extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]
                         If set to a percentile value or a list of percentile
                         values, data corresponding to those percentiles will
-                        be returned. For example setting '--extract_percentile
-                        50' will result in the 50th percentile (median) values
-                        being returned from a cube of probabilities or
-                        percentiles.
+                        be returned. For example setting '--
+                        extract_percentiles 25 50 75' will result in the 25th,
+                        50th, and 75th percentiles being returned from a cube
+                        of probabilities, percentiles, or realizations. Note
+                        that for percentile inputs, the desired percentile(s)
+                        must exist in the input cube.
 
 Temperature lapse rate adjustment:
   --temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -84,7 +84,9 @@ Neighbour finding method:
                         land_constraint.
 
 Extract percentiles:
-  Extract particular percentiles from probabilistic data.
+  Extract particular percentiles from probabilistic or realization inputs.
+  If deterministic input is provided a warning is raised and all leading
+  dimensions are included in the returned spot-data cube.
 
   --extract_percentile EXTRACT_PERCENTILE [EXTRACT_PERCENTILE ...]
                         If set to a percentile value or a list of percentile

--- a/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
+++ b/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_thresholds.nc" \
-      --extract_percentile 50 "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" --extract_percentile 50 
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
+++ b/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+  KGO="spot-extract/outputs/extract_percentile_kgo.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_thresholds.nc" \
+      --extract_percentile 50 "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
+++ b/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_thresholds.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50 
+      "$TEST_DIR/output.nc" --extract_percentiles 50
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
+++ b/tests/improver-spot-extract/14-extract_percentile_thresholded_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract extract percentiles from thresholded input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/extract_percentile_kgo.nc"
 

--- a/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
+++ b/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract extract percentiles from percentile input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/extract_percentile_kgo.nc"
 

--- a/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
+++ b/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
-      --extract_percentile 50 "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" --extract_percentile 50
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
+++ b/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50
+      "$TEST_DIR/output.nc" --extract_percentiles 50
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
+++ b/tests/improver-spot-extract/15-extract_percentile_percentile_input.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+  KGO="spot-extract/outputs/extract_percentile_kgo.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
+      --extract_percentile 50 "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
+++ b/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
@@ -38,7 +38,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 45
+      "$TEST_DIR/output.nc" --extract_percentiles 45
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true

--- a/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
+++ b/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
@@ -38,7 +38,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
-      --extract_percentile 45 "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" --extract_percentile 45
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true

--- a/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
+++ b/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
+      --extract_percentile 45 "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: The percentile diagnostic cube does not contain the requested percentile value.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
+++ b/tests/improver-spot-extract/16-extract_percentile_percentile_input_unavailable_percentile.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract try to extract unavailable percentile from percentile input" {
   improver_check_skip_acceptance
 
   # Run spot extract processing and check it passes.

--- a/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
+++ b/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50
+      "$TEST_DIR/output.nc" --extract_percentiles 50
   echo "status = ${status}"
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true

--- a/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
+++ b/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract try to extract percentile from deterministic input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
 

--- a/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
+++ b/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+  KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
+      --extract_percentile 50 "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+UserWarning: Diagnostic cube is not a known probabilistic type. The 50 percentile could not be extracted. Extracting data from the cube including any leading dimensions.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
+++ b/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      --extract_percentile 50 --suppress_warnings "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" --extract_percentile 50 --suppress_warnings 
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true
 __TEXT__

--- a/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
+++ b/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract try to extract percentile from deterministic input - warnings suppressed" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
 

--- a/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
+++ b/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50 --suppress_warnings 
+      "$TEST_DIR/output.nc" --extract_percentiles 50 --suppress_warnings
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true
 __TEXT__

--- a/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
+++ b/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      --extract_percentile 50 --quiet_mode "$TEST_DIR/output.nc"
+      --extract_percentile 50 --suppress_warnings "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true
 __TEXT__

--- a/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
+++ b/tests/improver-spot-extract/18-extract_percentile_quiet_warnings.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+  KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
+      --extract_percentile 50 --quiet_mode "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+__TEXT__
+  [[ "$output" = "$expected" ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract/19-extract_multiple_percentiles_thresholded_input.bats
+++ b/tests/improver-spot-extract/19-extract_multiple_percentiles_thresholded_input.bats
@@ -33,19 +33,14 @@
 
 @test "spot-extract nearest temperatures" {
   improver_check_skip_acceptance
-  KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
+  KGO="spot-extract/outputs/extract_multiple_percentiles_kgo.nc"
 
   # Run spot extract processing and check it passes.
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
-      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50
-  echo "status = ${status}"
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_thresholds.nc" \
+      "$TEST_DIR/output.nc" --extract_percentile 25 50 75
   [[ "$status" -eq 0 ]]
-  read -d '' expected <<'__TEXT__' || true
-UserWarning: Diagnostic cube is not a known probabilistic type. The [50] percentile could not be extracted. Extracting data from the cube including any leading dimensions.
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
 
   improver_check_recreate_kgo "output.nc" $KGO
 

--- a/tests/improver-spot-extract/19-extract_multiple_percentiles_thresholded_input.bats
+++ b/tests/improver-spot-extract/19-extract_multiple_percentiles_thresholded_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_thresholds.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 25 50 75
+      "$TEST_DIR/output.nc" --extract_percentiles 25 50 75
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/19-extract_multiple_percentiles_thresholded_input.bats
+++ b/tests/improver-spot-extract/19-extract_multiple_percentiles_thresholded_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract extract multiple percentiles from thresholded input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/extract_multiple_percentiles_kgo.nc"
 

--- a/tests/improver-spot-extract/20-extract_multiple_percentiles_percentile_input.bats
+++ b/tests/improver-spot-extract/20-extract_multiple_percentiles_percentile_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract extract multiple percentiles from percentile input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/extract_multiple_percentiles_kgo.nc"
 

--- a/tests/improver-spot-extract/20-extract_multiple_percentiles_percentile_input.bats
+++ b/tests/improver-spot-extract/20-extract_multiple_percentiles_percentile_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 25 50 75
+      "$TEST_DIR/output.nc" --extract_percentiles 25 50 75
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/20-extract_multiple_percentiles_percentile_input.bats
+++ b/tests/improver-spot-extract/20-extract_multiple_percentiles_percentile_input.bats
@@ -33,19 +33,14 @@
 
 @test "spot-extract nearest temperatures" {
   improver_check_skip_acceptance
-  KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
+  KGO="spot-extract/outputs/extract_multiple_percentiles_kgo.nc"
 
   # Run spot extract processing and check it passes.
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
-      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50
-  echo "status = ${status}"
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_percentiles.nc" \
+      "$TEST_DIR/output.nc" --extract_percentile 25 50 75
   [[ "$status" -eq 0 ]]
-  read -d '' expected <<'__TEXT__' || true
-UserWarning: Diagnostic cube is not a known probabilistic type. The [50] percentile could not be extracted. Extracting data from the cube including any leading dimensions.
-__TEXT__
-  [[ "$output" =~ "$expected" ]]
 
   improver_check_recreate_kgo "output.nc" $KGO
 

--- a/tests/improver-spot-extract/21-extract_percentile_realization_input.bats
+++ b/tests/improver-spot-extract/21-extract_percentile_realization_input.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+  KGO="spot-extract/outputs/extract_percentile_kgo.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_realizations.nc" \
+      "$TEST_DIR/output.nc" --extract_percentile 50
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract/21-extract_percentile_realization_input.bats
+++ b/tests/improver-spot-extract/21-extract_percentile_realization_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_realizations.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 50
+      "$TEST_DIR/output.nc" --extract_percentiles 50
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/21-extract_percentile_realization_input.bats
+++ b/tests/improver-spot-extract/21-extract_percentile_realization_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract extract percentiles from realization input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/extract_percentile_kgo.nc"
 

--- a/tests/improver-spot-extract/22-extract_multiple_percentiles_realization_input.bats
+++ b/tests/improver-spot-extract/22-extract_multiple_percentiles_realization_input.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract nearest temperatures" {
+  improver_check_skip_acceptance
+  KGO="spot-extract/outputs/extract_multiple_percentiles_kgo.nc"
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_realizations.nc" \
+      "$TEST_DIR/output.nc" --extract_percentile 25 50 75
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-spot-extract/22-extract_multiple_percentiles_realization_input.bats
+++ b/tests/improver-spot-extract/22-extract_multiple_percentiles_realization_input.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/enukx_temperature_realizations.nc" \
-      "$TEST_DIR/output.nc" --extract_percentile 25 50 75
+      "$TEST_DIR/output.nc" --extract_percentiles 25 50 75
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/22-extract_multiple_percentiles_realization_input.bats
+++ b/tests/improver-spot-extract/22-extract_multiple_percentiles_realization_input.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract nearest temperatures" {
+@test "spot-extract extract multiple percentiles from realization input" {
   improver_check_skip_acceptance
   KGO="spot-extract/outputs/extract_multiple_percentiles_kgo.nc"
 


### PR DESCRIPTION
This change helps to speed up and simplify the extraction of the 50th percentile for spot purposes, The percentile extraction is moved to occur after the spot extract, thus massively reducing the number of data points that are being processed (in line with Stephen's approach for verification preprocessing). The change also enables us to remove the percentile_extract step from the suite which usually precedes spot_extract. The CLI is written to handle thresholded, percentile, and deterministic input.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
