### PR TITLE
Added functionality to add_coord to support new threshold coordinate …

### DIFF
--- a/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/lib/improver/tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -248,11 +248,12 @@ class Test_process(IrisTest):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_input_cube_no_change(self):
-        """Test that the plugin does not change the origonal input cube."""
+        """Test that the plugin does not change the original input cube."""
 
         # Add threshold axis to standard input cube.
-        changes = {'points': [0.5], 'units': '1'}
-        cube_with_thresh = add_coord(self.cube.copy(), 'threshold', changes)
+        changes = {'points': [0], 'units': '1', 'var_name': 'threshold'}
+        cube_with_thresh = add_coord(
+            self.cube.copy(), 'precipitation_amount', changes)
         original_cube = cube_with_thresh.copy()
 
         width = 2.0
@@ -278,11 +279,13 @@ class Test_process(IrisTest):
         expected_cube = self.cube[0].copy(data.astype(np.float32))
 
         # Add threshold axis to expected output cube.
-        changes = {'points': [0.5], 'units': '1'}
-        expected_cube = add_coord(expected_cube, 'threshold', changes)
+        changes = {'points': [0.5], 'units': '1', 'var_name': 'threshold'}
+        expected_cube = add_coord(
+            expected_cube, 'precipitation_amount', changes)
 
         # Add threshold axis to standard input cube.
