### PR TITLE
Bugfix: WMO ID now stored as a string to allow nonetypes

### DIFF
--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -521,8 +521,9 @@ class NeighbourSelection:
         vertical_displacements = (site_altitudes -
                                   orography.data[tuple(nearest_indices.T)])
 
-        # Create a list of WMO IDs if available.
-        wmo_ids = [site.get('wmo_id', None) for site in sites]
+        # Create a list of WMO IDs if available. These are stored as strings
+        # to accommodate the use of 'None' for unset IDs.
+        wmo_ids = [str(site.get('wmo_id', None)) for site in sites]
 
         # Construct a name to describe the neighbour finding method employed
         method_name = self.neighbour_finding_method_name()

--- a/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
@@ -656,7 +656,7 @@ class Test_process(Test_NeighbourSelection):
         plugin = NeighbourSelection()
         sites = self.global_sites + [self.global_sites.copy()[0].copy()]
         sites[1]['wmo_id'] = None
-        expected = [1, None]
+        expected = ['1', 'None']
 
         result = plugin.process(sites, self.global_orography,
                                 self.global_land_mask)

--- a/tests/improver-neighbour-finding/17-wmo-ids-include-some-unset.bats
+++ b/tests/improver-neighbour-finding/17-wmo-ids-include-some-unset.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "neighbour-finding" {
+  improver_check_skip_acceptance
+  KGO="neighbour-finding/outputs/nearest_uk_kgo_some_unset_wmo_ids.nc"
+
+  # Run cube extraction processing and check it passes.
+  run improver neighbour-finding \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/uk_sites_missing_wmo_ids.json" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_orography.nc" \
+      "$IMPROVER_ACC_TEST_DIR/neighbour-finding/inputs/ukvx_landmask.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
For sitelists with undefined WMO ids, the spot-data code is using values of None. When neighbour cubes were being created, the wmo_id coordinate could not describe the int values and None values in a consistent format that netcdf could handle; if they were all None, the type was not something netcdf could handle either. This change makes all WMO ids into strings such that the id numbers and Nonetypes can both be described in a single format that can be written to a netcdf file. There are no implications for this elsewhere in IMPROVER at present as the wmo_id is not used; I will need to check with verificaiton to ensure they can handle this change (e.g. add an int() to their use of the IDs).

One unit test was updated, and a new CLI test was added to capture the problem that had previously been overlooked.

New acceptance test data can be found in my DATADIR/improver_tests

Testing:
 - [x] Ran tests and they passed OK
