### PR TITLE
IMPRO-1157: spot-extract altered to accept lapse rate from taskfilelist

### DIFF
--- a/lib/improver/cli/spot_extract.py
+++ b/lib/improver/cli/spot_extract.py
@@ -68,6 +68,14 @@ def main(argv=None):
     parser.add_argument("diagnostic_filepath", metavar="DIAGNOSTIC_FILEPATH",
                         help="Path to a NetCDF file containing the diagnostic "
                              "data to be extracted.")
+    parser.add_argument("temperature_lapse_rate_filepath",
+                        metavar="LAPSE_RATE_FILEPATH", nargs='?',
+                        help="(Optional) Filepath to a NetCDF file containing"
+                        " temperature lapse rates. If this cube is provided,"
+                        " and a screen temperature cube is being processed,"
+                        " the lapse rates will be used to adjust the"
+                        " temperatures to better represent each spot's"
+                        " site-altitude.")
     parser.add_argument("output_filepath", metavar="OUTPUT_FILEPATH",
                         help="The output path for the resulting NetCDF")
 
@@ -109,15 +117,6 @@ def main(argv=None):
         "--ecc_bounds_warning", default=False, action="store_true",
         help="If True, where calculated percentiles are outside the ECC "
         "bounds range, raise a warning rather than an exception.")
-
-    lapse_group = parser.add_argument_group(
-        "Temperature lapse rate adjustment")
-    lapse_group.add_argument(
-        "--temperature_lapse_rate_filepath",
-        help="Filepath to a NetCDF file containing temperature lapse rates. "
-        "If this cube is provided, and a screen temperature cube is being "
-        "processed, the lapse rates will be used to adjust the temperatures "
-        "to better represent each spot's site-altitude.")
 
     meta_group = parser.add_argument_group("Metadata")
     meta_group.add_argument(

--- a/lib/improver/cli/spot_extract.py
+++ b/lib/improver/cli/spot_extract.py
@@ -212,7 +212,7 @@ def main(argv=None):
     # Check whether a lapse rate cube has been provided and we are dealing with
     # temperature data.
     if (args.temperature_lapse_rate_filepath and
-            diagnostic_cube.name() == "air_temperature"):
+            result.name() == "air_temperature"):
 
         lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath)
         try:

--- a/lib/improver/cli/spot_extract.py
+++ b/lib/improver/cli/spot_extract.py
@@ -215,6 +215,11 @@ def main(argv=None):
             result.name() == "air_temperature"):
 
         lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath)
+        if not lapse_rate_cube.name() == 'air_temperature_lapse_rate':
+            msg = ("A cube has been provided as a lapserate cube but does "
+                   "not have the expected name air_temperature_lapse_rate: "
+                   "{}".format(lapse_rate_cube.name()))
+            raise ValueError(msg)
         try:
             lapse_rate_height_coord = lapse_rate_cube.coord("height")
         except (ValueError, CoordinateNotFoundError):

--- a/tests/improver-spot-extract/00-null.bats
+++ b/tests/improver-spot-extract/00-null.bats
@@ -37,11 +37,10 @@ usage: improver spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
                              [--extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]]
                              [--ecc_bounds_warning]
-                             [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
                              [--json_file JSON_FILE] [--suppress_warnings]
                              NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
-                             OUTPUT_FILEPATH
+                             [LAPSE_RATE_FILEPATH] OUTPUT_FILEPATH
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-spot-extract/00-null.bats
+++ b/tests/improver-spot-extract/00-null.bats
@@ -34,6 +34,7 @@
   [[ "$status" -eq 2 ]]
   read -d '' expected <<'__TEXT__' || true
 usage: improver spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
+                             [--apply_lapse_rate_correction]
                              [--land_constraint] [--minimum_dz]
                              [--extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]]
                              [--ecc_bounds_warning]

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -38,11 +38,10 @@ usage: improver spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
                              [--land_constraint] [--minimum_dz]
                              [--extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]]
                              [--ecc_bounds_warning]
-                             [--temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH]
                              [--grid_metadata_identifier GRID_METADATA_IDENTIFIER]
                              [--json_file JSON_FILE] [--suppress_warnings]
                              NEIGHBOUR_FILEPATH DIAGNOSTIC_FILEPATH
-                             OUTPUT_FILEPATH
+                             [LAPSE_RATE_FILEPATH] OUTPUT_FILEPATH
 
 Extract diagnostic data from gridded fields for spot data sites. It is
 possible to apply a temperature lapse rate adjustment to temperature data that
