### PR TITLE
Fix pylint Travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda install -c conda-forge iris=2.1 cftime=1.0.1
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage
+  - conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage
   - pip install codacy-coverage codecov
 
   # List the name and version of all the dependencies within the conda environment.


### PR DESCRIPTION
Pylint 2.1.1 doesn't work with astroid 2.2.0, which is now being pulled into our Travis build instead of astroid 2.1.0 - I've hardcoded this to 2.1.0 now.

Astroid version is the only difference between e.g. https://travis-ci.org/metoppv/improver/builds/499210080#L1121 (failing) and https://travis-ci.org/metoppv/improver/builds/498992208#L1120 (succeeding), so I think this should work...
