### PR TITLE
Refactor and increase stability of EMOS unit tests

### DIFF
--- a/lib/improver/cli/ensemble_calibration.py
+++ b/lib/improver/cli/ensemble_calibration.py
@@ -174,6 +174,16 @@ def main(argv=None):
                              'then the number of iterations may require '
                              'increasing, as there will be more coefficients '
                              'to solve for.')
+    parser.add_argument('--decimals', metavar='DECIMALS',
+                        type=np.int32, default=5,
+                        help='Integer to define how many decimals the inputs '
+                             'to the minimisation will be rounded to. This is '
+                             'for the purpose of obtaining consistent output '
+                             'from the minimisation across different packages '
+                             'and processors, where differences at the '
+                             'machine precision level will cause the '
+                             'minimisation to go in different directions and '
+                             'reach different solutions.')
     args = parser.parse_args(args=argv)
 
     current_forecast = load_cube(args.input_filepath)

--- a/lib/improver/cli/estimate_emos_coefficients.py
+++ b/lib/improver/cli/estimate_emos_coefficients.py
@@ -102,6 +102,16 @@ def main(argv=None):
                              'then the number of iterations may require '
                              'increasing, as there will be more coefficients '
                              'to solve for.')
+    parser.add_argument('--decimals', metavar='DECIMALS',
+                        type=np.int32, default=5,
+                        help='Integer to define how many decimals the inputs '
+                             'to the minimisation will be rounded to. This is '
+                             'for the purpose of obtaining consistent output '
+                             'from the minimisation across different packages '
+                             'and processors, where differences at the '
+                             'machine precision level will cause the '
+                             'minimisation to go in different directions and '
+                             'reach different solutions.')
 
     args = parser.parse_args(args=argv)
 

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -286,8 +286,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
             sigma * (xz * (2 * normal_cdf - 1) + 2 * normal_pdf - 1 / sqrt_pi))
         if not np.isfinite(np.min(mu/sigma)):
             result = self.BAD_VALUE
-        # print("coeffs = ", initial_guess)
-        # print("CRPS = ", result)
+
         return result
 
     def truncated_normal_crps_minimiser(
@@ -720,8 +719,6 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                 historic_forecast.coord("realization").points)
             forecast_predictor = historic_forecast
 
-        # print("historic_forecast {}, historic_forecast.dtype {} = ".format(
-        #     historic_forecast.data, historic_forecast.data.dtype))
         forecast_var = historic_forecast.collapsed(
             "realization", iris.analysis.VARIANCE)
 

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -107,7 +107,6 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         # Maximum iterations for minimisation using Nelder-Mead.
         self.max_iterations = max_iterations
         self.decimals = decimals
-        print("decimals = ", decimals)
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -214,17 +213,17 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         sqrt_pi = np.around(sqrt_pi, decimals=self.decimals)
         initial_guess = np.around(initial_guess, decimals=self.decimals)
         #print("initial_guess {}, initial_guess.dtype {} = ".format(initial_guess, initial_guess.dtype))
-        # print("forecast_predictor_data {}, forecast_predictor_data.dtype {} = ".format(forecast_predictor_data, forecast_predictor_data.dtype))
-        # print("forecast_var {}, forecast_var.dtype {} = ".format(forecast_var_data, forecast_var_data.dtype))
-        # print("truth_data {}, truth_data.dtype {} = ".format(truth_data, truth_data.dtype))
-        # print("sqrt_pi {}, sqrt_pi.dtype {} = ".format(sqrt_pi, sqrt_pi.dtype))
+        #print("forecast_predictor_data {}, forecast_predictor_data.dtype {} = ".format(forecast_predictor_data, forecast_predictor_data.dtype))
+        #print("forecast_var {}, forecast_var.dtype {} = ".format(forecast_var_data, forecast_var_data.dtype))
+        #print("truth_data {}, truth_data.dtype {} = ".format(truth_data, truth_data.dtype))
+        #print("sqrt_pi {}, sqrt_pi.dtype {} = ".format(sqrt_pi, sqrt_pi.dtype))
         optimised_coeffs = minimize(
             minimisation_function, initial_guess,
             args=(forecast_predictor_data, truth_data,
                   forecast_var_data, sqrt_pi, predictor_of_mean_flag),
             method="Nelder-Mead",
             options={"maxiter": self.max_iterations, "return_all": True})
-        #print("optimised_coeffs.x {}, optimised_coeffs.x.dtype {} = ".format(optimised_coeffs, optimised_coeffs.x.dtype))
+        #print("optimised_coeffs.x {}, optimised_coeffs.x.dtype {} = ".format(optimised_coeffs.x, optimised_coeffs.x.dtype))
         if not optimised_coeffs.success:
             msg = ("Minimisation did not result in convergence after "
                    "{} iterations. \n{}".format(
@@ -702,7 +701,8 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         # Set default values for whether there are NaN values within the
         # initial guess.
         nan_in_initial_guess = False
-
+        #print("historic_forecast = ", historic_forecast)
+        #print("self.desired_units = ", self.desired_units)
         # Make sure inputs have the same units.
         if self.desired_units:
             historic_forecast.convert_units(self.desired_units)
@@ -728,7 +728,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         forecast_var = historic_forecast.collapsed(
             "realization", iris.analysis.VARIANCE)
         # print("forecast_var {}, forecast_var.dtype {} = ".format(forecast_var.data, forecast_var.data.dtype))
-
+        #print("forecast_predictor = ", forecast_predictor)
         # Computing initial guess for EMOS coefficients
         # If no initial guess from a previous iteration, or if there
         # are NaNs in the initial guess, calculate an initial guess.

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -206,24 +206,22 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         forecast_var_data = forecast_var_data.astype(np.float32)
         truth_data = truth_data.astype(np.float32)
         sqrt_pi = np.sqrt(np.pi).astype(np.float32)
+
         forecast_predictor_data = (
             np.around(forecast_predictor_data, decimals=self.decimals))
-        forecast_var_data = np.around(forecast_var_data, decimals=self.decimals)
+        forecast_var_data = np.around(
+            forecast_var_data, decimals=self.decimals)
         truth_data = np.around(truth_data, decimals=self.decimals)
         sqrt_pi = np.around(sqrt_pi, decimals=self.decimals)
         initial_guess = np.around(initial_guess, decimals=self.decimals)
-        #print("initial_guess {}, initial_guess.dtype {} = ".format(initial_guess, initial_guess.dtype))
-        #print("forecast_predictor_data {}, forecast_predictor_data.dtype {} = ".format(forecast_predictor_data, forecast_predictor_data.dtype))
-        #print("forecast_var {}, forecast_var.dtype {} = ".format(forecast_var_data, forecast_var_data.dtype))
-        #print("truth_data {}, truth_data.dtype {} = ".format(truth_data, truth_data.dtype))
-        #print("sqrt_pi {}, sqrt_pi.dtype {} = ".format(sqrt_pi, sqrt_pi.dtype))
+
         optimised_coeffs = minimize(
             minimisation_function, initial_guess,
             args=(forecast_predictor_data, truth_data,
                   forecast_var_data, sqrt_pi, predictor_of_mean_flag),
             method="Nelder-Mead",
             options={"maxiter": self.max_iterations, "return_all": True})
-        #print("optimised_coeffs.x {}, optimised_coeffs.x.dtype {} = ".format(optimised_coeffs.x, optimised_coeffs.x.dtype))
+
         if not optimised_coeffs.success:
             msg = ("Minimisation did not result in convergence after "
                    "{} iterations. \n{}".format(
@@ -701,8 +699,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         # Set default values for whether there are NaN values within the
         # initial guess.
         nan_in_initial_guess = False
-        #print("historic_forecast = ", historic_forecast)
-        #print("self.desired_units = ", self.desired_units)
+
         # Make sure inputs have the same units.
         if self.desired_units:
             historic_forecast.convert_units(self.desired_units)
@@ -727,8 +724,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         #     historic_forecast.data, historic_forecast.data.dtype))
         forecast_var = historic_forecast.collapsed(
             "realization", iris.analysis.VARIANCE)
-        # print("forecast_var {}, forecast_var.dtype {} = ".format(forecast_var.data, forecast_var.data.dtype))
-        #print("forecast_predictor = ", forecast_predictor)
+
         # Computing initial guess for EMOS coefficients
         # If no initial guess from a previous iteration, or if there
         # are NaNs in the initial guess, calculate an initial guess.

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
@@ -394,6 +394,7 @@ def _create_truth(cube):
         truth.append(temp_cube)
     truth = concatenate_cubes(
         truth, coordinates_for_association=["forecast_reference_time"])
+    truth.data = truth.data.data
     return truth
 
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -352,7 +352,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
         self.expected_mean_coefficients = (
             [-0.000236, 0.797574, 0.000423, 0.997329])
         self.expected_realizations_coefficients = (
-            [-0.000006, 1.2016, 0.000040, 0.50111, 0.54699, 0.6685])
+            [0., 1.05, 0., 0.5774, 0.5774, 0.5774])
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
@@ -366,7 +366,6 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
         """
         predictor_of_mean_flag = "mean"
         distribution = "gaussian"
-
         plugin = Plugin()
         result = plugin.crps_minimiser_wrapper(
             self.initial_guess_for_mean,
@@ -381,8 +380,10 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in convergence",
-                          "divide by zero encountered in"],
-        warning_types=[UserWarning, UserWarning, RuntimeWarning])
+                          "divide by zero encountered in",
+                          "invalid value encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_basic_realizations_predictor(self):
         """
         Test that the plugin returns a numpy array.
@@ -390,8 +391,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
         """
         predictor_of_mean_flag = "realizations"
         distribution = "gaussian"
-
-        plugin = Plugin()
+        plugin = Plugin(max_iterations=5)
         result = plugin.crps_minimiser_wrapper(
             self.initial_guess_for_realization,
             self.temperature_forecast_predictor_realizations,
@@ -454,8 +454,10 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
                           "Minimisation did not result in convergence",
-                          "divide by zero encountered in"],
-        warning_types=[UserWarning, UserWarning, RuntimeWarning])
+                          "divide by zero encountered in",
+                          "invalid value encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_realizations_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
@@ -466,7 +468,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
         the initial guess.
         """
         predictor_of_mean_flag = "realizations"
-        max_iterations = 400
+        max_iterations = 5
         distribution = "gaussian"
 
         plugin = Plugin(max_iterations=max_iterations)
@@ -476,7 +478,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupInputs):
             self.temperature_truth_cube,  self.temperature_forecast_variance,
             predictor_of_mean_flag, distribution)
         self.assertArrayAlmostEqual(
-            result, self.expected_realizations_coefficients, decimal=5)
+            result, self.expected_realizations_coefficients, decimal=4)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
@@ -575,7 +577,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupInputs):
         self.expected_mean_coefficients = (
             [-0.14688, 1.386366, -0.080467, 0.866662])
         self.expected_realizations_coefficients = (
-            [-0.141053, 1.312867, -0.120514, 0.658704, -0.013513, 0.664249])
+            [0.000281, 1.05625, 0.000281, 0.559308, 0.534049, 0.537657])
 
     """Test minimising the CRPS for a truncated_normal distribution."""
     @ManageWarnings(
@@ -614,7 +616,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupInputs):
         predictor_of_mean_flag = "realizations"
         distribution = "truncated gaussian"
 
