### PR TITLE
Removing calibration method as an option for ensemble calibration.

### DIFF
--- a/lib/improver/cli/ensemble_calibration.py
+++ b/lib/improver/cli/ensemble_calibration.py
@@ -71,15 +71,6 @@ def main(argv=None):
         'Ensemble Copula Coupling.')
     # Arguments for EnsembleCalibration
     parser.add_argument(
-        'calibration_method',
-        metavar='ENSEMBLE_CALIBRATION_METHOD',
-        choices=['ensemble model output statistics',
-                 'nonhomogeneous gaussian regression'],
-        help='The calibration method that will be applied. '
-             'Supported methods are: "emos" '
-             '(ensemble model output statistics) '
-             'and "ngr" (nonhomogeneous gaussian regression).')
-    parser.add_argument(
         'units', metavar='UNITS_TO_CALIBRATE_IN',
         help='The unit that calibration should be undertaken in. The current '
              'forecast, historical forecast and truth will be converted as '
@@ -228,7 +219,7 @@ def main(argv=None):
 
     # Ensemble-Calibration to calculate the mean and variance.
     forecast_predictor, forecast_variance = EnsembleCalibration(
-        args.calibration_method, args.distribution, args.units,
+        args.distribution, args.units,
         predictor_of_mean_flag=args.predictor_of_mean,
         max_iterations=args.max_iterations).process(
             current_forecast, historic_forecast, truth)

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -963,7 +963,7 @@ class EnsembleCalibration(object):
     2. Apply optimised EMOS coefficients for future dates.
 
     """
-    def __init__(self, calibration_method, distribution, desired_units=None,
+    def __init__(self, distribution, desired_units=None,
                  predictor_of_mean_flag="mean", max_iterations=1000):
         """
         Create an ensemble calibration plugin that, for Nonhomogeneous Gaussian
@@ -971,18 +971,6 @@ class EnsembleCalibration(object):
         applies the coefficients to the current forecast.
 
         Args:
-            calibration_method (str):
-                The calibration method that will be applied.
-                Supported methods are:
-
-                    ensemble model output statistics
-                    nonhomogeneous gaussian regression
-
-                Currently these methods are not supported:
-
-                    logistic regression
-                    bayesian model averaging
-
             distribution (str):
                 The distribution that will be used for calibration. This will
                 be dependent upon the input phenomenon. This has to be
@@ -1007,7 +995,13 @@ class EnsembleCalibration(object):
                 iterations may require increasing, as there will be
                 more coefficients to solve for.
         """
-        self.calibration_method = calibration_method
+        valid_distributions = (ContinuousRankedProbabilityScoreMinimisers().
+                                minimisation_dict.keys())
+        if distribution not in vailid_distributions:
+            msg = ("Given distribution {} not available. Available "
+                   "distributions are {}".format(
+                       distribution, valid_distributions))
+            raise ValueError(msg)
         self.distribution = distribution
         self.desired_units = desired_units
         self.predictor_of_mean_flag = predictor_of_mean_flag
@@ -1016,13 +1010,12 @@ class EnsembleCalibration(object):
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
         result = ('<EnsembleCalibration: '
-                  'calibration_method: {}; '
                   'distribution: {}; '
                   'desired_units: {}; '
                   'predictor_of_mean_flag: {}; '
                   'max_iterations: {}>')
         return result.format(
-            self.calibration_method, self.distribution, self.desired_units,
+            self.distribution, self.desired_units,
             self.predictor_of_mean_flag, self.max_iterations)
 
     def process(self, current_forecast, historic_forecast, truth):
@@ -1050,34 +1043,21 @@ class EnsembleCalibration(object):
                     Cube containing the calibrated forecast variance.
 
         """
-        def format_calibration_method(calibration_method):
-            """Lowercase input string, and replace underscores with spaces."""
-            return calibration_method.lower().replace("_", " ")
-
         # Ensure predictor_of_mean_flag is valid.
         check_predictor_of_mean_flag(self.predictor_of_mean_flag)
 
-        if (format_calibration_method(self.calibration_method) in
-                ["ensemble model output statistics",
-                 "nonhomogeneous gaussian regression"]):
-            if (format_calibration_method(self.distribution) in
-                    ["gaussian", "truncated gaussian"]):
-                current_cycle = datetime_to_cycletime(
-                    iris_time_to_datetime(
-                        current_forecast.coord("forecast_reference_time"))[0])
-                ec = EstimateCoefficientsForEnsembleCalibration(
-                    self.distribution, current_cycle=current_cycle,
-                    desired_units=self.desired_units,
-                    predictor_of_mean_flag=self.predictor_of_mean_flag,
-                    max_iterations=self.max_iterations)
-                coefficient_cube = (
-                    ec.estimate_coefficients_for_ngr(
-                        historic_forecast, truth))
-        else:
-            msg = ("Other calibration methods are not available. "
-                   "{} is not available".format(
-                       format_calibration_method(self.calibration_method)))
-            raise ValueError(msg)
+        current_cycle = datetime_to_cycletime(
+            iris_time_to_datetime(
+                current_forecast.coord("forecast_reference_time"))[0])
+        ec = EstimateCoefficientsForEnsembleCalibration(
+            self.distribution, current_cycle=current_cycle,
+            desired_units=self.desired_units,
+            predictor_of_mean_flag=self.predictor_of_mean_flag,
+            max_iterations=self.max_iterations)
+        coefficient_cube = (
+            ec.estimate_coefficients_for_ngr(
+                historic_forecast, truth))
+
         ac = ApplyCoefficientsFromEnsembleCalibration(
             current_forecast, coefficient_cube,
             predictor_of_mean_flag=self.predictor_of_mean_flag)

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -996,8 +996,8 @@ class EnsembleCalibration(object):
                 more coefficients to solve for.
         """
         valid_distributions = (ContinuousRankedProbabilityScoreMinimisers().
-                                minimisation_dict.keys())
-        if distribution not in vailid_distributions:
+                               minimisation_dict.keys())
+        if distribution not in valid_distributions:
             msg = ("Given distribution {} not available. Available "
                    "distributions are {}".format(
                        distribution, valid_distributions))

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/helper_functions.py
@@ -99,7 +99,6 @@ class SetupCubes(IrisTest):
     def setUp(self):
         """Set up temperature and wind speed cubes for testing."""
         super().setUp()
-        self.calibration_method = "ensemble model output_statistics"
         base_data = np.array([[[0.3, 1.1, 2.6],
                                [4.2, 5.3, 6.],
                                [7.1, 8.2, 9.]],

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -158,6 +158,18 @@ class SetupExpectedResults(IrisTest):
                  [0.4439, 0.0305, 0.0125]], dtype=np.float32))
 
 
+class Test__init__(SetupCubes):
+
+    """Test the __init__ method."""
+
+    def test_raises_error(self):
+        """Test an error is raised for an invalid distribution"""
+        distribution = "biscuits"
+        msg = "Given distribution biscuits not available. "
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin = Plugin(distribution)
+
+
 class Test_process_basic(SetupCubes):
 
     """Test the basic output from the process method."""
@@ -170,7 +182,7 @@ class Test_process_basic(SetupCubes):
         with the desired length. The ensemble mean is the predictor.
         """
         distribution = "gaussian"
-        plugin = Plugin(self.calibration_method, distribution)
+        plugin = Plugin(distribution)
         result = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -187,9 +199,8 @@ class Test_process_basic(SetupCubes):
         """
         distribution = "gaussian"
         predictor_of_mean_flag = "realizations"
-        plugin = Plugin(
-            self.calibration_method, distribution,
-            predictor_of_mean_flag=predictor_of_mean_flag)
+        plugin = Plugin(distribution,
+                        predictor_of_mean_flag=predictor_of_mean_flag)
         result = plugin.process(
             self.current_temperature_forecast_cube,
             self.historic_temperature_forecast_cube,
@@ -205,7 +216,7 @@ class Test_process_basic(SetupCubes):
         with the desired length. The ensemble mean is the predictor.
         """
         distribution = "truncated gaussian"
-        plugin = Plugin(self.calibration_method, distribution)
+        plugin = Plugin(distribution)
         result = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
@@ -222,50 +233,14 @@ class Test_process_basic(SetupCubes):
         """
         distribution = "truncated gaussian"
         predictor_of_mean_flag = "realizations"
-        plugin = Plugin(
-            self.calibration_method, distribution,
-            predictor_of_mean_flag=predictor_of_mean_flag)
+        plugin = Plugin(distribution,
+                        predictor_of_mean_flag=predictor_of_mean_flag)
         result = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
             self.wind_speed_truth_cube)
         self.assertIsInstance(result, tuple)
         self.assertEqual(len(result), 2)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_alternative_calibration_name(self):
-        """
-        Test that the plugin returns the calibrated predictor and the
-        calibrated variance if an alternative name for the calibration
-        is provided. The ensemble mean is the predictor.
-        """
-        calibration_method = "nonhomogeneous gaussian regression"
-        distribution = "gaussian"
-        plugin = Plugin(calibration_method, distribution)
-        calibrated_predictor, calibrated_variance = plugin.process(
-            self.current_temperature_forecast_cube,
-            self.historic_temperature_forecast_cube,
-            self.temperature_truth_cube)
-        self.assertIsInstance(calibrated_predictor, iris.cube.Cube)
-        self.assertIsInstance(calibrated_variance, iris.cube.Cube)
-
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
-    def test_unknown_calibration_method(self):
-        """
-        Test that the plugin raises an error if an unknown calibration method
-        is requested. The ensemble mean is the predictor.
-        """
-        calibration_method = "unknown"
-        distribution = "gaussian"
-        plugin = Plugin(calibration_method, distribution)
-        msg = "unknown"
-        with self.assertRaisesRegex(ValueError, msg):
-            plugin.process(
-                self.current_temperature_forecast_cube,
-                self.historic_temperature_forecast_cube,
-                self.temperature_truth_cube)
 
 
 class Test_process_check_data(SetupCubes, SetupExpectedResults,
@@ -283,7 +258,7 @@ class Test_process_check_data(SetupCubes, SetupExpectedResults,
         variance. The ensemble mean is the predictor.
         """
         distribution = "gaussian"
-        plugin = Plugin(self.calibration_method, distribution)
+        plugin = Plugin(distribution)
 
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
@@ -307,7 +282,7 @@ class Test_process_check_data(SetupCubes, SetupExpectedResults,
         The ensemble mean is the predictor.
         """
         distribution = "gaussian"
-        plugin = Plugin(self.calibration_method, distribution,
+        plugin = Plugin(distribution,
                         max_iterations=10000)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
@@ -330,7 +305,7 @@ class Test_process_check_data(SetupCubes, SetupExpectedResults,
         variance. The ensemble mean is the predictor.
         """
         distribution = "truncated gaussian"
-        plugin = Plugin(self.calibration_method, distribution)
+        plugin = Plugin(distribution)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
             self.historic_wind_speed_forecast_cube,
@@ -353,7 +328,7 @@ class Test_process_check_data(SetupCubes, SetupExpectedResults,
         The ensemble mean is the predictor.
         """
         distribution = "truncated gaussian"
-        plugin = Plugin(self.calibration_method, distribution,
+        plugin = Plugin(distribution,
                         max_iterations=10000)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
@@ -389,7 +364,7 @@ class Test_process_with_statsmodels(SetupCubes, SetupExpectedResults,
         distribution = "gaussian"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution,
+            distribution,
             predictor_of_mean_flag=predictor_of_mean_flag)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
@@ -425,7 +400,7 @@ class Test_process_with_statsmodels(SetupCubes, SetupExpectedResults,
         distribution = "truncated gaussian"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution,
+            distribution,
             predictor_of_mean_flag=predictor_of_mean_flag)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,
@@ -471,7 +446,7 @@ class Test_process_without_statsmodels(SetupCubes, SetupExpectedResults,
         distribution = "gaussian"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution,
+            distribution,
             predictor_of_mean_flag=predictor_of_mean_flag)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_temperature_forecast_cube,
@@ -507,7 +482,7 @@ class Test_process_without_statsmodels(SetupCubes, SetupExpectedResults,
         distribution = "truncated gaussian"
         predictor_of_mean_flag = "realizations"
         plugin = Plugin(
-            self.calibration_method, distribution,
+            distribution,
             predictor_of_mean_flag=predictor_of_mean_flag)
         calibrated_predictor, calibrated_variance = plugin.process(
             self.current_wind_speed_forecast_cube,

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -167,7 +167,7 @@ class Test__init__(SetupCubes):
         distribution = "biscuits"
         msg = "Given distribution biscuits not available. "
         with self.assertRaisesRegex(ValueError, msg):
-            plugin = Plugin(distribution)
+            Plugin(distribution)
 
 
 class Test_process_basic(SetupCubes):

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EnsembleCalibration.py
@@ -158,7 +158,7 @@ class SetupExpectedResults(IrisTest):
                  [0.4439, 0.0305, 0.0125]], dtype=np.float32))
 
 
-class Test__init__(SetupCubes):
+class Test__init__(unittest.TestCase):
 
     """Test the __init__ method."""
 

--- a/tests/improver-ensemble-calibration/00-null.bats
+++ b/tests/improver-ensemble-calibration/00-null.bats
@@ -42,7 +42,6 @@
                                      [--random_seed RANDOM_SEED]
                                      [--ecc_bounds_warning]
                                      [--max_iterations MAX_ITERATIONS]
-                                     ENSEMBLE_CALIBRATION_METHOD
                                      UNITS_TO_CALIBRATE_IN DISTRIBUTION
                                      INPUT_FILE HISTORIC_DATA_FILE
                                      TRUTH_DATA_FILE OUTPUT_FILE

--- a/tests/improver-ensemble-calibration/01-help.bats
+++ b/tests/improver-ensemble-calibration/01-help.bats
@@ -43,7 +43,6 @@ usage: improver ensemble-calibration [-h] [--profile]
                                      [--random_seed RANDOM_SEED]
                                      [--ecc_bounds_warning]
                                      [--max_iterations MAX_ITERATIONS]
-                                     ENSEMBLE_CALIBRATION_METHOD
                                      UNITS_TO_CALIBRATE_IN DISTRIBUTION
                                      INPUT_FILE HISTORIC_DATA_FILE
                                      TRUTH_DATA_FILE OUTPUT_FILE
@@ -62,10 +61,6 @@ input, percentiles are output.If realizations are input, realizations are
 regenerated using Ensemble Copula Coupling.
 
 positional arguments:
-  ENSEMBLE_CALIBRATION_METHOD
-                        The calibration method that will be applied. Supported
-                        methods are: "emos" (ensemble model output statistics)
-                        and "ngr" (nonhomogeneous gaussian regression).
   UNITS_TO_CALIBRATE_IN
                         The unit that calibration should be undertaken in. The
                         current forecast, historical forecast and truth will

--- a/tests/improver-ensemble-calibration/02-gaussian.bats
+++ b/tests/improver-ensemble-calibration/02-gaussian.bats
@@ -36,8 +36,8 @@
   KGO="ensemble-calibration/gaussian/kgo.nc"
 
   # Run ensemble calibration and check it passes.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc" --random_seed 0

--- a/tests/improver-ensemble-calibration/03-trunc_gaussian.bats
+++ b/tests/improver-ensemble-calibration/03-trunc_gaussian.bats
@@ -36,8 +36,7 @@
   KGO="ensemble-calibration/truncated_gaussian/kgo.nc"
 
   # Run ensemble calibration and check it passes.
-  run improver ensemble-calibration 'ensemble model output statistics' \
-      'm s-1' 'truncated gaussian' \
+  run improver ensemble-calibration 'm s-1' 'truncated gaussian' \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/truncated_gaussian/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/truncated_gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/truncated_gaussian/truth/*.nc" \
@@ -50,4 +49,3 @@
   improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }
-

--- a/tests/improver-ensemble-calibration/04-save_mean_and_var.bats
+++ b/tests/improver-ensemble-calibration/04-save_mean_and_var.bats
@@ -37,8 +37,8 @@
   KGO_VARIANCE="ensemble-calibration/gaussian/kgo_variance.nc"
 
   # Run ensemble calibration with saving of mean and variance and check it passes.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc" \

--- a/tests/improver-ensemble-calibration/05-current_forecast_probabilities.bats
+++ b/tests/improver-ensemble-calibration/05-current_forecast_probabilities.bats
@@ -36,8 +36,8 @@
   KGO="ensemble-calibration/probabilities/kgo.nc"
 
   # Run ensemble calibration when probabilities are input as the current forecast.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/probabilities/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/probabilities/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc" --num_realizations=18

--- a/tests/improver-ensemble-calibration/06-current_forecast_probabilities_error.bats
+++ b/tests/improver-ensemble-calibration/06-current_forecast_probabilities_error.bats
@@ -34,8 +34,8 @@
 @test "ensemble-calibration emos gaussian probabilities" {
   improver_check_skip_acceptance
   # Run ensemble calibration with saving of mean and variance and check it passes.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/probabilities/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/probabilities/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-ensemble-calibration/07-current_forecast_percentiles.bats
+++ b/tests/improver-ensemble-calibration/07-current_forecast_percentiles.bats
@@ -36,8 +36,8 @@
   KGO="ensemble-calibration/percentiles/kgo.nc"
 
   # Run ensemble calibration when percentiles are input as the current forecast.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/percentiles/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/percentiles/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc" --num_realizations=18

--- a/tests/improver-ensemble-calibration/08-current_forecast_percentiles_error.bats
+++ b/tests/improver-ensemble-calibration/08-current_forecast_percentiles_error.bats
@@ -34,8 +34,8 @@
 @test "ensemble-calibration emos gaussian percentiles" {
   improver_check_skip_acceptance
   # Run ensemble calibration with saving of mean and variance and check it passes.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/percentiles/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/percentiles/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-ensemble-calibration/09-current_forecast_rebadged_percentiles.bats
+++ b/tests/improver-ensemble-calibration/09-current_forecast_rebadged_percentiles.bats
@@ -36,8 +36,8 @@
   KGO="ensemble-calibration/percentiles/kgo.nc"
 
   # Run ensemble calibration with percentiles rebadged as realizations.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/rebadged_percentiles/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/rebadged_percentiles/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-ensemble-calibration/10-predictor_of_mean.bats
+++ b/tests/improver-ensemble-calibration/10-predictor_of_mean.bats
@@ -40,8 +40,8 @@
   fi
 
   # Run ensemble calibration using realizations as the predictor.
-  run improver ensemble-calibration 'ensemble model output statistics' 'K' \
-      'gaussian' "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
+  run improver ensemble-calibration 'K' 'gaussian' \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/history/*.nc" \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/truth/*.nc" \
       --predictor_of_mean 'realizations' \


### PR DESCRIPTION
Addresses IMPRO-1206

Removed an unused option for ensemble calibration.