### PR TITLE
Fixes a bug in the nowcast lightning code

### DIFF
--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -431,12 +431,13 @@ class NowcastLightning(object):
                     raise ConstraintMismatchError(err_string.format(threshold))
                 # Linearly reduce impact of ice as fcmins increases to 2H30M.
                 ice_scaling = [0., (prob_max * (1. - (fcmins / 150.)))]
-                cube_slice.data = np.maximum(
-                    rescale(ice_slice.data,
-                            data_range=(0., 1.),
-                            scale_range=ice_scaling,
-                            clip=True),
-                    cube_slice.data)
+                if ice_scaling[1] > 0:
+                    cube_slice.data = np.maximum(
+                        rescale(ice_slice.data,
+                                data_range=(0., 1.),
+                                scale_range=ice_scaling,
+                                clip=True),
+                        cube_slice.data)
             new_cube_list.append(cube_slice)
 
         new_cube = new_cube_list.merge_cube()

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -708,8 +708,8 @@ class Test_apply_ice(IrisTest):
         self.fg_cube.coord('forecast_period').points = [3600]  # 1 hour
         fg_cube_next = self.fg_cube.copy()
         time_pt, = self.fg_cube.coord('time').points
-        fg_cube_next.coord('time').points = [time_pt + 7200]  # 2 hours
-        fg_cube_next.coord('forecast_period').points = [10800]  # 3 hours
+        fg_cube_next.coord('time').points = [time_pt + 5400]  # 1.5 hours
+        fg_cube_next.coord('forecast_period').points = [9000]  # 2.5 hours
         self.fg_cube = CubeList([squeeze(self.fg_cube),
                                  squeeze(fg_cube_next)]).merge_cube()
         expected = self.fg_cube.copy()

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -704,25 +704,23 @@ class Test_apply_ice(IrisTest):
         """Test that large VII probs do increase zero lightning risk when
         forecast lead time is non-zero (three forecast_period points)"""
         self.ice_cube.data[:, 1, 1] = 1.
-        fg_cube_template = self.fg_cube.copy()
-        fg_cube_template.data[1, 1] = 0.
-        fg_cube_template.coord('forecast_period').points = [0]
-        frt_point = fg_cube_template.coord('forecast_reference_time').points[0]
-        self.fg_cube = CubeList([])
+        self.fg_cube.data[1, 1] = 0.
+        frt_point = self.fg_cube.coord('forecast_reference_time').points[0]
+        fg_cube_input = CubeList([])
         for fc_time in [1, 2.5, 3]:  # hours
-            fg_cube_next = fg_cube_template.copy()
+            fg_cube_next = self.fg_cube.copy()
             fg_cube_next.coord('time').points = (
                 [frt_point + fc_time * 3600])  # seconds
             fg_cube_next.coord('forecast_period').points = (
                 [(fc_time) * 3600])
-            self.fg_cube.append(squeeze(fg_cube_next))
-        self.fg_cube = self.fg_cube.merge_cube()
-        expected = self.fg_cube.copy()
+            fg_cube_input.append(squeeze(fg_cube_next))
+        fg_cube_input = fg_cube_input.merge_cube()
+        expected = fg_cube_input.copy()
         # expected.data contains all ones except:
         expected.data[0, 1, 1] = 0.54
         expected.data[1, 1, 1] = 0.0
         expected.data[2, 1, 1] = 0.0
-        result = self.plugin.apply_ice(self.fg_cube,
+        result = self.plugin.apply_ice(fg_cube_input,
                                        self.ice_cube)
         self.assertArrayAlmostEqual(result.data, expected.data)
 

--- a/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/lib/improver/tests/nowcasting/lightning/test_NowcastLightning.py
@@ -707,12 +707,10 @@ class Test_apply_ice(IrisTest):
         self.fg_cube.data[1, 1] = 0.
         frt_point = self.fg_cube.coord('forecast_reference_time').points[0]
         fg_cube_input = CubeList([])
-        for fc_time in [1, 2.5, 3]:  # hours
+        for fc_time in np.array([1, 2.5, 3]) * 3600:  # seconds
             fg_cube_next = self.fg_cube.copy()
-            fg_cube_next.coord('time').points = (
-                [frt_point + fc_time * 3600])  # seconds
-            fg_cube_next.coord('forecast_period').points = (
-                [(fc_time) * 3600])
+            fg_cube_next.coord('time').points = [frt_point + fc_time]
+            fg_cube_next.coord('forecast_period').points = [fc_time]
             fg_cube_input.append(squeeze(fg_cube_next))
         fg_cube_input = fg_cube_input.merge_cube()
         expected = fg_cube_input.copy()


### PR DESCRIPTION
Fixes a bug in the nowcast lightning code that triggers when processing a forecast period of exactly 2.5 hours. This was found when testing the code for PS43.
In this case, the rescale function aborts because the min and max to rescale to are identical. Larger lead times were ok as the rescale max became negative (which is allowed).
I have also added a filter to prevent calling the rescale function when the lead time is larger than 2.5 hours as the results will be rejected anyway.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