-        plugin = Plugin()
+        plugin = Plugin(max_iterations=5)
         result = plugin.crps_minimiser_wrapper(
             self.initial_guess_for_realization,
             self.wind_speed_forecast_predictor_realizations,
@@ -709,7 +711,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupInputs):
         the initial guess.
         """
         predictor_of_mean_flag = "realizations"
-        max_iterations = 800
+        max_iterations = 5
         distribution = "truncated gaussian"
 
         plugin = Plugin(max_iterations=max_iterations)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -306,7 +306,12 @@ class Test_truncated_normal_crps_minimiser(IrisTest):
 
 
 class SetupCubes(IrisTest):
+
     """Create a class for setting up cubes for testing."""
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."],
+        warning_types=[UserWarning])
     def setUp(self):
         """Set up expected output."""
         data = np.array([[[0., 1.1, 3.],
@@ -386,7 +391,9 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning])
     def test_basic_mean_predictor(self):
         """
         Test that the plugin returns a numpy float value.
@@ -408,7 +415,9 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning])
     def test_basic_realizations_predictor(self):
         """
         Test that the plugin returns a numpy array.
@@ -451,7 +460,9 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning])
     def test_mean_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
@@ -476,7 +487,9 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning])
     def test_realizations_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
@@ -501,7 +514,9 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning])
     def test_mean_predictor_decimals(self):
         """
         Test that the plugin returns a list of coefficients
@@ -514,7 +529,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(SetupCubes):
         """
         predictor_of_mean_flag = "mean"
         distribution = "gaussian"
-        decimals = 2
+        decimals = 4
 
         plugin = Plugin(decimals=decimals)
         result = plugin.crps_minimiser_wrapper(
@@ -591,14 +606,18 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupCubes):
     def setUp(self):
         """Set up expected output."""
         super().setUp()
-        self.expected_mean_coefficients = [0., 1.00625, 0., 1.04375]
+        self.expected_mean_coefficients = [0., 1.05, 0., 1.]
         self.expected_realizations_coefficients = (
-            [0., 1., 0., 0.5774, 0.5774, 0.6062])
+            [0., 1.05, 0., 0.57735, 0.57735, 0.57735])
 
     """Test minimising the CRPS for a truncated_normal distribution."""
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "invalid value encountered in",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_basic_mean_predictor(self):
         """
         Test that the plugin returns a numpy float value.
@@ -618,7 +637,11 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "invalid value encountered in",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_basic_realizations_predictor(self):
         """Test that the plugin returns a numpy array."""
         predictor_of_mean_flag = "realizations"
@@ -632,7 +655,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupCubes):
             predictor_of_mean_flag, distribution)
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayAlmostEqual(
-            result, self.expected_mean_coefficients, decimal=4)
+            result, self.expected_realizations_coefficients, decimal=4)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -676,7 +699,11 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "invalid value encountered in",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_mean_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
@@ -700,7 +727,11 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "invalid value encountered in",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_realizations_predictor_max_iterations(self):
         """
         Test that the plugin returns a list of coefficients
@@ -725,7 +756,11 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(SetupCubes):
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "Minimisation did not result in convergence"])
+                          "Minimisation did not result in convergence",
+                          "invalid value encountered in",
+                          "divide by zero encountered in"],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning,
+                       RuntimeWarning])
     def test_mean_predictor_decimals(self):
         """
         Test that the plugin returns a list of coefficients

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -362,10 +362,10 @@ class Test_process_check_data(SetupCubes):
             self.temperature_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_temperature_predictor_data, decimal=3)
+            self.expected_temperature_predictor_data)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_temperature_variance_data, decimal=3)
+            self.expected_temperature_variance_data)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -380,17 +380,42 @@ class Test_process_check_data(SetupCubes):
         distribution = "gaussian"
         desired_units = "degreesC"
         plugin = Plugin(self.calibration_method, distribution, desired_units,
-                        max_iterations=100)
+                        max_iterations=10)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
             self.temperature_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_temperature_predictor_data, decimal=3)
+            self.expected_temperature_predictor_data, decimal=4)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_temperature_variance_data, decimal=3)
+            self.expected_temperature_variance_data, decimal=4)
+
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
+    def test_temperature_data_check_decimals(self):
+        """
+        Test that the plugin returns an iris.cube.CubeList
+        of temperature cubes with the expected data, where the plugin
+        returns a cubelist of, firstly, the predictor and, secondly the
+        variance when the maximum number of iterations is specified.
+        The ensemble mean is the predictor.
+        """
+        distribution = "gaussian"
+        desired_units = "degreesC"
+        plugin = Plugin(self.calibration_method, distribution, desired_units,
+                        decimals=2)
+        calibrated_predictor, calibrated_variance = plugin.process(
+            self.current_temperature_forecast_cube,
+            self.historic_temperature_forecast_cube,
+            self.temperature_truth_cube)
+        self.assertArrayAlmostEqual(
+            calibrated_predictor.data,
+            self.expected_temperature_predictor_data)
+        self.assertArrayAlmostEqual(
+            calibrated_variance.data,
+            self.expected_temperature_variance_data)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -411,10 +436,10 @@ class Test_process_check_data(SetupCubes):
             self.wind_speed_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_wind_speed_predictor_data, decimal=3)
