### PR TITLE
Fix time lagging of 09Z file

### DIFF
--- a/lib/improver/tests/utilities/test_GenerateTimeLaggedEnsemble.py
+++ b/lib/improver/tests/utilities/test_GenerateTimeLaggedEnsemble.py
@@ -203,36 +203,21 @@ class Test_process(IrisTest):
 
     def test_non_monotonic_realizations(self):
         """Test handling of case where realization coordinates cannot be
-        concatenated into a monotonic coordinate (eg 09Z cycle from
-        MOGREPS-UK)"""
+        directly concatenated into a monotonic coordinate"""
         data = 275.*np.ones((3, 3, 3), dtype=np.float32)
         cycletime = dt(2019, 6, 24, 9)
         cube1 = set_up_variable_cube(
-            data, realizations=[3, 4, 5], time=cycletime,
-            frt=dt(2019, 6, 24, 4))
-        cube2 = set_up_variable_cube(
-            data, realizations=[6, 7, 8], time=cycletime,
-            frt=dt(2019, 6, 24, 5))
-        cube3 = set_up_variable_cube(
-            data, realizations=[9, 10, 11], time=cycletime,
-            frt=dt(2019, 6, 24, 6))
-        cube4 = set_up_variable_cube(
-            data, realizations=[12, 13, 14], time=cycletime,
-            frt=dt(2019, 6, 24, 7))
-        cube5 = set_up_variable_cube(
             data, realizations=[15, 16, 17], time=cycletime,
             frt=dt(2019, 6, 24, 8))
-        cube6 = set_up_variable_cube(
+        cube2 = set_up_variable_cube(
             data, realizations=[0, 18, 19], time=cycletime, frt=cycletime)
 
         expected_cube = set_up_variable_cube(
-            275.*np.ones((18, 3, 3), dtype=np.float32),
-            realizations=[0, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-                          12, 13, 14, 15, 16, 17, 18, 19],
+            275.*np.ones((6, 3, 3), dtype=np.float32),
+            realizations=[0, 15, 16, 17, 18, 19],
             time=cycletime, frt=cycletime)
 
-        input_cubelist = iris.cube.CubeList(
-            [cube1, cube2, cube3, cube4, cube5, cube6])
+        input_cubelist = iris.cube.CubeList([cube1, cube2])
         result = GenerateTimeLaggedEnsemble().process(input_cubelist)
         self.assertEqual(result, expected_cube)
 

--- a/lib/improver/utilities/time_lagging.py
+++ b/lib/improver/utilities/time_lagging.py
@@ -31,6 +31,7 @@
 """Provide support utilities for time lagging ensembles"""
 
 import numpy as np
+import iris
 
 from improver.utilities.temporal import (
     unify_forecast_reference_time, cycletime_to_datetime,
@@ -103,6 +104,10 @@ class GenerateTimeLaggedEnsemble(object):
                     first_realization, first_realization + n_realization)
                 first_realization = first_realization + n_realization
 
+        # slice over realization to deal with cases where direct concatenation
+        # would result in a non-monotonic coordinate
         lagged_ensemble = concatenate_cubes(
-            cubelist, master_coord="realization")
+            cubelist, master_coord="realization",
+            coords_to_slice_over=["realization"])
+
         return lagged_ensemble

--- a/lib/improver/utilities/time_lagging.py
+++ b/lib/improver/utilities/time_lagging.py
@@ -31,7 +31,6 @@
 """Provide support utilities for time lagging ensembles"""
 
 import numpy as np
-import iris
 
 from improver.utilities.temporal import (
     unify_forecast_reference_time, cycletime_to_datetime,


### PR DESCRIPTION
Fixes problem of not being able to create time-lagged ensembles including the 09Z MOGREPS-UK level 1 file because of the numbering of realizations.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