-        cube_with_thresh = add_coord(self.cube.copy(), 'threshold', changes)
+        cube_with_thresh = add_coord(
+            self.cube.copy(), 'precipitation_amount', changes)
 
         width = 2.0
         plugin = TriangularWeightedBlendAcrossAdjacentPoints(
@@ -292,8 +295,8 @@ class Test_process(IrisTest):
 
         # Test that the result cube retains threshold co-ordinates
         # from original cube.
-        self.assertEqual(expected_cube.coord('threshold'),
-                         result.coord('threshold'))
+        self.assertEqual(expected_cube.coord('precipitation_amount'),
+                         result.coord('precipitation_amount'))
         self.assertArrayEqual(expected_cube.data, result.data)
         self.assertEqual(expected_cube, result)
 
@@ -307,20 +310,23 @@ class Test_process(IrisTest):
         thresh_cube = self.cube.copy()
         thresh_cube.remove_coord("forecast_reference_time")
 
-        changes = {'points': [0.25], 'units': '1'}
-        cube_with_thresh1 = add_coord(thresh_cube.copy(), 'threshold', changes)
+        changes = {'points': [0.25], 'units': '1', 'var_name': 'threshold'}
+        cube_with_thresh1 = add_coord(
+            thresh_cube.copy(), 'precipitation_amount', changes)
 
-        changes = {'points': [0.5], 'units': '1'}
-        cube_with_thresh2 = add_coord(thresh_cube.copy(), 'threshold', changes)
+        changes = {'points': [0.5], 'units': '1', 'var_name': 'threshold'}
+        cube_with_thresh2 = add_coord(
+            thresh_cube.copy(), 'precipitation_amount', changes)
 
-        changes = {'points': [0.75], 'units': '1'}
-        cube_with_thresh3 = add_coord(thresh_cube.copy(), 'threshold', changes)
+        changes = {'points': [0.75], 'units': '1', 'var_name': 'threshold'}
+        cube_with_thresh3 = add_coord(
+            thresh_cube.copy(), 'precipitation_amount', changes)
 
         cubelist = iris.cube.CubeList([cube_with_thresh1, cube_with_thresh2,
                                        cube_with_thresh3])
 
-        thresh_cubes = concatenate_cubes(cubelist,
-                                         coords_to_slice_over='threshold')
+        thresh_cubes = concatenate_cubes(
+            cubelist, coords_to_slice_over='precipitation_amount')
 
         plugin = TriangularWeightedBlendAcrossAdjacentPoints(
             'forecast_period', self.forecast_period, 'hours', width,
@@ -329,8 +335,8 @@ class Test_process(IrisTest):
 
         # Test that the result cube retains threshold co-ordinates
         # from original cube.
-        self.assertEqual(thresh_cubes.coord('threshold'),
-                         result.coord('threshold'))
+        self.assertEqual(thresh_cubes.coord('precipitation_amount'),
+                         result.coord('precipitation_amount'))
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -142,7 +142,7 @@ class Test_add_coord(IrisTest):
         result_coord = result.coord(self.coord_name)
         self.assertIsInstance(result, Cube)
         self.assertArrayEqual(result_coord.points, np.array([2.0]))
-        self.assertArrayEqual(result_coord.bounds,np.array([[0.1, 2.0]]))
+        self.assertArrayEqual(result_coord.bounds, np.array([[0.1, 2.0]]))
         self.assertEqual(str(result_coord.units), 'mm')
         self.assertEqual(result_coord.var_name, "threshold")
 

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -128,7 +128,8 @@ class Test_add_coord(IrisTest):
         self.changes = {
             'points': [2.0],
             'bounds': [0.1, 2.0],
-            'units': 'mm'
+            'units': 'mm',
+            'var_name': 'threshold'
             }
         cube = create_cube_with_threshold()
         self.coord_name = find_threshold_coordinate(cube).name()
@@ -136,14 +137,20 @@ class Test_add_coord(IrisTest):
         self.cube = iris.util.squeeze(cube)
 
     def test_basic(self):
-        """Test that add_coord returns a Cube and adds coord correctly. """
+        """Test that add_coord returns a Cube and adds coord correctly"""
         result = add_coord(self.cube, self.coord_name, self.changes)
+        result_coord = result.coord(self.coord_name)
         self.assertIsInstance(result, Cube)
-        self.assertArrayEqual(result.coord(self.coord_name).points,
-                              np.array([2.0]))
-        self.assertArrayEqual(result.coord(self.coord_name).bounds,
-                              np.array([[0.1, 2.0]]))
-        self.assertEqual(str(result.coord(self.coord_name).units), 'mm')
+        self.assertArrayEqual(result_coord.points, np.array([2.0]))
+        self.assertArrayEqual(result_coord.bounds,np.array([[0.1, 2.0]]))
+        self.assertEqual(str(result_coord.units), 'mm')
+        self.assertEqual(result_coord.var_name, "threshold")
+
+    def test_standard_name(self):
+        """Test default is for coordinate to be added as standard name"""
+        result = add_coord(self.cube, self.coord_name, self.changes)
+        self.assertEqual(
+            result.coord(self.coord_name).standard_name, self.coord_name)
 
     def test_long_name(self):
         """Test a coordinate can be added with a name that is not standard"""

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -157,6 +157,14 @@ class Test_add_coord(IrisTest):
         result = add_coord(self.cube, "threshold", self.changes)
         self.assertEqual(result.coord("threshold").long_name, "threshold")
 
+    def test_non_name_value_error(self):
+        """Test value errors thrown by iris.Coord (eg invalid units) are
+        still raised"""
+        self.changes['units'] = 'narwhal'
+        msg = 'Failed to parse unit "narwhal"'
+        with self.assertRaisesRegex(ValueError, msg):
+            add_coord(self.cube, self.coord_name, self.changes)
+
     def test_fails_no_points(self):
         """Test that add_coord fails if points not included in metadata """
         changes = {'bounds': [0.1, 2.0], 'units': 'mm'}

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -145,11 +145,23 @@ def add_coord(cube, coord_name, changes, warnings_on=False):
         bounds = changes['bounds']
     units = None
     if 'units' in changes:
-        units = changes["units"]
-    new_coord = new_coord_method(long_name=coord_name,
-                                 points=points,
-                                 bounds=bounds,
-                                 units=units)
+        units = changes['units']
+    var_name = None
+    if 'var_name' in changes:
+        var_name = changes['var_name']
+
+    try:
+        new_coord = new_coord_method(
+            standard_name=coord_name, var_name=var_name, points=points,
+            bounds=bounds, units=units)
+    except ValueError as cause:
+        if 'is not a valid standard_name' in str(cause):
+            new_coord = new_coord_method(
+                long_name=coord_name, var_name=var_name, points=points,
+                bounds=bounds, units=units)
+        else:
+            raise ValueError(cause)
+
     result.add_aux_coord(new_coord)
     if metatype == 'DimCoord':
         result = iris.util.new_axis(result, coord_name)
@@ -541,6 +553,8 @@ def resolve_metadata_diff(cube1, cube2, warnings_on=False):
                     coord_dict['bounds'] = result1.coord(coord).bounds
                     coord_dict['units'] = result1.coord(coord).units
                     coord_dict['metatype'] = 'DimCoord'
+                    if result1.coord(coord).var_name is not None:
+                        coord_dict['var_name'] = result1.coord(coord).var_name
                     result2 = add_coord(result2, coord, coord_dict,
                                         warnings_on=warnings_on)
                     result2 = iris.util.as_compatible_shape(result2,

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -104,7 +104,10 @@ def add_coord(cube, coord_name, changes, warnings_on=False):
         coord_name (string):
             Name of the coordinate being added.
         changes (dict):
-            Details on coordinate to be added to the cube.
+            Details of coordinate to be added to the cube, with string keys.
+            Valid keys are 'metatype' (which should have value 'DimCoord' or
+            'AuxCoord'), 'points', 'bounds', 'units' and 'var_name'. Any other
+            key strings in the dictionary are ignored.
 
     Keyword Args:
         warnings_on (bool):


### PR DESCRIPTION
…format.

Part of #833 

Added support for standard_name and var_name to `improver.utilities.cube_metadata.add_coord`.  Updated unit test cube setup function in test_cube_metadata.py and tests for triangular time blending to use new threshold coordinate format.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
