### PR TITLE
Impro1122 threshold update plugins

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -442,8 +442,13 @@ class WeightedBlendAcrossWholeDimension:
                 blending.
 
         Raises:
-            ValueError : If an invalid weighting_mode is given.
+            ValueError: If the blend coordinate is "threshold".
+            ValueError: If an invalid weighting_mode is given.
         """
+        if coord == "threshold":
+            msg = "Blending over thresholds is not supported"
+            raise ValueError(msg)
+
         self.coord = coord
         if weighting_mode not in ['weighted_maximum', 'weighted_mean']:
             msg = ("weighting_mode: {} is not recognised, must be either "

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -780,14 +780,19 @@ class GenerateProbabilitiesFromMeanAndVariance(object):
         """
         check_for_x_and_y_axes(cube, require_dim_coords=True)
         dim_coords = [coord.name() for coord in cube.coords(dim_coords=True)]
-
-        if 'threshold' in dim_coords and len(dim_coords) < 4:
-            enforce_coordinate_ordering(cube, 'threshold')
-            return
-
         msg = ('GenerateProbabilitiesFromMeanAndVariance expects a cube with '
                'only a leading threshold dimension, followed by spatial (y/x) '
                'dimensions. Got dimensions: {}'.format(dim_coords))
+
+        try:
+            threshold_coord = find_threshold_coordinate(cube)
+        except CoordinateNotFoundError:
+            raise ValueError(msg)
+
+        if len(dim_coords) < 4:
+            enforce_coordinate_ordering(cube, threshold_coord.name())
+            return
+
         raise ValueError(msg)
 
     @staticmethod

--- a/lib/improver/tests/blending/spatial_weights/test_SpatiallyVaryingWeightsFromMask.py
+++ b/lib/improver/tests/blending/spatial_weights/test_SpatiallyVaryingWeightsFromMask.py
@@ -45,6 +45,7 @@ from datetime import datetime
 
 from improver.blending.spatial_weights import SpatiallyVaryingWeightsFromMask
 from improver.tests.set_up_test_cubes import set_up_probability_cube
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.warnings_handler import ManageWarnings
 
 
@@ -354,7 +355,8 @@ class Test_multiply_weights(IrisTest):
             "projection_x_coordinate")
         self.one_dimensional_weights_cube.remove_coord(
             "projection_y_coordinate")
-        self.one_dimensional_weights_cube.remove_coord("threshold")
+        self.one_dimensional_weights_cube.remove_coord(
+            find_threshold_coordinate(self.one_dimensional_weights_cube))
         self.one_dimensional_weights_cube.data = np.array(
             [0.2, 0.5, 0.3], dtype=np.float32)
         self.plugin = SpatiallyVaryingWeightsFromMask()
@@ -653,11 +655,12 @@ class Test_create_template_slice(IrisTest):
         """Test error is raised when mask varies along collapsing dim"""
         # Check fails when blending along threshold coordinate, as mask
         # varies along this coordinate.
+        threshold_coord = find_threshold_coordinate(self.cube_to_collapse)
         message = (
             "The mask on the input cube can only vary along the blend_coord")
         with self.assertRaisesRegex(ValueError, message):
             self.plugin.create_template_slice(
-                self.cube_to_collapse, "threshold")
+                self.cube_to_collapse, threshold_coord.name())
 
     def test_scalar_blend_coord_fail(self):
         """Test error is raised when blend_coord is scalar"""
@@ -747,7 +750,8 @@ class Test_process(IrisTest):
             "projection_x_coordinate")
         self.one_dimensional_weights_cube.remove_coord(
             "projection_y_coordinate")
-        self.one_dimensional_weights_cube.remove_coord("threshold")
+        self.one_dimensional_weights_cube.remove_coord(
+            find_threshold_coordinate(self.one_dimensional_weights_cube))
         self.one_dimensional_weights_cube.data = np.array(
             [0.2, 0.5, 0.3], dtype=np.float32)
         self.plugin = SpatiallyVaryingWeightsFromMask(fuzzy_length=4)

