### PR TITLE
Remove CRPS specific assertions

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -234,8 +234,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
             self, initial_guess, forecast_predictor, truth, forecast_var,
             sqrt_pi, predictor_of_mean_flag):
         """
-        Minimisation function to calculate coefficients based on minimising the
-        CRPS for a normal distribution.
+        Calculate the CRPS for a normal distribution.
 
         Scientific Reference:
         Gneiting, T. et al., 2005.
@@ -263,7 +262,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
 
         Returns:
             result (float):
-                Minimum value for the CRPS achieved.
+                CRPS for the current set of coefficients.
 
         """
         if predictor_of_mean_flag.lower() == "mean":
@@ -293,8 +292,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
             self, initial_guess, forecast_predictor, truth, forecast_var,
             sqrt_pi, predictor_of_mean_flag):
         """
-        Minimisation function to calculate coefficients based on minimising the
-        CRPS for a truncated_normal distribution.
+        Calculate the CRPS for a truncated normal distribution.
 
         Scientific Reference:
         Thorarinsdottir, T.L. & Gneiting, T., 2010.
@@ -323,7 +321,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
 
         Returns:
             result (float):
-                Minimum value for the CRPS achieved.
+                CRPS for the current set of coefficients.
 
         """
         if predictor_of_mean_flag.lower() == "mean":
@@ -820,6 +818,21 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
                     raise ValueError(msg)
             except CoordinateNotFoundError:
                 pass
+
+        # Check that the domain of the current forecast and coefficients cube
+        # matches.
+        for axis in ["x", "y"]:
+            current_forecast_points = [
+                current_forecast.coord(axis=axis).points[0],
+                current_forecast.coord(axis=axis).points[-1]]
+            if not np.allclose(current_forecast_points,
+                               coefficients_cube.coord(axis=axis).bounds):
+                msg = ("The domain along the {} axis given by the "
+                       "current forecast {} does not match the domain given "
+                       "by the coefficients cube {}.".format(
+                        axis, current_forecast_points,
+                        coefficients_cube.coord(axis=axis).bounds))
+                raise ValueError(msg)
 
         # Ensure predictor_of_mean_flag is valid.
         check_predictor_of_mean_flag(predictor_of_mean_flag)

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -819,21 +819,6 @@ class ApplyCoefficientsFromEnsembleCalibration(object):
             except CoordinateNotFoundError:
                 pass
 
-        # Check that the domain of the current forecast and coefficients cube
-        # matches.
-        for axis in ["x", "y"]:
-            current_forecast_points = [
-                current_forecast.coord(axis=axis).points[0],
-                current_forecast.coord(axis=axis).points[-1]]
-            if not np.allclose(current_forecast_points,
-                               coefficients_cube.coord(axis=axis).bounds):
-                msg = ("The domain along the {} axis given by the "
-                       "current forecast {} does not match the domain given "
-                       "by the coefficients cube {}.".format(
-                        axis, current_forecast_points,
-                        coefficients_cube.coord(axis=axis).bounds))
-                raise ValueError(msg)
-
         # Ensure predictor_of_mean_flag is valid.
         check_predictor_of_mean_flag(predictor_of_mean_flag)
         self.predictor_of_mean_flag = predictor_of_mean_flag

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -92,11 +92,11 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 more coefficients to solve for.
 
         """
-        # Dictionary containing the minimisation functions, which will
-        # be used, depending upon the distribution, which is requested.
+        # Dictionary containing the functions that will be minimised,
+        # depending upon the distribution requested.
         self.minimisation_dict = {
-            "gaussian": self.normal_crps_minimiser,
-            "truncated gaussian": self.truncated_normal_crps_minimiser}
+            "gaussian": self.calculate_normal_crps,
+            "truncated gaussian": self.calculate_truncated_normal_crps}
         # Maximum iterations for minimisation using Nelder-Mead.
         self.max_iterations = max_iterations
 
@@ -109,11 +109,11 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
             print_dict.update({key: self.minimisation_dict[key].__name__})
         return result.format(print_dict, self.max_iterations)
 
-    def crps_minimiser_wrapper(
+    def crps_minimiser(
             self, initial_guess, forecast_predictor, truth, forecast_var,
             predictor_of_mean_flag, distribution):
         """
