### PR TITLE
Edits to add domain information to the EMOS coefficients cube

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -494,7 +494,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
 
         # Create x and y coordinates
         for axis in ["x", "y"]:
-            coord_point = np.mean(historic_forecast.coord(axis=axis).points)
+            coord_point = np.median(historic_forecast.coord(axis=axis).points)
             coord_bounds = [historic_forecast.coord(axis=axis).points[0],
                             historic_forecast.coord(axis=axis).points[-1]]
             new_coord = historic_forecast.coord(axis=axis).copy(

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -539,9 +539,10 @@ class EstimateCoefficientsForEnsembleCalibration(object):
 
         # Create x and y coordinates
         for axis in ["x", "y"]:
-            coord_point = np.median(historic_forecast.coord(axis=axis).points)
-            coord_bounds = [historic_forecast.coord(axis=axis).points[0],
-                            historic_forecast.coord(axis=axis).points[-1]]
+            historic_coord_points = historic_forecast.coord(axis=axis).points
+            coord_point = np.median(historic_coord_points)
+            coord_bounds = [historic_coord_points[0],
+                            historic_coord_points[-1]]
             new_coord = historic_forecast.coord(axis=axis).copy(
                 points=coord_point, bounds=coord_bounds)
             aux_coords_and_dims.append((new_coord, None))

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -459,7 +459,6 @@ class EstimateCoefficientsForEnsembleCalibration(object):
         # Create a forecast_reference_time coordinate.
         frt_point = cycletime_to_datetime(self.current_cycle)
         try:
-
             frt_coord = (
                 historic_forecast.coord("forecast_reference_time").copy(
                     datetime_to_iris_time(frt_point, time_units="seconds")))
@@ -492,6 +491,15 @@ class EstimateCoefficientsForEnsembleCalibration(object):
                     time_units=str(historic_forecast.coord("time").units))
                 time_coord = historic_forecast.coord("time").copy(time_point)
                 aux_coords_and_dims.append((time_coord, None))
+
+        # Create x and y coordinates
+        for axis in ["x", "y"]:
+            coord_point = np.mean(historic_forecast.coord(axis=axis).points)
+            coord_bounds = [historic_forecast.coord(axis=axis).points[0],
+                            historic_forecast.coord(axis=axis).points[-1]]
+            new_coord = historic_forecast.coord(axis=axis).copy(
+                points=coord_point, bounds=coord_bounds)
+            aux_coords_and_dims.append((new_coord, None))
 
         attributes = {"diagnostic_standard_name": historic_forecast.name()}
         for attribute in historic_forecast.attributes.keys():

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -263,9 +263,22 @@ class Test_create_coefficients_cube(IrisTest):
         frt_point = np.max(frt_orig_coord.points) + 60*60*24
         frt_coord = frt_orig_coord.copy(frt_point)
 
+        x_point = np.mean(self.historic_forecast.coord(axis="x").points)
+        x_bounds = [self.historic_forecast.coord(axis="x").points[0],
+                    self.historic_forecast.coord(axis="x").points[-1]]
+        self.x_coord = self.historic_forecast.coord(axis="x").copy(
+            points=x_point, bounds=x_bounds)
+
+        y_point = np.mean(self.historic_forecast.coord(axis="y").points)
+        y_bounds = [self.historic_forecast.coord(axis="y").points[0],
+                    self.historic_forecast.coord(axis="y").points[-1]]
+        self.y_coord = self.historic_forecast.coord(axis="y").copy(
+            points=y_point, bounds=y_bounds)
+
         aux_coords_and_dims = [
             (coefficient_name, 0), (time_coord, None), (frt_coord, None),
-            (self.historic_forecast[-1].coord("forecast_period"), None)]
+            (self.historic_forecast[-1].coord("forecast_period"), None),
+            (self.x_coord, None), (self.y_coord, None)]
 
         attributes = {"mosg__model_configuration": "uk_det",
                       "diagnostic_standard_name": "air_temperature"}
@@ -327,7 +340,8 @@ class Test_create_coefficients_cube(IrisTest):
 
         aux_coords_and_dims = [
             (coefficient_name, 0), (time_coord, None), (frt_coord, None),
-            (self.historic_forecast[-1].coord("forecast_period"), None)]
+            (self.historic_forecast[-1].coord("forecast_period"), None),
+            (self.x_coord, None), (self.y_coord, None)]
 
         attributes = {"mosg__model_configuration": "uk_det",
                       "diagnostic_standard_name": "air_temperature"}

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -263,13 +263,13 @@ class Test_create_coefficients_cube(IrisTest):
         frt_point = np.max(frt_orig_coord.points) + 60*60*24
         frt_coord = frt_orig_coord.copy(frt_point)
 
-        x_point = np.mean(self.historic_forecast.coord(axis="x").points)
+        x_point = np.median(self.historic_forecast.coord(axis="x").points)
         x_bounds = [self.historic_forecast.coord(axis="x").points[0],
                     self.historic_forecast.coord(axis="x").points[-1]]
         self.x_coord = self.historic_forecast.coord(axis="x").copy(
             points=x_point, bounds=x_bounds)
 
-        y_point = np.mean(self.historic_forecast.coord(axis="y").points)
+        y_point = np.median(self.historic_forecast.coord(axis="y").points)
         y_bounds = [self.historic_forecast.coord(axis="y").points[0],
                     self.historic_forecast.coord(axis="y").points[-1]]
         self.y_coord = self.historic_forecast.coord(axis="y").copy(


### PR DESCRIPTION
Addresses part of #854 

Description
This PRs amends the metadata associated with the EMOS coefficients cube, so that the cube includes scalar x and y coordinates, where the bounds represent the domain that the coefficients are valid for.

There is currently no known good output for this PR. This will be generated after #875 is merged.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

