### PR TITLE
Simplify environment for readthedocs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3
-  - iris
+  - iris=2.1
   - numpy
-  - pandas
-  - netcdf4
+  - cf_units
   - sphinx
   - python-stratify


### PR DESCRIPTION
Our documentation build keeps failing. I think this is because readthedocs is running out of memory (a common problem when using conda) - as a short term fix, I've simplified the environment (removing unnecessary things) and pinned the iris version to match the Travis build.

(Tested on my fork, so hopefully will fix `upstream/master` as well).