### PR TITLE
Impro 1121 rename probability cubes

### DIFF
--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -158,12 +158,28 @@ def main():
         fuzzy_bounds=fuzzy_bounds, threshold_units=args.threshold_units,
         below_thresh_ok=args.below_threshold).process(cube)
 
+    # if args.vicinity is not None:
+    #     # smooth thresholded occurrences over local vicinity
+    #     result_no_collapse_coord = OccurrenceWithinVicinity(
+    #         args.vicinity).process(result_no_collapse_coord)
+    #     result_no_collapse_coord.rename(
+    #         result_no_collapse_coord.name() + '_in_vicinity')
+
     if args.vicinity is not None:
         # smooth thresholded occurrences over local vicinity
         result_no_collapse_coord = OccurrenceWithinVicinity(
             args.vicinity).process(result_no_collapse_coord)
-        result_no_collapse_coord.rename(
-            result_no_collapse_coord.name() + '_in_vicinity')
+        cube_name = result_no_collapse_coord.name()
+        relative_to_threshold_index = max(
+            cube_name.find('_above_threshold'),
+            cube_name.find('_below_threshold'))
+        if relative_to_threshold_index == -1:
+            new_cube_name = cube_name + '_in_vicinity'
+        else:
+            new_cube_name = (cube_name[:relative_to_threshold_index] +
+                             '_in_vicinity' +
+                             cube_name[relative_to_threshold_index:])
+        result_no_collapse_coord.rename(new_cube_name)
 
     if args.collapse_coord == "None":
         save_netcdf(result_no_collapse_coord, args.output_filepath)

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -158,13 +158,6 @@ def main():
         fuzzy_bounds=fuzzy_bounds, threshold_units=args.threshold_units,
         below_thresh_ok=args.below_threshold).process(cube)
 
-    # if args.vicinity is not None:
-    #     # smooth thresholded occurrences over local vicinity
-    #     result_no_collapse_coord = OccurrenceWithinVicinity(
-    #         args.vicinity).process(result_no_collapse_coord)
-    #     result_no_collapse_coord.rename(
-    #         result_no_collapse_coord.name() + '_in_vicinity')
-
     if args.vicinity is not None:
         # smooth thresholded occurrences over local vicinity
         result_no_collapse_coord = OccurrenceWithinVicinity(

--- a/bin/improver-threshold
+++ b/bin/improver-threshold
@@ -41,6 +41,7 @@ import warnings
 from improver.threshold import BasicThreshold
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
+from improver.utilities.cube_metadata import in_vicinity_name_format
 from improver.utilities.spatial import OccurrenceWithinVicinity
 from improver.blending.weights import ChooseDefaultWeightsLinear
 from improver.blending.weighted_blend import WeightedBlendAcrossWholeDimension
@@ -162,16 +163,10 @@ def main():
         # smooth thresholded occurrences over local vicinity
         result_no_collapse_coord = OccurrenceWithinVicinity(
             args.vicinity).process(result_no_collapse_coord)
-        cube_name = result_no_collapse_coord.name()
-        relative_to_threshold_index = max(
-            cube_name.find('_above_threshold'),
-            cube_name.find('_below_threshold'))
-        if relative_to_threshold_index == -1:
-            new_cube_name = cube_name + '_in_vicinity'
-        else:
-            new_cube_name = (cube_name[:relative_to_threshold_index] +
-                             '_in_vicinity' +
-                             cube_name[relative_to_threshold_index:])
+
+        new_cube_name = in_vicinity_name_format(
+            result_no_collapse_coord.name())
+
         result_no_collapse_coord.rename(new_cube_name)
 
     if args.collapse_coord == "None":

--- a/bin/improver-wxcode
+++ b/bin/improver-wxcode
@@ -92,9 +92,8 @@ def interrogate_decision_tree(wxtree):
                                   return_index=True)
         output.append('{}; thresholds: {}'.format(
             requirement, ', '.join([
-                '{} {} ({})'.format(str(relation),
-                                    str(threshold.points.item()),
-                                    str(threshold.units))
+                '{} ({})'.format(str(threshold.points.item()),
+                                 str(threshold.units))
                 for threshold, relation in
                 zip(entries[thresholds], relations[thresholds])])))
     return output

--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -186,7 +186,7 @@ class NowcastLightning(object):
         Modify the meta data of input cube to resemble a Nowcast of lightning
         probability.
 
-        1. Rename to "probability_of_lightning"
+        1. Rename to "probability_of_lightning_above_threshold"
 
         2. Remove "threshold" coord
         (or causes iris.exceptions.CoordinateNotFoundError)
@@ -204,7 +204,7 @@ class NowcastLightning(object):
                 The data array will be a copy of the input cube.data
         """
         new_cube = cube.copy()
-        new_cube.rename("probability_of_lightning")
+        new_cube.rename("probability_of_lightning_above_threshold")
         new_cube.remove_coord('threshold')
         new_cube.cell_methods = None
         return new_cube
@@ -465,16 +465,16 @@ class NowcastLightning(object):
                 If cubelist does not contain the expected cubes.
         """
         first_guess_lightning_cube = cubelist.extract(
-            "probability_of_lightning", strict=True)
+            "probability_of_lightning_above_threshold", strict=True)
         lightning_rate_cube = cubelist.extract(
             "rate_of_lightning", strict=True)
         lightning_rate_cube.convert_units("min^-1")  # Ensure units are correct
         prob_precip_cube = cubelist.extract(
-            "probability_of_precipitation", strict=True)
+            "probability_of_precipitation_above_threshold", strict=True)
         # Now find prob_vii_cube. Can't use strict=True here as cube may not be
         # present, so will use a normal extract and then merge_cube if needed.
         prob_vii_cube = cubelist.extract(
-            "probability_of_vertical_integral_of_ice")
+            "probability_of_vertical_integral_of_ice_above_threshold")
         if prob_vii_cube:
             prob_vii_cube = prob_vii_cube.merge_cube()
         prob_precip_cube.coord('threshold').convert_units('mm hr-1')

--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -186,7 +186,7 @@ class NowcastLightning(object):
         Modify the meta data of input cube to resemble a Nowcast of lightning
         probability.
 
-        1. Rename to "probability_of_lightning_above_threshold"
+        1. Rename to "probability_of_lightning_rate_above_threshold"
 
         2. Remove "threshold" coord
         (or causes iris.exceptions.CoordinateNotFoundError)
@@ -204,7 +204,7 @@ class NowcastLightning(object):
                 The data array will be a copy of the input cube.data
         """
         new_cube = cube.copy()
-        new_cube.rename("probability_of_lightning_above_threshold")
+        new_cube.rename("probability_of_lightning_rate_above_threshold")
         new_cube.remove_coord('threshold')
         new_cube.cell_methods = None
         return new_cube
@@ -465,12 +465,12 @@ class NowcastLightning(object):
                 If cubelist does not contain the expected cubes.
         """
         first_guess_lightning_cube = cubelist.extract(
-            "probability_of_lightning_above_threshold", strict=True)
+            "probability_of_lightning_rate_above_threshold", strict=True)
         lightning_rate_cube = cubelist.extract(
             "rate_of_lightning", strict=True)
         lightning_rate_cube.convert_units("min^-1")  # Ensure units are correct
         prob_precip_cube = cubelist.extract(
-            "probability_of_precipitation_above_threshold", strict=True)
+            "probability_of_precipitation_rate_above_threshold", strict=True)
         # Now find prob_vii_cube. Can't use strict=True here as cube may not be
         # present, so will use a normal extract and then merge_cube if needed.
         prob_vii_cube = cubelist.extract(

--- a/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -183,9 +183,9 @@ class Test_weighted_blend(IrisTest):
         data_threshold[1, 1, :, :] = 0.6
         data_threshold[1, 2, :, :] = 0.8
 
-        cube_threshold = Cube(data_threshold, long_name="probability_of_"
-                                                        "precipitation_amount"
-                                                        "_below_threshold")
+        cube_threshold = Cube(
+            data_threshold,
+            long_name="probability_of_precipitation_amount_below_threshold")
         cube_threshold.add_dim_coord(threshold, 0)
         cube_threshold.add_dim_coord(frt_coord, 1)
         cube_threshold.add_dim_coord(lat_coord, 2)

--- a/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -183,9 +183,9 @@ class Test_weighted_blend(IrisTest):
         data_threshold[1, 1, :, :] = 0.6
         data_threshold[1, 2, :, :] = 0.8
 
-        cube_threshold = Cube(
-            data_threshold, long_name=
-            "probability_of_precipitation_amount_below_threshold")
+        cube_threshold = Cube(data_threshold, long_name="probability_of_"
+                                                        "precipitation_amount"
+                                                        "_below_threshold")
         cube_threshold.add_dim_coord(threshold, 0)
         cube_threshold.add_dim_coord(frt_coord, 1)
         cube_threshold.add_dim_coord(lat_coord, 2)

--- a/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/lib/improver/tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -183,8 +183,9 @@ class Test_weighted_blend(IrisTest):
         data_threshold[1, 1, :, :] = 0.6
         data_threshold[1, 2, :, :] = 0.8
 
-        cube_threshold = Cube(data_threshold,
-                              long_name="probability_of_precipitation_amount")
+        cube_threshold = Cube(
+            data_threshold, long_name=
+            "probability_of_precipitation_amount_below_threshold")
         cube_threshold.add_dim_coord(threshold, 0)
         cube_threshold.add_dim_coord(frt_coord, 1)
         cube_threshold.add_dim_coord(lat_coord, 2)

--- a/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
+++ b/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
@@ -54,18 +54,16 @@ class Test_rationalise_blend_time_coords(IrisTest):
         # coming from the UKV
         data = np.full((3, 3), 0.6, dtype=np.float32)
         self.ukv_cube = set_up_variable_cube(
-            data, name=
-            'probability_of_air_temperature_above_threshold', units='1',
-            time=datetime(2017, 1, 10, 3, 0), frt=datetime(2017, 1, 9, 23, 0),
-            standard_grid_metadata='uk_det')
+            data, name='probability_of_air_temperature_above_threshold',
+            units='1', time=datetime(2017, 1, 10, 3, 0),
+            frt=datetime(2017, 1, 9, 23, 0), standard_grid_metadata='uk_det')
 
         # make a cube labelled as coming from MOGREPS-UK, with a different
         # forecast reference time from the UKV cube
         self.enuk_cube = set_up_variable_cube(
-            data, name=
-            'probability_of_air_temperature_above_threshold', units='1',
-            time=datetime(2017, 1, 10, 3, 0), frt=datetime(2017, 1, 10, 0, 0),
-            standard_grid_metadata='uk_ens')
+            data, name='probability_of_air_temperature_above_threshold',
+            units='1', time=datetime(2017, 1, 10, 3, 0),
+            frt=datetime(2017, 1, 10, 0, 0), standard_grid_metadata='uk_ens')
 
         # make a cube list and merged cube containing the two model cubes, for
         # use in defining reference coordinates for tests below

