### PR TITLE
Modify load plugin to load a cube without xy coordinates

### DIFF
--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -198,6 +198,20 @@ class Test_load_cube(IrisTest):
         self.assertArrayAlmostEqual(result.coord_dims("latitude")[0], 3)
         self.assertArrayAlmostEqual(result.coord_dims("longitude")[0], 4)
 
+    def test_cube_without_xy_coordinates(self):
+        """Test that a cube can be loaded that does not have x and y
+        coordinates."""
+        data = np.array([1.], dtype=np.float32)
+        coord = iris.coords.DimCoord(
+            10, long_name="example_name", units="1")
+        cube = iris.cube.Cube(
+            data, long_name="cube_with_no_xy_coordinates",
+            dim_coords_and_dims=[(coord, 0)], units="1")
+        save_netcdf(cube, self.filepath)
+        result = load_cube(self.filepath)
+        self.assertEqual(result.long_name, cube.long_name)
+        self.assertArrayAlmostEqual(result.data, cube.data)
+
     def test_attributes(self):
         """Test that metadata attributes are successfully stripped out."""
         result = load_cube(self.filepath)

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -33,7 +33,7 @@
 import glob
 
 import iris
-from iris.exceptions import ConstraintMismatchError
+from iris.exceptions import CoordinateNotFoundError
 
 from improver.utilities.cube_manipulation import (
     enforce_coordinate_ordering, merge_cubes)
@@ -91,10 +91,17 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
     # cube and are in the specified order.
     cube = enforce_coordinate_ordering(
         cube, ["realization", "percentile_over", "threshold"])
+
     # Ensure the y and x dimensions are the last dimensions within the cube.
-    y_name = cube.coord(axis="y").name()
-    x_name = cube.coord(axis="x").name()
-    cube = enforce_coordinate_ordering(cube, [y_name, x_name], anchor="end")
+    try:
+        x_name = cube.coord(axis="x").name()
+        y_name = cube.coord(axis="y").name()
+    except CoordinateNotFoundError:
+        pass
+    else:
+        cube = enforce_coordinate_ordering(
+            cube, [y_name, x_name], anchor="end")
+
     if no_lazy_load:
         # Force the cube's data into memory by touching the .data attribute.
         cube.data


### PR DESCRIPTION
Description
Modification to load plugin to be able to load a cube without xy coordinates. 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

