### PR TITLE
Travis: Fix numpy version to 1.15.4 until we are 1.16.2 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda install -c conda-forge iris=2.1 cftime=1.0.1
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage
+  - conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 numpy=1.15.4 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage
   - pip install codacy-coverage codecov
 
   # List the name and version of all the dependencies within the conda environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate $ENV_NAME
 
   # Download Iris 2.0 and all dependencies.
-  - conda install -c conda-forge iris=2.1 cftime=1.0.1
+  - conda install -c conda-forge iris=2.1 cftime=1.0.1 numpy=1.15.4
 
   # Install our own extra dependencies (+ filelock for Iris test).
   - conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 numpy=1.15.4 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage


### PR DESCRIPTION
Set numpy to fixed version 1.15.4 until we have a chance to iron out the changes neccessary to use numpy 1.16.2.

Numpy 1.16.2 is causing PRs to fail the pylint test in the travis tests. This seems to be because previous warnings have now been escalated to errors. All of these are of the following types:

```
improver/utilities/solar.py:139:4: E1111: Assigning result of a function call, where the function has no return (assignment-from-no-return)
improver/orographic_enhancement.py:447:51: E1130: bad operand type for unary ~: tuple (invalid-unary-operand-type)
```

Testing:
 - [ ] Ran tests and they passed OK