--- a/lib/improver/tests/blending/weights/test_WeightsUtilities.py
+++ b/lib/improver/tests/blending/weights/test_WeightsUtilities.py
@@ -40,6 +40,7 @@ import iris
 from iris.tests import IrisTest
 
 from improver.blending.weights import WeightsUtilities
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.tests.utilities.test_cube_metadata import (
@@ -324,7 +325,7 @@ class Test_build_weights_cube(IrisTest):
         scalar."""
 
         weights = [1.0]
-        blending_coord = 'threshold'
+        blending_coord = find_threshold_coordinate(self.cube).name()
         cube = iris.util.squeeze(self.cube)
 
         plugin = WeightsUtilities.build_weights_cube

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
@@ -122,7 +122,7 @@ def set_up_probability_above_threshold_spot_cube(
     except ValueError:
         cube.add_dim_coord(
             DimCoord(forecast_thresholds, long_name=phenomenon_standard_name,
-                     units=phenomenon_units, var_name="threshold"), 0)     
+                     units=phenomenon_units, var_name="threshold"), 0)
 
     time_origin = "hours since 1970-01-01 00:00:00"
     calendar = "gregorian"

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
@@ -57,10 +57,16 @@ def set_up_probability_threshold_cube(
             phenomenon_standard_name, relative_to_threshold))
     cube = Cube(data, long_name=cube_long_name,
                 units=1)
-    coord_long_name = "threshold"
-    cube.add_dim_coord(
-        DimCoord(forecast_thresholds, long_name=coord_long_name,
-                 units=phenomenon_units), 0)
+
+    try:
+        cube.add_dim_coord(
+            DimCoord(forecast_thresholds, phenomenon_standard_name,
+                     units=phenomenon_units, var_name="threshold"), 0)
+    except ValueError:
+        cube.add_dim_coord(
+            DimCoord(forecast_thresholds, long_name=phenomenon_standard_name,
+                     units=phenomenon_units, var_name="threshold"), 0)
+
     time_origin = "hours since 1970-01-01 00:00:00"
     calendar = "gregorian"
     tunit = Unit(time_origin, calendar)
@@ -108,10 +114,16 @@ def set_up_probability_above_threshold_spot_cube(
         "probability_of_{}_above_threshold".format(phenomenon_standard_name))
     cube = Cube(data, long_name=cube_long_name,
                 units=1)
-    coord_long_name = "threshold"
-    cube.add_dim_coord(
-        DimCoord(forecast_thresholds, long_name=coord_long_name,
-                 units=phenomenon_units), 0)
+
+    try:
+        cube.add_dim_coord(
+            DimCoord(forecast_thresholds, phenomenon_standard_name,
+                     units=phenomenon_units, var_name="threshold"), 0)
+    except ValueError:
+        cube.add_dim_coord(
+            DimCoord(forecast_thresholds, long_name=phenomenon_standard_name,
+                     units=phenomenon_units, var_name="threshold"), 0)     
+
     time_origin = "hours since 1970-01-01 00:00:00"
     calendar = "gregorian"
     tunit = Unit(time_origin, calendar)

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -42,6 +42,7 @@ from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GenerateProbabilitiesFromMeanAndVariance as Plugin)
 from improver.tests.ensemble_calibration.ensemble_calibration. \
     helper_functions import set_up_probability_above_threshold_temperature_cube
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 
 
@@ -78,7 +79,7 @@ class Test__check_template_cube(IrisTest):
         the leading dimension. Check that threshold is moved to be leading."""
         cube = iris.util.squeeze(self.cube)
         enforce_coordinate_ordering(cube, 'latitude')
-        expected = ['threshold', 'latitude', 'longitude']
+        expected = ['air_temperature', 'latitude', 'longitude']
         Plugin()._check_template_cube(cube)
         result = [coord.name() for coord in cube.coords(dim_coords=True)]
         self.assertListEqual(expected, result)
@@ -153,7 +154,8 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
 
         # Thresholds such that we obtain probabilities of 75%, 50%, and 25% for
         # the mean and variance values set here.
-        self.template_cube.coord('threshold').points = [8.65105, 10., 11.34895]
+        threshold_coord = find_threshold_coordinate(self.template_cube)
+        threshold_coord.points = [8.65105, 10., 11.34895]
         mean_values = np.ones((3, 3)) * 10
         variance_values = np.ones((3, 3)) * 4
         self.means = self.template_cube[0, :, :].copy(data=mean_values)
@@ -191,7 +193,8 @@ class Test_process(IrisTest):
             set_up_probability_above_threshold_temperature_cube())
         self.template_cube = iris.util.squeeze(self.template_cube)
 
