### PR TITLE
Add save compression

### DIFF
--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -129,4 +129,13 @@ def save_netcdf(cubelist, filename):
 
     cubelist = append_metadata_cube(cubelist, global_keys)
 
-    iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys)
+    chunksizes = None
+    if cube.ndim >= 2:
+        xy_chunksizes = [
+            min([128, cube.shape[-2]]),
+            min([128, cube.shape[-1]])
+        ]
+        chunksizes = tuple([1] * (cube.ndim - 2) + xy_chunksizes)
+    iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys,
+                                 complevel=1, shuffle=True, zlib=True,
+                                 chunksizes=chunksizes)


### PR DESCRIPTION
Addresses #394 - chunk by x-y in generic save wrapper and apply (lossless) compression.

Same code logic as is used for real time demo internally.

CLI tests pass.

Implementation in the suite - no measurable difference in execution on the whole, given the large amount of noise - if anything, faster, although I seriously doubt it! For our UK ensemble, 6x saving in disk space per cycle.