### PR TITLE
Impro1122 find threshold coordinate

### DIFF
--- a/lib/improver/convection.py
+++ b/lib/improver/convection.py
@@ -36,6 +36,7 @@ import numpy as np
 from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
 from improver.threshold import BasicThreshold
 from improver.nbhood.nbhood import NeighbourhoodProcessing
+from improver.utilities.cube_checker import find_threshold_coordinate
 
 
 class DiagnoseConvectivePrecipitation(object):
@@ -232,7 +233,8 @@ class DiagnoseConvectivePrecipitation(object):
                     below_thresh_ok=self.below_thresh_ok
                     ).process(cube.copy()))
             # Will only ever contain one slice on threshold
-            for cube_slice in threshold_cube.slices_over('threshold'):
+            for cube_slice in threshold_cube.slices_over(
+                    find_threshold_coordinate(threshold_cube)):
                 threshold_cube = cube_slice
 
             cubes.append(threshold_cube)

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -51,8 +51,8 @@ from improver.ensemble_copula_coupling.ensemble_copula_coupling_utilities \
 from improver.utilities.cube_manipulation import (
     concatenate_cubes, enforce_coordinate_ordering)
 from improver.utilities.cube_checker import (
-    find_percentile_coordinate, check_for_x_and_y_axes,
-    check_cube_coordinates)
+    find_percentile_coordinate, find_threshold_coordinate,
+    check_for_x_and_y_axes, check_cube_coordinates)
 from improver.utilities.indexing_operations import choose
 
 
@@ -799,7 +799,8 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
         Raises:
             ValueError: If units of input cubes are not compatible.
         """
-        threshold_units = probability_cube_template.coord('threshold').units
+        threshold_units = (
+            find_threshold_coordinate(probability_cube_template).units)
 
         try:
             mean_values.convert_units(threshold_units)
@@ -833,7 +834,8 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
                 the provided thresholds in the way described by
                 relative_to_threshold.
         """
-        thresholds = probability_cube_template.coord('threshold').points
+        thresholds = (
+            find_threshold_coordinate(probability_cube_template).points)
         relative_to_threshold = (
             probability_cube_template.attributes['relative_to_threshold'])
 

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -424,8 +424,8 @@ class GeneratePercentilesFromProbabilities(object):
                 air_temperature at the required percentiles.
 
         """
-        threshold_coord = forecast_probabilities.coord("threshold")
-        threshold_unit = forecast_probabilities.coord("threshold").units
+        threshold_coord = find_threshold_coordinate(forecast_probabilities)
+        threshold_unit = threshold_coord.units
         threshold_points = threshold_coord.points
 
         # Ensure that the percentile dimension is first, so that the
@@ -550,12 +550,12 @@ class GeneratePercentilesFromProbabilities(object):
                 "Cannot specify both no_of_percentiles and percentiles to "
                 "GeneratePercentilesFromProbabilities")
 
+        threshold_coord = find_threshold_coordinate(forecast_probabilities)
         forecast_probabilities = concatenate_cubes(
             forecast_probabilities,
-            coords_to_slice_over="threshold",
+            coords_to_slice_over=threshold_coord,
             coordinates_for_association=[])
 
-        threshold_coord = forecast_probabilities.coord("threshold")
         phenom_name = (
             forecast_probabilities.name().replace(
                 "probability_of_", "").replace("_above_threshold", "").replace(

--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -34,7 +34,8 @@ import numpy as np
 import iris
 from iris.exceptions import ConstraintMismatchError
 from improver.nbhood.nbhood import NeighbourhoodProcessing
-from improver.utilities.cube_checker import check_cube_coordinates
+from improver.utilities.cube_checker import (
+    check_cube_coordinates, find_threshold_coordinate)
 from improver.utilities.temporal import (
     extract_nearest_time_point, iris_time_to_datetime)
 from improver.utilities.rescale import apply_double_scaling, rescale
@@ -205,7 +206,8 @@ class NowcastLightning(object):
         """
         new_cube = cube.copy()
         new_cube.rename("probability_of_rate_of_lightning_above_threshold")
-        new_cube.remove_coord('threshold')
+        threshold_coord = find_threshold_coordinate(new_cube)
+        new_cube.remove_coord(threshold_coord)
         new_cube.cell_methods = None
         return new_cube
 