+            self.expected_wind_speed_predictor_data)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_wind_speed_variance_data, decimal=3)
+            self.expected_wind_speed_variance_data)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -439,15 +464,48 @@ class Test_process_check_data(SetupCubes):
         distribution = "truncated gaussian"
         desired_units = "m s^-1"
         plugin = Plugin(self.calibration_method, distribution, desired_units,
-                        max_iterations=100)
+                        max_iterations=10)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
             self.wind_speed_truth_cube)
         self.assertArrayAlmostEqual(calibrated_predictor.data,
-                                    predictor_data, decimal=3)
+                                    predictor_data)
         self.assertArrayAlmostEqual(calibrated_variance.data,
-                                    variance_data, decimal=3)
+                                    variance_data)
+
+    @ManageWarnings(
+        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
+    def test_wind_speed_data_check_decimals(self):
+        """
+        Test that the plugin returns an iris.cube.CubeList
+        of wind_speed cubes with the expected data, where the plugin
+        returns a cubelist of, firstly, the predictor and, secondly the
+        variance when the maximum number of iterations is specified.
+        The ensemble mean is the predictor.
+        """
+        predictor_data = np.array(
+            [[0., 1., 2.],
+             [3., 4., 5.],
+             [6., 7., 8.]], dtype=np.float32)
+        variance_data = np.array(
+            [[0., 0., 0.],
+             [0., 0., 0.],
+             [0., 0., 0.]],
+            dtype=np.float32
+        )
+        distribution = "truncated gaussian"
+        desired_units = "m s^-1"
+        plugin = Plugin(self.calibration_method, distribution, desired_units,
+                        decimals=2)
+        calibrated_predictor, calibrated_variance = plugin.process(
+            self.current_wind_speed_forecast_cube,
+            self.historic_wind_speed_forecast_cube,
+            self.wind_speed_truth_cube)
+        self.assertArrayAlmostEqual(calibrated_predictor.data,
+                                    predictor_data)
+        self.assertArrayAlmostEqual(calibrated_variance.data,
+                                    variance_data)
 
 
 class Test_process_check_data_with_variance(SetupCubesWithVariance):
@@ -457,14 +515,14 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
     def setUp(self):
         super().setUp()
         self.expected_temperature_predictor_data = np.array(
-            [[274.14844, 275.14844, 276.14844],
-             [277.14844, 278.1484, 279.1484],
-             [280.1484, 281.1484, 282.1484]], dtype=np.float32)
+            [[274.0577, 275.05737, 276.057],
+             [277.05667, 278.05634, 279.056],
+             [280.05563, 281.0553, 282.05496]], dtype=np.float32)
 
         self.expected_temperature_variance_data = np.array(
-            [[0.00000326, 0.00000326, 0.00000326],
-             [0.00000326, 0.00000326, 0.00000326],
-             [0.00000326, 0.00000326, 0.00000326]], dtype=np.float32)
+            [[0.000002, 0.000002, 0.000002],
+             [0.000002, 0.000002, 0.000002],
+             [0.000002, 0.000002, 0.000002]], dtype=np.float32)
 
         self.expected_wind_speed_predictor_data = np.array(
             [[1.7818475, 2.5791492, 3.376451],
@@ -489,17 +547,17 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
         distribution = "gaussian"
         desired_units = "degreesC"
         plugin = Plugin(self.calibration_method, distribution,
-                        desired_units)
+                        desired_units, decimals=5)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
             self.temperature_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_temperature_predictor_data, decimal=3)
+            self.expected_temperature_predictor_data)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_temperature_variance_data, decimal=3)
+            self.expected_temperature_variance_data)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -522,10 +580,10 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
             self.temperature_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_temperature_predictor_data, decimal=3)
+            self.expected_temperature_predictor_data)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_temperature_variance_data, decimal=3)
+            self.expected_temperature_variance_data)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -547,10 +605,10 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
             self.wind_speed_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_wind_speed_predictor_data, decimal=3)
+            self.expected_wind_speed_predictor_data)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_wind_speed_variance_data, decimal=3)
+            self.expected_wind_speed_variance_data)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -573,10 +631,10 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
             self.wind_speed_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_wind_speed_predictor_data, decimal=3)
+            self.expected_wind_speed_predictor_data)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_wind_speed_variance_data, decimal=3)
+            self.expected_wind_speed_variance_data)
 
 
 @unittest.skipIf(
@@ -604,7 +662,7 @@ class Test_process_with_statsmodels(SetupCubes):
         plugin = Plugin(
             self.calibration_method, distribution, desired_units,
             predictor_of_mean_flag=predictor_of_mean_flag,
-            max_iterations=300)
+            max_iterations=400)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -640,17 +698,17 @@ class Test_process_with_statsmodels(SetupCubes):
         plugin = Plugin(
             self.calibration_method, distribution, desired_units,
             predictor_of_mean_flag=predictor_of_mean_flag,
-            max_iterations=300)
+            max_iterations=400)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
             self.wind_speed_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data, expected_wind_speed_predictor_data,
-            decimal=3)
+            decimal=5)
         self.assertArrayAlmostEqual(
             calibrated_variance.data, expected_wind_speed_variance_data,
-            decimal=3)
+            decimal=5)
 
 
 @unittest.skipIf(
@@ -684,10 +742,10 @@ class Test_process_without_statsmodels(SetupCubes):
             self.temperature_truth_cube)
         self.assertArrayAlmostEqual(
             calibrated_predictor.data,
-            self.expected_temperature_predictor_data, decimal=3)
+            self.expected_temperature_predictor_data, decimal=4)
         self.assertArrayAlmostEqual(
             calibrated_variance.data,
-            self.expected_temperature_variance_data, decimal=3)
+            self.expected_temperature_variance_data, decimal=4)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -42,8 +42,7 @@ import numpy as np
 from improver.ensemble_calibration.ensemble_calibration import (
     EnsembleCalibration as Plugin)
 from improver.tests.ensemble_calibration.ensemble_calibration.\
-    helper_functions import _create_historic_forecasts, _create_truth
-from improver.tests.set_up_test_cubes import set_up_variable_cube
+    helper_functions import SetupCubes
 from improver.utilities.warnings_handler import ManageWarnings
 
 try:
@@ -72,60 +71,6 @@ WARNING_TYPES = [UserWarning, ImportWarning, FutureWarning, RuntimeWarning,
                  UserWarning, RuntimeWarning, RuntimeWarning]
 
 
-class SetupCubes(IrisTest):
-
-    """Set up cubes for testing."""
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def setUp(self):
-        """Set up temperature and wind speed cubes for testing."""
-        # Note: test_temperature_realizations_data_check produces ~0.5K
-        # different results when the temperature forecast cube is float32
-        # below. A bug?
-        super().setUp()
-        self.calibration_method = "ensemble model output_statistics"
-        data = np.array([[[0.3, 1.1, 2.6],
-                          [4.2, 5.3, 6.],
-                          [7.1, 8.2, 9.]],
-                         [[0.7, 2., 3],
-                          [4.3, 5.6, 6.4],
-                          [7., 8., 9.]],
-                         [[2.1, 3., 3.],
-                          [4.8, 5., 6.],
-                          [7.9, 8., 8.9]]])
-        data = data + 273.15
-        data = data.astype(np.float32)
-        self.current_temperature_forecast_cube = set_up_variable_cube(
-            data, units="Kelvin", realizations=[0, 1, 2])
-
-        self.historic_temperature_forecast_cube = (
-            _create_historic_forecasts(self.current_temperature_forecast_cube))
-
-        self.temperature_truth_cube = (
-            _create_truth(self.current_temperature_forecast_cube))
-
-        # Create a cube for testing wind speed.
-        data = np.array([[[0.3, 1.1, 2.6],
-                          [4.2, 5.3, 6.],
-                          [7.1, 8.2, 9.]],
-                         [[0.7, 2., 3],
-                          [4.3, 5.6, 6.4],
-                          [7., 8., 9.]],
-                         [[2.1, 3., 3.],
-                          [4.8, 5., 6.],
-                          [7.9, 8., 8.9]]])
-        data = data.astype(np.float32)
-        self.current_wind_speed_forecast_cube = set_up_variable_cube(
-            data, name="wind_speed", units="m s-1", realizations=[0, 1, 2])
-
-        self.historic_wind_speed_forecast_cube = (
-            _create_historic_forecasts(self.current_wind_speed_forecast_cube))
-
-        self.wind_speed_truth_cube = (
-            _create_truth(self.current_wind_speed_forecast_cube))
-
-
 class SetupExpectedResults(IrisTest):
 
     """Set up expected results."""
