### PR TITLE
improver wxcode: use low cloud instead of cloud below 1000ft asl

### DIFF
--- a/lib/improver/cli/wxcode.py
+++ b/lib/improver/cli/wxcode.py
@@ -141,7 +141,9 @@ def main(argv=None):
     if args.wxtree == 'global':
         required_number_of_inputs = n_files_global
     if len(cubes) != required_number_of_inputs:
-        msg = 'Incorrect number of inputs'
+        msg = ('Incorrect number of inputs: files {} gave {} cubes' +
+               ', {} required').format(args.input_filepaths, len(cubes),
+                                       required_number_of_inputs)
         raise argparse.ArgumentTypeError(msg)
 
     result = (WeatherSymbols(wxtree=args.wxtree).process(cubes))

--- a/lib/improver/cli/wxcode.py
+++ b/lib/improver/cli/wxcode.py
@@ -135,7 +135,7 @@ def main(argv=None):
 
     args = parser.parse_args(args=argv)
 
-    cubes = load_cubelist(args.input_filepaths)
+    cubes = load_cubelist(args.input_filepaths, no_lazy_load=True)
 
     required_number_of_inputs = n_files
     if args.wxtree == 'global':

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -115,13 +115,12 @@ def set_up_wxcubes():
         spp__relative_to_threshold='above',
         forecast_thresholds=np.array([0.1875, 0.8125])))
 
-    data_cld_1000ft = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
-                                0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
-    cloud_below_1000ft = (
+    data_cld_low = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                             0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
+    cloud_low = (
         set_up_probability_threshold_cube(
-            data_cld_1000ft,
-            'cloud_area_fraction_assuming_only'
-            '_consider_surface_to_1000_feet_asl',
+            data_cld_low,
+            'low_type_cloud_area_fraction',
             '1',
             spp__relative_to_threshold='above',
             forecast_thresholds=np.array([0.85])))
@@ -140,7 +139,7 @@ def set_up_wxcubes():
 
     cubes = iris.cube.CubeList([snowfall_rate, rainfall_rate,
                                 snowfall_vicinity, rainfall_vicinity,
-                                cloud, cloud_below_1000ft,
+                                cloud, cloud_low,
                                 visibility])
     return cubes
 
@@ -185,13 +184,12 @@ def set_up_wxcubes_global():
         spp__relative_to_threshold='above',
         forecast_thresholds=np.array([0.1875, 0.8125])))
 
-    data_cld_1000ft = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
-                                0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
-    cloud_below_1000ft = (
+    data_cld_low = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                            0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
+    cloud_low = (
         set_up_probability_threshold_cube(
-            data_cld_1000ft,
-            'cloud_area_fraction_assuming_only'
-            '_consider_surface_to_1000_feet_asl',
+            data_cld_low,
+            'low_type_cloud_area_fraction',
             '1',
             spp__relative_to_threshold='above',
             forecast_thresholds=np.array([0.85])))
@@ -210,7 +208,7 @@ def set_up_wxcubes_global():
                      ).attributes['spp__relative_to_threshold'] = 'below'
 
     cubes = iris.cube.CubeList([snowfall_rate, rainfall_rate,
-                                cloud, cloud_below_1000ft,
+                                cloud, cloud_low,
                                 visibility])
     return cubes
 
@@ -651,8 +649,8 @@ class Test_process(IrisTest):
         data_cloud = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0,
                                0.0, 1.0, 0.0, 1.0, 0.0, 1.0,
                                0.0, 1.0, 1.0]).reshape(2, 1, 3, 3)
-        data_cld_1000ft = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                                    0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
+        data_cld_low = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                 0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
         data_vis = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                              0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                              0.0, 0.0, 0.0]).reshape(2, 1, 3, 3)
@@ -662,7 +660,7 @@ class Test_process(IrisTest):
         cubes[2].data = data_snowv
         cubes[3].data = data_rainv
         cubes[4].data = data_cloud
-        cubes[5].data = data_cld_1000ft
+        cubes[5].data = data_cld_low
         cubes[6].data = data_vis
         result = plugin.process(cubes)
         expected_wxcode = np.array([14, 15, 17,
@@ -701,8 +699,8 @@ class Test_process(IrisTest):
         data_cloud = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0,
                                0.0, 1.0, 0.0, 1.0, 0.0, 1.0,
                                0.0, 1.0, 1.0]).reshape(2, 1, 3, 3)
-        data_cld_1000ft = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                                    0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
+        data_cld_low = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                 0.0, 0.0, 0.0]).reshape(1, 1, 3, 3)
         data_vis = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                              0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                              0.0, 0.0, 0.0]).reshape(2, 1, 3, 3)
@@ -710,7 +708,7 @@ class Test_process(IrisTest):
         cubes[0].data = data_snow
         cubes[1].data = data_rain
         cubes[2].data = data_cloud
