### PR TITLE
Ensure a matching domain when applying EMOS coefficients

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -821,6 +821,21 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
             except CoordinateNotFoundError:
                 pass
 
+        # Check that the domain of the current forecast and coefficients cube
+        # matches.
+        for axis in ["x", "y"]:
+            current_forecast_points = [
+                current_forecast.coord(axis=axis).points[0],
+                current_forecast.coord(axis=axis).points[-1]]
+            if not np.allclose(current_forecast_points,
+                               coefficients_cube.coord(axis=axis).bounds):
+                msg = ("The domain along the {} axis given by the "
+                       "current forecast {} does not match the domain given "
+                       "by the coefficients cube {}.".format(
+                        axis, current_forecast_points,
+                        coefficients_cube.coord(axis=axis).bounds))
+                raise ValueError(msg)
+
         # Ensure predictor_of_mean_flag is valid.
         check_predictor_of_mean_flag(predictor_of_mean_flag)
         self.predictor_of_mean_flag = predictor_of_mean_flag

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -46,6 +46,9 @@ from improver.ensemble_calibration.ensemble_calibration import (
 
 from improver.ensemble_calibration.ensemble_calibration import (
     EstimateCoefficientsForEnsembleCalibration)
+from improver.tests.ensemble_calibration.ensemble_calibration.\
+    test_EstimateCoefficientsForEnsembleCalibration import (
+        create_coefficients_cube)
 from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.warnings_handler import ManageWarnings
 
@@ -58,8 +61,10 @@ class Test__init__(IrisTest):
         """Test up test cubes."""
         data = np.ones([2, 2], dtype=np.float32)
         self.current_forecast = set_up_variable_cube(data)
-        self.coefficients_cube = (
-            set_up_variable_cube(data, name="emos_coefficients"))
+        coeff_names = ["gamma", "delta", "alpha", "beta"]
+        coeff_values = np.array([0, 1, 2, 3], np.int32)
+        self.coefficients_cube, _, _ = create_coefficients_cube(
+            self.current_forecast, coeff_names, coeff_values)
 
     def test_basic(self):
         """Test without specifying any keyword arguments."""
@@ -81,6 +86,14 @@ class Test__init__(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             Plugin(self.current_forecast, self.coefficients_cube)
 
+    def test_matching_domain(self):
+        """Test whether the domain of the forecast and the domain of the
+        coefficients cube matches."""
+        current_forecast = self.current_forecast[0, :]
+        msg = "The domain along the"
+        with self.assertRaisesRegex(ValueError, msg):
+            Plugin(current_forecast, self.coefficients_cube)
+
 
 class Test__repr__(IrisTest):
 
@@ -90,8 +103,10 @@ class Test__repr__(IrisTest):
         """Test up test cubes."""
         data = np.ones([2, 2], dtype=np.float32)
         self.current_forecast = set_up_variable_cube(data)
-        self.coefficients_cube = (
-            set_up_variable_cube(data, name="emos_coefficients"))
+        coeff_names = ["gamma", "delta", "alpha", "beta"]
+        coeff_values = np.array([0, 1, 2, 3], np.int32)
+        self.coefficients_cube, _, _ = create_coefficients_cube(
+            self.current_forecast, coeff_names, coeff_values)
 
     def test_basic(self):
         """Test without specifying keyword arguments"""

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -58,7 +58,7 @@ class Test__init__(IrisTest):
     """Test the __init__ method."""
 
     def setUp(self):
-        """Test up test cubes."""
+        """Set up test cubes."""
         data = np.ones([2, 2], dtype=np.float32)
         self.current_forecast = set_up_variable_cube(data)
         coeff_names = ["gamma", "delta", "alpha", "beta"]
@@ -100,7 +100,7 @@ class Test__repr__(IrisTest):
     """Test the __repr__ method."""
 
     def setUp(self):
-        """Test up test cubes."""
+        """Set up test cubes."""
         data = np.ones([2, 2], dtype=np.float32)
         self.current_forecast = set_up_variable_cube(data)
         coeff_names = ["gamma", "delta", "alpha", "beta"]


### PR DESCRIPTION
Addresses part of #854 

Description
Add a check to ensure that the domain of the forecast cube and the domain of the EMOS coefficients cube match when the EMOS coefficients cube is applied.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