-        Function to pass a given minimisation function to the scipy minimize
+        Function to pass a given function to the scipy minimize
         function to estimate optimised values for the coefficients.
 
         If the predictor_of_mean_flag is the ensemble mean, this function
@@ -146,8 +146,8 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
                 Currently the ensemble mean ("mean") and the ensemble
                 realizations ("realizations") are supported as the predictors.
             distribution (str):
-                String used to access the appropriate minimisation function
-                within self.minimisation_dict.
+                String used to access the appropriate function for use in the
+                minimisation within self.minimisation_dict.
 
         Returns:
             optimised_coeffs (list):
@@ -230,7 +230,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
         calculate_percentage_change_in_last_iteration(optimised_coeffs.allvecs)
         return optimised_coeffs.x.astype(np.float32)
 
-    def normal_crps_minimiser(
+    def calculate_normal_crps(
             self, initial_guess, forecast_predictor, truth, forecast_var,
             sqrt_pi, predictor_of_mean_flag):
         """
@@ -288,7 +288,7 @@ class ContinuousRankedProbabilityScoreMinimisers(object):
 
         return result
 
-    def truncated_normal_crps_minimiser(
+    def calculate_truncated_normal_crps(
             self, initial_guess, forecast_predictor, truth, forecast_var,
             sqrt_pi, predictor_of_mean_flag):
         """
@@ -760,7 +760,7 @@ class EstimateCoefficientsForEnsembleCalibration(object):
             # Need to access the x attribute returned by the
             # minimisation function.
             optimised_coeffs = (
-                self.minimiser.crps_minimiser_wrapper(
+                self.minimiser.crps_minimiser(
                     initial_guess, forecast_predictor,
                     truth, forecast_var,
                     self.predictor_of_mean_flag,

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
@@ -89,22 +89,6 @@ class EnsembleCalibrationAssertions(IrisTest):
          """
         self.assertArrayAlmostEqual(first, second, decimal=4)
 
-    def assertCRPSAlmostEqual(self, first, second):
-        """Overriding of the assertAlmostEqual method to check whether
-        array are matching to 3 decimal places. This is specifically
-        for use in assertions involving the Continuous Ranked Probability Score
-        calculations. This is justified based on a 0.0001 precision level
-        difference within the ensemble calibration coefficients that may
-        escalate when these coefficients are combined.
-
-        Args:
-            first (np.array):
-                First array to compare.
-            second (np.array):
-                Second array to compare.
-         """
-        self.assertAlmostEqual(first, second, places=3)
-
 
 class SetupCubes(IrisTest):
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -57,8 +57,8 @@ class Test__repr__(IrisTest):
         """A simple tests for the __repr__ method."""
         result = str(Plugin())
         msg = ("<ContinuousRankedProbabilityScoreMinimisers: "
-               "minimisation_dict: {'gaussian': 'normal_crps_minimiser', "
-               "'truncated gaussian': 'truncated_normal_crps_minimiser'}; "
+               "minimisation_dict: {'gaussian': 'calculate_normal_crps', "
+               "'truncated gaussian': 'calculate_truncated_normal_crps'}; "
                "max_iterations: 1000>")
         self.assertEqual(result, msg)
 
@@ -67,8 +67,8 @@ class Test__repr__(IrisTest):
         keyword argument."""
         result = str(Plugin(max_iterations=10))
         msg = ("<ContinuousRankedProbabilityScoreMinimisers: "
-               "minimisation_dict: {'gaussian': 'normal_crps_minimiser', "
-               "'truncated gaussian': 'truncated_normal_crps_minimiser'}; "
+               "minimisation_dict: {'gaussian': 'calculate_normal_crps', "
+               "'truncated gaussian': 'calculate_truncated_normal_crps'}; "
                "max_iterations: 10>")
         self.assertEqual(result, msg)
 
@@ -124,7 +124,7 @@ class SetupGaussianInputs(SetupInputs, SetupCubes):
             np.float64)
 
 
-class Test_normal_crps_minimiser(SetupGaussianInputs):
+class Test_calculate_normal_crps(SetupGaussianInputs):
 
     """
     Test minimising the CRPS for a gaussian distribution.
@@ -142,7 +142,7 @@ class Test_normal_crps_minimiser(SetupGaussianInputs):
         predictor_of_mean_flag = "mean"
 
         plugin = Plugin()
-        result = plugin.normal_crps_minimiser(
+        result = plugin.calculate_normal_crps(
             self.initial_guess_for_mean, self.forecast_predictor_data,
             self.truth_data, self.forecast_variance_data, self.sqrt_pi,
             predictor_of_mean_flag)
@@ -161,7 +161,7 @@ class Test_normal_crps_minimiser(SetupGaussianInputs):
         predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
-        result = plugin.normal_crps_minimiser(
+        result = plugin.calculate_normal_crps(
             self.initial_guess_for_realization,
             self.forecast_predictor_data_realizations, self.truth_data,
             self.forecast_variance_data, self.sqrt_pi,
@@ -187,7 +187,7 @@ class Test_normal_crps_minimiser(SetupGaussianInputs):
         predictor_of_mean_flag = "mean"
 
         plugin = Plugin()
-        result = plugin.normal_crps_minimiser(
+        result = plugin.calculate_normal_crps(
             initial_guess, self.forecast_predictor_data, self.truth_data,
             self.forecast_variance_data, self.sqrt_pi, predictor_of_mean_flag)
 
@@ -195,7 +195,7 @@ class Test_normal_crps_minimiser(SetupGaussianInputs):
         self.assertAlmostEqual(result, plugin.BAD_VALUE)
 
 
-class Test_crps_minimiser_wrapper_gaussian_distribution(
+class Test_crps_minimiser_gaussian_distribution(
         SetupGaussianInputs, EnsembleCalibrationAssertions):
 
     """
@@ -226,7 +226,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         predictor_of_mean_flag = "mean"
         distribution = "gaussian"
         plugin = Plugin()
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_mean, self.forecast_predictor_mean,
             self.truth, self.forecast_variance, predictor_of_mean_flag,
             distribution)
@@ -250,7 +250,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         predictor_of_mean_flag = "realizations"
         distribution = "gaussian"
         plugin = Plugin()
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_realization,
             self.forecast_predictor_realizations, self.truth,
             self.forecast_variance, predictor_of_mean_flag, distribution)
@@ -273,7 +273,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         plugin = Plugin()
         msg = "Distribution requested"
         with self.assertRaisesRegex(KeyError, msg):
-            plugin.crps_minimiser_wrapper(
+            plugin.crps_minimiser(
                 self.initial_guess_for_mean, self.forecast_predictor_mean,
                 self.truth, self.forecast_variance,
                 predictor_of_mean_flag, distribution)
@@ -297,7 +297,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         distribution = "gaussian"
 
         plugin = Plugin(max_iterations=max_iterations)
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_mean, self.forecast_predictor_mean,
             self.truth, self.forecast_variance,
             predictor_of_mean_flag, distribution)
@@ -325,7 +325,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         distribution = "gaussian"
 
         plugin = Plugin(max_iterations=max_iterations)
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_realization,
             self.forecast_predictor_realizations, self.truth,
             self.forecast_variance, predictor_of_mean_flag, distribution)