@@ -333,7 +335,8 @@ class NowcastLightning(object):
         """
         new_cube_list = iris.cube.CubeList([])
         # check prob-precip threshold units are as expected
-        prob_precip_cube.coord('threshold').convert_units('mm hr-1')
+        precip_threshold_coord = find_threshold_coordinate(prob_precip_cube)
+        precip_threshold_coord.convert_units('mm hr-1')
         # extract precipitation probabilities at required thresholds
         for cube_slice in prob_lightning_cube.slices_over('time'):
             this_time = iris_time_to_datetime(
@@ -409,7 +412,8 @@ class NowcastLightning(object):
         """
         prob_lightning_cube.coord('forecast_period').convert_units('minutes')
         # check prob-ice threshold units are as expected
-        ice_cube.coord('threshold').convert_units('kg m^-2')
+        ice_threshold_coord = find_threshold_coordinate(ice_cube)
+        ice_threshold_coord.convert_units('kg m^-2')
         new_cube_list = iris.cube.CubeList([])
         err_string = "No matching prob(Ice) cube for threshold {}"
         for cube_slice in prob_lightning_cube.slices_over('time'):
@@ -478,7 +482,8 @@ class NowcastLightning(object):
             "probability_of_vertical_integral_of_ice_above_threshold")
         if prob_vii_cube:
             prob_vii_cube = prob_vii_cube.merge_cube()
-        prob_precip_cube.coord('threshold').convert_units('mm hr-1')
+        precip_threshold_coord = find_threshold_coordinate(prob_precip_cube)
+        precip_threshold_coord.convert_units('mm hr-1')
         precip_slice = prob_precip_cube.extract(
             iris.Constraint(threshold=lambda t: isclose(t.point, 0.5)))
         if not isinstance(precip_slice, iris.cube.Cube):

--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -341,15 +341,33 @@ class NowcastLightning(object):
         for cube_slice in prob_lightning_cube.slices_over('time'):
             this_time = iris_time_to_datetime(
                 cube_slice.coord('time').copy())[0]