@@ -136,7 +81,7 @@ class SetupExpectedResults(IrisTest):
         """Set up temperature and wind speed cubes for testing."""
         super().setUp()
         self.expected_temperature_predictor_data = np.array(
-            [[273.74304, 274.6559 , 275.41663],
+            [[273.74304, 274.6559, 275.41663],
              [276.84677, 277.63788, 278.39862],
              [279.49405, 280.16348, 280.98505]], dtype=np.float32)
 
@@ -151,9 +96,10 @@ class SetupExpectedResults(IrisTest):
              [6.379119, 7.0684023, 7.914342]], dtype=np.float32)
 
         self.expected_wind_speed_variance_data = np.array(
-            [[2.1278856 , 2.151705  , 0.12705675],
-             [0.24615386, 0.2143944 , 0.12705675],
-             [0.5796253 , 0.03177907, 0.0079598]], dtype=np.float32)
+            [[2.1278856, 2.151705, 0.12705675],
+             [0.24615386, 0.2143944, 0.12705675],
+             [0.5796253, 0.03177907, 0.0079598]], dtype=np.float32)
+
 
 class Test_process_basic(SetupCubes):
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -230,6 +230,7 @@ class Test_process_check_data(SetupCubes, SetupExpectedResults):
         """
         distribution = "gaussian"
         plugin = Plugin(self.calibration_method, distribution)
+
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -328,24 +329,24 @@ class Test_process_with_statsmodels(SetupCubes, SetupExpectedResults):
         """Set up temperature and wind speed cubes for testing."""
         super().setUp()
         self.expected_specific_temperature_predictor_data = np.array(
-            [[274.19583, 275.15402, 275.31442],
-             [277.03394, 277.4055, 278.3714],
-             [280.06595, 280.30804, 281.2208]], dtype=np.float32)
+            [[273.86142, 274.81866, 274.97934],
+             [276.69644, 277.0681, 278.03275],
+             [279.7245, 279.96674, 280.87842]], dtype=np.float32)
 
         self.expected_specific_temperature_variance_data = np.array(
-            [[0.89734596, 0.90739626, 0.05357203],
-             [0.10380029, 0.09040731, 0.05357203],
-             [0.2444245, 0.01339514, 0.00334887]], dtype=np.float32)
+            [[0.89703304, 0.9070798, 0.05355331],
+             [0.10376406, 0.09037575, 0.05355331],
+             [0.24433926, 0.01339043, 0.00334767]], dtype=np.float32)
 
         self.expected_specific_wind_speed_predictor_data = np.array(
-            [[1.0959406, 2.043556, 2.2561445],
-             [3.8869126, 4.308816, 5.229468],
-             [6.7901444, 7.0756545, 7.9622397]], dtype=np.float32)
+            [[1.188099, 2.1237986, 2.2544427],
+             [3.9671648, 4.3037915, 5.263716],
+             [6.973962, 7.1881437, 8.087225]], dtype=np.float32)
 
         self.expected_specific_wind_speed_variance_data = np.array(
-            [[1.5079881, 1.5248687, 0.09002924],
-             [0.17443168, 0.15192421, 0.09002924],
-             [0.4107582, 0.0225073, 0.00562692]], dtype=np.float32)
+            [[1.2159258, 1.2295369, 0.07259262],
+             [0.14064826, 0.12249996, 0.07259262],
+             [0.3312038, 0.01814811, 0.00453707]], dtype=np.float32)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -362,7 +363,7 @@ class Test_process_with_statsmodels(SetupCubes, SetupExpectedResults):
         plugin = Plugin(
             self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
-            max_iterations=2000)
+            max_iterations=15)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -395,7 +396,7 @@ class Test_process_with_statsmodels(SetupCubes, SetupExpectedResults):
         plugin = Plugin(
             self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
-            max_iterations=400)
+            max_iterations=15)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
@@ -427,24 +428,25 @@ class Test_process_without_statsmodels(SetupCubes, SetupExpectedResults):
         """Set up temperature and wind speed cubes for testing."""
         super().setUp()
         self.expected_specific_temperature_predictor_data = np.array(
-            [[273.6069, 274.5989, 275.27478],
-             [276.86993, 277.62445, 278.48648],
-             [279.79132, 280.4114, 281.3137]], dtype=np.float32)
+            [[274.1831, 275.1831, 276.01642],
+             [277.5831, 278.44977, 279.28308],
+             [280.4831, 281.21643, 282.11642]], dtype=np.float32)
 
         self.expected_specific_temperature_variance_data = np.array(
-            [[1.2898316, 1.3042778, 0.07700347],
-             [0.14920083, 0.12994996, 0.07700346],
-             [0.351332, 0.0192538, 0.00481345]], dtype=np.float32)
+            [[0.9848877, 0.9959185, 0.0587982],
+             [0.11392655, 0.099227, 0.05879819],
+             [0.26826957, 0.01470179, 0.00367545]], dtype=np.float32)
 
         self.expected_specific_wind_speed_predictor_data = np.array(
-            [[0.93635756, 1.6808116, 2.3318303],
-             [3.820501, 4.3862634, 5.1313596],
-             [6.44708, 6.968665, 7.713064]], dtype=np.float32)
+            [[0.9008325, 1.782031, 2.536477],
+             [3.9281034, 4.7007966, 5.437016],
+             [6.501492, 7.1597147, 7.955351]], dtype=np.float32)
 
         self.expected_specific_wind_speed_variance_data = np.array(
-            [[1.5596627, 1.576899, 0.11182244],
-             [0.19800353, 0.17502174, 0.11182244],
-             [0.43931028, 0.04287757, 0.02564146]], dtype=np.float32)
+            [[0.9966598, 1.0078166, 0.05950218],
+             [0.11528546, 0.10040981, 0.05950218],
+             [0.2714784, 0.01487557, 0.00371899]], dtype=np.float32)
+
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_temperature_realizations_data_check(self):
@@ -460,7 +462,7 @@ class Test_process_without_statsmodels(SetupCubes, SetupExpectedResults):
         plugin = Plugin(
             self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
-            max_iterations=2000)
+            max_iterations=5)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -496,7 +498,7 @@ class Test_process_without_statsmodels(SetupCubes, SetupExpectedResults):
         plugin = Plugin(
             self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
-            max_iterations=2000)
+            max_iterations=5)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -72,81 +72,6 @@ WARNING_TYPES = [UserWarning, ImportWarning, FutureWarning, RuntimeWarning,
                  UserWarning, RuntimeWarning, RuntimeWarning]
 
 
-class SetupCubes(IrisTest):
-
-    """Set up cubes for class."""
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def setUp(self):
-        """Set up temperature and wind speed cubes for testing."""
-        # Note: test_temperature_realizations_data_check produces ~0.5K
-        # different results when the temperature forecast cube is float32
-        # below. A bug?
-        self.calibration_method = "ensemble model output_statistics"
-        data = np.array([[[1., 2., 3.],
-                          [4., 5., 6.],
-                          [7., 8., 9.]],
-                         [[1., 2., 3],
-                          [4., 5., 6.],
-                          [7., 8., 9.]],
-                         [[1., 2., 3.],
-                          [4., 5., 6.],
-                          [7., 8., 9.]]])
-        data = data + 273.15
-        data = data.astype(np.float32)
-        self.current_temperature_forecast_cube = set_up_variable_cube(
-            data, units="Kelvin", realizations=[0, 1, 2])
-
-        self.historic_temperature_forecast_cube = (
-            _create_historic_forecasts(self.current_temperature_forecast_cube))
-
-        self.temperature_truth_cube = (
-            _create_truth(self.current_temperature_forecast_cube))
-
-        self.expected_temperature_predictor_data = np.array(
-            [[273.15, 274.15, 275.15],
-             [276.15, 277.15, 278.15],
-             [279.15, 280.15, 281.15]], dtype=np.float32)
-
-        self.expected_temperature_variance_data = np.array(
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]])
-
-        # Create a cube for testing wind speed.
-        data = np.array([[[1., 2., 3.],
-                          [4., 5., 6.],
-                          [7., 8., 9.]],
-                         [[1., 2., 3],
-                          [4., 5., 6.],
-                          [7., 8., 9.]],
-                         [[1., 2., 3.],
-                          [4., 5., 6.],
-                          [7., 8., 9.]]])
-        data = data.astype(np.float32)
-        self.current_wind_speed_forecast_cube = set_up_variable_cube(
-            data, name="wind_speed", units="m s-1", realizations=[0, 1, 2])
-
-        self.historic_wind_speed_forecast_cube = (
-            _create_historic_forecasts(self.current_wind_speed_forecast_cube))
-
-        self.wind_speed_truth_cube = (
-            _create_truth(self.current_wind_speed_forecast_cube))
-
-        self.expected_wind_speed_predictor_data = np.array(
-            [[0., 1., 2.],
-             [3., 4., 5.],
-             [6., 7., 8.]], dtype=np.float32)
-
-        self.expected_wind_speed_variance_data = np.array(
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            dtype=np.float32
-        )
-
-
 class SetupCubesWithVariance(IrisTest):
 
     """Set up cubes for class."""
@@ -159,15 +84,15 @@ class SetupCubesWithVariance(IrisTest):
         # different results when the temperature forecast cube is float32
         # below. A bug?
         self.calibration_method = "ensemble model output_statistics"
-        data = np.array([[[0., 1., 2.],
-                          [3., 4., 5.],
-                          [6., 7., 8.]],
+        data = np.array([[[0., 1.1, 3.],
+                          [4., 5.3, 6.],
+                          [7., 8.2, 9.]],
                          [[1., 2., 3],
-                          [4., 5., 6.],
+                          [4., 5.6, 6.],
                           [7., 8., 9.]],
-                         [[2., 3., 4.],
-                          [5., 6., 7.],
-                          [8., 9., 10.]]])
+                         [[2., 3., 3.],
+                          [4.8, 5., 6.],
+                          [7.9, 8., 9.]]])
         data = data + 273.15
         data = data.astype(np.float32)
         self.current_temperature_forecast_cube = set_up_variable_cube(
@@ -180,25 +105,25 @@ class SetupCubesWithVariance(IrisTest):
             _create_truth(self.current_temperature_forecast_cube))
 
         self.expected_temperature_predictor_data = np.array(
-            [[273.15, 274.15, 275.15],
-             [276.15, 277.15, 278.15],
-             [279.15, 280.15, 281.15]], dtype=np.float32)
+            [[273.51123, 274.5292, 275.31207],
+             [276.63153, 277.5993, 278.30295],
+             [279.66272, 280.3389, 281.29385]], dtype=np.float32)
 
         self.expected_temperature_variance_data = np.array(
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]], dtype=np.float32)
+            [[5.9336913e-01, 5.3600669e-01, 5.1369886e-09],
+             [1.2659121e-01, 5.3404309e-02, 5.1369886e-09],
+             [1.6020750e-01, 7.9125594e-03, 5.1369886e-09]], dtype=np.float32)
 
         # Create a cube for testing wind speed.
-        data = np.array([[[0., 1., 2.],
-                          [3., 4., 5.],
-                          [6., 7., 8.]],
+        data = np.array([[[0., 1.1, 3.],
+                          [4., 5.3, 6.],
+                          [7., 8.2, 9.]],
                          [[1., 2., 3],
-                          [4., 5., 6.],
+                          [4., 5.6, 6.],
                           [7., 8., 9.]],
-                         [[2., 3., 4.],
-                          [5., 6., 7.],
-                          [8., 9., 10.]]])
+                         [[2., 3., 3.],
+                          [4.8, 5., 6.],
+                          [7.9, 8., 9.]]])
         data = data.astype(np.float32)
         self.current_wind_speed_forecast_cube = set_up_variable_cube(
             data, name="wind_speed", units="m s-1", realizations=[0, 1, 2])
@@ -210,17 +135,17 @@ class SetupCubesWithVariance(IrisTest):
             _create_truth(self.current_wind_speed_forecast_cube))
 
         self.expected_wind_speed_predictor_data = np.array(
-            [[0., 1., 2.],
-             [3., 4., 5.],
-             [6., 7., 8.]], dtype=np.float32)
+            [[0.99999917, 2.0333316, 2.9999974],
+             [4.266663, 5.2999954, 5.9999948],
+             [7.299994, 8.06666, 8.999992]], dtype=np.float32)
 
         self.expected_wind_speed_variance_data = np.array(
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]], dtype=np.float32)
+            [[1.1024998, 0.99592483, 0.],
+             [0.23520009, 0.09922495, 0.],
+             [0.297675, 0.01469997, 0.]], dtype=np.float32)
 
 
-class Test_process_basic(SetupCubes):
+class Test_process_basic(SetupCubesWithVariance):
 
     """Test the basic output from the process method."""
 
@@ -233,8 +158,7 @@ class Test_process_basic(SetupCubes):
         The ensemble mean is the predictor.
         """
         distribution = "gaussian"
