### PR TITLE
Removing sources of sphinx compilation warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -127,7 +127,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['modules.rst']
+exclude_patterns = ['modules.rst', 'extended_documentation']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/lib/improver/utilities/statistical_operations.py
+++ b/lib/improver/utilities/statistical_operations.py
@@ -139,7 +139,6 @@ class ProbabilitiesFromPercentiles2D(object):
         Returns:
             probability_cube (iris.cube.Cube):
                 A new 2-dimensional probability cube with suitable metadata.
-
         """
         cube_format = next(cube.slices([cube.coord(axis='y'),
                                         cube.coord(axis='x')]))
@@ -294,15 +293,20 @@ class ProbabilitiesFromPercentiles2D(object):
             2. When all slices have been interated over, the interpolants are
                calculated using the threshold values and the values_bounds.
                ::
-               (threshold_cube.data - lower_bound)/(upper_bound - lower_bound)
+
+                   (threshold_cube.data - lower_bound) /
+                   (upper_bound - lower_bound)
+
                If the upper_bound and lower_bound are the same this leads to
                a divide by 0 calculation, resulting in np.inf as the output.
 
             3. The interpolants are used to calculate the percentile value at
                each point in the array using the percentile_bounds.
                ::
+
                    lower_percentile_bound + interpolants *
-                       (upper_percentile_bounds - lower_percentile_bounds)
+                   (upper_percentile_bounds - lower_percentile_bounds)
+
                The percentiles are divided by 100 to give a fractional
                probability.
 
@@ -386,6 +390,7 @@ class ProbabilitiesFromPercentiles2D(object):
         Slice the percentiles cube over any non-spatial coordinates
         (realization, time, etc) if present, and call the percentile
         interpolation method for each resulting cube.
+
         Args:
             threshold_cube (iris.cube.Cube):
                 A cube of values, that effectively behave as thresholds, for

--- a/lib/improver/utilities/temporal_interpolation.py
+++ b/lib/improver/utilities/temporal_interpolation.py
@@ -61,9 +61,11 @@ class TemporalInterpolation(object):
             interval_in_minutes (int):
                 Specifies the interval in minutes at which to interpolate
                 between the two input cubes. A number of minutes which does not
-                divide up the interval equally will raise an exception
-                    e.g. cube_t0 valid at 03Z, cube_t1 valid at 06Z,
-                    interval_in_minutes = 60 --> interpolate to 04Z and 05Z.
+                divide up the interval equally will raise an exception.
+
+                   | e.g. cube_t0 valid at 03Z, cube_t1 valid at 06Z,
+                   | interval_in_minutes = 60 --> interpolate to 04Z and 05Z.
+
             times (list or tuple of datetime.datetime objects):
                 A list of datetime objects specifying the times to which to
                 interpolate.
@@ -116,9 +118,10 @@ class TemporalInterpolation(object):
             list:
                 A list containing a tuple that specifies the coordinate and a
                 list of points along that coordinate to which to interpolate,
-                as required by the iris interpolation method:
-                    e.g. [('time', [<datetime object 0>,
-                                    <datetime object 1>])]
+                as required by the iris interpolation method, e.g.::
+
+                    [('time', [<datetime object 0>,
+                               <datetime object 1>])]
 
         Raises:
             ValueError: If list of times provided falls outside the range

--- a/lib/improver/wind_calculations/wind_downscaling.py
+++ b/lib/improver/wind_calculations/wind_downscaling.py
@@ -261,27 +261,43 @@ class RoughnessCorrectionUtilities(object):
 
         Function to calculate wavenumber k of typical orographic
         lengthscale L:
-            k = 2*pi / L (1)
+
+        .. math::
+          :label:
+
+            k = 2 * \\pi / L
 
         L is approximated from half the peak-to-trough height h_over_2
         and the silhoutte roughness a_over_s (average of up-slopes per
         unit length over several cross-sections through a grid cell)
         as:
-            L = 2*h_over_2 / a_over_s (2)
+
+        .. math::
+          :label:
+
+            L = 2 * \\rm{h\_over\_2} / \\rm{a\_over\_s}
 
         a_over_s is dimensionless since it is the sum of up-slopes
         measured in the same unit lengths as it is calculated over.
 
         h_over_2 is calculated from the standard deviation of height in
         a grid cell, sigma, as:
-            h_over_2 = sqrt(2) * sigma
+
+        .. math
+          :label:
+
+            h_over_2 = sqrt(2) * \\rm{sigma}
 
         which is based on the assumptions of sine waves, see
         sigma2hover2.
 
         From eq. (1) and (2) it follows that:
-            k = 2*pi / (2*h_over_2 / a_over_s)
-              = a_over_s * pi / h_over_2
+
+        .. math::
+          :label:
+
+            k = 2*\\pi / (2 * \\rm{h\_over\_2} / \\rm{a\_over\_s)}
+              = \\rm{a\_over\_s} * \\pi / \\rm{h\_over\_2}
 
         Returns:
             wavn (np.ndarray):

--- a/lib/improver/wind_calculations/wind_downscaling.py
+++ b/lib/improver/wind_calculations/wind_downscaling.py
@@ -283,10 +283,10 @@ class RoughnessCorrectionUtilities(object):
         h_over_2 is calculated from the standard deviation of height in
         a grid cell, sigma, as:
 
-        .. math
+        .. math::
           :label:
 
-            h_over_2 = sqrt(2) * \\rm{sigma}
+            \\rm{h\\_over\\_2} = \\sqrt{2} * \\rm{sigma}
 
         which is based on the assumptions of sine waves, see
         sigma2hover2.

--- a/lib/improver/wind_calculations/wind_downscaling.py
+++ b/lib/improver/wind_calculations/wind_downscaling.py
@@ -275,7 +275,7 @@ class RoughnessCorrectionUtilities(object):
         .. math::
           :label:
 
-            L = 2 * \\rm{h\_over\_2} / \\rm{a\_over\_s}
+            L = 2 * \\rm{h\\_over\\_2} / \\rm{a\\_over\\_s}
 
         a_over_s is dimensionless since it is the sum of up-slopes
         measured in the same unit lengths as it is calculated over.
@@ -296,8 +296,8 @@ class RoughnessCorrectionUtilities(object):
         .. math::
           :label:
 
-            k = 2*\\pi / (2 * \\rm{h\_over\_2} / \\rm{a\_over\_s)}
-              = \\rm{a\_over\_s} * \\pi / \\rm{h\_over\_2}
+            k = 2*\\pi / (2 * \\rm{h\\_over\\_2} / \\rm{a\\_over\\_s)}
+              = \\rm{a\\_over\\_s} * \\pi / \\rm{h\\_over\\_2}
 
         Returns:
             wavn (np.ndarray):

--- a/lib/improver/wxcode/wxcode_decision_tree.py
+++ b/lib/improver/wxcode/wxcode_decision_tree.py
@@ -37,6 +37,7 @@ def wxcode_decision_tree():
     """
     Define queries that comprise the weather symbol decision tree.
     Each queries contains the following elements:
+
         * succeed: The next query to call if the diagnostic being queried
               satisfies the current query.
         * fail: The next query to call if the diagnostic being queried
@@ -64,6 +65,7 @@ def wxcode_decision_tree():
         * diagnostic_conditions: The condition that is expected to have
               been applied to the input data; this can be used to ensure
               the thresholding is as expected.
+
     Returns:
         queries (dict):
             A dictionary containing the queries that comprise the decision


### PR DESCRIPTION
Fixes to all current sphinx compliance warnings. The equations in wind downscaling are improved but still not lovely to behold, so we may wish to consider these further if wind downscaling is remaining.

Testing:
 - [ ] Ran tests and they passed OK