--- a/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
+++ b/lib/improver/tests/blending/weighted_blend/test_rationalise_blend_time_coords.py
@@ -54,14 +54,16 @@ class Test_rationalise_blend_time_coords(IrisTest):
         # coming from the UKV
         data = np.full((3, 3), 0.6, dtype=np.float32)
         self.ukv_cube = set_up_variable_cube(
-            data, name='probability_of_air_temperature', units='1',
+            data, name=
+            'probability_of_air_temperature_above_threshold', units='1',
             time=datetime(2017, 1, 10, 3, 0), frt=datetime(2017, 1, 9, 23, 0),
             standard_grid_metadata='uk_det')
 
         # make a cube labelled as coming from MOGREPS-UK, with a different
         # forecast reference time from the UKV cube
         self.enuk_cube = set_up_variable_cube(
-            data, name='probability_of_air_temperature', units='1',
+            data, name=
+            'probability_of_air_temperature_above_threshold', units='1',
             time=datetime(2017, 1, 10, 3, 0), frt=datetime(2017, 1, 10, 0, 0),
             standard_grid_metadata='uk_ens')
 

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -115,7 +115,8 @@ class Test__update_metadata(IrisTest):
         cell methods to be discarded."""
         result = self.plugin._update_metadata(self.cube)
         self.assertIsInstance(result, Cube)
-        self.assertEqual(result.name(), "probability_of_lightning")
+        self.assertEqual(
+            result.name(), "probability_of_lightning_above_threshold")
         msg = ("Expected to find exactly 1 threshold coordinate, but found "
                "none.")
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
@@ -427,21 +428,21 @@ class Test_apply_precip(IrisTest):
         self.fg_cube:
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
             All points contain float(1.)
-            Cube name is "probability_of_lightning".
+            Cube name is "probability_of_lightning_above_threshold".
         self.precip_cube:
             With extra coordinate of length(3) "threshold" containing
             points [0.5, 7., 35.] mm hr-1.
             All points contain float(1.) except the
             zero point [0, 0, 1, 1] which is float(0.)
             and [1:, 0, ...] which are float(0.)
-            Cube name is "probability_of_precipitation".
+            Cube name is "probability_of_precipitation_above_threshold".
             Cube has added attribute {'relative_to_threshold': 'above'}
         """
         self.fg_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[],
                                              num_grid_points=3),
             fp_point=0.0)
-        self.fg_cube.rename("probability_of_lightning")
+        self.fg_cube.rename("probability_of_lightning_above_threshold")
         self.precip_cube = (
             add_forecast_reference_time_and_forecast_period(
                 set_up_cube(num_realization_points=3,
@@ -451,7 +452,7 @@ class Test_apply_precip(IrisTest):
         threshold_coord.points = [0.5, 7.0, 35.0]
         threshold_coord.rename('threshold')
         threshold_coord.units = cf_units.Unit('mm hr-1')
-        self.precip_cube.rename("probability_of_precipitation")
+        self.precip_cube.rename("probability_of_precipitation_above_threshold")
         self.precip_cube.attributes.update({'relative_to_threshold': 'above'})
         self.precip_cube.data[1:, 0, ...] = 0.
         self.plugin = Plugin()
@@ -598,19 +599,20 @@ class Test_apply_ice(IrisTest):
         Data:
         self.fg_cube:
             All points contain float(1.)
-            Cube name is "probability_of_lightning".
+            Cube name is "probability_of_lightning_above_threshold".
         self.ice_cube:
             With extra coordinate of length(3) "threshold" containing
             points [0.5, 1., 2.] kg m^-2.
             Time and forecast_period dimensions "sqeezed" to be Scalar coords.
             All points contain float(0.)
-            Cube name is "probability_of_vertical_integral_of_ice".
+            Cube name is
+            "probability_of_vertical_integral_of_ice_above_threshold".
         """
         self.fg_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[],
                                              num_grid_points=3),
             fp_point=0.0)
-        self.fg_cube.rename("probability_of_lightning")
+        self.fg_cube.rename("probability_of_lightning_above_threshold")
         self.ice_cube = squeeze(
             add_forecast_reference_time_and_forecast_period(
                 set_up_cube(num_realization_points=3,
@@ -622,7 +624,8 @@ class Test_apply_ice(IrisTest):
         threshold_coord.rename('threshold')
         threshold_coord.units = cf_units.Unit('kg m^-2')
         self.ice_cube.data = np.zeros_like(self.ice_cube.data)
-        self.ice_cube.rename("probability_of_vertical_integral_of_ice")
+        self.ice_cube.rename(
+            "probability_of_vertical_integral_of_ice_above_threshold")
         self.plugin = Plugin()
 
     def test_basic(self):
@@ -748,7 +751,7 @@ class Test_process(IrisTest):
         Data:
         self.fg_cube:
             All points contain float(1.)
-            Cube name is "probability_of_lightning".
+            Cube name is "probability_of_lightning_above_threshold".
         self.ltng_cube:
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
             All points contain float(1.)
@@ -760,7 +763,7 @@ class Test_process(IrisTest):
             All points contain float(1.) except the
             zero point [0, 0, 7, 7] which is float(0.)
             and [1:, 0, ...] which are float(0.)
-            Cube name is "probability_of_precipitation".
+            Cube name is "probability_of_precipitation_above_threshold".
             Cube has added attribute {'relative_to_threshold': 'above'}
         self.vii_cube:
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
@@ -769,11 +772,12 @@ class Test_process(IrisTest):
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
             Time and forecast_period dimensions "sqeezed" to be Scalar coords.
             All points contain float(0.)
-            Cube name is "probability_of_vertical_integral_of_ice".
+            Cube name is
+            "probability_of_vertical_integral_of_ice_above_threshold".
         """
         self.fg_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[]))
-        self.fg_cube.rename("probability_of_lightning")
+        self.fg_cube.rename("probability_of_lightning_above_threshold")
         self.ltng_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[]),
             fp_point=0.0)
@@ -786,7 +790,7 @@ class Test_process(IrisTest):
         threshold_coord.points = [0.5, 7.0, 35.0]
         threshold_coord.rename('threshold')
         threshold_coord.units = cf_units.Unit('mm hr-1')
-        self.precip_cube.rename("probability_of_precipitation")
+        self.precip_cube.rename("probability_of_precipitation_above_threshold")
         self.precip_cube.attributes.update({'relative_to_threshold': 'above'})
         self.precip_cube.data[1:, 0, ...] = 0.
         self.vii_cube = squeeze(
@@ -799,7 +803,8 @@ class Test_process(IrisTest):
         threshold_coord.rename('threshold')
         threshold_coord.units = cf_units.Unit('kg m^-2')
         self.vii_cube.data = np.zeros_like(self.vii_cube.data)
-        self.vii_cube.rename("probability_of_vertical_integral_of_ice")
+        self.vii_cube.rename(
+            "probability_of_vertical_integral_of_ice_above_threshold")
         self.plugin = Plugin()
 
     def set_up_vii_input_output(self):
@@ -860,7 +865,8 @@ class Test_process(IrisTest):
         # We expect the threshold coordinate to have been removed.
         self.assertCountEqual(find_dimension_coordinate_mismatch(
                 result, self.precip_cube), ['threshold'])
-        self.assertTrue(result.name() == 'probability_of_lightning')
+        self.assertTrue(
+            result.name() == 'probability_of_lightning_above_threshold')
 
     def test_basic_with_vii(self):
         """Test that the method returns the expected cube type when vii is
@@ -874,13 +880,14 @@ class Test_process(IrisTest):
         # We expect the threshold coordinate to have been removed.
         self.assertCountEqual(find_dimension_coordinate_mismatch(
                 result, self.precip_cube), ['threshold'])
-        self.assertTrue(result.name() == 'probability_of_lightning')
+        self.assertTrue(
+            result.name() == 'probability_of_lightning_above_threshold')
 
     def test_no_first_guess_cube(self):
         """Test that the method raises an error if the first_guess cube is
         omitted from the cubelist"""
         msg = (r"Got 0 cubes for constraint Constraint\(name=\'probability_of_"
-               r"lightning\'\), expecting 1.")
+               r"lightning_above_threshold\'\), expecting 1.")
         with self.assertRaisesRegex(ConstraintMismatchError, msg):
             self.plugin.process(CubeList([
                 self.ltng_cube,
@@ -900,7 +907,7 @@ class Test_process(IrisTest):
         """Test that the method raises an error if the precip cube is
         omitted from the cubelist"""
         msg = (r"Got 0 cubes for constraint Constraint\(name=\'probability_of_"
-               r"precipitation\'\), expecting 1.")
+               r"precipitation_above_threshold\'\), expecting 1.")
         with self.assertRaisesRegex(ConstraintMismatchError, msg):
             self.plugin.process(CubeList([
                 self.fg_cube,

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -116,7 +116,7 @@ class Test__update_metadata(IrisTest):
         result = self.plugin._update_metadata(self.cube)
         self.assertIsInstance(result, Cube)
         self.assertEqual(
-            result.name(), "probability_of_lightning_above_threshold")
+            result.name(), "probability_of_lightning_rate_above_threshold")
         msg = ("Expected to find exactly 1 threshold coordinate, but found "
                "none.")
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
@@ -428,21 +428,21 @@ class Test_apply_precip(IrisTest):
         self.fg_cube:
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
             All points contain float(1.)
-            Cube name is "probability_of_lightning_above_threshold".
+            Cube name is "probability_of_lightning_rate_above_threshold".
         self.precip_cube:
             With extra coordinate of length(3) "threshold" containing
             points [0.5, 7., 35.] mm hr-1.
             All points contain float(1.) except the
             zero point [0, 0, 1, 1] which is float(0.)
             and [1:, 0, ...] which are float(0.)
-            Cube name is "probability_of_precipitation_above_threshold".
+            Cube name is "probability_of_precipitation_rate_above_threshold".
             Cube has added attribute {'relative_to_threshold': 'above'}
         """
         self.fg_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[],
                                              num_grid_points=3),
             fp_point=0.0)
