### PR TITLE
Add creation of a coefficient cube for EMOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ etc/site-init
 
 # Files from build of doc
 *.rst
-!/doc/source/extended_documentation/*.rst
+!/doc/source/extended_documentation/**
 /doc/build/
 
 # Code coverage files

--- a/doc/source/extended_documentation/ensemble_calibration/ensemble_calibration/create_coefficients_cube.rst
+++ b/doc/source/extended_documentation/ensemble_calibration/ensemble_calibration/create_coefficients_cube.rst
@@ -23,5 +23,5 @@ An example of the coefficient_index coordinate is::
 
 An example of the coefficient_name coordinate is::
 
- AuxCoord(array(['gamma', 'delta', 'a', 'beta'], dtype='<U5'), standard_name=None, units=Unit('no_unit'), long_name='coefficient_name')
+ AuxCoord(array(['gamma', 'delta', 'alpha', 'beta'], dtype='<U5'), standard_name=None, units=Unit('no_unit'), long_name='coefficient_name')
 

--- a/doc/source/extended_documentation/ensemble_calibration/ensemble_calibration/create_coefficients_cube.rst
+++ b/doc/source/extended_documentation/ensemble_calibration/ensemble_calibration/create_coefficients_cube.rst
@@ -1,0 +1,27 @@
+**Examples**
+
+For a cube containing coefficients calculated using Ensemble
+Model Output Statistics::
+
+ emos_coefficients / (1)             (coefficient_index: 4)
+     Dimension coordinates:
+          coefficient_index                           x
+     Auxiliary coordinates:
+          coefficient_name                            x
+     Scalar coordinates:
+          forecast_period: 14400 seconds
+          forecast_reference_time: 2017-11-10 00:00:00
+          time: 2017-11-10 04:00:00
+     Attributes:
+          diagnostic_standard_name: air_temperature
+          mosg__model_configuration: uk_det
+
+
+An example of the coefficient_index coordinate is::
+
+ DimCoord(array([0, 1, 2, 3]), standard_name=None, units=Unit('1'), long_name='coefficient_index')
+
+An example of the coefficient_name coordinate is::
+
+ AuxCoord(array(['gamma', 'delta', 'a', 'beta'], dtype='<U5'), standard_name=None, units=Unit('no_unit'), long_name='coefficient_name')
+

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -388,9 +388,9 @@ class EstimateCoefficientsForEnsembleCalibration(object):
             self, optimised_coeffs, current_forecast):
         """Create a cube for storing the coefficients computed using EMOS.
 
-        # .. See the documentation for examples of these cubes.
-        # .. include:: extended_documentation/ensemble_calibration/
-        #    ensemble_calibration/ensemble_calibration_examples.rst
+        .. See the documentation for examples of these cubes.
+        .. include:: extended_documentation/ensemble_calibration/
+           ensemble_calibration/create_coefficients_cube.rst
 
         Args:
             optimised_coeffs (list):

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -354,7 +354,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         # coefficient name in the list, as there can potentially be
         # multiple beta coefficients if the ensemble realizations, rather
         # than the ensemble mean, are provided as the predictor.
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         import imp
         try:
@@ -409,7 +409,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                 the coordinate are e.g. gamma, delta, alpha, beta.
 
         """
-        if self.predictor_of_mean_flag.lower() in ["realizations"]:
+        if self.predictor_of_mean_flag.lower() == "realizations":
             realization_coeffs = []
             for realization in current_forecast.coord("realization").points:
                 realization_coeffs.append(
@@ -993,7 +993,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                 if predictor_of_mean_flag.lower() in ["mean"]:
                     # Calculate predicted mean = a + b*X, where X is the
                     # raw ensemble mean. In this case, b = beta.
-                    beta = [optimised_coeffs_at_date["a"],
+                    beta = [optimised_coeffs_at_date["alpha"],
                             optimised_coeffs_at_date["beta"]]
                     forecast_predictor_flat = (
                         forecast_predictor_at_date.data.flatten())
@@ -1008,7 +1008,7 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                     # Calculate predicted mean = a + b*X, where X is the
                     # raw ensemble mean. In this case, b = beta^2.
                     beta = np.concatenate(
-                        [[optimised_coeffs_at_date["a"]],
+                        [[optimised_coeffs_at_date["alpha"]],
                          optimised_coeffs_at_date["beta"]**2])
                     forecast_predictor = (
                         enforce_coordinate_ordering(

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -1155,7 +1155,7 @@ class EnsembleCalibration(object):
                 ec = EstimateCoefficientsForEnsembleCalibration(
                     self.distribution, self.desired_units,
                     predictor_of_mean_flag=self.predictor_of_mean_flag)
-                optimised_coeffs, coeff_names = (
+                optimised_coeffs = (
                     ec.estimate_coefficients_for_ngr(
                         current_forecast, historic_forecast, truth))
         else:
@@ -1164,7 +1164,7 @@ class EnsembleCalibration(object):
                        format_calibration_method(self.calibration_method)))
             raise ValueError(msg)
         ac = ApplyCoefficientsFromEnsembleCalibration(
-            current_forecast, optimised_coeffs, coeff_names,
+            current_forecast, optimised_coeffs, ec.coeff_names,
             predictor_of_mean_flag=self.predictor_of_mean_flag)
         (calibrated_forecast_predictor, calibrated_forecast_variance,
          calibrated_forecast_coefficients) = ac.apply_params_entry()

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -67,7 +67,7 @@ class Test__find_coords_of_length_one(IrisTest):
         self.cube = set_up_temperature_cube()
         self.optimised_coeffs = [4.55819380e-06, -8.02401974e-09,
                                  1.66667055e+00, 1.00000011e+00]
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
     def test_basic(self):
         """Test that the plugin returns a list."""
@@ -120,7 +120,7 @@ class Test__separate_length_one_coords_into_aux_and_dim(IrisTest):
         self.cube = set_up_temperature_cube()
         self.optimised_coeffs = [4.55819380e-06, -8.02401974e-09,
                                  1.66667055e+00, 1.00000011e+00]
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
         self.plugin = Plugin(self.cube, self.optimised_coeffs,
                              self.coeff_names)
 
@@ -281,7 +281,7 @@ class Test___create_coefficient_cube(IrisTest):
         self.cube = set_up_temperature_cube()
         self.optimised_coeffs = [4.55819380e-06, -8.02401974e-09,
                                  1.66667055e+00, 1.00000011e+00]
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
         self.plugin = Plugin(self.cube, self.optimised_coeffs,
                              self.coeff_names)
 
@@ -337,7 +337,7 @@ class Test_apply_params_entry(IrisTest):
             add_forecast_reference_time_and_forecast_period(
                 set_up_temperature_cube()))
 
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -466,7 +466,7 @@ class Test__apply_params(IrisTest):
             add_forecast_reference_time_and_forecast_period(
                 set_up_temperature_cube()))
 
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         self.default_optimised_coeffs = [
             4.55819380e-06, -8.02401974e-09, 1.66667055e+00, 1.00000011e+00]
@@ -684,7 +684,7 @@ class Test__apply_params(IrisTest):
             the_date = datetime_from_timestamp(time_slice.coord("time").points)
             optimised_coeffs[the_date] = np.array(
                 [5, 1, 0, 0.57, 0.6, 0.6], dtype=np.float32)
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         predictor_cube = cube.copy()
         variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
@@ -728,7 +728,7 @@ class Test__apply_params(IrisTest):
             the_date = datetime_from_timestamp(time_slice.coord("time").points)
             optimised_coeffs[the_date] = np.array(
                 [5, 1, 0, 0.57, 0.6, 0.6])
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         predictor_cube = cube.copy()
         variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
@@ -769,7 +769,7 @@ class Test__apply_params(IrisTest):
             the_date = datetime_from_timestamp(time_slice.coord("time").points)
             optimised_coeffs[the_date] = np.array(
                 [5, 1, 0, 0.57, 0.6, 0.6])
-        self.coeff_names = ["gamma", "delta", "a", "beta"]
+        self.coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         predictor_cube = cube.copy()
         variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -227,6 +227,10 @@ class Test_create_coefficients_cube(IrisTest):
         expected_coeff_names = ["gamma", "delta", "a", "beta"]
         result = self.plugin.create_coefficients_cube(
             self.optimised_coeffs, self.current_forecast)
+        print("result")
+        print(result)
+        print(result.coord("coefficient_index"))
+        print(result.coord("coefficient_name"))
         self.assertEqual(result, self.expected)
         self.assertEqual(
             self.plugin.coeff_names, expected_coeff_names)
@@ -571,12 +575,10 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         plugin = Plugin(distribution, desired_units)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs, coeff_names = result
-        self.assertIsInstance(optimised_coeffs, dict)
-        self.assertIsInstance(coeff_names, list)
-        for key in optimised_coeffs.keys():
-            self.assertEqual(
-                len(optimised_coeffs[key]), len(coeff_names))
+        self.assertIsInstance(result, dict)
+        self.assertIsInstance(plugin.coeff_names, list)
+        for key in result.keys():
+            self.assertEqual(len(result[key]), len(plugin.coeff_names))
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -602,11 +604,11 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         plugin = Plugin(distribution, desired_units)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs, coeff_names = result
 
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(optimised_coeffs[key], data)
-        self.assertListEqual(coeff_names, ["gamma", "delta", "a", "beta"])
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data)
+        self.assertListEqual(
+            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -631,11 +633,11 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         plugin = Plugin(distribution, desired_units)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs, coeff_names = result
 
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(optimised_coeffs[key], data)
-        self.assertListEqual(coeff_names, ["gamma", "delta", "a", "beta"])
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data)
+        self.assertListEqual(
+            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -672,12 +674,11 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
                         predictor_of_mean_flag=predictor_of_mean_flag)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs, coeff_names = result
 
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(optimised_coeffs[key], data,
-                                        decimal=5)
-        self.assertListEqual(coeff_names, ["gamma", "delta", "a", "beta"])
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data, decimal=5)
+        self.assertListEqual(
+            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -716,10 +717,10 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
                         predictor_of_mean_flag=predictor_of_mean_flag)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs, coeff_names = result
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(optimised_coeffs[key], data)
-        self.assertListEqual(coeff_names, ["gamma", "delta", "a", "beta"])
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data)
+        self.assertListEqual(
+            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -767,11 +768,9 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         plugin = Plugin(distribution, desired_units)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs = result[0]
 
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(optimised_coeffs[key], data,
-                                        decimal=5)
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data, decimal=5)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -797,11 +796,9 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         plugin = Plugin(distribution, desired_units)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs = result[0]
 
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(
-                optimised_coeffs[key], data, decimal=5)
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data, decimal=5)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -827,10 +824,9 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         plugin = Plugin(distribution, desired_units)
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs = result[0]
 
-        for key in optimised_coeffs.keys():
-            self.assertArrayAlmostEqual(optimised_coeffs[key], data)
+        for key in result.keys():
+            self.assertArrayAlmostEqual(result[key], data)
 
     def test_truth_data_is_none(self):
         """
@@ -875,9 +871,8 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
 
         result = plugin.estimate_coefficients_for_ngr(
             current_forecast, historic_forecasts, truth)
-        optimised_coeffs, coeff_names = result
-        self.assertFalse(optimised_coeffs)
-        self.assertCountEqual(coeff_names, desired_coeff_names)
+        self.assertFalse(result)
+        self.assertCountEqual(plugin.coeff_names, desired_coeff_names)
 
     @ManageWarnings(record=True)
     def test_current_forecast_cubes_is_fake_catch_warning(self,

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -227,10 +227,6 @@ class Test_create_coefficients_cube(IrisTest):
         expected_coeff_names = ["gamma", "delta", "a", "beta"]
         result = self.plugin.create_coefficients_cube(
             self.optimised_coeffs, self.current_forecast)
-        print("result")
-        print(result)
-        print(result.coord("coefficient_index"))
-        print(result.coord("coefficient_name"))
         self.assertEqual(result, self.expected)
         self.assertEqual(
             self.plugin.coeff_names, expected_coeff_names)
@@ -274,7 +270,8 @@ class Test_create_coefficients_cube(IrisTest):
         result = plugin.create_coefficients_cube(
             optimised_coeffs, self.current_forecast_with_realizations)
         self.assertEqual(result, expected)
-        self.assertEqual(plugin.coeff_names, expected_coeff_names)
+        self.assertArrayEqual(
+            result.coord("coefficient_name").points, expected_coeff_names)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -188,7 +188,7 @@ class Test_create_coefficients_cube(IrisTest):
             data_with_realizations, realizations=[0, 1, 2],
             standard_grid_metadata="uk_det")
         self.optimised_coeffs = [0, 1, 2, 3]
-        coeff_names = ["gamma", "delta", "a", "beta"]
+        coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         coefficient_index = iris.coords.DimCoord(
             self.optimised_coeffs, long_name="coefficient_index", units="1")
@@ -224,7 +224,7 @@ class Test_create_coefficients_cube(IrisTest):
     def test_coefficients_from_mean(self):
         """Test that the expected coefficient cube is returned when the
         ensemble mean is used as the predictor."""
-        expected_coeff_names = ["gamma", "delta", "a", "beta"]
+        expected_coeff_names = ["gamma", "delta", "alpha", "beta"]
         result = self.plugin.create_coefficients_cube(
             self.optimised_coeffs, self.current_forecast)
         self.assertEqual(result, self.expected)
@@ -237,7 +237,7 @@ class Test_create_coefficients_cube(IrisTest):
         """Test that the expected coefficient cube is returned when the
         ensemble realizations are used as the predictor."""
         expected_coeff_names = (
-            ["gamma", "delta", "a", "beta0", "beta1", "beta2"])
+            ["gamma", "delta", "alpha", "beta0", "beta1", "beta2"])
         predictor_of_mean_flag = "realizations"
         optimised_coeffs = [0, 1, 2, 3, 4, 5]
 
@@ -278,24 +278,22 @@ class Test_create_coefficients_cube(IrisTest):
     def test_forecast_period_coordinate_not_present(self):
         """Test that the coefficients cube is created correctly when the
         forecast_period coordinate is not present within the input cube."""
-        expected = self.expected.copy()
-        expected.remove_coord("forecast_period")
+        self.expected.remove_coord("forecast_period")
         self.current_forecast.remove_coord("forecast_period")
         result = self.plugin.create_coefficients_cube(
             self.optimised_coeffs, self.current_forecast)
-        self.assertEqual(result, expected)
+        self.assertEqual(result, self.expected)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_model_configuration_not_present(self):
         """Test that the coefficients cube is created correctly when a
         model_configuration coordinate is not present within the input cube."""
-        expected = self.expected.copy()
-        expected.attributes.pop("mosg__model_configuration")
+        self.expected.attributes.pop("mosg__model_configuration")
         self.current_forecast.attributes.pop("mosg__model_configuration")
         result = self.plugin.create_coefficients_cube(
             self.optimised_coeffs, self.current_forecast)
-        self.assertEqual(result, expected)
+        self.assertEqual(result, self.expected)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -605,7 +603,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         for key in result.keys():
             self.assertArrayAlmostEqual(result[key], data)
         self.assertListEqual(
-            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
+            plugin.coeff_names, ["gamma", "delta", "alpha", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -634,7 +632,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         for key in result.keys():
             self.assertArrayAlmostEqual(result[key], data)
         self.assertListEqual(
-            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
+            plugin.coeff_names, ["gamma", "delta", "alpha", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -675,7 +673,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         for key in result.keys():
             self.assertArrayAlmostEqual(result[key], data, decimal=5)
         self.assertListEqual(
-            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
+            plugin.coeff_names, ["gamma", "delta", "alpha", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -717,7 +715,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         for key in result.keys():
             self.assertArrayAlmostEqual(result[key], data)
         self.assertListEqual(
-            plugin.coeff_names, ["gamma", "delta", "a", "beta"])
+            plugin.coeff_names, ["gamma", "delta", "alpha", "beta"])
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -853,7 +851,7 @@ class Test_estimate_coefficients_for_ngr(IrisTest):
         and the expected coefficient names are generated, if the input
         cubelist for the historic_forecasts is empty.
         """
-        desired_coeff_names = ["gamma", "delta", "a", "beta"]
+        desired_coeff_names = ["gamma", "delta", "alpha", "beta"]
 
         current_forecast = self.current_temperature_forecast_cube
 


### PR DESCRIPTION
Addresses: Part of #854 

Description
This PR adds the creation of a coefficient cube when estimating the EMOS coefficients. This PR only adds the required method, but does not use this method at present, so as to reduce the size of this PR. A follow-on PR will implement the usage of this coefficients cube.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