@@ -54,6 +53,11 @@ positional arguments:
                         file also contains the spot site information.
   DIAGNOSTIC_FILEPATH   Path to a NetCDF file containing the diagnostic data
                         to be extracted.
+  LAPSE_RATE_FILEPATH   (Optional) Filepath to a NetCDF file containing
+                        temperature lapse rates. If this cube is provided, and
+                        a screen temperature cube is being processed, the
+                        lapse rates will be used to adjust the temperatures to
+                        better represent each spot's site-altitude.
   OUTPUT_FILEPATH       The output path for the resulting NetCDF
 
 optional arguments:
@@ -97,14 +101,6 @@ Extract percentiles:
                         of probabilities, percentiles, or realizations. Note
                         that for percentile inputs, the desired percentile(s)
                         must exist in the input cube.
-
-Temperature lapse rate adjustment:
-  --temperature_lapse_rate_filepath TEMPERATURE_LAPSE_RATE_FILEPATH
-                        Filepath to a NetCDF file containing temperature lapse
-                        rates. If this cube is provided, and a screen
-                        temperature cube is being processed, the lapse rates
-                        will be used to adjust the temperatures to better
-                        represent each spot's site-altitude.
 
 Metadata:
   --grid_metadata_identifier GRID_METADATA_IDENTIFIER

--- a/tests/improver-spot-extract/01-help.bats
+++ b/tests/improver-spot-extract/01-help.bats
@@ -35,6 +35,7 @@
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__HELP__' || true
 usage: improver spot-extract [-h] [--profile] [--profile_file PROFILE_FILE]
+                             [--apply_lapse_rate_correction]
                              [--land_constraint] [--minimum_dz]
                              [--extract_percentiles EXTRACT_PERCENTILES [EXTRACT_PERCENTILES ...]]
                              [--ecc_bounds_warning]
@@ -65,6 +66,11 @@ optional arguments:
   --profile             Switch on profiling information.
   --profile_file PROFILE_FILE
                         Dump profiling info to a file. Implies --profile.
+  --apply_lapse_rate_correction
+                        If the option is set and a lapse rate cube has been
+                        provided, extracted screen temperatures will be
+                        adjusted to better match the altitude of the spot site
+                        for which they have been extracted.
   --ecc_bounds_warning  If True, where calculated percentiles are outside the
                         ECC bounds range, raise a warning rather than an
                         exception.

--- a/tests/improver-spot-extract/04-lapse_rate_adjusted_uk.bats
+++ b/tests/improver-spot-extract/04-lapse_rate_adjusted_uk.bats
@@ -40,7 +40,8 @@
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate.nc" \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" \
+      --apply_lapse_rate_correction
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/04-lapse_rate_adjusted_uk.bats
+++ b/tests/improver-spot-extract/04-lapse_rate_adjusted_uk.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      --temperature_lapse_rate_filepath "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-spot-extract/07-alternate_metadata.bats
+++ b/tests/improver-spot-extract/07-alternate_metadata.bats
@@ -39,10 +39,9 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk_alternate_metadata.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature_alternate_metadata.nc" \
-      --temperature_lapse_rate_filepath \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_alternate_metadata.nc" \
-      --grid_metadata_identifier my_grid_metadata \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" \
+      --grid_metadata_identifier my_grid_metadata
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-spot-extract/09-unmatched_lapse_rate_height.bats
+++ b/tests/improver-spot-extract/09-unmatched_lapse_rate_height.bats
@@ -40,7 +40,8 @@
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_2m.nc" \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" \
+      --apply_lapse_rate_correction
   echo "status = ${status}"
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true

--- a/tests/improver-spot-extract/09-unmatched_lapse_rate_height.bats
+++ b/tests/improver-spot-extract/09-unmatched_lapse_rate_height.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      --temperature_lapse_rate_filepath "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_2m.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_2m.nc" \
       "$TEST_DIR/output.nc"
   echo "status = ${status}"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-spot-extract/10-missing_lapse_rate_height.bats
+++ b/tests/improver-spot-extract/10-missing_lapse_rate_height.bats
@@ -39,7 +39,8 @@
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_no_height.nc" \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" \
+      --apply_lapse_rate_correction
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true

--- a/tests/improver-spot-extract/10-missing_lapse_rate_height.bats
+++ b/tests/improver-spot-extract/10-missing_lapse_rate_height.bats
@@ -38,7 +38,6 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      --temperature_lapse_rate_filepath \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_no_height.nc" \
       "$TEST_DIR/output.nc"
   echo "status = ${status}"

