### PR TITLE
Correcting the variable name for ultraviolet_index

### DIFF
--- a/lib/improver/tests/uv_index/test_uv_index.py
+++ b/lib/improver/tests/uv_index/test_uv_index.py
@@ -94,8 +94,8 @@ class Test_uv_index(IrisTest):
         and name = ultraviolet index)."""
         result = calculate_uv_index(self.cube_uv_up, self.cube_uv_down)
         self.assertEqual(str(result.standard_name), 'ultraviolet_index')
-        self.assertEqual(str(result.var_name), 'None')
-        self.assertEqual(str(result.long_name), 'None')
+        self.assertIsNone(result.var_name)
+        self.assertIsNone(result.long_name)
         self.assertEqual((result.units), Unit("1"))
 
     def test_diff_units(self):

--- a/lib/improver/tests/uv_index/test_uv_index.py
+++ b/lib/improver/tests/uv_index/test_uv_index.py
@@ -91,9 +91,11 @@ class Test_uv_index(IrisTest):
 
     def test_metadata(self):
         """ Tests that the uv index output has the correct metadata (no units,
-        and name = uv index)."""
+        and name = ultraviolet index)."""
         result = calculate_uv_index(self.cube_uv_up, self.cube_uv_down)
         self.assertEqual(str(result.standard_name), 'ultraviolet_index')
+        self.assertEqual(str(result.var_name), 'None')
+        self.assertEqual(str(result.long_name), 'None')
         self.assertEqual((result.units), Unit("1"))
 
     def test_diff_units(self):

--- a/lib/improver/uv_index.py
+++ b/lib/improver/uv_index.py
@@ -93,5 +93,7 @@ def calculate_uv_index(uv_upward, uv_downward, scale_factor=3.6):
         uv_index.data = (uv_upward.data +
                          uv_downward.data) * scale_factor
         uv_index.standard_name = "ultraviolet_index"
+        uv_index.long_name = "ultraviolet_index"
+        uv_index._var_name = None
         uv_index.units = Unit("1")
         return uv_index

--- a/lib/improver/uv_index.py
+++ b/lib/improver/uv_index.py
@@ -93,7 +93,7 @@ def calculate_uv_index(uv_upward, uv_downward, scale_factor=3.6):
         uv_index.data = (uv_upward.data +
                          uv_downward.data) * scale_factor
         uv_index.standard_name = "ultraviolet_index"
-        uv_index.long_name = "ultraviolet_index"
-        uv_index._var_name = None
+        uv_index.long_name = None
+        uv_index.var_name = None
         uv_index.units = Unit("1")
         return uv_index

--- a/lib/improver/uv_index.py
+++ b/lib/improver/uv_index.py
@@ -92,8 +92,6 @@ def calculate_uv_index(uv_upward, uv_downward, scale_factor=3.6):
         uv_index = uv_upward.copy()
         uv_index.data = (uv_upward.data +
                          uv_downward.data) * scale_factor
-        uv_index.standard_name = "ultraviolet_index"
-        uv_index.long_name = None
-        uv_index.var_name = None
+        uv_index.rename("ultraviolet_index")
         uv_index.units = Unit("1")
         return uv_index


### PR DESCRIPTION
Addresses #832 

Description
Correcting the variable name for ultraviolet_index to make sure it the same in the metadata no matter how it is viewed.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