-        cubes[3].data = data_cld_1000ft
+        cubes[3].data = data_cld_low
         cubes[4].data = data_vis
         result = plugin.process(cubes)
         expected_wxcode = np.array([14, 15, 17,

--- a/lib/improver/wxcode/wxcode_decision_tree.py
+++ b/lib/improver/wxcode/wxcode_decision_tree.py
@@ -274,9 +274,8 @@ def wxcode_decision_tree():
             'condition_combination': 'AND',
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
-                 ('probability_of_cloud_area_fraction_'
-                  'assuming_only_consider_surface_to_1000'
-                  '_feet_asl_above_threshold')],
+                 ('probability_of_low_type_cloud_area_fraction_'
+                  'above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above', 'above']},
@@ -299,8 +298,8 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                [('probability_of_cloud_area_fraction_assuming_only_consider_'
-                    'surface_to_1000_feet_asl_above_threshold')],
+                [('probability_of_low_type_cloud_area_fraction_'
+                  'above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above']},
 

--- a/lib/improver/wxcode/wxcode_decision_tree_global.py
+++ b/lib/improver/wxcode/wxcode_decision_tree_global.py
@@ -274,9 +274,8 @@ def wxcode_decision_tree_global():
             'condition_combination': 'AND',
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
-                 ('probability_of_cloud_area_fraction_'
-                  'assuming_only_consider_surface_to_1000'
-                  '_feet_asl_above_threshold')],
+                 ('probability_of_low_type_cloud_area_fraction_'
+                  'above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above', 'above']},
@@ -299,9 +298,8 @@ def wxcode_decision_tree_global():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                [('probability_of_cloud_area_fraction_'
-                  'assuming_only_consider_surface_to_1000'
-                  '_feet_asl_above_threshold')],
+                [('probability_of_low_type_cloud_area_fraction_'
+                  'above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above']},
 

--- a/tests/improver-wxcode/01-help.bats
+++ b/tests/improver-wxcode/01-help.bats
@@ -45,7 +45,7 @@ be converted:
  - probability_of_lwe_snowfall_rate_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
  - probability_of_cloud_area_fraction_above_threshold; thresholds: 0.1875 (1), 0.8125 (1)
  - probability_of_visibility_in_air_below_threshold; thresholds: 1000.0 (m), 5000.0 (m)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: 0.85 (1)
+ - probability_of_low_type_cloud_area_fraction_above_threshold; thresholds: 0.85 (1)
  - probability_of_rainfall_rate_in_vicinity_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
  - probability_of_lwe_snowfall_rate_in_vicinity_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
 
@@ -55,7 +55,7 @@ be converted:
  - probability_of_lwe_snowfall_rate_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
  - probability_of_cloud_area_fraction_above_threshold; thresholds: 0.1875 (1), 0.8125 (1)
  - probability_of_visibility_in_air_below_threshold; thresholds: 1000.0 (m), 5000.0 (m)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: 0.85 (1)
+ - probability_of_low_type_cloud_area_fraction_above_threshold; thresholds: 0.85 (1)
 
 positional arguments:
   INPUT_FILES           Paths to files containing the required input diagnostics.

--- a/tests/improver-wxcode/02-basic.bats
+++ b/tests/improver-wxcode/02-basic.bats
@@ -43,7 +43,7 @@
       "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_lwe_snowfall_rate_in_vicinity_above_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_visibility_in_air_below_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_above_threshold.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_low_type_cloud_area_fraction_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/03-native_units.bats
+++ b/tests/improver-wxcode/03-native_units.bats
@@ -43,7 +43,7 @@
       "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_lwe_snowfall_rate_in_vicinity_above_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_visibility_in_air_below_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_cloud_area_fraction_above_threshold.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_low_type_cloud_area_fraction_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/04-global.bats
+++ b/tests/improver-wxcode/04-global.bats
@@ -41,7 +41,7 @@
       "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_snowfall_rate_above_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_visibility_at_screen_level_below_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_above_threshold.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_low_type_cloud_area_fraction_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/05-insufficient-files.bats
+++ b/tests/improver-wxcode/05-insufficient-files.bats
@@ -39,15 +39,13 @@
       "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_rainfall_rate_above_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_snowfall_rate_above_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_above_threshold.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_low_type_cloud_area_fraction_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
    read -d '' expected <<'__TEXT__' || true
-   argparse.ArgumentTypeError: Incorrect number of inputs
+   argparse.ArgumentTypeError: Incorrect number of inputs: files .* gave 4 cubes, 5 required
 __TEXT__
-  echo $output
-  echo $expected
-  [[ "$output" =~ "$expected" ]]
+  [[ "$output" =~ $expected ]]
 
 }


### PR DESCRIPTION
We specify that weather symbols (as currently configured) use cloud amount below 1000ft asl, but we actually tend to use low type cloud fraction in the suite, although we rename it to shoehorn it in - this makes it explicit and avoids the tricky renaming within the suite.

Data renamed (cube + filename rename), and I changed an error message to make it clearer when things fail.