--- a/tests/improver-spot-extract/12-lapse_rate_for_non_temperature_data.bats
+++ b/tests/improver-spot-extract/12-lapse_rate_for_non_temperature_data.bats
@@ -33,24 +33,18 @@
 
 @test "spot-extract lapse rates provided for non-temperature diagnostic" {
   improver_check_skip_acceptance
-  KGO="spot-extract/outputs/nearest_uk_pmsl.nc"
 
   # Run spot extract processing and check it passes.
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_pmsl.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate.nc" \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" \
+      --apply_lapse_rate_correction
   echo "status = ${status}"
-  [[ "$status" -eq 0 ]]
+  [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-UserWarning: A lapse rate cube was provided, but the diagnostic being processed is not air temperature. The lapse rate cube was not used.
+ValueError: A lapse rate cube was provided, but the diagnostic being processed is not air temperature and cannot be adjusted.
 __TEXT__
   [[ "$output" =~ "$expected" ]]
-
-  improver_check_recreate_kgo "output.nc" $KGO
-
-  # Run nccmp to compare the output and kgo.
-  improver_compare_output "$TEST_DIR/output.nc" \
-      "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-spot-extract/12-lapse_rate_for_non_temperature_data.bats
+++ b/tests/improver-spot-extract/12-lapse_rate_for_non_temperature_data.bats
@@ -39,7 +39,7 @@
   run improver spot-extract \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_pmsl.nc" \
-      --temperature_lapse_rate_filepath "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate.nc" \
       "$TEST_DIR/output.nc"
   echo "status = ${status}"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-spot-extract/23-invalid_lapse_rate_cube.bats
+++ b/tests/improver-spot-extract/23-invalid_lapse_rate_cube.bats
@@ -39,11 +39,12 @@
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
       "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
-      "$TEST_DIR/output.nc"
+      "$TEST_DIR/output.nc" \
+      --apply_lapse_rate_correction
   echo "status = ${status}"
   [[ "$status" -eq 1 ]]
   read -d '' expected <<'__TEXT__' || true
-ValueError: A cube has been provided as a lapserate cube but does not have the expected name air_temperature_lapse_rate: air_temperature
+ValueError: A cube has been provided as a lapse rate cube but does not have the expected name air_temperature_lapse_rate: air_temperature
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-spot-extract/23-invalid_lapse_rate_cube.bats
+++ b/tests/improver-spot-extract/23-invalid_lapse_rate_cube.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "spot-extract lapse rate cube has no height coordinate" {
+  improver_check_skip_acceptance
+
+  # Run spot extract processing and check it passes.
+  run improver spot-extract \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
+      "$TEST_DIR/output.nc"
+  echo "status = ${status}"
+  [[ "$status" -eq 1 ]]
+  read -d '' expected <<'__TEXT__' || true
+ValueError: A cube has been provided as a lapserate cube but does not have the expected name air_temperature_lapse_rate: air_temperature
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
+}

--- a/tests/improver-spot-extract/24-lapse_rate_adjustment_enabled_no_lapse_rate_cube.bats
+++ b/tests/improver-spot-extract/24-lapse_rate_adjustment_enabled_no_lapse_rate_cube.bats
@@ -31,19 +31,22 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "spot-extract test non-default metadata can be used" {
+@test "spot-extract lapse rate cube not provided by option enabled" {
   improver_check_skip_acceptance
-  KGO="spot-extract/outputs/nearest_uk_temperatures_alternate_metadata.nc"
+  KGO="spot-extract/outputs/nearest_uk_temperatures.nc"
 
   # Run spot extract processing and check it passes.
   run improver spot-extract \
-      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk_alternate_metadata.nc" \
-      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature_alternate_metadata.nc" \
-      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_lapse_rate_alternate_metadata.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/all_methods_uk.nc" \
+      "$IMPROVER_ACC_TEST_DIR/spot-extract/inputs/ukvx_temperature.nc" \
       "$TEST_DIR/output.nc" \
-      --apply_lapse_rate_correction \
-      --grid_metadata_identifier my_grid_metadata
+      --apply_lapse_rate_correction
+  echo "status = ${status}"
   [[ "$status" -eq 0 ]]
+  read -d '' expected <<'__TEXT__' || true
+UserWarning: A lapse rate cube was not provided, but the option to apply the lapse rate correction was enabled. No lapse rate correction could be applied.
+__TEXT__
+  [[ "$output" =~ "$expected" ]]
 
   improver_check_recreate_kgo "output.nc" $KGO
 


### PR DESCRIPTION
Moves the lapse-rate filepath argument to be an optional positional argument. This enables the suite to use the taskfilelist file name generator to get the correct lapse rate filename.

The lapse rate adjustment is thus employed if the argument is present, and not used if it is not provided/available.

Testing:
 - [x] Ran tests and they passed OK