-        desired_units = "degreesC"
-        plugin = Plugin(self.calibration_method, distribution, desired_units)
+        plugin = Plugin(self.calibration_method, distribution)
         result = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -251,10 +175,9 @@ class Test_process_basic(SetupCubes):
         The ensemble realizations is the predictor.
         """
         distribution = "gaussian"
-        desired_units = "degreesC"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution, desired_units,
+            self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag)
         result = plugin.process(
             self.current_temperature_forecast_cube,
@@ -272,8 +195,7 @@ class Test_process_basic(SetupCubes):
         The ensemble mean is the predictor.
         """
         distribution = "truncated gaussian"
-        desired_units = "m s^-1"
-        plugin = Plugin(self.calibration_method, distribution, desired_units)
+        plugin = Plugin(self.calibration_method, distribution)
         result = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
@@ -290,10 +212,9 @@ class Test_process_basic(SetupCubes):
         The ensemble realizations is the predictor.
         """
         distribution = "truncated gaussian"
-        desired_units = "m s^-1"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution, desired_units,
+            self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag)
         result = plugin.process(
             self.current_wind_speed_forecast_cube,
@@ -312,8 +233,7 @@ class Test_process_basic(SetupCubes):
         """
         calibration_method = "nonhomogeneous gaussian regression"
         distribution = "gaussian"