-        self.fg_cube.rename("probability_of_lightning_above_threshold")
+        self.fg_cube.rename("probability_of_lightning_rate_above_threshold")
         self.precip_cube = (
             add_forecast_reference_time_and_forecast_period(
                 set_up_cube(num_realization_points=3,
@@ -452,7 +452,8 @@ class Test_apply_precip(IrisTest):
         threshold_coord.points = [0.5, 7.0, 35.0]
         threshold_coord.rename('threshold')
         threshold_coord.units = cf_units.Unit('mm hr-1')
-        self.precip_cube.rename("probability_of_precipitation_above_threshold")
+        self.precip_cube.rename(
+            "probability_of_precipitation_rate_above_threshold")
         self.precip_cube.attributes.update({'relative_to_threshold': 'above'})
         self.precip_cube.data[1:, 0, ...] = 0.
         self.plugin = Plugin()
@@ -599,7 +600,7 @@ class Test_apply_ice(IrisTest):
         Data:
         self.fg_cube:
             All points contain float(1.)
-            Cube name is "probability_of_lightning_above_threshold".
+            Cube name is "probability_of_lightning_rate_above_threshold".
         self.ice_cube:
             With extra coordinate of length(3) "threshold" containing
             points [0.5, 1., 2.] kg m^-2.
@@ -612,7 +613,7 @@ class Test_apply_ice(IrisTest):
             set_up_cube_with_no_realizations(zero_point_indices=[],
                                              num_grid_points=3),
             fp_point=0.0)
-        self.fg_cube.rename("probability_of_lightning_above_threshold")
+        self.fg_cube.rename("probability_of_lightning_rate_above_threshold")
         self.ice_cube = squeeze(
             add_forecast_reference_time_and_forecast_period(
                 set_up_cube(num_realization_points=3,
@@ -751,7 +752,7 @@ class Test_process(IrisTest):
         Data:
         self.fg_cube:
             All points contain float(1.)
-            Cube name is "probability_of_lightning_above_threshold".
+            Cube name is "probability_of_lightning_rate_above_threshold".
         self.ltng_cube:
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
             All points contain float(1.)
@@ -763,7 +764,7 @@ class Test_process(IrisTest):
             All points contain float(1.) except the
             zero point [0, 0, 7, 7] which is float(0.)
             and [1:, 0, ...] which are float(0.)
-            Cube name is "probability_of_precipitation_above_threshold".
+            Cube name is "probability_of_precipitation_rate_above_threshold".
             Cube has added attribute {'relative_to_threshold': 'above'}
         self.vii_cube:
             forecast_period (on time coord): 0.0 hours (simulates nowcast data)
@@ -777,7 +778,7 @@ class Test_process(IrisTest):
         """
         self.fg_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[]))
-        self.fg_cube.rename("probability_of_lightning_above_threshold")
+        self.fg_cube.rename("probability_of_lightning_rate_above_threshold")
         self.ltng_cube = add_forecast_reference_time_and_forecast_period(
             set_up_cube_with_no_realizations(zero_point_indices=[]),
             fp_point=0.0)
@@ -790,7 +791,8 @@ class Test_process(IrisTest):
         threshold_coord.points = [0.5, 7.0, 35.0]
         threshold_coord.rename('threshold')
         threshold_coord.units = cf_units.Unit('mm hr-1')
-        self.precip_cube.rename("probability_of_precipitation_above_threshold")
+        self.precip_cube.rename(
+            "probability_of_precipitation_rate_above_threshold")
         self.precip_cube.attributes.update({'relative_to_threshold': 'above'})
         self.precip_cube.data[1:, 0, ...] = 0.
         self.vii_cube = squeeze(
@@ -866,7 +868,7 @@ class Test_process(IrisTest):
         self.assertCountEqual(find_dimension_coordinate_mismatch(
                 result, self.precip_cube), ['threshold'])
         self.assertTrue(
-            result.name() == 'probability_of_lightning_above_threshold')
+            result.name() == 'probability_of_lightning_rate_above_threshold')
 
     def test_basic_with_vii(self):
         """Test that the method returns the expected cube type when vii is
@@ -881,13 +883,13 @@ class Test_process(IrisTest):
         self.assertCountEqual(find_dimension_coordinate_mismatch(
                 result, self.precip_cube), ['threshold'])
         self.assertTrue(
-            result.name() == 'probability_of_lightning_above_threshold')
+            result.name() == 'probability_of_lightning_rate_above_threshold')
 
     def test_no_first_guess_cube(self):
         """Test that the method raises an error if the first_guess cube is
         omitted from the cubelist"""
         msg = (r"Got 0 cubes for constraint Constraint\(name=\'probability_of_"
-               r"lightning_above_threshold\'\), expecting 1.")
+               r"lightning_rate_above_threshold\'\), expecting 1.")
         with self.assertRaisesRegex(ConstraintMismatchError, msg):
             self.plugin.process(CubeList([
                 self.ltng_cube,
@@ -907,7 +909,7 @@ class Test_process(IrisTest):
         """Test that the method raises an error if the precip cube is
         omitted from the cubelist"""
         msg = (r"Got 0 cubes for constraint Constraint\(name=\'probability_of_"
-               r"precipitation_above_threshold\'\), expecting 1.")
+               r"precipitation_rate_above_threshold\'\), expecting 1.")
         with self.assertRaisesRegex(ConstraintMismatchError, msg):
             self.plugin.process(CubeList([
                 self.fg_cube,

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -323,7 +323,8 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
     - option to specify additional scalar coordinates
     - "relative_to_threshold" attribute (default "above")
     - default or configurable attributes
-    - configurable cube data, name conforms to "probability_of_X" convention
+    - configurable cube data, name conforms to
+    "probability_of_X_above(or below)_threshold" convention
 
     Args:
         data (np.ndarray):

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -372,8 +372,12 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
 
     if relative_to_threshold == 'above':
         name = name_prefix + '{}_above_threshold'.format(variable_name)
-    else:
+    elif relative_to_threshold == 'below':
         name = name_prefix + '{}_below_threshold'.format(variable_name)
+    else:
+        msg = 'The relative_to_threshold attribute MUST be set for ' \
+              'IMPROVER probability cubes'
+        raise ValueError(msg)
 
     cube = set_up_variable_cube(
         data, name=name, units='1', spatial_grid=spatial_grid,

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -366,9 +366,15 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
         attributes['relative_to_threshold'] = relative_to_threshold
 
     if variable_name.startswith('probability_of_'):
-        name = variable_name
+        name_prefix = ''
     else:
-        name = 'probability_of_{}'.format(variable_name)
+        name_prefix = 'probability_of_'
+
+    if relative_to_threshold == 'above':
+        name = name_prefix + '{}_above_threshold'.format(variable_name)
+    else:
+        name = name_prefix + '{}_below_threshold'.format(variable_name)
+
     cube = set_up_variable_cube(
         data, name=name, units='1', spatial_grid=spatial_grid,
         time=time, frt=frt, time_bounds=time_bounds,

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -361,6 +361,15 @@ class test_set_up_probability_cube(IrisTest):
         self.assertEqual(len(result.attributes), 1)
         self.assertEqual(result.attributes['relative_to_threshold'], 'below')
 
+    def test_relative_to_threshold_set(self):
+        """Test that an error is raised if the "relative_to_threshold"
+        attribute has not been set when setting up a probability cube"""
+        data = np.flipud(self.data)
+        msg = 'The relative_to_threshold attribute MUST be set'
+        with self.assertRaisesRegex(ValueError, msg):
+            set_up_probability_cube(data, self.thresholds,
+                                    relative_to_threshold=None)
+
     def test_standard_grid_metadata(self):
         """Test standard grid metadata"""
         result = set_up_probability_cube(self.data, self.thresholds,

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -337,7 +337,8 @@ class test_set_up_probability_cube(IrisTest):
         and metadata"""
         result = set_up_probability_cube(self.data, self.thresholds)
         thresh_coord = result.coord("threshold")
-        self.assertEqual(result.name(), 'probability_of_air_temperature')
+        self.assertEqual(
+            result.name(), 'probability_of_air_temperature_above_threshold')
         self.assertEqual(result.units, '1')
         self.assertArrayEqual(thresh_coord.points, self.thresholds)
         self.assertEqual(thresh_coord.units, 'K')
@@ -349,7 +350,8 @@ class test_set_up_probability_cube(IrisTest):
         result = set_up_probability_cube(
             self.data, self.thresholds,
             variable_name='probability_of_air_temperature')
-        self.assertEqual(result.name(), 'probability_of_air_temperature')
+        self.assertEqual(
+            result.name(), 'probability_of_air_temperature_above_threshold')
 
     def test_relative_to_threshold(self):
         """Test ability to reset the "relative_to_threshold" attribute"""

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -364,10 +364,9 @@ class test_set_up_probability_cube(IrisTest):
     def test_relative_to_threshold_set(self):
         """Test that an error is raised if the "relative_to_threshold"
         attribute has not been set when setting up a probability cube"""
-        data = np.flipud(self.data)
         msg = 'The relative_to_threshold attribute MUST be set'
         with self.assertRaisesRegex(ValueError, msg):
-            set_up_probability_cube(data, self.thresholds,
+            set_up_probability_cube(self.data, self.thresholds,
                                     relative_to_threshold=None)
 
     def test_standard_grid_metadata(self):

--- a/lib/improver/tests/threshold/test_BasicThreshold.py
+++ b/lib/improver/tests/threshold/test_BasicThreshold.py
@@ -190,7 +190,7 @@ class Test_process(IrisTest):
         plugin = Threshold(0.1)
         result = plugin.process(cube)
         # The single 0.5-valued point => 1.0, so cheat by * 2.0 vs orig data.
-        name = "probability_of_{}"
+        name = "probability_of_{}_above_threshold"
         expected_name = name.format(self.cube.name())
         expected_attribute = "above"
         expected_units = 1

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -58,15 +58,16 @@ def set_up_precip_probability_cube():
                       [0.02, 0.02, 0.00],
                       [0.01, 0.00, 0.00]]])
 
-    MMH_TO_MS = 0.001/3600.
-    threshold = DimCoord(MMH_TO_MS*np.array([0.03, 0.1, 1.0]),
+    MMH_TO_MS = 0.001 / 3600.
+    threshold = DimCoord(MMH_TO_MS * np.array([0.03, 0.1, 1.0]),
                          long_name="threshold", units="m s-1")
     ycoord = DimCoord(np.arange(3), "projection_y_coordinate")
     xcoord = DimCoord(np.arange(3), "projection_x_coordinate")
 
-    cube = iris.cube.Cube(data, long_name="probability_of_precipitation",
-                          dim_coords_and_dims=[(threshold, 0), (ycoord, 1),
-                                               (xcoord, 2)], units="1")
+    cube = iris.cube.Cube(
+        data, long_name="probability_of_precipitation_above_threshold",
+        dim_coords_and_dims=[(threshold, 0), (ycoord, 1),
+                             (xcoord, 2)], units="1")
     return cube
 
 
@@ -189,7 +190,8 @@ class Test_apply_extraction(IrisTest):
 
     def test_basic_no_units(self):
         """ Test cube extraction for single constraint without units """
-        constraint_dict = {"name": "probability_of_precipitation"}
+        constraint_dict = {
+            "name": "probability_of_precipitation_above_threshold"}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(self.precip_cube, constr)
         self.assertIsInstance(cube, iris.cube.Cube)
@@ -208,8 +210,9 @@ class Test_apply_extraction(IrisTest):
 
     def test_multiple_constraints_with_units(self):
         """ Test behaviour with a list of constraints and units """
-        constraint_dict = {"name": "probability_of_precipitation",
-                           "threshold": 0.03}
+        constraint_dict = {
+            "name": "probability_of_precipitation_above_threshold",
+                    "threshold": 0.03}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(self.precip_cube, constr, self.units_dict)
         self.assertIsInstance(cube, iris.cube.Cube)
@@ -219,7 +222,8 @@ class Test_apply_extraction(IrisTest):
     def test_error_non_coord_units(self):
         """ Test error raised if units are provided for a non-coordinate
         constraint """
-        constraint_dict = {"name": "probability_of_precipitation"}
+        constraint_dict = {
+            "name": "probability_of_precipitation_above_threshold"}
         units_dict = {"name": "1"}
         with self.assertRaises(CoordinateNotFoundError):
             apply_extraction(self.precip_cube, constraint_dict, units_dict)
@@ -228,8 +232,9 @@ class Test_apply_extraction(IrisTest):
         """ Test function returns None rather than raising an error where
         no subcubes match the required constraints, when unit conversion is
         required """
-        constraint_dict = {"name": "probability_of_precipitation",
-                           "threshold": 5}
+        constraint_dict = {
+            "name": "probability_of_precipitation_above_threshold",
+                    "threshold": 5}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(self.precip_cube, constr, self.units_dict)
         self.assertFalse(cube)

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -65,7 +65,7 @@ def set_up_precip_probability_cube():
     xcoord = DimCoord(np.arange(3), "projection_x_coordinate")
 
     cube = iris.cube.Cube(
-        data, long_name="probability_of_precipitation_above_threshold",
+        data, long_name="probability_of_precipitation_rate_above_threshold",
         dim_coords_and_dims=[(threshold, 0), (ycoord, 1),
                              (xcoord, 2)], units="1")
     return cube
@@ -191,7 +191,7 @@ class Test_apply_extraction(IrisTest):
     def test_basic_no_units(self):
         """ Test cube extraction for single constraint without units """
         constraint_dict = {
-            "name": "probability_of_precipitation_above_threshold"}
+            "name": "probability_of_precipitation_rate_above_threshold"}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(self.precip_cube, constr)
         self.assertIsInstance(cube, iris.cube.Cube)
@@ -211,7 +211,7 @@ class Test_apply_extraction(IrisTest):
     def test_multiple_constraints_with_units(self):
         """ Test behaviour with a list of constraints and units """
         constraint_dict = {
-            "name": "probability_of_precipitation_above_threshold",
+            "name": "probability_of_precipitation_rate_above_threshold",
                     "threshold": 0.03}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(self.precip_cube, constr, self.units_dict)
@@ -223,7 +223,7 @@ class Test_apply_extraction(IrisTest):
         """ Test error raised if units are provided for a non-coordinate
         constraint """
         constraint_dict = {
-            "name": "probability_of_precipitation_above_threshold"}
+            "name": "probability_of_precipitation_rate_above_threshold"}
         units_dict = {"name": "1"}
         with self.assertRaises(CoordinateNotFoundError):
             apply_extraction(self.precip_cube, constraint_dict, units_dict)
@@ -233,7 +233,7 @@ class Test_apply_extraction(IrisTest):
         no subcubes match the required constraints, when unit conversion is
         required """
         constraint_dict = {
-            "name": "probability_of_precipitation_above_threshold",
+            "name": "probability_of_precipitation_rate_above_threshold",
                     "threshold": 5}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(self.precip_cube, constr, self.units_dict)

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -68,7 +68,7 @@ def create_cube_with_threshold(data=None, threshold_values=None):
         data[:, 0, :, :] = 0.5
         data[:, 1, :, :] = 0.6
 
-    long_name = "probability_of_rainfall_rate"
+    long_name = "probability_of_rainfall_rate_above_threshold"
     units = "m s^-1"
 
     cube = set_up_probability_cube(
@@ -717,7 +717,7 @@ class Test_delete_attributes(IrisTest):
     def setUp(self):
         """Create a cube with attributes to be deleted."""
         data = np.zeros((2, 2))
-        long_name = "probability_of_rainfall_rate"
+        long_name = "probability_of_rainfall_rate_above_threshold"
         units = "m s^-1"
         attributes = {'title': 'This is a cube',
                       'tithe': '10 percent',

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -48,7 +48,8 @@ from improver.utilities.cube_metadata import (
     update_attribute,
     update_cell_methods,
     update_coord,
-    update_stage_v110_metadata)
+    update_stage_v110_metadata,
+    in_vicinity_name_format)
 from improver.utilities.warnings_handler import ManageWarnings
 
 from improver.tests.set_up_test_cubes import (
@@ -611,6 +612,29 @@ class Test_amend_metadata(IrisTest):
                             for item in warning_list))
         self.assertEqual(result.attributes['new_attribute'],
                          'new_value')
+
+    def test_in_vicinity_name_format(self):
+        """Test that the 'in_vicinity' above/below threshold probability
+        cube naming function produces the correctly formatted names"""
+        self.cube.rename('probability_of_rainfall_rate_above_threshold')
+        name_above = (
+            'probability_of_rainfall_rate_in_vicinity_above_threshold')
+        new_name_above = in_vicinity_name_format(self.cube.name())
+
+        self.cube.rename('probability_of_visibility_below_threshold')
+        name_below = (
+            'probability_of_visibility_in_vicinity_below_threshold')
+        new_name_below = in_vicinity_name_format(self.cube.name())
+
+        # Test the case of name without above/below_threshold
+        self.cube.rename('probability_of_diagnostic')
+        name_no_threshold = (
+            'probability_of_diagnostic_in_vicinity')
+        new_name_no_threshold = in_vicinity_name_format(self.cube.name())
+
+        self.assertEqual(new_name_above, name_above)
+        self.assertEqual(new_name_below, name_below)
+        self.assertEqual(new_name_no_threshold, name_no_threshold)
 
 
 class Test_resolve_metadata_diff(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -617,24 +617,24 @@ class Test_amend_metadata(IrisTest):
         """Test that the 'in_vicinity' above/below threshold probability
         cube naming function produces the correctly formatted names"""
         self.cube.rename('probability_of_rainfall_rate_above_threshold')
-        name_above = (
+        correct_name_above = (
             'probability_of_rainfall_rate_in_vicinity_above_threshold')
         new_name_above = in_vicinity_name_format(self.cube.name())
 
         self.cube.rename('probability_of_visibility_below_threshold')
-        name_below = (
+        correct_name_below = (
             'probability_of_visibility_in_vicinity_below_threshold')
         new_name_below = in_vicinity_name_format(self.cube.name())
 
         # Test the case of name without above/below_threshold
         self.cube.rename('probability_of_diagnostic')
-        name_no_threshold = (
+        correct_name_no_threshold = (
             'probability_of_diagnostic_in_vicinity')
         new_name_no_threshold = in_vicinity_name_format(self.cube.name())
 
-        self.assertEqual(new_name_above, name_above)
-        self.assertEqual(new_name_below, name_below)
-        self.assertEqual(new_name_no_threshold, name_no_threshold)
+        self.assertEqual(new_name_above, correct_name_above)
+        self.assertEqual(new_name_below, correct_name_below)
+        self.assertEqual(new_name_no_threshold, correct_name_no_threshold)
 
 
 class Test_resolve_metadata_diff(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -805,7 +805,7 @@ class Test_add_history_attribute(IrisTest):
         self.assertTrue("Nowcast" in cube.attributes["history"])
 
 
-class Test_probability_cube_in_vicinity_rename(IrisTest):
+class Test_in_vicinity_name_format(IrisTest):
     """Test that the 'in_vicinity' above/below threshold probability
     cube naming function produces the correctly formatted names."""
 

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -836,6 +836,13 @@ class Test_probability_cube_in_vicinity_rename(IrisTest):
         new_name_no_threshold = in_vicinity_name_format(self.cube.name())
         self.assertEqual(new_name_no_threshold, correct_name_no_threshold)
 
+    def test_in_vicinity_already_exists(self):
+        """Test the case of 'in_vicinity' already existing in the cube name"""
+        self.cube.rename('probability_of_X_in_vicinity')
+        msg = "Cube name already contains 'in_vicinity'"
+        with self.assertRaisesRegex(ValueError, msg):
+            in_vicinity_name_format(self.cube.name())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -613,29 +613,6 @@ class Test_amend_metadata(IrisTest):
         self.assertEqual(result.attributes['new_attribute'],
                          'new_value')
 
-    def test_in_vicinity_name_format(self):
-        """Test that the 'in_vicinity' above/below threshold probability
-        cube naming function produces the correctly formatted names"""
-        self.cube.rename('probability_of_X_rate_above_threshold')
-        correct_name_above = (
-            'probability_of_X_rate_in_vicinity_above_threshold')
-        new_name_above = in_vicinity_name_format(self.cube.name())
-
-        self.cube.rename('probability_of_X_below_threshold')
-        correct_name_below = (
-            'probability_of_X_in_vicinity_below_threshold')
-        new_name_below = in_vicinity_name_format(self.cube.name())
-
-        # Test the case of name without above/below_threshold
-        self.cube.rename('probability_of_X')
-        correct_name_no_threshold = (
-            'probability_of_X_in_vicinity')
-        new_name_no_threshold = in_vicinity_name_format(self.cube.name())
-
-        self.assertEqual(new_name_above, correct_name_above)
-        self.assertEqual(new_name_below, correct_name_below)
-        self.assertEqual(new_name_no_threshold, correct_name_no_threshold)
-
 
 class Test_resolve_metadata_diff(IrisTest):
     """Test the resolve_metadata_diff method."""
@@ -826,6 +803,38 @@ class Test_add_history_attribute(IrisTest):
         add_history_attribute(cube, "Nowcast", append=True)
         self.assertTrue("history" in cube.attributes)
         self.assertTrue("Nowcast" in cube.attributes["history"])
+
+
+class Test_probability_cube_in_vicinity_rename(IrisTest):
+    """Test that the 'in_vicinity' above/below threshold probability
+    cube naming function produces the correctly formatted names."""
+
+    def setUp(self):
+        """Set up test cube"""
+        self.cube = create_cube_with_threshold()
+        self.cube.long_name = 'probability_of_X_rate_above_threshold'
+
+    def test_in_vicinity_name_format(self):
+        """Test that 'in_vicinity' is added correctly to the name for both
+        above and below threshold cases"""
+        correct_name_above = (
+            'probability_of_X_rate_in_vicinity_above_threshold')
+        new_name_above = in_vicinity_name_format(self.cube.name())
+        self.cube.rename('probability_of_X_below_threshold')
+        correct_name_below = (
+            'probability_of_X_in_vicinity_below_threshold')
+        new_name_below = in_vicinity_name_format(self.cube.name())
+        self.assertEqual(new_name_above, correct_name_above)
+        self.assertEqual(new_name_below, correct_name_below)
+
+    def test_no_above_below_threshold(self):
+        """Test the case of name without above/below_threshold is handled
+        correctly"""
+        self.cube.rename('probability_of_X')
+        correct_name_no_threshold = (
+            'probability_of_X_in_vicinity')
+        new_name_no_threshold = in_vicinity_name_format(self.cube.name())
+        self.assertEqual(new_name_no_threshold, correct_name_no_threshold)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -616,20 +616,20 @@ class Test_amend_metadata(IrisTest):
     def test_in_vicinity_name_format(self):
         """Test that the 'in_vicinity' above/below threshold probability
         cube naming function produces the correctly formatted names"""
-        self.cube.rename('probability_of_rainfall_rate_above_threshold')
+        self.cube.rename('probability_of_X_rate_above_threshold')
         correct_name_above = (
-            'probability_of_rainfall_rate_in_vicinity_above_threshold')
+            'probability_of_X_rate_in_vicinity_above_threshold')
         new_name_above = in_vicinity_name_format(self.cube.name())
 
-        self.cube.rename('probability_of_visibility_below_threshold')
+        self.cube.rename('probability_of_X_below_threshold')
         correct_name_below = (
-            'probability_of_visibility_in_vicinity_below_threshold')
+            'probability_of_X_in_vicinity_below_threshold')
         new_name_below = in_vicinity_name_format(self.cube.name())
 
         # Test the case of name without above/below_threshold
-        self.cube.rename('probability_of_diagnostic')
+        self.cube.rename('probability_of_X')
         correct_name_no_threshold = (
-            'probability_of_diagnostic_in_vicinity')
+            'probability_of_X_in_vicinity')
         new_name_no_threshold = in_vicinity_name_format(self.cube.name())
 
         self.assertEqual(new_name_above, correct_name_above)

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -419,8 +419,8 @@ class Test_create_condition_chain(IrisTest):
                     "name='probability_of_lwe_snowfall_rate_above_threshold',"
                     " threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max}))[0].data >= 0.5)".format(
-            t_min=(1. - WeatherSymbols().float_tolerance),
-            t_max=(1. + WeatherSymbols().float_tolerance)))
+                        t_min=(1. - WeatherSymbols().float_tolerance),
+                        t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, list)
         self.assertIsInstance(result[0], str)
         self.assertEqual(result[0], expected)
@@ -441,8 +441,8 @@ class Test_construct_extract_constraint(IrisTest):
                     "name='probability_of_rainfall_rate_above_threshold', "
                     "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max})".format(
-            t_min=(1. - WeatherSymbols().float_tolerance),
-            t_max=(1. + WeatherSymbols().float_tolerance)))
+                        t_min=(1. - WeatherSymbols().float_tolerance),
+                        t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 
@@ -461,8 +461,8 @@ class Test_construct_extract_constraint(IrisTest):
                     "name='probability_of_lwe_snowfall_rate_above_threshold', "
                     "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max})".format(
-            t_min=(1. - WeatherSymbols().float_tolerance),
-            t_max=(1. + WeatherSymbols().float_tolerance)))
+                        t_min=(1. - WeatherSymbols().float_tolerance),
+                        t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, list)
         self.assertIsInstance(result[1], str)
         self.assertEqual(len(result), 2)

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -114,8 +114,8 @@ def set_up_wxcubes():
     cloud_below_1000ft = (
         set_up_probability_above_threshold_cube(
             data_cld_1000ft,
-            'cloud_area_fraction_above_threshold_assuming_only'
-            '_consider_surface_to_1000_feet_asl',
+            'cloud_area_fraction_assuming_only'
+            '_consider_surface_to_1000_feet_asl_above_threshold',
             '1',
             forecast_thresholds=np.array([0.85])))
 
@@ -179,8 +179,8 @@ def set_up_wxcubes_global():
     cloud_below_1000ft = (
         set_up_probability_above_threshold_cube(
             data_cld_1000ft,
-            'cloud_area_fraction_above_threshold_assuming_only'
-            '_consider_surface_to_1000_feet_asl',
+            'cloud_area_fraction_assuming_only'
+            '_consider_surface_to_1000_feet_asl_above_threshold',
             '1',
             forecast_thresholds=np.array([0.85])))
 

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -34,7 +34,6 @@ import unittest
 
 import numpy as np
 
-
 import iris
 from iris.tests import IrisTest
 from iris.coords import AuxCoord
@@ -202,7 +201,6 @@ def set_up_wxcubes_global():
 
 
 class Test__repr__(IrisTest):
-
     """Test the repr method."""
 
     def test_basic(self):
@@ -219,7 +217,6 @@ class Test__repr__(IrisTest):
 
 
 class Test_check_input_cubes(IrisTest):
-
     """Test the check_input_cubes method."""
 
     def setUp(self):
@@ -274,7 +271,6 @@ class Test_check_input_cubes(IrisTest):
 
 
 class Test_invert_condition(IrisTest):
-
     """Test the invert condition method."""
 
     def test_basic(self):
@@ -311,19 +307,19 @@ class Test_invert_condition(IrisTest):
 
 
 class Test_construct_condition(IrisTest):
-
     """Test the construct condition method."""
 
     def test_basic(self):
         """Test that the construct_condition method returns a string."""
         plugin = WeatherSymbols()
-        constraint_value = iris.Constraint(name='probability_of_rainfall_rate',
-                                           coord_values={'threshold': 0.03})
+        constraint_value = iris.Constraint(
+            name='probability_of_rainfall_rate__above_threshold',
+            coord_values={'threshold': 0.03})
         condition = '<'
         prob_threshold = 0.5
         gamma = None
         expected = ("cubes.extract(Constraint(name="
-                    "'probability_of_rainfall_rate',"
+                    "'probability_of_rainfall_rate_above_threshold',"
                     " coord_values={'threshold': 0.03})"
                     ")[0].data < 0.5")
         result = plugin.construct_condition(constraint_value,
@@ -338,18 +334,20 @@ class Test_construct_condition(IrisTest):
         of Constraints. """
         plugin = WeatherSymbols()
         constraint_list = [
-            iris.Constraint(name='probability_of_lwe_snowfall_rate',
-                            coord_values={'threshold': 0.03}),
-            iris.Constraint(name='probability_of_rainfall_rate',
-                            coord_values={'threshold': 0.03})]
+            iris.Constraint(
+                name='probability_of_lwe_snowfall_rate_above_threshold',
+                coord_values={'threshold': 0.03}),
+            iris.Constraint(
+                name='probability_of_rainfall_rate_above_threshold',
+                coord_values={'threshold': 0.03})]
         condition = '<'
         prob_threshold = 0.5
         gamma = 0.7
         expected = ("(cubes.extract(Constraint(name="
-                    "'probability_of_lwe_snowfall_rate', "
+                    "'probability_of_lwe_snowfall_rate_above_threshold', "
                     "coord_values={'threshold': 0.03}))[0].data - "
                     "cubes.extract(Constraint(name="
-                    "'probability_of_rainfall_rate', "
+                    "'probability_of_rainfall_rate_above_threshold', "
                     "coord_values={'threshold': 0.03}))[0].data * 0.7) < 0.5")
         result = plugin.construct_condition(constraint_list,
                                             condition,
@@ -360,7 +358,6 @@ class Test_construct_condition(IrisTest):
 
 
 class Test_format_condition_chain(IrisTest):
-
     """Test the format_condition_chain method."""
 
     def test_basic(self):
@@ -384,7 +381,6 @@ class Test_format_condition_chain(IrisTest):
 
 
 class Test_create_condition_chain(IrisTest):
-
     """Test the create_condition_chain method."""
 
     def setUp(self):
@@ -396,12 +392,13 @@ class Test_create_condition_chain(IrisTest):
                 'probability_thresholds': [0.5, 0.5],
                 'threshold_condition': '>=',
                 'condition_combination': 'OR',
-                'diagnostic_fields': ['probability_of_rainfall_rate',
-                                      'probability_of_lwe_snowfall_rate'],
+                'diagnostic_fields':
+                    ['probability_of_rainfall_rate_above_threshold',
+                     'probability_of_lwe_snowfall_rate_above_threshold'],
                 'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                           AuxCoord(0.03, units='mm hr-1')],
                 'diagnostic_conditions': ['above', 'above']}
-            }
+        }
 
     def test_basic(self):
         """Test create_condition_chain returns a list of strings."""
@@ -409,34 +406,36 @@ class Test_create_condition_chain(IrisTest):
         test_condition = self.dummy_queries['significant_precipitation']
         result = plugin.create_condition_chain(test_condition)
         expected = ("(cubes.extract(iris.Constraint(name='probability_of_"
-                    "rainfall_rate', threshold=lambda cell: 0.03 * {t_min} < "
+                    "rainfall_rate_above_threshold', threshold=lambda cell: "
+                    "0.03 * {t_min} < "
                     "cell < 0.03 * {t_max}))[0].data >= 0.5) | (cubes.extract"
-                    "(iris.Constraint(name='probability_of_lwe_snowfall_rate',"
+                    "(iris.Constraint("
+                    "name='probability_of_lwe_snowfall_rate_above_threshold',"
                     " threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max}))[0].data >= 0.5)".format(
-                        t_min=(1. - WeatherSymbols().float_tolerance),
-                        t_max=(1. + WeatherSymbols().float_tolerance)))
+            t_min=(1. - WeatherSymbols().float_tolerance),
+            t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, list)
         self.assertIsInstance(result[0], str)
         self.assertEqual(result[0], expected)
 
 
 class Test_construct_extract_constraint(IrisTest):
-
     """Test the construct_extract_constraint method ."""
 
     def test_basic(self):
         """Test construct_extract_constraint returns a iris.Constraint."""
         plugin = WeatherSymbols()
-        diagnostic = 'probability_of_rainfall_rate'
+        diagnostic = 'probability_of_rainfall_rate_above_threshold'
         threshold = AuxCoord(0.03, units='mm hr-1')
         result = plugin.construct_extract_constraint(diagnostic,
                                                      threshold)
-        expected = ("iris.Constraint(name='probability_of_rainfall_rate', "
+        expected = ("iris.Constraint("
+                    "name='probability_of_rainfall_rate'_above_threshold, "
                     "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max})".format(
-                        t_min=(1. - WeatherSymbols().float_tolerance),
-                        t_max=(1. + WeatherSymbols().float_tolerance)))
+            t_min=(1. - WeatherSymbols().float_tolerance),
+            t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 
@@ -444,18 +443,19 @@ class Test_construct_extract_constraint(IrisTest):
         """Test construct_extract_constraint returns a list
            of iris.Constraint."""
         plugin = WeatherSymbols()
-        diagnostics = ['probability_of_rainfall_rate',
-                       'probability_of_lwe_snowfall_rate']
+        diagnostics = ['probability_of_rainfall_rate_above_threshold',
+                       'probability_of_lwe_snowfall_rate_above_threshold']
         thresholds = [AuxCoord(0.03, units='mm hr-1'),
                       AuxCoord(0.03, units='mm hr-1')]
         result = plugin.construct_extract_constraint(diagnostics,
                                                      thresholds)
 
-        expected = ("iris.Constraint(name='probability_of_lwe_snowfall_rate', "
+        expected = ("iris.Constraint("
+                    "name='probability_of_lwe_snowfall_rate_above_threshold', "
                     "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max})".format(
-                        t_min=(1. - WeatherSymbols().float_tolerance),
-                        t_max=(1. + WeatherSymbols().float_tolerance)))
+            t_min=(1. - WeatherSymbols().float_tolerance),
+            t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, list)
         self.assertIsInstance(result[1], str)
         self.assertEqual(len(result), 2)
@@ -463,7 +463,6 @@ class Test_construct_extract_constraint(IrisTest):
 
 
 class Test_find_all_routes(IrisTest):
-
     """Test the find_all_routes method ."""
 
     def setUp(self):
@@ -506,7 +505,6 @@ class Test_find_all_routes(IrisTest):
 
 
 class Test_create_symbol_cube(IrisTest):
-
     """Test the create_symbol_cube method ."""
 
     def setUp(self):
@@ -534,8 +532,8 @@ class Test_create_symbol_cube(IrisTest):
 
 
 class Test_process(IrisTest):
-
     """Test the find_all_routes method ."""
+
     def setUp(self):
         """ Set up wxcubes for testing. """
         self.cubes = set_up_wxcubes()

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -54,7 +54,7 @@ def set_up_wxcubes():
     snowfall_rate = (
         set_up_probability_above_threshold_cube(
             data_snow,
-            'lwe_snowfall_rate',
+            'lwe_snowfall_rate_above_threshold',
             'm s-1',
             forecast_thresholds=np.array([8.33333333e-09,
                                           2.77777778e-08,
@@ -67,7 +67,7 @@ def set_up_wxcubes():
     rainfall_rate = (
         set_up_probability_above_threshold_cube(
             data_rain,
-            'rainfall_rate',
+            'rainfall_rate_above_threshold',
             'm s-1',
             forecast_thresholds=np.array([8.33333333e-09,
                                           2.77777778e-08,
@@ -80,7 +80,7 @@ def set_up_wxcubes():
     snowfall_vicinity = (
         set_up_probability_above_threshold_cube(
             data_snowv,
-            'lwe_snowfall_rate_in_vicinity',
+            'lwe_snowfall_rate_in_vicinity_above_threshold',
             'm s-1',
             forecast_thresholds=np.array([8.33333333e-09,
                                           2.77777778e-08,
@@ -93,7 +93,7 @@ def set_up_wxcubes():
     rainfall_vicinity = (
         set_up_probability_above_threshold_cube(
             data_rainv,
-            'rainfall_rate_in_vicinity',
+            'rainfall_rate_in_vicinity_above_threshold',
             'm s-1',
             forecast_thresholds=np.array([8.33333333e-09,
                                           2.77777778e-08,
@@ -104,7 +104,7 @@ def set_up_wxcubes():
                            0.0, 0.0, 1.0]).reshape(2, 1, 3, 3)
     cloud = (set_up_probability_above_threshold_cube(
         data_cloud,
-        'cloud_area_fraction',
+        'cloud_area_fraction_above_threshold',
         '1',
         forecast_thresholds=np.array([0.1875, 0.8125])))
 
@@ -113,7 +113,7 @@ def set_up_wxcubes():
     cloud_below_1000ft = (
         set_up_probability_above_threshold_cube(
             data_cld_1000ft,
-            'cloud_area_fraction_assuming_only'
+            'cloud_area_fraction_above_threshold_assuming_only'
             '_consider_surface_to_1000_feet_asl',
             '1',
             forecast_thresholds=np.array([0.85])))
@@ -124,7 +124,7 @@ def set_up_wxcubes():
     visibility = (
         set_up_probability_above_threshold_cube(
             data_vis,
-            'visibility_in_air',
+            'visibility_in_air_below_threshold',
             'm',
             forecast_thresholds=np.array([1000.0, 5000.0])))
     visibility.attributes['relative_to_threshold'] = 'below'
@@ -145,7 +145,7 @@ def set_up_wxcubes_global():
     snowfall_rate = (
         set_up_probability_above_threshold_cube(
             data_snow,
-            'lwe_snowfall_rate',
+            'lwe_snowfall_rate_above_threshold',
             'm s-1',
             forecast_thresholds=np.array([8.33333333e-09,
                                           2.77777778e-08,
@@ -158,7 +158,7 @@ def set_up_wxcubes_global():
     rainfall_rate = (
         set_up_probability_above_threshold_cube(
             data_rain,
-            'rainfall_rate',
+            'rainfall_rate_above_threshold',
             'm s-1',
             forecast_thresholds=np.array([8.33333333e-09,
                                           2.77777778e-08,
@@ -169,7 +169,7 @@ def set_up_wxcubes_global():
                            0.0, 0.0, 1.0]).reshape(2, 1, 3, 3)
     cloud = (set_up_probability_above_threshold_cube(
         data_cloud,
-        'cloud_area_fraction',
+        'cloud_area_fraction_above_threshold',
         '1',
         forecast_thresholds=np.array([0.1875, 0.8125])))
 
@@ -178,7 +178,7 @@ def set_up_wxcubes_global():
     cloud_below_1000ft = (
         set_up_probability_above_threshold_cube(
             data_cld_1000ft,
-            'cloud_area_fraction_assuming_only'
+            'cloud_area_fraction_above_threshold_assuming_only'
             '_consider_surface_to_1000_feet_asl',
             '1',
             forecast_thresholds=np.array([0.85])))
@@ -189,7 +189,7 @@ def set_up_wxcubes_global():
     visibility = (
         set_up_probability_above_threshold_cube(
             data_vis,
-            'visibility_in_air',
+            'visibility_in_air_below_threshold',
             'm',
             forecast_thresholds=np.array([1000.0, 5000.0])))
     visibility.attributes['relative_to_threshold'] = 'below'
@@ -313,7 +313,7 @@ class Test_construct_condition(IrisTest):
         """Test that the construct_condition method returns a string."""
         plugin = WeatherSymbols()
         constraint_value = iris.Constraint(
-            name='probability_of_rainfall_rate__above_threshold',
+            name='probability_of_rainfall_rate_above_threshold',
             coord_values={'threshold': 0.03})
         condition = '<'
         prob_threshold = 0.5
@@ -431,7 +431,7 @@ class Test_construct_extract_constraint(IrisTest):
         result = plugin.construct_extract_constraint(diagnostic,
                                                      threshold)
         expected = ("iris.Constraint("
-                    "name='probability_of_rainfall_rate'_above_threshold, "
+                    "name='probability_of_rainfall_rate_above_threshold', "
                     "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
                     "{t_max})".format(
             t_min=(1. - WeatherSymbols().float_tolerance),

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -34,6 +34,7 @@ import unittest
 
 import numpy as np
 
+
 import iris
 from iris.tests import IrisTest
 from iris.coords import AuxCoord
@@ -201,6 +202,7 @@ def set_up_wxcubes_global():
 
 
 class Test__repr__(IrisTest):
+
     """Test the repr method."""
 
     def test_basic(self):
@@ -217,6 +219,7 @@ class Test__repr__(IrisTest):
 
 
 class Test_check_input_cubes(IrisTest):
+
     """Test the check_input_cubes method."""
 
     def setUp(self):
@@ -271,6 +274,7 @@ class Test_check_input_cubes(IrisTest):
 
 
 class Test_invert_condition(IrisTest):
+
     """Test the invert condition method."""
 
     def test_basic(self):
@@ -307,6 +311,7 @@ class Test_invert_condition(IrisTest):
 
 
 class Test_construct_condition(IrisTest):
+
     """Test the construct condition method."""
 
     def test_basic(self):
@@ -358,6 +363,7 @@ class Test_construct_condition(IrisTest):
 
 
 class Test_format_condition_chain(IrisTest):
+
     """Test the format_condition_chain method."""
 
     def test_basic(self):
@@ -421,6 +427,7 @@ class Test_create_condition_chain(IrisTest):
 
 
 class Test_construct_extract_constraint(IrisTest):
+
     """Test the construct_extract_constraint method ."""
 
     def test_basic(self):
@@ -463,6 +470,7 @@ class Test_construct_extract_constraint(IrisTest):
 
 
 class Test_find_all_routes(IrisTest):
+
     """Test the find_all_routes method ."""
 
     def setUp(self):
@@ -505,6 +513,7 @@ class Test_find_all_routes(IrisTest):
 
 
 class Test_create_symbol_cube(IrisTest):
+
     """Test the create_symbol_cube method ."""
 
     def setUp(self):
@@ -532,6 +541,7 @@ class Test_create_symbol_cube(IrisTest):
 
 
 class Test_process(IrisTest):
+
     """Test the find_all_routes method ."""
 
     def setUp(self):

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -198,12 +198,12 @@ class BasicThreshold(object):
                 a given threshold has been exceeded or not.
 
                 The cube meta-data will contain:
-                 * input_cube name prepended with
-                 `probability_of_X_above(or below)_threshold where X is
-                 the diagnostic under consideration`
-                 * threshold dimension coordinate with same units as input_cube
-                 * threshold attribute (above or below threshold)
-                 * cube units set to (1).
+                * Input_cube name prepended with
+                probability_of_X_above(or below)_threshold (where X is
+                the diagnostic under consideration)
+                * Threshold dimension coordinate with same units as input_cube
+                * Threshold attribute (above or below threshold)
+                * Cube units set to (1).
 
         Raises:
             ValueError: if a np.nan value is detected within the input cube.

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -274,7 +274,7 @@ class BasicThreshold(object):
             cube.attributes.update({'relative_to_threshold': 'below'})
         else:
             cube.attributes.update({'relative_to_threshold': 'above'})
-        cube.rename("probability_of_{}".format(cube.name()))
+        cube.rename("probability_of_{}_above_threshold".format(cube.name()))
         cube.units = Unit(1)
 
         cube = enforce_coordinate_ordering(

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -198,7 +198,9 @@ class BasicThreshold(object):
                 a given threshold has been exceeded or not.
 
                 The cube meta-data will contain:
-                 * input_cube name prepended with `probability_of_`
+                 * input_cube name prepended with
+                 `probability_of_X_above(or below)_threshold where X is
+                 the diagnostic under consideration`
                  * threshold dimension coordinate with same units as input_cube
                  * threshold attribute (above or below threshold)
                  * cube units set to (1).

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -272,9 +272,12 @@ class BasicThreshold(object):
         # Force the metadata to temporary conventions
         if self.below_thresh_ok:
             cube.attributes.update({'relative_to_threshold': 'below'})
+            cube.rename(
+                "probability_of_{}_below_threshold".format(cube.name()))
         else:
             cube.attributes.update({'relative_to_threshold': 'above'})
-        cube.rename("probability_of_{}_above_threshold".format(cube.name()))
+            cube.rename(
+                "probability_of_{}_above_threshold".format(cube.name()))
         cube.units = Unit(1)
 
         cube = enforce_coordinate_ordering(

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -609,3 +609,30 @@ def add_history_attribute(cube, value, append=False):
         cube.attributes["history"] += '; {}'.format(new_history)
     else:
         cube.attributes["history"] = new_history
+
+
+def in_vicinity_name_format(cube_name):
+    """Generate the correct name format for an 'in_vicinity' probability
+    cube, taking into account the _'above/below_threshold' suffix required
+    by convention.
+
+    Args:
+        cube_name (str):
+            The 'in_vicinity' probability cube name to be formatted.
+
+    Returns:
+        new_cube_name (str):
+            Correctly formatted name following the accepted convention e.g.
+            'probability_of_X_in_vicinity_above_threshold'.
+    """
+    relative_to_threshold_index = max(
+        cube_name.find('_above_threshold'),
+        cube_name.find('_below_threshold'))
+    if relative_to_threshold_index == -1:
+        new_cube_name = cube_name + '_in_vicinity'
+    else:
+        new_cube_name = (cube_name[:relative_to_threshold_index] +
+                         '_in_vicinity' +
+                         cube_name[relative_to_threshold_index:])
+
+    return new_cube_name

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -624,11 +624,19 @@ def in_vicinity_name_format(cube_name):
         new_cube_name (str):
             Correctly formatted name following the accepted convention e.g.
             'probability_of_X_in_vicinity_above_threshold'.
+
+    Raises:
+        ValueError: If the input cube name already contains 'in_vicinity'.
     """
     relative_to_threshold_index = max(
         cube_name.find('_above_threshold'),
         cube_name.find('_below_threshold'))
-    if relative_to_threshold_index == -1:
+
+    if 'in_vicinity' in cube_name:
+        msg = "Cube name already contains 'in_vicinity'"
+        raise ValueError(msg)
+
+    elif relative_to_threshold_index == -1:
         new_cube_name = cube_name + '_in_vicinity'
     else:
         new_cube_name = (cube_name[:relative_to_threshold_index] +

--- a/lib/improver/wxcode/weather_symbols.py
+++ b/lib/improver/wxcode/weather_symbols.py
@@ -196,7 +196,7 @@ class WeatherSymbols(object):
                 e.g.::
 
                   cubes.extract(Constraint(
-                          name='probability_of_rainfall_rate',
+                          name='probability_of_rainfall_rate_above_threshold',
                           coord_values={'threshold': 0.03})
                                 )[0].data < 0.5)
         """
@@ -248,11 +248,12 @@ class WeatherSymbols(object):
 
                   [
                     "(cubes.extract(Constraint(
-                          name='probability_of_rainfall_rate',
+                          name='probability_of_rainfall_rate_above_threshold',
                           coord_values={'threshold': 0.03})
                      )[0].data < 0.5) |
                      (cubes.extract(Constraint(
-                          name='probability_of_lwe_snowfall_rate',
+                          name=
+                          'probability_of_lwe_snowfall_rate_above_threshold',
                           coord_values={'threshold': 0.03})
                      )[0].data < 0.5)"
                   ]

--- a/lib/improver/wxcode/wxcode_decision_tree.py
+++ b/lib/improver/wxcode/wxcode_decision_tree.py
@@ -274,9 +274,9 @@ def wxcode_decision_tree():
             'condition_combination': 'AND',
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
-                 ('probability_of_cloud_area_fraction_above_threshold_'
+                 ('probability_of_cloud_area_fraction_'
                   'assuming_only_consider_surface_to_1000'
-                  '_feet_asl')],
+                  '_feet_asl_above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above', 'above']},
@@ -299,9 +299,9 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                [('probability_of_cloud_area_fraction_above_threshold_'
-                                   'assuming_only_consider_surface_to_1000'
-                                   '_feet_asl')],
+                [('probability_of_cloud_area_fraction_assuming'
+                                   '_only_consider_surface_to_1000_feet_asl'
+                                   '_above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above']},
 

--- a/lib/improver/wxcode/wxcode_decision_tree.py
+++ b/lib/improver/wxcode/wxcode_decision_tree.py
@@ -79,8 +79,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'OR',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  'probability_of_lwe_snowfall_rate'],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 'probability_of_lwe_snowfall_rate_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1'),
                                       AuxCoord(1.0, units='mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
@@ -91,7 +92,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -101,10 +103,11 @@ def wxcode_decision_tree():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')],
@@ -119,10 +122,11 @@ def wxcode_decision_tree():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')],
@@ -137,8 +141,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')]],
@@ -150,8 +155,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')]],
@@ -163,8 +169,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'OR',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  'probability_of_lwe_snowfall_rate'],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 'probability_of_lwe_snowfall_rate_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.1, units='mm hr-1'),
                                       AuxCoord(0.1, units='mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
@@ -175,7 +182,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -185,10 +193,11 @@ def wxcode_decision_tree():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')],
@@ -203,8 +212,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')]],
@@ -216,10 +226,11 @@ def wxcode_decision_tree():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')],
@@ -234,8 +245,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')]],
@@ -247,8 +259,9 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  'probability_of_visibility_in_air'],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 'probability_of_visibility_in_air_below_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(5000., units='m')],
             'diagnostic_conditions': ['above', 'below']},
@@ -259,10 +272,11 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  ('probability_of_cloud_area_fraction_'
-                                   'assuming_only_consider_surface_to_1000'
-                                   '_feet_asl')],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 ('probability_of_cloud_area_fraction_above_threshold_'
+                  'assuming_only_consider_surface_to_1000'
+                  '_feet_asl')],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above', 'above']},
@@ -273,7 +287,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -283,7 +298,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [('probability_of_cloud_area_fraction_'
+            'diagnostic_fields':
+                [('probability_of_cloud_area_fraction_above_threshold_'
                                    'assuming_only_consider_surface_to_1000'
                                    '_feet_asl')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
@@ -295,7 +311,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.1875, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -306,8 +323,9 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': 'OR',
             'diagnostic_fields': [
-                'probability_of_rainfall_rate_in_vicinity',
-                'probability_of_lwe_snowfall_rate_in_vicinity'],
+                'probability_of_rainfall_rate_in_vicinity_above_threshold',
+                'probability_of_lwe_snowfall_rate_in_vicinity_'
+                'above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.1, units='mm hr-1'),
                                       AuxCoord(0.1, units='mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
@@ -319,10 +337,12 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': 'AND',
             'diagnostic_fields': [
-                ['probability_of_lwe_snowfall_rate_in_vicinity',
-                 'probability_of_rainfall_rate_in_vicinity'],
-                ['probability_of_rainfall_rate_in_vicinity',
-                 'probability_of_lwe_snowfall_rate_in_vicinity']],
+                ['probability_of_lwe_snowfall_rate_in_vicinity_'
+                 'above_threshold',
+                 'probability_of_rainfall_rate_in_vicinity_above_threshold'],
+                ['probability_of_rainfall_rate_in_vicinity_above_threshold',
+                 'probability_of_lwe_snowfall_rate_in_vicinity_'
+                 'above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')],
@@ -338,8 +358,9 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields': [
-                ['probability_of_lwe_snowfall_rate_in_vicinity',
-                 'probability_of_rainfall_rate_in_vicinity']],
+                ['probability_of_lwe_snowfall_rate_in_vicinity_'
+                 'above_threshold',
+                 'probability_of_rainfall_rate_in_vicinity_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')]],
@@ -351,7 +372,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -362,7 +384,8 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields': [
-                'probability_of_lwe_snowfall_rate_in_vicinity'],
+                'probability_of_lwe_snowfall_rate_in_vicinity_'
+                'above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
             'diagnostic_conditions': ['above']},
 
@@ -373,7 +396,8 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields': [
-                'probability_of_lwe_snowfall_rate_in_vicinity'],
+                'probability_of_lwe_snowfall_rate_in_vicinity_'
+                'above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
             'diagnostic_conditions': ['above']},
 
@@ -383,7 +407,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -394,7 +419,7 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields': [
-                'probability_of_rainfall_rate_in_vicinity'],
+                'probability_of_rainfall_rate_in_vicinity_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
             'diagnostic_conditions': ['above']},
 
@@ -405,7 +430,7 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields': [
-                'probability_of_rainfall_rate_in_vicinity'],
+                'probability_of_rainfall_rate_in_vicinity_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
             'diagnostic_conditions': ['above']},
 
@@ -415,7 +440,8 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_visibility_in_air'],
+            'diagnostic_fields':
+                ['probability_of_visibility_in_air_below_threshold'],
             'diagnostic_thresholds': [AuxCoord(5000., units='m')],
             'diagnostic_conditions': ['below']},
 
@@ -425,9 +451,10 @@ def wxcode_decision_tree():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_visibility_in_air'],
+            'diagnostic_fields':
+                ['probability_of_visibility_in_air_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1000., units='m')],
             'diagnostic_conditions': ['below']},
-        }
+    }
 
     return queries

--- a/lib/improver/wxcode/wxcode_decision_tree.py
+++ b/lib/improver/wxcode/wxcode_decision_tree.py
@@ -452,7 +452,7 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                ['probability_of_visibility_in_air_above_threshold'],
+                ['probability_of_visibility_in_air_below_threshold'],
             'diagnostic_thresholds': [AuxCoord(1000., units='m')],
             'diagnostic_conditions': ['below']},
     }

--- a/lib/improver/wxcode/wxcode_decision_tree.py
+++ b/lib/improver/wxcode/wxcode_decision_tree.py
@@ -299,9 +299,8 @@ def wxcode_decision_tree():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                [('probability_of_cloud_area_fraction_assuming'
-                                   '_only_consider_surface_to_1000_feet_asl'
-                                   '_above_threshold')],
+                [('probability_of_cloud_area_fraction_assuming_only_consider_'
+                    'surface_to_1000_feet_asl_above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above']},
 

--- a/lib/improver/wxcode/wxcode_decision_tree_global.py
+++ b/lib/improver/wxcode/wxcode_decision_tree_global.py
@@ -274,9 +274,9 @@ def wxcode_decision_tree_global():
             'condition_combination': 'AND',
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
-                 ('probability_of_cloud_area_fraction_above_threshold_'
+                 ('probability_of_cloud_area_fraction_'
                   'assuming_only_consider_surface_to_1000'
-                  '_feet_asl')],
+                  '_feet_asl_above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above', 'above']},
@@ -299,9 +299,9 @@ def wxcode_decision_tree_global():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                [('probability_of_cloud_area_fraction_above_threshold_'
+                [('probability_of_cloud_area_fraction_'
                   'assuming_only_consider_surface_to_1000'
-                  '_feet_asl')],
+                  '_feet_asl_above_threshold')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above']},
 

--- a/lib/improver/wxcode/wxcode_decision_tree_global.py
+++ b/lib/improver/wxcode/wxcode_decision_tree_global.py
@@ -79,8 +79,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'OR',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  'probability_of_lwe_snowfall_rate'],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 'probability_of_lwe_snowfall_rate_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1'),
                                       AuxCoord(1.0, units='mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
@@ -91,7 +92,8 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -101,10 +103,11 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')],
@@ -119,10 +122,11 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')],
@@ -137,8 +141,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')]],
@@ -150,8 +155,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
                                        AuxCoord(1.0, units='mm hr-1')]],
@@ -163,8 +169,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'OR',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  'probability_of_lwe_snowfall_rate'],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 'probability_of_lwe_snowfall_rate_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.1, units='mm hr-1'),
                                       AuxCoord(0.1, units='mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
@@ -175,7 +182,8 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -185,10 +193,11 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')],
@@ -203,8 +212,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')]],
@@ -216,10 +226,11 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0., 0.],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate'],
-                                  ['probability_of_rainfall_rate',
-                                   'probability_of_lwe_snowfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold'],
+                 ['probability_of_rainfall_rate_above_threshold',
+                  'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')],
@@ -234,8 +245,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [['probability_of_lwe_snowfall_rate',
-                                   'probability_of_rainfall_rate']],
+            'diagnostic_fields':
+                [['probability_of_lwe_snowfall_rate_above_threshold',
+                  'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
                                        AuxCoord(0.1, units='mm hr-1')]],
@@ -247,8 +259,9 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  'probability_of_visibility_in_air'],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 'probability_of_visibility_in_air_below_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(5000., units='m')],
             'diagnostic_conditions': ['above', 'below']},
@@ -259,10 +272,11 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5, 0.5],
             'threshold_condition': '>=',
             'condition_combination': 'AND',
-            'diagnostic_fields': ['probability_of_rainfall_rate',
-                                  ('probability_of_cloud_area_fraction_'
-                                   'assuming_only_consider_surface_to_1000'
-                                   '_feet_asl')],
+            'diagnostic_fields':
+                ['probability_of_rainfall_rate_above_threshold',
+                 ('probability_of_cloud_area_fraction_above_threshold_'
+                  'assuming_only_consider_surface_to_1000'
+                  '_feet_asl')],
             'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
                                       AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above', 'above']},
@@ -273,7 +287,8 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -283,9 +298,10 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': [('probability_of_cloud_area_fraction_'
-                                   'assuming_only_consider_surface_to_1000'
-                                   '_feet_asl')],
+            'diagnostic_fields':
+                [('probability_of_cloud_area_fraction__above_threshold_'
+                  'assuming_only_consider_surface_to_1000'
+                  '_feet_asl')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -295,7 +311,8 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_cloud_area_fraction'],
+            'diagnostic_fields':
+                ['probability_of_cloud_area_fraction_above_threshold'],
             'diagnostic_thresholds': [AuxCoord(0.1875, units=1)],
             'diagnostic_conditions': ['above']},
 
@@ -305,7 +322,8 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_visibility_in_air'],
+            'diagnostic_fields':
+                ['probability_of_visibility_in_air_below_threshold'],
             'diagnostic_thresholds': [AuxCoord(5000., units='m')],
             'diagnostic_conditions': ['below']},
 
@@ -315,9 +333,10 @@ def wxcode_decision_tree_global():
             'probability_thresholds': [0.5],
             'threshold_condition': '>=',
             'condition_combination': '',
-            'diagnostic_fields': ['probability_of_visibility_in_air'],
+            'diagnostic_fields':
+                ['probability_of_visibility_in_air_below_threshold'],
             'diagnostic_thresholds': [AuxCoord(1000., units='m')],
             'diagnostic_conditions': ['below']},
-        }
+    }
 
     return queries

--- a/lib/improver/wxcode/wxcode_decision_tree_global.py
+++ b/lib/improver/wxcode/wxcode_decision_tree_global.py
@@ -299,7 +299,7 @@ def wxcode_decision_tree_global():
             'threshold_condition': '>=',
             'condition_combination': '',
             'diagnostic_fields':
-                [('probability_of_cloud_area_fraction__above_threshold_'
+                [('probability_of_cloud_area_fraction_above_threshold_'
                   'assuming_only_consider_surface_to_1000'
                   '_feet_asl')],
             'diagnostic_thresholds': [AuxCoord(0.85, units=1)],

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -95,6 +95,7 @@ optional arguments:
                         collapse over. The default is set to None.
   --vicinity VICINITY   If set, distance in metres used to define the vicinity
                         within which to search for an occurrence.
+
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-threshold/01-help.bats
+++ b/tests/improver-threshold/01-help.bats
@@ -95,7 +95,6 @@ optional arguments:
                         collapse over. The default is set to None.
   --vicinity VICINITY   If set, distance in metres used to define the vicinity
                         within which to search for an occurrence.
-
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-wxcode/01-help.bats
+++ b/tests/improver-wxcode/01-help.bats
@@ -41,21 +41,21 @@ Calculate gridded weather symbol codes.
 This plugin requires a specific set of input diagnostics, where data
 may be in any units to which the thresholds given below can
 be converted:
- - probability_of_rainfall_rate; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_cloud_area_fraction; thresholds: above 0.1875 (1), above 0.8125 (1)
- - probability_of_visibility_in_air; thresholds: below 1000.0 (m), below 5000.0 (m)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl; thresholds: above 0.85 (1)
- - probability_of_rainfall_rate_in_vicinity; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate_in_vicinity; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_rainfall_rate_above_threshold; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_cloud_area_fraction_above_threshold; thresholds: above 0.1875 (1), above 0.8125 (1)
+ - probability_of_visibility_in_air_below_threshold; thresholds: below 1000.0 (m), below 5000.0 (m)
+ - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: above 0.85 (1)
+ - probability_of_rainfall_rate_in_vicinity_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_in_vicinity_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
 
  or for global data
 
- - probability_of_rainfall_rate; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_cloud_area_fraction; thresholds: above 0.1875 (1), above 0.8125 (1)
- - probability_of_visibility_in_air; thresholds: below 1000.0 (m), below 5000.0 (m)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl; thresholds: above 0.85 (1)
+ - probability_of_rainfall_rate_above_threshold; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_cloud_area_fraction_above_threshold; thresholds: above 0.1875 (1), above 0.8125 (1)
+ - probability_of_visibility_in_air_below_threshold; thresholds: below 1000.0 (m), below 5000.0 (m)
+ - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: above 0.85 (1)
 
 positional arguments:
   INPUT_FILES           Paths to files containing the required input diagnostics.
@@ -69,6 +69,7 @@ optional arguments:
   --wxtree WXTREE       Weather Code tree.
                         Choices are high_resolution or global.
                         Default=high_resolution.
+
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-wxcode/01-help.bats
+++ b/tests/improver-wxcode/01-help.bats
@@ -41,21 +41,21 @@ Calculate gridded weather symbol codes.
 This plugin requires a specific set of input diagnostics, where data
 may be in any units to which the thresholds given below can
 be converted:
- - probability_of_rainfall_rate_above_threshold; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_cloud_area_fraction_above_threshold; thresholds: above 0.1875 (1), above 0.8125 (1)
- - probability_of_visibility_in_air_below_threshold; thresholds: below 1000.0 (m), below 5000.0 (m)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: above 0.85 (1)
- - probability_of_rainfall_rate_in_vicinity_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate_in_vicinity_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
+ - probability_of_rainfall_rate_above_threshold; thresholds: 0.03 (mm hr-1), 0.1 (mm hr-1), 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
+ - probability_of_cloud_area_fraction_above_threshold; thresholds: 0.1875 (1), 0.8125 (1)
+ - probability_of_visibility_in_air_below_threshold; thresholds: 1000.0 (m), 5000.0 (m)
+ - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: 0.85 (1)
+ - probability_of_rainfall_rate_in_vicinity_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_in_vicinity_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
 
  or for global data
 
- - probability_of_rainfall_rate_above_threshold; thresholds: above 0.03 (mm hr-1), above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_lwe_snowfall_rate_above_threshold; thresholds: above 0.1 (mm hr-1), above 1.0 (mm hr-1)
- - probability_of_cloud_area_fraction_above_threshold; thresholds: above 0.1875 (1), above 0.8125 (1)
- - probability_of_visibility_in_air_below_threshold; thresholds: below 1000.0 (m), below 5000.0 (m)
- - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: above 0.85 (1)
+ - probability_of_rainfall_rate_above_threshold; thresholds: 0.03 (mm hr-1), 0.1 (mm hr-1), 1.0 (mm hr-1)
+ - probability_of_lwe_snowfall_rate_above_threshold; thresholds: 0.1 (mm hr-1), 1.0 (mm hr-1)
+ - probability_of_cloud_area_fraction_above_threshold; thresholds: 0.1875 (1), 0.8125 (1)
+ - probability_of_visibility_in_air_below_threshold; thresholds: 1000.0 (m), 5000.0 (m)
+ - probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold; thresholds: 0.85 (1)
 
 positional arguments:
   INPUT_FILES           Paths to files containing the required input diagnostics.

--- a/tests/improver-wxcode/02-basic.bats
+++ b/tests/improver-wxcode/02-basic.bats
@@ -43,7 +43,7 @@
       "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_lwe_snowfall_rate_in_vicinity_above_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_visibility_in_air_below_threshold.nc" \
       "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_above_threshold.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_above_threshold_assuming_only_consider_surface_to_1000_feet_asl.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/02-basic.bats
+++ b/tests/improver-wxcode/02-basic.bats
@@ -37,13 +37,13 @@
 
   # Run wxcode processing and check it passes.
   run improver wxcode \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_rainfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_rainfall_rate_in_vicinity.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_lwe_snowfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_lwe_snowfall_rate_in_vicinity.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_visibility_in_air.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_rainfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_rainfall_rate_in_vicinity_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_lwe_snowfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_lwe_snowfall_rate_in_vicinity_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_visibility_in_air_below_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/basic/probability_of_cloud_area_fraction_above_threshold_assuming_only_consider_surface_to_1000_feet_asl.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/03-native_units.bats
+++ b/tests/improver-wxcode/03-native_units.bats
@@ -37,13 +37,13 @@
 
   # Run wxcode processing and check it passes.
   run improver wxcode \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_rainfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_rainfall_rate_in_vicinity.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_lwe_snowfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_lwe_snowfall_rate_in_vicinity.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_visibility_in_air.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_cloud_area_fraction.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_rainfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_rainfall_rate_in_vicinity_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_lwe_snowfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_lwe_snowfall_rate_in_vicinity_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_visibility_in_air_below_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_cloud_area_fraction_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/native_units/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/04-global.bats
+++ b/tests/improver-wxcode/04-global.bats
@@ -37,11 +37,11 @@
 
   # Run wxcode processing and check it passes.
   run improver wxcode --wxtree='global' \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_rainfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_snowfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_visibility_at_screen_level.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_rainfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_snowfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_visibility_at_screen_level_below_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-wxcode/05-insufficient-files.bats
+++ b/tests/improver-wxcode/05-insufficient-files.bats
@@ -36,10 +36,10 @@
 
   # Run wxcode processing and check it passes.
   run improver wxcode --wxtree='global' \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_rainfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_snowfall_rate.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction.nc" \
-      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_rainfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_snowfall_rate_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_above_threshold.nc" \
+      "$IMPROVER_ACC_TEST_DIR/wxcode/global/probability_of_cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl_above_threshold.nc" \
       "$TEST_DIR/output.nc"
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]


### PR DESCRIPTION
Addresses #GitHubissuenum

Rename all IMPROVER cubes that contain probabilities like `probability_of_rainfall_rate` to follow a specified convention that includes whether the probability is above or below a threshold within the cube name, so that the cube name better describes the contents of the cube. For example:

-  `probability_of_rainfall_rate_above_threshold`
-  `probability_of_visibility_in_air_below_threshold`
-  `probability_of_lwe_precipitation_rate_in_vicinity_above_threshold`

Testing:
 - [x] Ran tests and they passed OK
 - [x] Update/added new tests for the changes

This PR covers an initial set of changes with a final set being made in PR #817 (this PR will be rebased on master once these initial changes have been merged in).

