### PR TITLE
Uses built-in Iris time to datetime method.

### DIFF
--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -286,6 +286,8 @@ class Test_iris_time_to_datetime(IrisTest):
         """Test iris_time_to_datetime returns list of datetime """
         result = iris_time_to_datetime(self.cube.coord('time'))
         self.assertIsInstance(result, list)
+        for item in result:
+            self.assertIsInstance(item, datetime.datetime)
         self.assertEqual(result[0], datetime.datetime(2017, 2, 17, 6, 0))
 
     def test_input_cube_unmodified(self):

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -243,7 +243,7 @@ def iris_time_to_datetime(time_coord):
     """
     coord = time_coord.copy()
     coord.convert_units('seconds since 1970-01-01 00:00:00')
-    return [datetime.utcfromtimestamp(value) for value in coord.points]
+    return [value.point for value in coord.cells()]
 
 
 def datetime_to_iris_time(dt_in, time_units="hours"):


### PR DESCRIPTION
Uses built-in Iris time to datetime method rather than converting the points value using the coord units.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)
I couldn't devise a test to trap the intermittent errors caused by using the old method, but this way is more pythonic.