-        desired_units = "degreesC"
-        plugin = Plugin(calibration_method, distribution, desired_units)
+        plugin = Plugin(calibration_method, distribution)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -329,8 +249,7 @@ class Test_process_basic(SetupCubes):
         """
         calibration_method = "unknown"
         distribution = "gaussian"
-        desired_units = "degreesC"
-        plugin = Plugin(calibration_method, distribution, desired_units)
+        plugin = Plugin(calibration_method, distribution)
         msg = "unknown"
         with self.assertRaisesRegex(ValueError, msg):
             plugin.process(
@@ -339,200 +258,31 @@ class Test_process_basic(SetupCubes):
                 self.temperature_truth_cube)
 
 
-class Test_process_check_data(SetupCubes):
-
-    """Test the data output from the process method."""
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_temperature_data_check(self):
-        """
-        Test that the plugin returns an iris.cube.CubeList
-        of temperature cubes with the expected data, where the plugin
-        returns a cubelist of, firstly, the predictor and, secondly the
-        variance.
-        The ensemble mean is the predictor.
-        """
-        distribution = "gaussian"
-        desired_units = "degreesC"
-        plugin = Plugin(self.calibration_method, distribution, desired_units)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_temperature_forecast_cube,
-            self.historic_temperature_forecast_cube,
-            self.temperature_truth_cube)
-        self.assertArrayAlmostEqual(
-            calibrated_predictor.data,
-            self.expected_temperature_predictor_data)
-        self.assertArrayAlmostEqual(
-            calibrated_variance.data,
-            self.expected_temperature_variance_data)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_temperature_data_check_max_iterations(self):
-        """
-        Test that the plugin returns an iris.cube.CubeList
-        of temperature cubes with the expected data, where the plugin
-        returns a cubelist of, firstly, the predictor and, secondly the
-        variance when the maximum number of iterations is specified.
-        The ensemble mean is the predictor.
-        """
-        distribution = "gaussian"
-        desired_units = "degreesC"
-        plugin = Plugin(self.calibration_method, distribution, desired_units,
-                        max_iterations=10)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_temperature_forecast_cube,
-            self.historic_temperature_forecast_cube,
-            self.temperature_truth_cube)
-        self.assertArrayAlmostEqual(
-            calibrated_predictor.data,
-            self.expected_temperature_predictor_data, decimal=4)
-        self.assertArrayAlmostEqual(
-            calibrated_variance.data,
-            self.expected_temperature_variance_data, decimal=4)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_temperature_data_check_decimals(self):
-        """
-        Test that the plugin returns an iris.cube.CubeList
-        of temperature cubes with the expected data, where the plugin
-        returns a cubelist of, firstly, the predictor and, secondly the
-        variance when the maximum number of iterations is specified.
-        The ensemble mean is the predictor.
-        """
-        distribution = "gaussian"
-        desired_units = "degreesC"
-        plugin = Plugin(self.calibration_method, distribution, desired_units,
-                        decimals=2)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_temperature_forecast_cube,
-            self.historic_temperature_forecast_cube,
-            self.temperature_truth_cube)
-        self.assertArrayAlmostEqual(
-            calibrated_predictor.data,
-            self.expected_temperature_predictor_data)
-        self.assertArrayAlmostEqual(
-            calibrated_variance.data,
-            self.expected_temperature_variance_data)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_wind_speed_data_check(self):
-        """
-        Test that the plugin returns an iris.cube.CubeList
-        of wind_speed cubes with the expected data, where the plugin
-        returns a cubelist of, firstly, the predictor and, secondly the
-        variance.
-        The ensemble mean is the predictor.
-        """
-        distribution = "truncated gaussian"
-        desired_units = "m s^-1"
-        plugin = Plugin(self.calibration_method, distribution, desired_units)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_wind_speed_forecast_cube,
-            self.historic_wind_speed_forecast_cube,
-            self.wind_speed_truth_cube)
-        self.assertArrayAlmostEqual(
-            calibrated_predictor.data,
-            self.expected_wind_speed_predictor_data)
-        self.assertArrayAlmostEqual(
-            calibrated_variance.data,
-            self.expected_wind_speed_variance_data)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_wind_speed_data_check_max_iterations(self):
-        """
-        Test that the plugin returns an iris.cube.CubeList
-        of wind_speed cubes with the expected data, where the plugin
-        returns a cubelist of, firstly, the predictor and, secondly the
-        variance when the maximum number of iterations is specified.
-        The ensemble mean is the predictor.
-        """
-        predictor_data = np.array(
-            [[0., 1., 2.],
-             [3., 4., 5.],
-             [6., 7., 8.]], dtype=np.float32)
-        variance_data = np.array(
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            dtype=np.float32
-        )
-        distribution = "truncated gaussian"
-        desired_units = "m s^-1"
-        plugin = Plugin(self.calibration_method, distribution, desired_units,
-                        max_iterations=10)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_wind_speed_forecast_cube,
-            self.historic_wind_speed_forecast_cube,
-            self.wind_speed_truth_cube)
-        self.assertArrayAlmostEqual(calibrated_predictor.data,
-                                    predictor_data)
-        self.assertArrayAlmostEqual(calibrated_variance.data,
-                                    variance_data)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_wind_speed_data_check_decimals(self):
-        """
-        Test that the plugin returns an iris.cube.CubeList
-        of wind_speed cubes with the expected data, where the plugin
-        returns a cubelist of, firstly, the predictor and, secondly the
-        variance when the maximum number of iterations is specified.
-        The ensemble mean is the predictor.
-        """
-        predictor_data = np.array(
-            [[0., 1., 2.],
-             [3., 4., 5.],
-             [6., 7., 8.]], dtype=np.float32)
-        variance_data = np.array(
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            dtype=np.float32
-        )
-        distribution = "truncated gaussian"
-        desired_units = "m s^-1"
-        plugin = Plugin(self.calibration_method, distribution, desired_units,
-                        decimals=2)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_wind_speed_forecast_cube,
-            self.historic_wind_speed_forecast_cube,
-            self.wind_speed_truth_cube)
-        self.assertArrayAlmostEqual(calibrated_predictor.data,
-                                    predictor_data)
-        self.assertArrayAlmostEqual(calibrated_variance.data,
-                                    variance_data)
-
-
-class Test_process_check_data_with_variance(SetupCubesWithVariance):
+class Test_process_check_data(SetupCubesWithVariance):
 
     """Test the data with variance output from the process method."""
 
     def setUp(self):
         super().setUp()
         self.expected_temperature_predictor_data = np.array(
-            [[274.0577, 275.05737, 276.057],
-             [277.05667, 278.05634, 279.056],
-             [280.05563, 281.0553, 282.05496]], dtype=np.float32)
+            [[273.7406, 274.67642, 275.55182],
+             [276.69894, 277.63474, 278.26865],
+             [279.44595, 280.14026, 280.9855]], dtype=np.float32)
 
         self.expected_temperature_variance_data = np.array(
-            [[0.000002, 0.000002, 0.000002],
-             [0.000002, 0.000002, 0.000002],
-             [0.000002, 0.000002, 0.000002]], dtype=np.float32)
+            [[1., 0.9033276 , 0.],
+             [0.2133431, 0.09000183, 0.],
+             [0.26999635, 0.01333496, 0.]], dtype=np.float32)
 
         self.expected_wind_speed_predictor_data = np.array(
-            [[1.7818475, 2.5791492, 3.376451],
-             [4.173753, 4.9710546, 5.768356],
-             [6.5656576, 7.3629594, 8.160261]], dtype=np.float32)
+            [[0.59150004, 1.5272971, 2.4027202],
+             [3.5498266, 4.4856234, 5.1195507],
+             [6.2968435, 6.9911447, 7.836381]], dtype=np.float32)
 
         self.expected_wind_speed_variance_data = np.array(
-            [[0.08528984, 0.08528984, 0.08528984],
-             [0.08528984, 0.08528984, 0.08528984],
-             [0.08528984, 0.08528984, 0.08528984]], dtype=np.float32)
+            [[1.1024998, 0.99592483, 0.],
+             [0.23520009, 0.09922495, 0.],
+             [0.297675, 0.01469997, 0.]], dtype=np.float32)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
@@ -545,9 +295,8 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
         The ensemble mean is the predictor.
         """
         distribution = "gaussian"
-        desired_units = "degreesC"
         plugin = Plugin(self.calibration_method, distribution,
-                        desired_units, decimals=5)
+                        decimals=5)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -570,9 +319,7 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
         The ensemble mean is the predictor.
         """
         distribution = "gaussian"
-        desired_units = "degreesC"
         plugin = Plugin(self.calibration_method, distribution,
-                        desired_units,
                         max_iterations=10000)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
@@ -596,9 +343,7 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
         The ensemble mean is the predictor.
         """
         distribution = "truncated gaussian"
-        desired_units = "m s^-1"
-        plugin = Plugin(self.calibration_method, distribution,
-                        desired_units)
+        plugin = Plugin(self.calibration_method, distribution)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
@@ -621,9 +366,7 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
         The ensemble mean is the predictor.
         """
         distribution = "truncated gaussian"
-        desired_units = "m s^-1"
         plugin = Plugin(self.calibration_method, distribution,
-                        desired_units,
                         max_iterations=10000)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
@@ -639,7 +382,7 @@ class Test_process_check_data_with_variance(SetupCubesWithVariance):
 
 @unittest.skipIf(
     STATSMODELS_FOUND is False, "statsmodels module not available.")
-class Test_process_with_statsmodels(SetupCubes):
+class Test_process_with_statsmodels(SetupCubesWithVariance):
 
     """Additional tests for the process method when the statsmodels module
     is available. The statsmodels module is used for creating an initial
