### PR TITLE
IMPRO-1134: Remove numpy 1.16.2+ related errors & a wind warning

### DIFF
--- a/lib/improver/tests/wind_calculations/wind_direction/test_WindDirection.py
+++ b/lib/improver/tests/wind_calculations/wind_direction/test_WindDirection.py
@@ -413,7 +413,7 @@ class Test_wind_dir_decider(IrisTest):
         self.plugin.wdir_slice_mean.data = np.pad(wind_dir_deg_mean,
                                                   ((4, 4), (4, 4)),
                                                   "constant",
-                                                  constant_values=(0.0 + 0.0j))
+                                                  constant_values=0.0)
 
         self.plugin.wind_dir_decider(where_low_r, cube)
         result = self.plugin.wdir_slice_mean.data


### PR DESCRIPTION
There is an issue in pylint in combination with numpy 1.16.2 that raises errors as pylint misidentifies a numpy array as a tuple. The use of a unary operator (~) with a tuple is invalid, so pylint raises an error. This issue has been fixed in later versions of pylint than we are using, but we can remedy the issue by simplifying our code slightly to not use the unary operator in multiple places, rather simply invert the mask in question once.

Whilst making this change in preparation for numpy 1.16.2 I have also removed a warning in the wind direction unit tests where a complex number was being provided when only a float was expected and required.

Testing:
 - [x] Ran tests and they passed OK