### PR TITLE
Impro1122 threshold wxsymb fixes

### DIFF
--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
@@ -41,6 +41,7 @@ from iris.cube import Cube, CubeList
 import numpy as np
 
 from improver.utilities.cube_manipulation import concatenate_cubes
+from improver.utilities.cube_metadata import extract_diagnostic_name
 
 
 def set_up_probability_threshold_cube(
@@ -57,14 +58,15 @@ def set_up_probability_threshold_cube(
             phenomenon_standard_name, relative_to_threshold))
     cube = Cube(data, long_name=cube_long_name,
                 units=1)
+    threshold_coord_name = extract_diagnostic_name(cube_long_name)
 
     try:
         cube.add_dim_coord(
-            DimCoord(forecast_thresholds, phenomenon_standard_name,
+            DimCoord(forecast_thresholds, threshold_coord_name,
                      units=phenomenon_units, var_name="threshold"), 0)
     except ValueError:
         cube.add_dim_coord(
-            DimCoord(forecast_thresholds, long_name=phenomenon_standard_name,
+            DimCoord(forecast_thresholds, long_name=threshold_coord_name,
                      units=phenomenon_units, var_name="threshold"), 0)
 
     time_origin = "hours since 1970-01-01 00:00:00"

--- a/lib/improver/tests/utilities/test_cube_metadata.py
+++ b/lib/improver/tests/utilities/test_cube_metadata.py
@@ -874,10 +874,12 @@ class Test_extract_diagnostic_name(IrisTest):
         self.assertEqual(result, 'air_temperature')
 
     def test_in_vicinity(self):
-        """Test correct name is returned from an "in vicinity" probability"""
-        diagnostic = 'lwe_precipitation_rate_in_vicinity'
+        """Test correct name is returned from an "in vicinity" probability.
+        Name "cloud_height" is used in this test to illustrate why suffix
+        cannot be removed with "rstrip"."""
+        diagnostic = 'cloud_height'
         result = extract_diagnostic_name(
-            'probability_of_{}_above_threshold'.format(diagnostic))
+            'probability_of_{}_in_vicinity_above_threshold'.format(diagnostic))
         self.assertEqual(result, diagnostic)
 
     def test_error_not_probability(self):

--- a/lib/improver/utilities/cube_metadata.py
+++ b/lib/improver/utilities/cube_metadata.py
@@ -668,7 +668,8 @@ def in_vicinity_name_format(cube_name):
 def extract_diagnostic_name(cube_name):
     """
     Extract the standard or long name X of the diagnostic from a probability
-    cube name of the form 'probability_of_X_above/below_thresold'
+    cube name of the form 'probability_of_X_above/below_threshold', or
+    'probability_of_X_in_vicinity_above/below_threshold'.
 
     Args:
         cube_name (str):
@@ -691,6 +692,14 @@ def extract_diagnostic_name(cube_name):
 
     # 'probability_of_' is a 15-character string
     diagnostic_name = cube_name[15:relative_to_threshold_index]
+
+    # check for and remove '_in_vicinity' suffix if present
+    suffix_len = 12
+    if len(diagnostic_name) > suffix_len:
+        suffix = diagnostic_name[-suffix_len:]
+        if suffix == '_in_vicinity':
+            diagnostic_name = diagnostic_name[:-suffix_len]
+
     return diagnostic_name
 
 

--- a/lib/improver/wxcode/weather_symbols.py
+++ b/lib/improver/wxcode/weather_symbols.py
@@ -131,9 +131,8 @@ class WeatherSymbols(object):
 
                 # Check cube and threshold coordinate names match according to
                 # expected convention.  If not, add to exception dictionary.
-                if extract_diagnostic_name(matched_cube[0].name()) != (
-                        threshold_name):
-                    self.threshold_coord_names[matched_cube[0].name()] = (
+                if extract_diagnostic_name(diagnostic) != threshold_name:
+                    self.threshold_coord_names[diagnostic] = (
                         threshold_name)
 
                 # Set flag to check for old threshold coordinate names
@@ -369,6 +368,8 @@ class WeatherSymbols(object):
         # otherwise, return a string
         if coord_named_threshold:
             threshold_coord_name = "threshold"
+        elif diagnostics in self.threshold_coord_names:
+            threshold_coord_name = self.threshold_coord_names[diagnostics]
         else:
             threshold_coord_name = extract_diagnostic_name(diagnostics)
         threshold_val = thresholds.points.item()

--- a/lib/improver/wxcode/weather_symbols.py
+++ b/lib/improver/wxcode/weather_symbols.py
@@ -78,8 +78,8 @@ class WeatherSymbols(object):
         # flag to indicate whether to expect "threshold" as a coordinate name
         # (defaults to False, checked on reading input cubes)
         self.coord_named_threshold = False
-        # dictionary to contain names of threshold coordinates that do not match
-        # expected convention
+        # dictionary to contain names of threshold coordinates that do not
+        # match expected convention
         self.threshold_coord_names = {}
 
     def __repr__(self):


### PR DESCRIPTION
Addresses #833 

Fixes required for non-standard probability cube names ("in vicinity" and non-standard cloud area fraction) used in weather symbols code.

Testing separately via suite.  However suggest extension to weather symbols unit tests may be worth considering as follow-on, to cover more of these edge-type cases.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)