@@ -657,10 +400,9 @@ class Test_process_with_statsmodels(SetupCubes):
         The ensemble realizations is the predictor.
         """
         distribution = "gaussian"
-        desired_units = "degreesC"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution, desired_units,
+            self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
             max_iterations=400)
         calibrated_predictor, calibrated_variance = plugin.process(
@@ -693,10 +435,9 @@ class Test_process_with_statsmodels(SetupCubes):
              [0., 0., 0.],
              [0., 0., 0.]], dtype=np.float32)
         distribution = "truncated gaussian"
-        desired_units = "m s^-1"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution, desired_units,
+            self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
             max_iterations=400)
         calibrated_predictor, calibrated_variance = plugin.process(
@@ -713,7 +454,7 @@ class Test_process_with_statsmodels(SetupCubes):
 
 @unittest.skipIf(
     STATSMODELS_FOUND is True, "statsmodels module is available.")
-class Test_process_without_statsmodels(SetupCubes):
+class Test_process_without_statsmodels(SetupCubesWithVariance):
 
     """Additional tests for the process method when the statsmodels module
     is not available. A simple initial guess will be used for the
@@ -730,10 +471,9 @@ class Test_process_without_statsmodels(SetupCubes):
         The ensemble realizations is the predictor.
         """
         distribution = "gaussian"
-        desired_units = "degreesC"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution, desired_units,
+            self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
             max_iterations=2000)
         calibrated_predictor, calibrated_variance = plugin.process(
@@ -760,21 +500,10 @@ class Test_process_without_statsmodels(SetupCubes):
         dependent upon package versions and processor optimisation, in order
         to converge to a stable solution.
         """
-        predictor_data = np.array(
-            [[0.77, 1.53, 2.30],
-             [3.06, 3.82, 4.58],
-             [5.34, 6.10, 6.86]], dtype=np.float32)
-        variance_data = np.array(
-            [[2.76, 2.76, 2.76],
-             [2.76, 2.76, 2.76],
-             [2.76, 2.76, 2.76]],
-            dtype=np.float32
-        )
         distribution = "truncated gaussian"
-        desired_units = "m s^-1"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution, desired_units,
+            self.calibration_method, distribution,
             predictor_of_mean_flag=predictor_of_mean_flag,
             max_iterations=2000)
         calibrated_predictor, calibrated_variance = plugin.process(
@@ -782,9 +511,11 @@ class Test_process_without_statsmodels(SetupCubes):
             self.historic_wind_speed_forecast_cube,
             self.wind_speed_truth_cube)
         self.assertArrayAlmostEqual(
-            calibrated_predictor.data, predictor_data, decimal=2)
+            calibrated_predictor.data,
+            self.expected_wind_speed_predictor_data, decimal=2)
         self.assertArrayAlmostEqual(
-            calibrated_variance.data, variance_data, decimal=2)
+            calibrated_variance.data,
+            self.expected_wind_speed_variance_data, decimal=2)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -555,7 +555,7 @@ class Test_compute_initial_guess(IrisTest):
         """
         no_of_realizations = 3
 
-        data = [1., 1., 0.333333, 0., 0.333333, 0.666667]
+        data = [0., 1., 0.333333, 0., 0.333333, 0.666667]
 
         current_forecast_predictor = self.cube
         truth = self.cube.collapsed("realization", iris.analysis.MAX)
@@ -730,14 +730,15 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
         expected values, and the coefficient names also match
         expected values for a Gaussian distribution where the
         realizations are used as the predictor of the mean."""
-        data = [0.00001, -0.25516, -1., 0.66631, 0.55059, 0.50287]
+        data = [0., 1., -0.31216, -0.09061, 0.34935, 0.776475]
 
         predictor_of_mean_flag = "realizations"
         expected_coeff_names = (
             ['gamma', 'delta', 'alpha', 'beta0', 'beta1', 'beta2'])
 
         plugin = Plugin(self.distribution, self.current_cycle,
-                        predictor_of_mean_flag=predictor_of_mean_flag)
+                        predictor_of_mean_flag=predictor_of_mean_flag,
+                        max_iterations=5)
         result = plugin.estimate_coefficients_for_ngr(
             self.historic_temperature_forecast_cube,
             self.temperature_truth_cube)
@@ -760,7 +761,7 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
         to a common solution across different package versions and
         processors.
         """
-        data = np.array([0.00007, 1.01415, 0.00007, 0.58065, 0.57505, 0.57254],
+        data = np.array([0., 1.05, 0., 0.57735, 0.57735, 0.57735],
                         dtype=np.float32)
 
         predictor_of_mean_flag = "realizations"
@@ -769,7 +770,7 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
 
         plugin = Plugin(self.distribution, self.current_cycle,
                         predictor_of_mean_flag=predictor_of_mean_flag,
-                        max_iterations=10)
+                        max_iterations=5)
         result = plugin.estimate_coefficients_for_ngr(
             self.historic_temperature_forecast_cube,
             self.temperature_truth_cube)
@@ -786,7 +787,7 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
         expected values, and the coefficient names also match
         expected values for a truncated Gaussian distribution where the
         realizations are used as the predictor of the mean."""
-        data = [-0., 2.907516, 0.666669, 0.774827, -0.040465, 0.254308]
+        data = [0.000005, 1.059259, -0.758778, -0.084672, 0.370073, 0.783322]
 
         distribution = "truncated gaussian"
         predictor_of_mean_flag = "realizations"
@@ -794,7 +795,8 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
             ['gamma', 'delta', 'alpha', 'beta0', 'beta1', 'beta2'])
 
         plugin = Plugin(distribution, self.current_cycle,
-                        predictor_of_mean_flag=predictor_of_mean_flag)
+                        predictor_of_mean_flag=predictor_of_mean_flag,
+                        max_iterations=5)
         result = plugin.estimate_coefficients_for_ngr(
             self.historic_wind_speed_forecast_cube,
             self.wind_speed_truth_cube)
