### PR TITLE
Impro 895 snow falling level bug fix

### DIFF
--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -37,6 +37,7 @@ import iris
 from stratify import interpolate
 from scipy.interpolate import griddata
 from scipy.stats import linregress
+from scipy.spatial.qhull import QhullError
 from cf_units import Unit
 
 from improver.psychrometric_calculations import svp_table
@@ -971,16 +972,20 @@ class FallingSnowLevel(object):
         snow_filled = snow_level_data
         if np.any(index):
             ynum, xnum = snow_level_data.shape
-            print(index)
             (y_points, x_points) = np.mgrid[0:ynum, 0:xnum]
             values = snow_level_data[index]
-            if np.sum(index) > 2:
+            # Try to do the horizontal interpolation to fill in any gaps,
+            # but if there are not enough points or the points are not arranged
+            # in a way that allows the horizontal interpolation, skip
+            # and use nearest neighbour intead.
+            try:
                 snow_level_data_updated = griddata(
                     np.where(index), values, (y_points, x_points),
                     method='linear')
-                snow_filled = snow_level_data_updated
-            else:
+            except QhullError:
                 snow_level_data_updated = snow_level_data
+            else:
+                snow_filled = snow_level_data_updated
             # Fill in any remaining missing points using nearest neighbour.
             # This normallly only impact points at the corners of the domain,
             # where the linear fit doesn't reach.

--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -971,11 +971,16 @@ class FallingSnowLevel(object):
         snow_filled = snow_level_data
         if np.any(index):
             ynum, xnum = snow_level_data.shape
+            print(index)
             (y_points, x_points) = np.mgrid[0:ynum, 0:xnum]
             values = snow_level_data[index]
-            snow_level_data_updated = griddata(
-                np.where(index), values, (y_points, x_points), method='linear')
-            snow_filled = snow_level_data_updated
+            if np.sum(index) > 2:
+                snow_level_data_updated = griddata(
+                    np.where(index), values, (y_points, x_points),
+                    method='linear')
+                snow_filled = snow_level_data_updated
+            else:
+                snow_level_data_updated = snow_level_data
             # Fill in any remaining missing points using nearest neighbour.
             # This normallly only impact points at the corners of the domain,
             # where the linear fit doesn't reach.

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -315,12 +315,29 @@ class Test_fill_in_by_horizontal_interpolation(IrisTest):
         self.assertArrayEqual(snow_level_updated, expected)
 
     def test_not_enough_points_to_fill(self):
-        """Test when there are not enough points to fill the gaps"""
-        snow_level_data = np.ones((3, 3))
-        snow_level_data[0] = [np.nan, 1, np.nan]
-        snow_level_data[1] = [np.nan, np.nan, np.nan]
-        snow_level_data[2] = [np.nan, 1, np.nan]
-        print(snow_level_data)
+        """Test when there are not enough points to fill the gaps.
+           This raises a QhullError if there are less than 3 points available
+           to use for the interpolation. The QhullError is different to the one
+           raised by test_badly_arranged_valid_data"""
+        snow_level_data = np.array([[np.nan, 1, np.nan],
+                                    [np.nan, np.nan, np.nan],
+                                    [np.nan, 1, np.nan]])
+        expected = np.array([[1.0, 1.0, 1.0],
+                             [1.0, 1.0, 1.0],
+                             [1.0, 1.0, 1.0]])
+        snow_level_updated = self.plugin.fill_in_by_horizontal_interpolation(
+            snow_level_data, self.max_in_nbhood_orog, self.orog_data)
+        self.assertArrayEqual(snow_level_updated, expected)
+
+    def test_badly_arranged_valid_data(self):
+        """Test when there are enough points but they aren't in arranged in a
+           suitable way to allow horizontal interpolation. This raises a
+           QhullError that we want to ignore and use nearest neighbour
+           interpolation instead. This QhullError is different to the one
+           raised by test_not_enough_points_to_fill."""
+        snow_level_data = np.array([[np.nan, 1, np.nan],
+                                    [np.nan, 1, np.nan],
+                                    [np.nan, 1, np.nan]])
         expected = np.array([[1.0, 1.0, 1.0],
                              [1.0, 1.0, 1.0],
                              [1.0, 1.0, 1.0]])

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -314,6 +314,20 @@ class Test_fill_in_by_horizontal_interpolation(IrisTest):
             snow_level_data, self.max_in_nbhood_orog, self.orog_data)
         self.assertArrayEqual(snow_level_updated, expected)
 
+    def test_not_enough_points_to_fill(self):
+        """Test when there are not enough points to fill the gaps"""
+        snow_level_data = np.ones((3, 3))
+        snow_level_data[0] = [np.nan, 1, np.nan]
+        snow_level_data[1] = [np.nan, np.nan, np.nan]
+        snow_level_data[2] = [np.nan, 1, np.nan]
+        print(snow_level_data)
+        expected = np.array([[1.0, 1.0, 1.0],
+                             [1.0, 1.0, 1.0],
+                             [1.0, 1.0, 1.0]])
+        snow_level_updated = self.plugin.fill_in_by_horizontal_interpolation(
+            snow_level_data, self.max_in_nbhood_orog, self.orog_data)
+        self.assertArrayEqual(snow_level_updated, expected)
+
     def test_different_data(self):
         """Test when the points around the missing data have different
            values."""

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -330,7 +330,7 @@ class Test_fill_in_by_horizontal_interpolation(IrisTest):
         self.assertArrayEqual(snow_level_updated, expected)
 
     def test_badly_arranged_valid_data(self):
-        """Test when there are enough points but they aren't in arranged in a
+        """Test when there are enough points but they aren't arranged in a
            suitable way to allow horizontal interpolation. This raises a
            QhullError that we want to ignore and use nearest neighbour
            interpolation instead. This QhullError is different to the one


### PR DESCRIPTION
Addresses IMPRO-895

Fixes bugs raised where there are two few points to do the horizontal interpolation in the snow falling levels, or the points are not arranged in a triangle.

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