@@ -344,7 +344,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         distribution = "gaussian"
 
         plugin = Plugin(max_iterations=10)
-        plugin.crps_minimiser_wrapper(
+        plugin.crps_minimiser(
             self.initial_guess_for_mean, self.forecast_predictor_mean,
             self.truth, self.forecast_variance, predictor_of_mean_flag,
             distribution)
@@ -370,7 +370,7 @@ class Test_crps_minimiser_wrapper_gaussian_distribution(
         distribution = "gaussian"
 
         plugin = Plugin(max_iterations=5)
-        plugin.crps_minimiser_wrapper(
+        plugin.crps_minimiser(
             initial_guess, self.forecast_predictor_mean, self.truth,
             self.forecast_variance, predictor_of_mean_flag, distribution)
         warning_msg_min = "Minimisation did not result in convergence after"
@@ -418,7 +418,7 @@ class SetupTruncatedGaussianInputs(SetupInputs, SetupCubes):
         self.truth_data = self.truth.data.flatten().astype(np.float64)
 
 
-class Test_truncated_normal_crps_minimiser(SetupTruncatedGaussianInputs):
+class Test_calculate_truncated_normal_crps(SetupTruncatedGaussianInputs):
 
     """
     Test minimising the crps for a truncated gaussian distribution.
@@ -436,7 +436,7 @@ class Test_truncated_normal_crps_minimiser(SetupTruncatedGaussianInputs):
         predictor_of_mean_flag = "mean"
 
         plugin = Plugin()
-        result = plugin.truncated_normal_crps_minimiser(
+        result = plugin.calculate_truncated_normal_crps(
             self.initial_guess_for_mean, self.forecast_predictor_data,
             self.truth_data, self.forecast_variance_data, self.sqrt_pi,
             predictor_of_mean_flag)
@@ -455,7 +455,7 @@ class Test_truncated_normal_crps_minimiser(SetupTruncatedGaussianInputs):
         predictor_of_mean_flag = "realizations"
 
         plugin = Plugin()
-        result = plugin.truncated_normal_crps_minimiser(
+        result = plugin.calculate_truncated_normal_crps(
             self.initial_guess_for_realization,
             self.forecast_predictor_data_realizations, self.truth_data,
             self.forecast_variance_data, self.sqrt_pi, predictor_of_mean_flag)
@@ -480,7 +480,7 @@ class Test_truncated_normal_crps_minimiser(SetupTruncatedGaussianInputs):
         predictor_of_mean_flag = "mean"
 
         plugin = Plugin()
-        result = plugin.truncated_normal_crps_minimiser(
+        result = plugin.calculate_truncated_normal_crps(
             initial_guess, self.forecast_predictor_data, self.truth_data,
             self.forecast_variance_data, self.sqrt_pi, predictor_of_mean_flag)
 
@@ -488,7 +488,7 @@ class Test_truncated_normal_crps_minimiser(SetupTruncatedGaussianInputs):
         self.assertAlmostEqual(result, plugin.BAD_VALUE)
 
 
-class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
+class Test_crps_minimiser_truncated_gaussian_distribution(
         SetupTruncatedGaussianInputs, EnsembleCalibrationAssertions):
 
     """
@@ -520,7 +520,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         distribution = "truncated gaussian"
 
         plugin = Plugin()
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_mean, self.forecast_predictor_mean,
             self.truth, self.forecast_variance, predictor_of_mean_flag,
             distribution)
@@ -544,7 +544,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         distribution = "truncated gaussian"
 
         plugin = Plugin()
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_realization,
             self.forecast_predictor_realizations, self.truth,
             self.forecast_variance, predictor_of_mean_flag, distribution)
@@ -566,7 +566,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         plugin = Plugin()
         msg = "Distribution requested"
         with self.assertRaisesRegex(KeyError, msg):
-            plugin.crps_minimiser_wrapper(
+            plugin.crps_minimiser(
                 self.initial_guess_for_mean, self.forecast_predictor_mean,
                 self.truth, self.forecast_variance,
                 predictor_of_mean_flag, distribution)
@@ -585,7 +585,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         plugin = Plugin()
         msg = "Distribution requested"
         with self.assertRaisesRegex(KeyError, msg):
-            plugin.crps_minimiser_wrapper(
+            plugin.crps_minimiser(
                 self.initial_guess_for_realization,
                 self.forecast_predictor_realizations, self.truth,
                 self.forecast_variance, predictor_of_mean_flag, distribution)
@@ -612,7 +612,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         distribution = "truncated gaussian"
 
         plugin = Plugin(max_iterations=max_iterations)
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_mean, self.forecast_predictor_mean,
             self.truth, self.forecast_variance, predictor_of_mean_flag,
             distribution)
@@ -640,7 +640,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         distribution = "truncated gaussian"
 
         plugin = Plugin(max_iterations=max_iterations)
-        result = plugin.crps_minimiser_wrapper(
+        result = plugin.crps_minimiser(
             self.initial_guess_for_realization,
             self.forecast_predictor_realizations, self.truth,
             self.forecast_variance, predictor_of_mean_flag, distribution)
@@ -659,7 +659,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
         distribution = "truncated gaussian"
 
         plugin = Plugin(max_iterations=10)
-        plugin.crps_minimiser_wrapper(
+        plugin.crps_minimiser(
             self.initial_guess_for_mean, self.forecast_predictor_mean,
             self.truth, self.forecast_variance, predictor_of_mean_flag,
             distribution)
@@ -690,7 +690,7 @@ class Test_crps_minimiser_wrapper_truncated_gaussian_distribution(
 
         plugin = Plugin(max_iterations=5)
 
-        plugin.crps_minimiser_wrapper(
+        plugin.crps_minimiser(
             initial_guess, self.forecast_predictor_mean,
             self.truth, self.forecast_variance, predictor_of_mean_flag,
             distribution)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -124,8 +124,7 @@ class SetupGaussianInputs(SetupInputs, SetupCubes):
             np.float64)
 
 
-class Test_normal_crps_minimiser(
-        SetupGaussianInputs, EnsembleCalibrationAssertions):
+class Test_normal_crps_minimiser(SetupGaussianInputs):
 
     """
     Test minimising the CRPS for a gaussian distribution.
@@ -149,7 +148,7 @@ class Test_normal_crps_minimiser(
             predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertCRPSAlmostEqual(result, 11.741)
+        self.assertAlmostEqual(result, 11.7407838)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -169,7 +168,7 @@ class Test_normal_crps_minimiser(
             predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertCRPSAlmostEqual(result, 11.741)
+        self.assertAlmostEqual(result, 11.7407763)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
@@ -419,8 +418,7 @@ class SetupTruncatedGaussianInputs(SetupInputs, SetupCubes):
         self.truth_data = self.truth.data.flatten().astype(np.float64)
 
 
-class Test_truncated_normal_crps_minimiser(
-        SetupTruncatedGaussianInputs, EnsembleCalibrationAssertions):
+class Test_truncated_normal_crps_minimiser(SetupTruncatedGaussianInputs):
 
     """
     Test minimising the crps for a truncated gaussian distribution.
@@ -444,7 +442,7 @@ class Test_truncated_normal_crps_minimiser(
             predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertCRPSAlmostEqual(result, 7.516)
+        self.assertAlmostEqual(result, 7.5157541)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -463,7 +461,7 @@ class Test_truncated_normal_crps_minimiser(
             self.forecast_variance_data, self.sqrt_pi, predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertCRPSAlmostEqual(result, 7.516)
+        self.assertAlmostEqual(result, 7.5157531)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",


### PR DESCRIPTION
Addresses part of #854 

Description
Remove specific CRPS assertions, as in these unit tests the CRPS is tested when calculated directly, rather than following minimisation. As the CRPS values in these unit tests are not computed through minimisation, there is no dependence on a tolerance value.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