@@ -817,7 +819,7 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
         maximum number of iterations is to try to ensure convergence
         to a common solution across different package versions and
         processors."""
-        data = [0.00013, 1.15, 0.00036, 0.52924, 0.46188, 0.57414]
+        data = [0.00028, 1.05625, 0.00028, 0.55931, 0.53405, 0.53766]
 
         distribution = "truncated gaussian"
         predictor_of_mean_flag = "realizations"
@@ -826,7 +828,7 @@ class Test_estimate_coefficients_for_ngr(SetupCubes):
 
         plugin = Plugin(distribution, self.current_cycle,
                         predictor_of_mean_flag=predictor_of_mean_flag,
-                        max_iterations=10)
+                        max_iterations=5)
         result = plugin.estimate_coefficients_for_ngr(
             self.historic_wind_speed_forecast_cube,
             self.wind_speed_truth_cube)

--- a/tests/improver-ensemble-calibration/00-null.bats
+++ b/tests/improver-ensemble-calibration/00-null.bats
@@ -42,6 +42,7 @@
                                      [--random_seed RANDOM_SEED]
                                      [--ecc_bounds_warning]
                                      [--max_iterations MAX_ITERATIONS]
+                                     [--decimals DECIMALS]
                                      ENSEMBLE_CALIBRATION_METHOD
                                      UNITS_TO_CALIBRATE_IN DISTRIBUTION
                                      INPUT_FILE HISTORIC_DATA_FILE

--- a/tests/improver-ensemble-calibration/01-help.bats
+++ b/tests/improver-ensemble-calibration/01-help.bats
@@ -43,6 +43,7 @@ usage: improver ensemble-calibration [-h] [--profile]
                                      [--random_seed RANDOM_SEED]
                                      [--ecc_bounds_warning]
                                      [--max_iterations MAX_ITERATIONS]
+                                     [--decimals DECIMALS]
                                      ENSEMBLE_CALIBRATION_METHOD
                                      UNITS_TO_CALIBRATE_IN DISTRIBUTION
                                      INPUT_FILE HISTORIC_DATA_FILE
@@ -142,6 +143,13 @@ optional arguments:
                         "realizations", then the number of iterations may
                         require increasing, as there will be more coefficients
                         to solve for.
+  --decimals DECIMALS   Integer to define how many decimals the inputs to the
+                        minimisation will be rounded to. This is for the
+                        purpose of obtaining consistent output from the
+                        minimisation across different packages and processors,
+                        where differences at the machine precision level will
+                        cause the minimisation to go in different directions
+                        and reach different solutions.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-ensemble-calibration/02-gaussian.bats
+++ b/tests/improver-ensemble-calibration/02-gaussian.bats
@@ -46,6 +46,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-ensemble-calibration/03-trunc_gaussian.bats
+++ b/tests/improver-ensemble-calibration/03-trunc_gaussian.bats
@@ -47,7 +47,7 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }
 

--- a/tests/improver-ensemble-calibration/04-save_mean_and_var.bats
+++ b/tests/improver-ensemble-calibration/04-save_mean_and_var.bats
@@ -50,8 +50,8 @@
   improver_check_recreate_kgo "variance.nc" $KGO_VARIANCE
 
   # Run nccmp to compare the output mean and variance and check it passes.
-  improver_compare_output "$TEST_DIR/mean.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/mean.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO_MEAN"
-   improver_compare_output "$TEST_DIR/variance.nc" \
+   improver_compare_output_lower_precision "$TEST_DIR/variance.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO_VARIANCE"
 }

--- a/tests/improver-ensemble-calibration/05-current_forecast_probabilities.bats
+++ b/tests/improver-ensemble-calibration/05-current_forecast_probabilities.bats
@@ -46,6 +46,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output calibrated probabilities and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-ensemble-calibration/07-current_forecast_percentiles.bats
+++ b/tests/improver-ensemble-calibration/07-current_forecast_percentiles.bats
@@ -46,6 +46,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output calibrated percentiles and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-ensemble-calibration/09-current_forecast_rebadged_percentiles.bats
+++ b/tests/improver-ensemble-calibration/09-current_forecast_rebadged_percentiles.bats
@@ -49,6 +49,6 @@
   # is percentiles that have been rebadged as realizations. The known good
   # output in this case is the same as when passing in percentiles directly
   # and check it passes.
-  run nccmp -dmNsg -x realization "$TEST_DIR/output.nc" \
+  run nccmp -dmNsg -t 1e-3 -x realization "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-estimate-emos-coefficients/00-null.bats
+++ b/tests/improver-estimate-emos-coefficients/00-null.bats
@@ -37,6 +37,7 @@
                                            [--units UNITS]
                                            [--predictor_of_mean PREDICTOR_OF_MEAN]
                                            [--max_iterations MAX_ITERATIONS]
+                                           [--decimals DECIMALS]
                                            DISTRIBUTION CYCLETIME
                                            HISTORIC_FILEPATH TRUTH_FILEPATH
                                            OUTPUT_FILEPATH

--- a/tests/improver-estimate-emos-coefficients/01-help.bats
+++ b/tests/improver-estimate-emos-coefficients/01-help.bats
@@ -38,6 +38,7 @@ usage: improver estimate-emos-coefficients [-h] [--profile]
                                            [--units UNITS]
                                            [--predictor_of_mean PREDICTOR_OF_MEAN]
                                            [--max_iterations MAX_ITERATIONS]
+                                           [--decimals DECIMALS]
                                            DISTRIBUTION CYCLETIME
                                            HISTORIC_FILEPATH TRUTH_FILEPATH
                                            OUTPUT_FILEPATH
@@ -84,6 +85,13 @@ optional arguments:
                         "realizations", then the number of iterations may
                         require increasing, as there will be more coefficients
                         to solve for.
+  --decimals DECIMALS   Integer to define how many decimals the inputs to the
+                        minimisation will be rounded to. This is for the
+                        purpose of obtaining consistent output from the
+                        minimisation across different packages and processors,
+                        where differences at the machine precision level will
+                        cause the minimisation to go in different directions
+                        and reach different solutions.
 __HELP__
   [[ "$output" == "$expected" ]]
 }

--- a/tests/improver-estimate-emos-coefficients/02-gaussian.bats
+++ b/tests/improver-estimate-emos-coefficients/02-gaussian.bats
@@ -45,6 +45,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-estimate-emos-coefficients/03-trunc_gaussian.bats
+++ b/tests/improver-estimate-emos-coefficients/03-trunc_gaussian.bats
@@ -45,6 +45,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-estimate-emos-coefficients/04-units.bats
+++ b/tests/improver-estimate-emos-coefficients/04-units.bats
@@ -45,6 +45,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-estimate-emos-coefficients/05-predictor_of_mean.bats
+++ b/tests/improver-estimate-emos-coefficients/05-predictor_of_mean.bats
@@ -40,7 +40,7 @@
       --predictor_of_mean 'realizations' \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
-      --max_iterations 1200 \
+      --max_iterations 50 \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-estimate-emos-coefficients/05-predictor_of_mean.bats
+++ b/tests/improver-estimate-emos-coefficients/05-predictor_of_mean.bats
@@ -47,6 +47,6 @@
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output "$TEST_DIR/output.nc" \
+  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/lib/utils
+++ b/tests/lib/utils
@@ -53,6 +53,23 @@ function improver_compare_output {
   [[ "$output" =~ "are identical." ]]
 }
 
+function improver_compare_output_lower_precision {
+  # Run nccmp to compare the output and known good output.
+  # Specify a tolerance to compare the output and known good output with
+  # lower precision.
+  # nccmp options:
+  #    -d means compare data
+  #    -m also compare metadata
+  #    -N ignore NaN comparisons
+  #    -s report 'Files X and Y are identical' if they really are.
+  #    -g compares global attributes in the file
+  #    -t defines a tolerance in terms of the absolute difference.
+
+  run nccmp -dmNsg -t 1e-3 "$1" "$2"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "are identical." ]]
+}
+
 function improver_check_recreate_kgo {
   # If RECREATE_BATS_KGO set, copy output files created by test to a
   # new set of KGO located at the path specified by RECREATE_BATS_KGO


### PR DESCRIPTION
This is a draft PR.

Related to #854 

Description
Following some work in #865, it was noted that the results of the EMOS unit tests were not necessarily stable across different machines, even if the machines were using the same python environment. This was related to machine precision differences leading to the minimisation moving in different directions and therefore potentially finding quite different coefficients for minimising the CRPS. 

This PR:
- Rounds the inputs to the minimisation to a chosen level of precision based on the `decimals` keyword. This rounding helps to ensure that the inputs the minimisation are the same. 
- Refactors unit tests so that it is clearer where they are expected to share a common output. This is primarily achieved by currently "set-up classes" where the inputs and outputs that will be shared between multiple tests are set-up, so that they can be re-used as required.
- If the predictor for the calibrated ensemble mean is the uncalibrated ensemble realizations, rather than the uncalibrated ensemble mean, then the maximum of iterations is kept low e.g. 5 to 15. This is for the purpose of obtaining stable solutions across different platforms. The reason for this is that using the uncalibrated ensemble realizations as the predictor requires more coefficients to be solved. For example, using the uncalibrated ensemble mean requires solving for 4 coefficients, whereas solving using the uncalibrated ensemble realizations where there are 4 realizations, requires solving for 6 coefficients. Increasing the number of coefficients gives the minimisation more work and leads to it being more likely that there are multiple possible solutions with similar performance. 
- Update the initial guesses for EMOS, so that these are better. The choice of initial guess e.g. [0, 1, 0, 1] for the ordering [c, d, a, b] where these coefficients come from:
y|Xbar ~ _N_(a + b*Xbar, c + d * S^2)
where Xbar is the ensemble mean and S^2 is the ensemble variance. In this case, the initial guess of [0, 1, 0, 1] assumes that the uncalibrated forecasts are optimal, so that there is a 0 for the additive term for the ensemble mean and the ensemble variance and 1 for the multiplicative term for the ensemble mean and the ensemble variance. 
- Updates CLI and CLI tests, so that the `decimals` keyword can be specified. 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

