### PR TITLE
IMPRO-1283: Fix OMP_NUM_THREADS for bats tests

### DIFF
--- a/tests/bin/bats
+++ b/tests/bin/bats
@@ -57,6 +57,9 @@ export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
 
+# Fixed to ensure that the number of threads is consistent when running the
+# tests on different machines. Some CLI test results exhibit precision level
+# sensitivity to the number of threads.
 export OMP_NUM_THREADS=1
 
 options=()

--- a/tests/bin/bats
+++ b/tests/bin/bats
@@ -57,6 +57,8 @@ export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
 
+export OMP_NUM_THREADS=1
+
 options=()
 arguments=()
 for arg in "$@"; do


### PR DESCRIPTION
Add an export OMP_NUM_THREADS=1 statement into tests/bin/bats to force the testing of data using this number of threads. This speeds up CLI tests by more than a factor of 2 and also removes irregularities between testing on spice and local machines for those few tests that are somehow sensitive to the threading.

This PR requires the replacement of two KGO with new versions that exhibit precision level differences.

Testing:
 - [x] Ran tests and they passed OK