-            this_precip = prob_precip_cube.extract(
-                iris.Constraint(time=this_time) &
-                iris.Constraint(threshold=lambda t: isclose(t.point, 0.5)))
-            high_precip = prob_precip_cube.extract(
-                iris.Constraint(time=this_time) &
-                iris.Constraint(threshold=lambda t: isclose(t.point, 7.)))
-            torr_precip = prob_precip_cube.extract(
-                iris.Constraint(time=this_time) &
-                iris.Constraint(threshold=lambda t: isclose(t.point, 35.)))
+
+            if precip_threshold_coord.name() == 'threshold':
+                this_precip = prob_precip_cube.extract(
+                    iris.Constraint(time=this_time) &
+                    iris.Constraint(threshold=lambda t: isclose(t.point, 0.5)))
+                high_precip = prob_precip_cube.extract(
+                    iris.Constraint(time=this_time) &
+                    iris.Constraint(threshold=lambda t: isclose(t.point, 7.)))
+                torr_precip = prob_precip_cube.extract(
+                    iris.Constraint(time=this_time) &
+                    iris.Constraint(threshold=lambda t: isclose(t.point, 35.)))
+            else:
+                this_precip = prob_precip_cube.extract(
+                    iris.Constraint(time=this_time) &
+                    iris.Constraint(
+                        lwe_precipitation_rate=lambda t: isclose(
+                            t.point, 0.5)))
+                high_precip = prob_precip_cube.extract(
+                    iris.Constraint(time=this_time) &
+                    iris.Constraint(
+                        lwe_precipitation_rate=lambda t: isclose(t.point, 7.)))
+                torr_precip = prob_precip_cube.extract(
+                    iris.Constraint(time=this_time) &
+                    iris.Constraint(
+                        lwe_precipitation_rate=lambda t: isclose(
+                            t.point, 35.)))
+
             err_string = "No matching {} cube for {}"
             if not isinstance(this_precip, iris.cube.Cube):
                 raise ConstraintMismatchError(
@@ -420,9 +438,16 @@ class NowcastLightning(object):
             fcmins = cube_slice.coord('forecast_period').points[0]
             for threshold, prob_max in zip(self.ice_thresholds,
                                            self.ice_scaling):
-                ice_slice = ice_cube.extract(
-                    iris.Constraint(
-                        threshold=lambda t: isclose(t.point, threshold)))
+                if ice_threshold_coord.name() == "threshold":
+                    ice_slice = ice_cube.extract(
+                        iris.Constraint(
+                            threshold=lambda t: isclose(t.point, threshold)))
+                else:
+                    ice_slice = ice_cube.extract(
+                        iris.Constraint(
+                            vertical_integral_of_ice=lambda t: isclose(
+                                t.point, threshold)))
+
                 if not isinstance(ice_slice, iris.cube.Cube):
                     raise ConstraintMismatchError(err_string.format(threshold))
                 # Linearly reduce impact of ice as fcmins increases to 2H30M.
@@ -484,8 +509,14 @@ class NowcastLightning(object):
             prob_vii_cube = prob_vii_cube.merge_cube()
         precip_threshold_coord = find_threshold_coordinate(prob_precip_cube)
         precip_threshold_coord.convert_units('mm hr-1')
-        precip_slice = prob_precip_cube.extract(
-            iris.Constraint(threshold=lambda t: isclose(t.point, 0.5)))
+        if precip_threshold_coord.name() == "threshold":
+            precip_slice = prob_precip_cube.extract(
+                iris.Constraint(threshold=lambda t: isclose(t.point, 0.5)))
+        else:
+            precip_slice = prob_precip_cube.extract(
+                iris.Constraint(
+                    lwe_precipitation_rate=lambda t: isclose(t.point, 0.5)))
+
         if not isinstance(precip_slice, iris.cube.Cube):
             raise ConstraintMismatchError(
                 "Cannot find prob(precip > 0.5 mm hr-1) cube in cubelist.")

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -210,7 +210,7 @@ class Test__update_metadata(IrisTest):
         """Test that the method raises an error in Iris if the cube doesn't
         have a threshold coordinate to remove."""
         self.cube.remove_coord('threshold')
-        msg = ("Expected to find exactly 1 threshold coordinate, but found no")
+        msg = "No threshold coord found"
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             self.plugin._update_metadata(self.cube)
 
@@ -870,7 +870,7 @@ class Test_process(IrisTest):
         """Test that the method raises an error if the threshold coord is
         omitted from the precip_cube"""
         self.precip_cube.remove_coord('threshold')
-        msg = (r"Expected to find exactly 1 threshold coordinate, but found n")
+        msg = "No threshold coord found"
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             self.plugin.process(CubeList([
                 self.fg_cube,

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -495,14 +495,14 @@ class Test_find_threshold_coordinate(IrisTest):
         """Test error if given a non-cube argument"""
         msg = "Expecting data to be an instance of iris.cube.Cube"
         with self.assertRaisesRegex(TypeError, msg):
-            _ = find_threshold_coordinate([self.cube_new])
+            find_threshold_coordinate([self.cube_new])
 
     def test_fails_if_no_threshold_coord(self):
         """Test error if no threshold coordinate is present"""
         self.cube_new.coord("air_temperature").var_name = None
         msg = "No threshold coord found"
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
-            _ = find_threshold_coordinate(self.cube_new)
+            find_threshold_coordinate(self.cube_new)
 
 
 if __name__ == '__main__':

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -243,12 +243,12 @@ def find_percentile_coordinate(cube):
         cube (iris.cube.Cube):
             Cube contain one or more percentiles.
     Returns:
-        perc_coord(iris.coords.Coord) :
+        perc_coord(iris.coords.Coord):
             Percentile coordinate.
     Raises:
-        TypeError : If cube is not of type iris.cube.Cube.
-        CoordinateNotFoundError : If no percentile coordinate is found in cube.
-        ValueError : If there is more than one percentile coords in the cube.
+        TypeError: If cube is not of type iris.cube.Cube.
+        CoordinateNotFoundError: If no percentile coordinate is found in cube.
+        ValueError: If there is more than one percentile coords in the cube.
     """
     if not isinstance(cube, iris.cube.Cube):
         msg = ('Expecting data to be an instance of '
@@ -271,3 +271,43 @@ def find_percentile_coordinate(cube):
                 standard_name))
             raise ValueError(msg)
     return perc_coord
+
+
+def find_threshold_coordinate(cube):
+    """Find threshold coordinate in cube.
+
+    Compatible with both the old (cube.coord("threshold")) and new
+    (cube.coord.var_name == "threshold") IMPROVER metadata standards.
+
+    Args:
+        cube (iris.cube.Cube):
+            Cube containing thresholded probability data
+
+    Returns:
+        threshold_coord (iris.coords.Coord):
+            Threshold coordinate
+
+    Raises:
+        TypeError: If cube is not of type iris.cube.Cube.
+        CoordinateNotFoundError: If no threshold coordinate is found.
+    """
+    if not isinstance(cube, iris.cube.Cube):
+        msg = ('Expecting data to be an instance of '
+               'iris.cube.Cube but is {0}.'.format(type(cube)))
+        raise TypeError(msg)
+
+    threshold_coord = None
+    try:
+        threshold_coord = cube.coord("threshold")
+    except CoordinateNotFoundError:
+        for coord in cube.coords():
+            if coord.var_name == "threshold":
+                threshold_coord = coord
+                break
+
+    if threshold_coord is None:
+        msg = ('No threshold coord found on {0:s} data'.format(
+               cube.name()))
+        raise CoordinateNotFoundError(msg)
+
+    return threshold_coord

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -243,7 +243,7 @@ def find_percentile_coordinate(cube):
         cube (iris.cube.Cube):
             Cube contain one or more percentiles.
     Returns:
-        perc_coord(iris.coords.Coord):
+        perc_coord (iris.coords.Coord):
             Percentile coordinate.
     Raises:
         TypeError: If cube is not of type iris.cube.Cube.

--- a/lib/improver/utilities/cube_manipulation_new.py
+++ b/lib/improver/utilities/cube_manipulation_new.py
@@ -39,7 +39,7 @@ import iris
 from iris.coords import AuxCoord, DimCoord
 from iris.exceptions import CoordinateNotFoundError
 from improver.utilities.cube_checker import (
-    check_cube_coordinates, check_cube_not_float64)
+    check_cube_coordinates, check_cube_not_float64, find_threshold_coordinate)
 
 
 def equalise_cube_attributes(cubes, silent=None):
@@ -93,7 +93,9 @@ def strip_var_names(cubes):
     for cube in cubes:
         cube.var_name = None
         for coord in cube.coords():
-            coord.var_name = None
+            # retain var name required for threshold coordinate
+            if coord.var_name != "threshold":
+                coord.var_name = None
     return cubes
 
 
@@ -1005,8 +1007,15 @@ def enforce_coordinate_ordering(
         if cube.coords(coord_name):
             full_coord_name = coord_name
         else:
-            coord = [coord for coord in cube.coords()
-                     if coord_name in coord.name()]
+            # Handle "threshold" as an argument
+            if coord_name == "threshold":
+                try:
+                    coord = [find_threshold_coordinate(cube)]
+                except CoordinateNotFoundError:
+                    coord = []
+            else:
+                coord = [coord for coord in cube.coords()
+                         if coord_name in coord.name()]
             # If the coordinate is desired, raise an exception
             # if the coordinate is missing.
             if len(coord) == 0:

--- a/lib/improver/wxcode/weather_symbols.py
+++ b/lib/improver/wxcode/weather_symbols.py
@@ -35,6 +35,7 @@ import numpy as np
 import copy
 import iris
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.wxcode.wxcode_utilities import (add_wxcode_metadata,
                                               expand_nested_lists,
                                               update_daynight)
@@ -108,7 +109,7 @@ class WeatherSymbols(object):
                     continue
                 else:
                     cube_threshold_units = (
-                        matched_cube[0].coord('threshold').units)
+                        find_threshold_coordinate(matched_cube[0]).units)
                     threshold.convert_units(cube_threshold_units)
 
                 # Then we check if the required threshold is present in the
@@ -380,11 +381,12 @@ class WeatherSymbols(object):
                 A cube full of -1 values, with suitable metadata to describe
                 the weather symbols that will fill it.
         """
-        cube_format = next(cube.slices_over(['threshold']))
+        threshold_coord = find_threshold_coordinate(cube)
+        cube_format = next(cube.slices_over([threshold_coord]))
         symbols = cube_format.copy(data=np.full(cube_format.data.shape, -1,
                                                 dtype=np.int))
 
-        symbols.remove_coord('threshold')
+        symbols.remove_coord(threshold_coord)
         symbols.attributes.pop('relative_to_threshold')
         symbols = add_wxcode_metadata(symbols)
 


### PR DESCRIPTION
Partially addresses #833 

New function to find threshold coordinate using old form (long_name="threshold") or new form (standard_name=<diagnostic_name>, var_name="threshold").  Replaced use of "threshold" in plugins wherever possible to use this function.  Only exception is use of "threshold" string in `_equalise_cube_coords`, which requires a little more thought and may conflict with work on #835.

**Update:** see PR https://github.com/metoppv/improver/pull/842. I'll address the use of "threshold" in `merge_cubes` / `MergeCubes` in that PR, as I'd expect this one to be merged first.

Testing:
 - [x] Ran tests and they passed OK
