### PR TITLE
IMPRO-1165: Remove non-standard long name from wind gust diagnostic

### DIFF
--- a/lib/improver/tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/lib/improver/tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -119,7 +119,6 @@ class Test_add_metadata(IrisTest):
         plugin = WindGustDiagnostic(50.0, 80.0)
         result = plugin.add_metadata(self.cube_wg)
         self.assertEqual(result.standard_name, "wind_speed_of_gust")
-        self.assertEqual(result.long_name, "wind_gust_diagnostic")
         msg = ('<WindGustDiagnostic: wind-gust perc=50.0, '
                'wind-speed perc=80.0>')
         self.assertEqual(result.attributes['wind_gust_diagnostic'], msg)

--- a/lib/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/lib/improver/wind_calculations/wind_gust_diagnostic.py
@@ -95,8 +95,7 @@ class WindGustDiagnostic(object):
 
         """
         result = cube
-        result.standard_name = "wind_speed_of_gust"
-        result.long_name = "wind_gust_diagnostic"
+        result.rename("wind_speed_of_gust")
         if self.percentile_gust == 50.0 and self.percentile_windspeed == 95.0:
             diagnostic_txt = 'Typical gusts'
         elif (self.percentile_gust == 95.0 and


### PR DESCRIPTION
Remove setting of long name and var name for the wind-gust-diagnostic cube.

Testing:
 - [x] Ran tests and they passed OK
