### PR TITLE
Update lapse rate and nowcast lightning tests

### DIFF
--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -470,7 +470,8 @@ class NowcastLightning(object):
             "rate_of_lightning", strict=True)
         lightning_rate_cube.convert_units("min^-1")  # Ensure units are correct
         prob_precip_cube = cubelist.extract(
-            "probability_of_precipitation_rate_above_threshold", strict=True)
+            "probability_of_lwe_precipitation_rate_above_threshold",
+            strict=True)
         # Now find prob_vii_cube. Can't use strict=True here as cube may not be
         # present, so will use a normal extract and then merge_cube if needed.
         prob_vii_cube = cubelist.extract(

--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -186,7 +186,7 @@ class NowcastLightning(object):
         Modify the meta data of input cube to resemble a Nowcast of lightning
         probability.
 
-        1. Rename to "probability_of_lightning_rate_above_threshold"
+        1. Rename to "probability_of_rate_of_lightning_above_threshold"
 
         2. Remove "threshold" coord
         (or causes iris.exceptions.CoordinateNotFoundError)
@@ -204,7 +204,7 @@ class NowcastLightning(object):
                 The data array will be a copy of the input cube.data
         """
         new_cube = cube.copy()
-        new_cube.rename("probability_of_lightning_rate_above_threshold")
+        new_cube.rename("probability_of_rate_of_lightning_above_threshold")
         new_cube.remove_coord('threshold')
         new_cube.cell_methods = None
         return new_cube
@@ -465,7 +465,7 @@ class NowcastLightning(object):
                 If cubelist does not contain the expected cubes.
         """
         first_guess_lightning_cube = cubelist.extract(
-            "probability_of_lightning_rate_above_threshold", strict=True)
+            "probability_of_rate_of_lightning_above_threshold", strict=True)
         lightning_rate_cube = cubelist.extract(
             "rate_of_lightning", strict=True)
         lightning_rate_cube.convert_units("min^-1")  # Ensure units are correct

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -163,7 +163,7 @@ class Test__update_metadata(IrisTest):
 
     def setUp(self):
         """Create a cube like this:
-        probability_of_precipitation_amount / (1)
+        probability_of_lwe_precipitation_rate_above_threshold / (1)
         Dimension coordinates:
             threshold: 1;
             projection_y_coordinate: 3;
@@ -180,7 +180,7 @@ class Test__update_metadata(IrisTest):
         data = np.ones((1, 16, 16), dtype=np.float32)
         thresholds = np.array([0.5], dtype=np.float32)
         self.cube = set_up_probability_cube(
-            data, thresholds, variable_name='precipitation_amount',
+            data, thresholds, variable_name='lwe_precipitation_rate',
             threshold_units='mm h-1')
         self.cube.add_cell_method(CellMethod('mean', coords='realization'))
         self.plugin = Plugin()
@@ -231,8 +231,13 @@ class Test__modify_first_guess(IrisTest):
             forecast_reference_time: 2015-11-23 07:00:00
             forecast_period: 0 seconds
 
+        self.cube:
+            Metadata describes the nowcast lightning fields to be calculated.
+            forecast_period: 0 seconds (simulates nowcast data)
         self.fg_cube:
             Has 4 hour forecast period, to test impact at lr2
+        self.ltng_cube:
+            forecast_period: 0 seconds (simulates nowcast data)
         self.precip_cube:
             Has extra coordinate of length(3) "threshold" containing
             points [0.5, 7., 35.] mm h-1.

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -88,11 +88,14 @@ def set_up_lightning_test_cubes(validity_time=dt(2015, 11, 23, 7),
         time=validity_time, frt=validity_time, spatial_grid='equalarea')
     template_cube.data[1, 1] = 0.
 
-    # first guess lightning FORECAST cube with flexible forecast period
-    # (required for level 2 lighting risk index) # TODO this is a problem...
-    first_guess_cube = set_up_variable_cube(
-        data.copy(), name='probability_of_lightning_rate_above_threshold',
-        units='1', time=validity_time, frt=fg_frt, spatial_grid='equalarea')
+    # first guess lightning rate probability cube with flexible forecast
+    # period (required for level 2 lighting risk index)
+    prob_fg = np.array([data.copy()], dtype=np.float32)
+    first_guess_cube = set_up_probability_cube(
+        prob_fg, np.array([0], dtype=np.float32), threshold_units='s-1',
+        variable_name='lightning_rate', time=validity_time, frt=fg_frt,
+        spatial_grid='equalarea')
+    first_guess_cube = squeeze(first_guess_cube)
 
     # lightning rate cube full of ones
     lightning_rate_cube = set_up_variable_cube(

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -84,7 +84,7 @@ def set_up_lightning_test_cubes(validity_time=dt(2015, 11, 23, 7),
     # template cube full of ones with one zero point
     data = np.ones((grid_points, grid_points), dtype=np.float32)
     template_cube = set_up_variable_cube(
-        data.copy(), name='lightning_rate', units='min-1',
+        data.copy(), name='rate_of_lightning', units='min-1',
         time=validity_time, frt=validity_time, spatial_grid='equalarea')
     template_cube.data[1, 1] = 0.
 
@@ -166,8 +166,8 @@ class Test__update_metadata(IrisTest):
         probability_of_lwe_precipitation_rate_above_threshold / (1)
         Dimension coordinates:
             threshold: 1;
-            projection_y_coordinate: 3;
-            projection_x_coordinate: 3;
+            projection_y_coordinate: 16;
+            projection_x_coordinate: 16;
         Scalar coordinates:
             forecast_period: 14400 seconds
             forecast_reference_time: 2017-11-10 00:00:00
@@ -726,15 +726,18 @@ class Test_process(IrisTest):
         """Create test cubes and plugin instance.
         The cube coordinates look like this:
         Dimension coordinates:
-            projection_y_coordinate: 3;
-            projection_x_coordinate: 3;
+            projection_y_coordinate: 16;
+            projection_x_coordinate: 16;
         Scalar coordinates:
             time: 2015-11-23 07:00:00
             forecast_reference_time: 2015-11-23 07:00:00
             forecast_period: 0 seconds
 
         self.fg_cube:
-            Has 4 hour forecast period, to test impact at lr2
+            Has 4 hour forecast period, to test impact on "lightning risk
+            2 level" output (see improver.nowcasting.lightning for details)
+        self.ltng_cube:
+            forecast_period: 0 seconds (simulates nowcast data)
         self.precip_cube:
             Has extra coordinate of length(3) "threshold" containing
             points [0.5, 7., 35.] mm h-1.  Has a 4 hour forecast period.

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -32,11 +32,10 @@
 
 
 import unittest
-import cf_units
 import numpy as np
 from datetime import datetime as dt
 
-from iris.coords import DimCoord, CellMethod
+from iris.coords import CellMethod
 from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError, ConstraintMismatchError
 from iris.tests import IrisTest

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -89,10 +89,10 @@ def set_up_lightning_test_cubes(validity_time=dt(2015, 11, 23, 7),
     template_cube.data[1, 1] = 0.
 
     # first guess lightning FORECAST cube with flexible forecast period
-    # (required for level 2 lighting risk index)
+    # (required for level 2 lighting risk index) # TODO this is a problem...
     first_guess_cube = set_up_variable_cube(
-        data.copy(), name='probability_of_lightning', units='1',
-        time=validity_time, frt=fg_frt, spatial_grid='equalarea')
+        data.copy(), name='probability_of_lightning_rate_above_threshold',
+        units='1', time=validity_time, frt=fg_frt, spatial_grid='equalarea')
 
     # lightning rate cube full of ones
     lightning_rate_cube = set_up_variable_cube(

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -101,12 +101,11 @@ def set_up_lightning_test_cubes(validity_time=dt(2015, 11, 23, 7),
 
     # probability of precip rate exceedance cube with higher rate probabilities
     # set to zero, and central point of low rate probabilities set to zero
-    # TODO this name should be "lwe_precipitation_rate" - bug in code?
     precip_data = np.ones((3, grid_points, grid_points), dtype=np.float32)
     precip_thresholds = np.array([0.5, 7.0, 35.0], dtype=np.float32)
     prob_precip_cube = set_up_probability_cube(
         precip_data, precip_thresholds,
-        variable_name='precipitation', threshold_units='mm h-1',
+        variable_name='lwe_precipitation_rate', threshold_units='mm h-1',
         time=validity_time, frt=validity_time, spatial_grid='equalarea')
     prob_precip_cube.data[0, 1, 1] = 0.
     prob_precip_cube.data[1:, ...] = 0.
@@ -849,7 +848,7 @@ class Test_process(IrisTest):
         """Test that the method raises an error if the precip cube is
         omitted from the cubelist"""
         msg = (r"Got 0 cubes for constraint Constraint\(name=\'probability_of_"
-               r"precipitation_rate_above_threshold\'\), expecting 1.")
+               r"lwe_precipitation_rate_above_threshold\'\), expecting 1.")
         with self.assertRaisesRegex(ConstraintMismatchError, msg):
             self.plugin.process(CubeList([
                 self.fg_cube,

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -77,12 +77,17 @@ def construct_xy_coords(ypoints, xpoints, spatial_grid):
             "longitude", units="degrees", coord_system=GLOBAL_GRID_CCRS)
     elif 'equalarea':
         # use UK eastings and northings on standard grid
+        # round grid spacing to nearest integer to avoid precision issues
+        grid_spacing = np.around(1000000. / ypoints)
+        y_points_array = [-100000 + i*grid_spacing for i in range(ypoints)]
+        x_points_array = [-400000 + i*grid_spacing for i in range(xpoints)]
+
         y_coord = DimCoord(
-            np.linspace(-100000, 900000, ypoints, dtype=np.float32),
+            np.array(y_points_array, dtype=np.float32),
             "projection_y_coordinate", units="metres",
             coord_system=STANDARD_GRID_CCRS)
         x_coord = DimCoord(
-            np.linspace(-400000, 600000, xpoints, dtype=np.float32),
+            np.array(x_points_array, dtype=np.float32),
             "projection_x_coordinate", units="metres",
             coord_system=STANDARD_GRID_CCRS)
     else:

--- a/lib/improver/tests/utilities/test_pad_spatial.py
+++ b/lib/improver/tests/utilities/test_pad_spatial.py
@@ -137,7 +137,7 @@ class Test_create_cube_with_halo(IrisTest):
         self.cube = set_up_variable_cube(
             np.ones((11, 11), dtype=np.float32), spatial_grid='equalarea',
             standard_grid_metadata='uk_det', attributes=attrs)
-        self.grid_spacing = 100000
+        self.grid_spacing = np.diff(self.cube.coord(axis='x').points)[0]
 
     def test_basic(self):
         """Test function returns a cube with expected metadata"""
@@ -371,7 +371,7 @@ class Test_remove_cube_halo(IrisTest):
         self.cube_1d = set_up_variable_cube(
             np.ones((1, 11, 11), dtype=np.float32), spatial_grid='equalarea',
             standard_grid_metadata='uk_det', attributes=self.attrs)
-        self.grid_spacing = 100000
+        self.grid_spacing = np.diff(self.cube.coord(axis='x').points)[0]
 
     def test_basic(self):
         """Test function returns a cube with expected attributes and shape"""


### PR DESCRIPTION
Partially addresses #742 

Changes made in this PR:

- Updated test_LapseRate.py to use new cube setup utility, and added warnings wrapper where needed.
- Updated test_NowcastLightning.py to use new cube setup utility.  Identified potential bug in code around cube names - left as TODO in tests for reviewers to comment.
- Updated set_up_test_cubes.py to create equal area grids properly (avoiding float precision issues), and fixed minor downstream issues in test_pad_spatial.py