-        self.template_cube.coord('threshold').points = [8.65105, 10., 11.34895]
+        threshold_coord = find_threshold_coordinate(self.template_cube)
+        threshold_coord.points = [8.65105, 10., 11.34895]
         mean_values = np.ones((3, 3)) * 10
         variance_values = np.ones((3, 3)) * 4
         self.means = self.template_cube[0, :, :].copy(data=mean_values)

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -341,7 +341,7 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
     Kwargs:
         variable_name (str):
             Name of the underlying variable to which the probability field
-            applies
+            applies, eg "air_temperature".  NOT name of probability field.
         threshold_units (str):
             Units of the underlying variable / threshold.
         spatial_grid (str):
@@ -371,15 +371,10 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
     else:
         attributes['relative_to_threshold'] = relative_to_threshold
 
-    if variable_name.startswith('probability_of_'):
-        name_prefix = ''
-    else:
-        name_prefix = 'probability_of_'
-
     if relative_to_threshold == 'above':
-        name = name_prefix + '{}_above_threshold'.format(variable_name)
+        name = 'probability_of_{}_above_threshold'.format(variable_name)
     elif relative_to_threshold == 'below':
-        name = name_prefix + '{}_below_threshold'.format(variable_name)
+        name = 'probability_of_{}_below_threshold'.format(variable_name)
     else:
         msg = 'The relative_to_threshold attribute MUST be set for ' \
               'IMPROVER probability cubes'

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -391,8 +391,9 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
         realizations=thresholds, attributes=attributes,
         include_scalar_coords=include_scalar_coords,
         standard_grid_metadata=standard_grid_metadata)
-    cube.coord("realization").rename("threshold")
-    cube.coord("threshold").units = Unit(threshold_units)
+    cube.coord("realization").rename(variable_name)
+    cube.coord(variable_name).var_name = "threshold"
+    cube.coord(variable_name).units = Unit(threshold_units)
     return cube
 
 

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -348,14 +348,6 @@ class test_set_up_probability_cube(IrisTest):
         self.assertEqual(len(result.attributes), 1)
         self.assertEqual(result.attributes['relative_to_threshold'], 'above')
 
-    def test_probability_of_name(self):
-        """Test a name with "probability" at the start is correctly parsed"""
-        result = set_up_probability_cube(
-            self.data, self.thresholds,
-            variable_name='probability_of_air_temperature')
-        self.assertEqual(
-            result.name(), 'probability_of_air_temperature_above_threshold')
-
     def test_relative_to_threshold(self):
         """Test ability to reset the "relative_to_threshold" attribute"""
         data = np.flipud(self.data)

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -40,6 +40,7 @@ import iris
 from iris.tests import IrisTest
 
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.temporal import iris_time_to_datetime
 from improver.tests.set_up_test_cubes import (
     construct_xy_coords, construct_scalar_time_coords, set_up_variable_cube,
@@ -336,11 +337,13 @@ class test_set_up_probability_cube(IrisTest):
         """Test default arguments produce cube with expected dimensions
         and metadata"""
         result = set_up_probability_cube(self.data, self.thresholds)
-        thresh_coord = result.coord("threshold")
+        thresh_coord = find_threshold_coordinate(result)
         self.assertEqual(
             result.name(), 'probability_of_air_temperature_above_threshold')
         self.assertEqual(result.units, '1')
         self.assertArrayEqual(thresh_coord.points, self.thresholds)
+        self.assertEqual(thresh_coord.name(), 'air_temperature')
+        self.assertEqual(thresh_coord.var_name, 'threshold')
         self.assertEqual(thresh_coord.units, 'K')
         self.assertEqual(len(result.attributes), 1)
         self.assertEqual(result.attributes['relative_to_threshold'], 'above')

--- a/lib/improver/tests/utilities/cube_manipulation/test__equalise_cube_coords.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test__equalise_cube_coords.py
@@ -39,6 +39,7 @@ from iris.coords import DimCoord
 from iris.tests import IrisTest
 import numpy as np
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.cube_manipulation import _equalise_cube_coords
 
 from improver.tests.ensemble_calibration.ensemble_calibration.\
@@ -74,9 +75,9 @@ class Test__equalise_cube_coords(IrisTest):
         cube = set_up_probability_above_threshold_temperature_cube()
         cube1 = cube.copy()
         cube2 = cube.copy()
-        cube2.remove_coord("threshold")
+        cube2.remove_coord(find_threshold_coordinate(cube2))
         cubes = iris.cube.CubeList([cube1, cube2])
-        msg = "threshold coordinates must match to merge"
+        msg = "air_temperature coordinates must match to merge"
         with self.assertRaisesRegex(ValueError, msg):
             _equalise_cube_coords(cubes)
 

--- a/lib/improver/tests/utilities/cube_manipulation/test_merge_cubes.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_merge_cubes.py
@@ -41,6 +41,7 @@ from iris.exceptions import DuplicateDataError, MergeError
 from iris.tests import IrisTest
 import numpy as np
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.cube_manipulation import merge_cubes
 
 from improver.tests.ensemble_calibration.ensemble_calibration.\
@@ -215,7 +216,8 @@ class Test_merge_cubes(IrisTest):
     def test_one_threshold_data(self):
         """Test threshold data where one cube has single threshold as dim"""
         ukv_prob = self.prob_ukv[0]
-        ukv_prob = iris.util.new_axis(ukv_prob, 'threshold')
+        threshold_coord = find_threshold_coordinate(ukv_prob).name()
+        ukv_prob = iris.util.new_axis(ukv_prob, threshold_coord)
         enuk_prob = self.prob_enuk[0]
         cubes = iris.cube.CubeList([ukv_prob, enuk_prob])
         result = merge_cubes(cubes, model_id_attr='mosg__model_configuration')

--- a/lib/improver/tests/utilities/cube_manipulation_new/test__equalise_cube_coords.py
+++ b/lib/improver/tests/utilities/cube_manipulation_new/test__equalise_cube_coords.py
@@ -39,6 +39,7 @@ from iris.coords import DimCoord
 from iris.tests import IrisTest
 import numpy as np
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.cube_manipulation_new import _equalise_cube_coords
 
 from improver.tests.ensemble_calibration.ensemble_calibration.\
@@ -74,9 +75,9 @@ class Test__equalise_cube_coords(IrisTest):
         cube = set_up_probability_above_threshold_temperature_cube()
         cube1 = cube.copy()
         cube2 = cube.copy()
-        cube2.remove_coord("threshold")
+        cube2.remove_coord(find_threshold_coordinate(cube2))
         cubes = iris.cube.CubeList([cube1, cube2])
-        msg = "threshold coordinates must match to merge"
+        msg = "air_temperature coordinates must match to merge"
         with self.assertRaisesRegex(ValueError, msg):
             _equalise_cube_coords(cubes)
 

--- a/lib/improver/tests/utilities/cube_manipulation_new/test_merge_cubes.py
+++ b/lib/improver/tests/utilities/cube_manipulation_new/test_merge_cubes.py
@@ -41,6 +41,7 @@ from iris.exceptions import DuplicateDataError, MergeError
 from iris.tests import IrisTest
 import numpy as np
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.cube_manipulation_new import merge_cubes
 
 from improver.tests.ensemble_calibration.ensemble_calibration.\
@@ -215,7 +216,8 @@ class Test_merge_cubes(IrisTest):
     def test_one_threshold_data(self):
         """Test threshold data where one cube has single threshold as dim"""
         ukv_prob = self.prob_ukv[0]
-        ukv_prob = iris.util.new_axis(ukv_prob, 'threshold')
+        threshold_coord = find_threshold_coordinate(ukv_prob).name()
+        ukv_prob = iris.util.new_axis(ukv_prob, threshold_coord)
         enuk_prob = self.prob_enuk[0]
         cubes = iris.cube.CubeList([ukv_prob, enuk_prob])
         result = merge_cubes(cubes, model_id_attr='mosg__model_configuration')

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -464,10 +464,9 @@ class Test_find_threshold_coordinate(IrisTest):
         self.threshold_points = np.array([276, 277, 278], dtype=np.float32)
         cube = set_up_probability_cube(data, self.threshold_points)
 
-        self.cube_old = cube.copy()  # TODO update these with setup utility
         self.cube_new = cube.copy()
-        self.cube_new.coord("threshold").rename("air_temperature")
-        self.cube_new.coord("air_temperature").var_name = "threshold"
+        self.cube_old = cube.copy()
+        self.cube_old.coord("air_temperature").rename("threshold")
 
     def test_basic(self):
         """Test function returns an iris.coords.Coord"""

--- a/lib/improver/tests/utilities/test_cube_constraints.py
+++ b/lib/improver/tests/utilities/test_cube_constraints.py
@@ -35,6 +35,7 @@ import unittest
 import iris
 from iris.tests import IrisTest
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.utilities.cube_constraints import create_sorted_lambda_constraint
 from improver.tests.utilities.test_cube_extraction import (
     set_up_precip_probability_cube)
@@ -45,28 +46,27 @@ class Test_create_sorted_lambda_constraint(IrisTest):
     def setUp(self):
         """Set up cube with testing lambda constraint."""
         self.precip_cube = set_up_precip_probability_cube()
-        self.precip_cube.coord("threshold").convert_units("mm h-1")
+        self.coord_name = find_threshold_coordinate(self.precip_cube).name()
+        self.precip_cube.coord(self.coord_name).convert_units("mm h-1")
         self.expected_data = self.precip_cube[:2].data
 
     def test_basic_ascending(self):
         """Test that a constraint is created, if the input coordinates are
         ascending."""
-        coord_name = "threshold"
         values = [0.03, 0.1]
-        result = create_sorted_lambda_constraint(coord_name, values)
+        result = create_sorted_lambda_constraint(self.coord_name, values)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(list(result._coord_values.keys()), ["threshold"])
+        self.assertEqual(list(result._coord_values.keys()), [self.coord_name])
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 
     def test_basic_descending(self):
         """Test that a constraint is created, if the input coordinates are
         descending."""
-        coord_name = "threshold"
         values = [0.1, 0.03]
-        result = create_sorted_lambda_constraint(coord_name, values)
+        result = create_sorted_lambda_constraint(self.coord_name, values)
         self.assertIsInstance(result, iris.Constraint)
-        self.assertEqual(list(result._coord_values.keys()), ["threshold"])
+        self.assertEqual(list(result._coord_values.keys()), [self.coord_name])
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -847,6 +847,7 @@ class Test_in_vicinity_name_format(IrisTest):
 
 
 class Test_extract_diagnostic_name(IrisTest):
+    """Test utility to extract diagnostic name from probability cube name"""
 
     def test_basic(self):
         """Test correct name is returned from a standard diagnostic"""

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -850,19 +850,20 @@ class Test_extract_diagnostic_name(IrisTest):
     """Test utility to extract diagnostic name from probability cube name"""
 
     def test_basic(self):
-        """Test correct name is returned from a standard diagnostic"""
+        """Test correct name is returned from a standard (above threshold)
+        probability field"""
         result = extract_diagnostic_name(
             'probability_of_air_temperature_above_threshold')
         self.assertEqual(result, 'air_temperature')
 
     def test_below_threshold(self):
-        """Test correct name is returned from a standard diagnostic"""
+        """Test correct name is returned from a probability below threshold"""
         result = extract_diagnostic_name(
             'probability_of_air_temperature_below_threshold')
         self.assertEqual(result, 'air_temperature')
 
     def test_in_vicinity(self):
-        """Test correct name is returned from an "in vicinity" diagnostic"""
+        """Test correct name is returned from an "in vicinity" probability"""
         diagnostic = 'lwe_precipitation_rate_in_vicinity'
         result = extract_diagnostic_name(
             'probability_of_{}_above_threshold'.format(diagnostic))

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -50,7 +50,8 @@ from improver.utilities.cube_metadata import (
     update_cell_methods,
     update_coord,
     update_stage_v110_metadata,
-    in_vicinity_name_format)
+    in_vicinity_name_format,
+    extract_diagnostic_name)
 from improver.utilities.warnings_handler import ManageWarnings
 
 from improver.tests.set_up_test_cubes import (
@@ -843,6 +844,33 @@ class Test_in_vicinity_name_format(IrisTest):
         msg = "Cube name already contains 'in_vicinity'"
         with self.assertRaisesRegex(ValueError, msg):
             in_vicinity_name_format(self.cube.name())
+
+
+class Test_extract_diagnostic_name(IrisTest):
+
+    def test_basic(self):
+        """Test correct name is returned from a standard diagnostic"""
+        result = extract_diagnostic_name(
+            'probability_of_air_temperature_above_threshold')
+        self.assertEqual(result, 'air_temperature')
+
+    def test_below_threshold(self):
+        """Test correct name is returned from a standard diagnostic"""
+        result = extract_diagnostic_name(
+            'probability_of_air_temperature_below_threshold')
+        self.assertEqual(result, 'air_temperature')
+
+    def test_in_vicinity(self):
+        """Test correct name is returned from an "in vicinity" diagnostic"""
+        diagnostic = 'lwe_precipitation_rate_in_vicinity'
+        result = extract_diagnostic_name(
+            'probability_of_{}_above_threshold'.format(diagnostic))
+        self.assertEqual(result, diagnostic)
+
+    def test_error_not_probability(self):
+        """Test exception if input is not a probability cube name"""
+        with self.assertRaises(ValueError):
+            extract_diagnostic_name('lwe_precipitation_rate')
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -43,6 +43,7 @@ import numpy as np
 
 from improver.utilities.load import load_cube, load_cubelist
 from improver.utilities.save import save_netcdf
+from improver.utilities.cube_checker import find_threshold_coordinate
 
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, set_up_percentile_cube, set_up_probability_cube,
@@ -170,7 +171,8 @@ class Test_load_cube(IrisTest):
         cube.transpose([2, 1, 0])
         save_netcdf(cube, self.filepath)
         result = load_cube(self.filepath)
-        self.assertEqual(result.coord_dims("threshold")[0], 0)
+        threshold_coord = find_threshold_coordinate(result)
+        self.assertEqual(result.coord_dims(threshold_coord)[0], 0)
         self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 1)
         self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 2)
 
@@ -188,10 +190,11 @@ class Test_load_cube(IrisTest):
         cube.transpose([4, 3, 2, 1, 0])
         save_netcdf(cube, self.filepath)
         result = load_cube(self.filepath)
+        threshold_coord = find_threshold_coordinate(result)
         self.assertEqual(result.coord_dims("realization")[0], 0)
         self.assertEqual(
             result.coord_dims("percentile_over_neighbourhood")[0], 1)
-        self.assertEqual(result.coord_dims("threshold")[0], 2)
+        self.assertEqual(result.coord_dims(threshold_coord)[0], 2)
         self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 3)
         self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 4)
 

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -474,8 +474,8 @@ class Test_construct_extract_constraint(IrisTest):
                                                      threshold, False)
         expected = ("iris.Constraint("
                     "name='probability_of_rainfall_rate_above_threshold', "
-                    "rainfall_rate=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
-                    "{t_max})".format(
+                    "rainfall_rate=lambda cell: 0.03 * {t_min} < cell < "
+                    "0.03 * {t_max})".format(
                         t_min=(1. - WeatherSymbols().float_tolerance),
                         t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, str)

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -426,13 +426,34 @@ class Test_create_condition_chain(IrisTest):
         test_condition = self.dummy_queries['significant_precipitation']
         result = plugin.create_condition_chain(test_condition)
         expected = ("(cubes.extract(iris.Constraint(name='probability_of_"
-                    "rainfall_rate_above_threshold', threshold=lambda cell: "
-                    "0.03 * {t_min} < "
+                    "rainfall_rate_above_threshold', rainfall_rate=lambda "
+                    "cell: 0.03 * {t_min} < "
                     "cell < 0.03 * {t_max}))[0].data >= 0.5) | (cubes.extract"
                     "(iris.Constraint("
                     "name='probability_of_lwe_snowfall_rate_above_threshold',"
-                    " threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
-                    "{t_max}))[0].data >= 0.5)".format(
+                    " lwe_snowfall_rate=lambda cell: 0.03 * {t_min} < cell < "
+                    "0.03 * {t_max}))[0].data >= 0.5)".format(
+                        t_min=(1. - WeatherSymbols().float_tolerance),
+                        t_max=(1. + WeatherSymbols().float_tolerance)))
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], str)
+        self.assertEqual(result[0], expected)
+
+    def test_old_naming_convention(self):
+        """Test create_condition_chain can return conditions using old
+        threshold coordinate name"""
+        plugin = WeatherSymbols()
+        plugin.threshold_name = True
+        test_condition = self.dummy_queries['significant_precipitation']
+        result = plugin.create_condition_chain(test_condition)
+        expected = ("(cubes.extract(iris.Constraint(name='probability_of_"
+                    "rainfall_rate_above_threshold', threshold=lambda "
+                    "cell: 0.03 * {t_min} < "
+                    "cell < 0.03 * {t_max}))[0].data >= 0.5) | (cubes.extract"
+                    "(iris.Constraint("
+                    "name='probability_of_lwe_snowfall_rate_above_threshold',"
+                    " threshold=lambda cell: 0.03 * {t_min} < cell < "
+                    "0.03 * {t_max}))[0].data >= 0.5)".format(
                         t_min=(1. - WeatherSymbols().float_tolerance),
                         t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, list)
@@ -450,7 +471,24 @@ class Test_construct_extract_constraint(IrisTest):
         diagnostic = 'probability_of_rainfall_rate_above_threshold'
         threshold = AuxCoord(0.03, units='mm hr-1')
         result = plugin.construct_extract_constraint(diagnostic,
-                                                     threshold)
+                                                     threshold, False)
+        expected = ("iris.Constraint("
+                    "name='probability_of_rainfall_rate_above_threshold', "
+                    "rainfall_rate=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
+                    "{t_max})".format(
+                        t_min=(1. - WeatherSymbols().float_tolerance),
+                        t_max=(1. + WeatherSymbols().float_tolerance)))
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, expected)
+
+    def test_old_naming_convention(self):
+        """Test construct_extract_constraint can return a constraint with a
+        "threshold" coordinate"""
+        plugin = WeatherSymbols()
+        diagnostic = 'probability_of_rainfall_rate_above_threshold'
+        threshold = AuxCoord(0.03, units='mm hr-1')
+        result = plugin.construct_extract_constraint(diagnostic,
+                                                     threshold, True)
         expected = ("iris.Constraint("
                     "name='probability_of_rainfall_rate_above_threshold', "
                     "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
@@ -469,12 +507,12 @@ class Test_construct_extract_constraint(IrisTest):
         thresholds = [AuxCoord(0.03, units='mm hr-1'),
                       AuxCoord(0.03, units='mm hr-1')]
         result = plugin.construct_extract_constraint(diagnostics,
-                                                     thresholds)
+                                                     thresholds, False)
 
         expected = ("iris.Constraint("
                     "name='probability_of_lwe_snowfall_rate_above_threshold', "
-                    "threshold=lambda cell: 0.03 * {t_min} < cell < 0.03 * "
-                    "{t_max})".format(
+                    "lwe_snowfall_rate=lambda cell: 0.03 * {t_min} < cell "
+                    "< 0.03 * {t_max})".format(
                         t_min=(1. - WeatherSymbols().float_tolerance),
                         t_max=(1. + WeatherSymbols().float_tolerance)))
         self.assertIsInstance(result, list)

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -443,7 +443,7 @@ class Test_create_condition_chain(IrisTest):
         """Test create_condition_chain can return conditions using old
         threshold coordinate name"""
         plugin = WeatherSymbols()
-        plugin.threshold_name = True
+        plugin.coord_named_threshold = True
         test_condition = self.dummy_queries['significant_precipitation']
         result = plugin.create_condition_chain(test_condition)
         expected = ("(cubes.extract(iris.Constraint(name='probability_of_"

--- a/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/lib/improver/tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -40,6 +40,7 @@ from iris.tests import IrisTest
 from iris.coords import AuxCoord
 from cf_units import Unit
 
+from improver.utilities.cube_checker import find_threshold_coordinate
 from improver.wxcode.weather_symbols import WeatherSymbols
 from improver.wxcode.wxcode_utilities import WX_DICT
 from improver.tests.ensemble_calibration.ensemble_calibration. \
@@ -266,7 +267,8 @@ class Test_check_input_cubes(IrisTest):
         plugin = WeatherSymbols()
 
         msg = "Unable to convert from"
-        self.cubes[0].coord('threshold').units = Unit('mm kg-1')
+        threshold_coord = find_threshold_coordinate(self.cubes[0])
+        self.cubes[0].coord(threshold_coord).units = Unit('mm kg-1')
         with self.assertRaisesRegex(ValueError, msg):
             plugin.check_input_cubes(self.cubes)
 

--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -400,8 +400,12 @@ def _equalise_cube_coords(cubes):
         # Check for mismatches in dim coord bounds
         _check_coord_bounds(cubes)
 
-        # Throw an error for specific coordinate mismatches
-        error_keys = ['threshold']
+        # Throw an error for threshold coordinate mismatch
+        try:
+            error_keys = [find_threshold_coordinate(cubes[0]).name()]
+        except CoordinateNotFoundError:
+            error_keys = []
+
         for error_key in error_keys:
             for key in ([keyval for cube_dict in unmatching_coords
                          for keyval in cube_dict]):

--- a/lib/improver/utilities/cube_manipulation_new.py
+++ b/lib/improver/utilities/cube_manipulation_new.py
@@ -501,8 +501,12 @@ def _equalise_cube_coords(cubes):
         # Check for mismatches in dim coord bounds
         _check_coord_bounds(cubes)
 
-        # Throw an error for specific coordinate mismatches
-        error_keys = ['threshold']
+        # Throw an error for threshold coordinate mismatch
+        try:
+            error_keys = [find_threshold_coordinate(cubes[0]).name()]
+        except CoordinateNotFoundError:
+            error_keys = []
+
         for error_key in error_keys:
             for key in ([keyval for cube_dict in unmatching_coords
                          for keyval in cube_dict]):

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -644,3 +644,32 @@ def in_vicinity_name_format(cube_name):
                          cube_name[relative_to_threshold_index:])
 
     return new_cube_name
+
+
+def extract_diagnostic_name(cube_name):
+    """
+    Extract the standard or long name X of the diagnostic from a probability
+    cube name of the form 'probability_of_X_above/below_thresold'
+
+    Args:
+        cube_name (str):
+            The probability cube name
+
+    Returns:
+        diagnostic_name (str):
+            The name of the diagnostic underlying this probability
+
+    Raises:
+        ValueError: If the input name does not contain 'probability_of_'
+    """
+    if not cube_name.startswith('probability_of_'):
+        raise ValueError(
+            'Input {} is not a valid probability cube name'.format(cube_name))
+
+    relative_to_threshold_index = max(
+        cube_name.find('_above_threshold'),
+        cube_name.find('_below_threshold'))
+
+    # 'probability_of_' is a 15-character string
+    diagnostic_name = cube_name[15:relative_to_threshold_index]
+    return diagnostic_name

--- a/lib/improver/wxcode/weather_symbols.py
+++ b/lib/improver/wxcode/weather_symbols.py
@@ -115,11 +115,13 @@ class WeatherSymbols(object):
                 # Then we check if the required threshold is present in the
                 # cube, and that the thresholding is relative to it correctly.
                 threshold = threshold.points.item()
+                threshold_name = find_threshold_coordinate(
+                    matched_cube[0]).name()
                 test_condition = (
                     iris.Constraint(
-                        threshold=lambda cell: (
+                        coord_values={threshold_name: lambda cell: (
                             threshold * (1. - self.float_tolerance) < cell <
-                            threshold * (1. + self.float_tolerance)),
+                            threshold * (1. + self.float_tolerance))},
                         cube_func=lambda cube: (
                             cube.attributes['relative_to_threshold'] ==
                             condition)))


### PR DESCRIPTION
Partially addresses #833

Updated unit test setup functions and changed plugins to support new threshold coordinate convention in a backward-compatible way.  Functionality changed:

- Minor implementation changes to ECC, WeatherSymbols and cube manipulation utilities.
- WeightedBlendAcrossWholeDimension now explicitly rejects "threshold" as a coordinate name.  There was an issue with supporting var names in blending, and there is no reason to support this case.  Some unit tests for this case have been removed.

Functionality not yet fixed: some cube metadata utilities (`add_coord` and `update_coord`) don't support the new threshold coordinate metadata (standard and var names).  This and the affected unit tests will be addressed in a separate PR.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
