### PR TITLE
IMPRO-898: CubeCombiner changes

### DIFF
--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -36,6 +36,7 @@ import iris
 
 from improver.utilities.cube_metadata import (
     resolve_metadata_diff, amend_metadata)
+from improver.utilities.cube_manipulation import expand_bounds
 
 
 class CubeCombiner(object):
@@ -78,81 +79,7 @@ class CubeCombiner(object):
                                                self.warnings_on))
         return desc
 
-    @staticmethod
-    def expand_bounds(result_cube, cubelist, coord, point):
-        """Alter a coord such that bounds are expanded to cover
-        the entire range of the input cubes.
-
-        For example, in the case of time cubes if the input cubes have
-        bounds of [0000Z, 0100Z] & [0100Z, 0200Z] then the output cube will
-        have bounds of [0000Z,0200Z]
-
-        Args:
-            result_cube (iris.cube.Cube):
-                A cube with metadata for the results.
-            cubelist (iris.cube.CubeList):
-                The list of cubes with coordinates to be combined
-            coord (str):
-                The coordinate to be combined.
-            point (str):
-                The method of calculating the new point for the coordinate.
-                Currently accepts:
-
-                    | 'mid' - halfway between the bounds
-                    | 'upper' - equal to the upper bound
-        Returns:
-            result (iris.cube.Cube):
-                Cube with coord expanded.
-
-                n.b. If argument point == 'mid' then python will convert
-                result.coord('coord').points[0] to a float UNLESS the coord
-                units contain 'seconds'.  This is to ensure that midpoints are
-                not rounded down, for example when times are in hours.
-        """
-        if len(result_cube.coord(coord).points) != 1:
-            emsg = ('the expand bounds function should only be used on a'
-                    'coordinate with a single point. The coordinate \"{}\" '
-                    'has {} points.')
-            raise ValueError(emsg.format(
-                coord,
-                len(result_cube.coord(coord).points)))
-
-        bounds = ([cube.coord(coord).bounds for cube in cubelist])
-        if any(b is None for b in bounds):
-            points = ([cube.coord(coord).points for cube in cubelist])
-            new_low_bound = np.min(points)
-            new_top_bound = np.max(points)
-        else:
-            new_low_bound = np.min(bounds)
-            new_top_bound = np.max(bounds)
-        result_coord = result_cube.coord(coord)
-        result_coord.bounds = np.array(
-            [[new_low_bound, new_top_bound]])
-        if result_coord.bounds.dtype == np.float64:
-            result_coord.bounds = result_coord.bounds.astype(np.float32)
-
-        if point == 'mid':
-            if 'seconds' in str(result_coord.units):
-                # integer division of seconds required to retain precision
-                dtype_orig = result_coord.dtype
-                result_coord.points = [
-                    (new_top_bound - new_low_bound) // 2 + new_low_bound]
-                # re-cast to original precision to avoid escalating int32s
-                result_coord.points = result_coord.points.astype(dtype_orig)
-            else:
-                # float division of hours required for accuracy
-                result_coord.points = [
-                    (new_top_bound - new_low_bound) / 2. + new_low_bound]
-        elif point == 'upper':
-            result_coord.points = [new_top_bound]
-
-        if result_coord.points.dtype == np.float64:
-            result_coord.points = result_coord.points.astype(np.float32)
-
-        return result_cube
-
-    @staticmethod
-    def combine(cube1, cube2, operation):
+    def combine(self, cube1, cube2):
         """
         Combine cube data
 
@@ -161,30 +88,22 @@ class CubeCombiner(object):
                 Cube containing data to be combined.
             cube2 (iris.cube.Cube):
                 Cube containing data to be combined.
-            operation (str):
-                Operation (+, - etc) to apply to the incoming cubes)
-
         Returns:
             result (iris.cube.Cube):
                 Cube containing the combined data.
-        Raises:
-            ValueError: Unknown operation.
-
         """
         result = cube1
-        if operation == '+' or operation == 'add' or operation == 'mean':
+        if (self.operation == '+' or self.operation == 'add' or
+                self.operation == 'mean'):
             result.data = cube1.data + cube2.data
-        elif operation == '-' or operation == 'subtract':
+        elif self.operation == '-' or self.operation == 'subtract':
             result.data = cube1.data - cube2.data
-        elif operation == '*' or operation == 'multiply':
+        elif self.operation == '*' or self.operation == 'multiply':
             result.data = cube1.data * cube2.data
-        elif operation == 'min':
+        elif self.operation == 'min':
             result.data = np.minimum(cube1.data, cube2.data)
-        elif operation == 'max':
+        elif self.operation == 'max':
             result.data = np.maximum(cube1.data, cube2.data)
-        else:
-            msg = 'Unknown operation {}'.format(operation)
-            raise ValueError(msg)
 
         return result
 
@@ -205,16 +124,21 @@ class CubeCombiner(object):
                 Revised coordinates for combined cube.
             revised_attributes (dict or None):
                 Revised attributes for combined cube.
-
+            expanded_coord (dict or None):
+                Coordinates to be expanded as a key, with the value
+                indicating whether the upper or mid point of the coordinate
+                should be used as the point value, e.g.
+                {'time': 'upper'}.
         Returns:
             result (iris.cube.Cube):
                 Cube containing the combined data.
-
+        Raises:
+            TypeError: If a cube is passed in rather than a cubelist.
+            ValueError: If the cubelist contains only one cube.
         """
         if not isinstance(cube_list, iris.cube.CubeList):
-            msg = ('Expecting data to be an instance of '
-                   'iris.cube.CubeList but is'
-                   ' {0:s}.'.format(type(cube_list)))
+            msg = ('Expecting data to be an instance of iris.cube.CubeList '
+                   'but is {}.'.format(type(cube_list)))
             raise TypeError(msg)
         if len(cube_list) < 2:
             msg = 'Expecting 2 or more cubes in cube_list'
@@ -229,20 +153,14 @@ class CubeCombiner(object):
                 resolve_metadata_diff(result.copy(),
                                       cube_list[ind].copy(),
                                       warnings_on=self.warnings_on))
-            result = self.combine(cube1,
-                                  cube2,
-                                  self.operation)
+            result = self.combine(cube1, cube2)
 
         if self.operation == 'mean':
             result.data = result.data / len(cube_list)
 
         # If cube has coord bounds that we want to expand
         if expanded_coord:
-            for coord, treatment in expanded_coord.items():
-                result = self.expand_bounds(result,
-                                            cube_list,
-                                            coord=coord,
-                                            point=treatment)
+            result = expand_bounds(result, cube_list, expanded_coord)
 
         result = amend_metadata(result,
                                 new_diagnostic_name,

--- a/lib/improver/cube_combiner.py
+++ b/lib/improver/cube_combiner.py
@@ -133,7 +133,7 @@ class CubeCombiner(object):
             result (iris.cube.Cube):
                 Cube containing the combined data.
         Raises:
-            TypeError: If a cube is passed in rather than a cubelist.
+            TypeError: If cube_list is not an iris.cube.CubeList.
             ValueError: If the cubelist contains only one cube.
         """
         if not isinstance(cube_list, iris.cube.CubeList):

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -155,7 +155,7 @@ class Test_combine(set_up_cubes):
 
     def test_mean(self):
         """Test that the function adds the cubes correctly for mean."""
-        operation = '+'
+        operation = 'mean'
         plugin = CubeCombiner(operation)
         result = plugin.combine(self.cube1, self.cube2)
         expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -32,18 +32,14 @@
 import unittest
 
 import numpy as np
-from cf_units import date2num
-from datetime import datetime as dt
+from datetime import datetime
 
 import iris
 from iris.tests import IrisTest
 from iris.cube import Cube
 
 from improver.cube_combiner import CubeCombiner
-from improver.tests.utilities.test_cube_metadata import (
-    create_cube_with_threshold)
-from improver.utilities.warnings_handler import ManageWarnings
-from improver.tests.set_up_test_cubes import set_up_variable_cube
+from improver.tests.set_up_test_cubes import set_up_probability_cube
 
 TIME_UNIT = 'seconds since 1970-01-01 00:00:00'
 CALENDAR = 'gregorian'
@@ -76,242 +72,134 @@ class Test__repr__(IrisTest):
         self.assertEqual(result, msg)
 
 
-class Test_expand_bounds(IrisTest):
-
-    """Test expand_bounds method"""
-
-    def setUp(self):
-        """Set up a cubelist for testing"""
-
-        data = 275.5*np.ones((3, 3), dtype=np.float32)
-        frt = dt(2015, 11, 19, 0)
-        time_points = [dt(2015, 11, 19, 1), dt(2015, 11, 19, 3)]
-        time_bounds = [[dt(2015, 11, 19, 0), dt(2015, 11, 19, 2)],
-                       [dt(2015, 11, 19, 1), dt(2015, 11, 19, 3)]]
-
-        self.cubelist = iris.cube.CubeList([])
-        for tpoint, tbounds in zip(time_points, time_bounds):
-            cube = set_up_variable_cube(
-                data, frt=frt, time=tpoint, time_bounds=tbounds)
-            self.cubelist.append(cube)
-
-        self.expected_bounds_seconds = [
-            date2num(dt(2015, 11, 19, 0), TIME_UNIT,
-                     CALENDAR).astype(np.int64),
-            date2num(dt(2015, 11, 19, 3), TIME_UNIT,
-                     CALENDAR).astype(np.int64)]
-
-        self.expected_bounds_hours = [
-            date2num(dt(2015, 11, 19, 0), 'hours since 1970-01-01 00:00:00',
-                     CALENDAR),
-            date2num(dt(2015, 11, 19, 3), 'hours since 1970-01-01 00:00:00',
-                     CALENDAR)]
-
-    def test_basic_time_mid(self):
-        """Test that expand_bound produces sensible bounds
-        when given arg 'mid' for times in seconds"""
-        time_point = np.around(date2num(dt(2015, 11, 19, 1, 30), TIME_UNIT,
-                                        CALENDAR)).astype(np.int64)
-        expected_result = iris.coords.DimCoord(
-            [time_point], bounds=self.expected_bounds_seconds,
-            standard_name='time', units=TIME_UNIT)
-        result = CubeCombiner.expand_bounds(
-            self.cubelist[0], self.cubelist, 'time', 'mid')
-        self.assertEqual(result.coord('time'), expected_result)
-        self.assertEqual(result.coord('time').dtype, np.int64)
-
-    def test_time_mid_data_precision(self):
-        """Test that expand_bound does not escalate precision when input is
-        of dtype int32"""
-        expected_result = iris.coords.DimCoord(
-            np.array([5400], dtype=np.int32),
-            bounds=np.array([0, 10800], dtype=np.int32),
-            standard_name='forecast_period', units='seconds')
-        result = CubeCombiner.expand_bounds(
-            self.cubelist[0], self.cubelist, 'forecast_period', 'mid')
-        self.assertEqual(result.coord('forecast_period'), expected_result)
-        self.assertEqual(result.coord('forecast_period').dtype, np.int32)
-
-    def test_float_time_mid(self):
-        """Test that expand_bound produces sensible bounds
-        when given arg 'mid' for times in hours"""
-        time_unit = 'hours since 1970-01-01 00:00:00'
-        for cube in self.cubelist:
-            cube.coord("time").convert_units(time_unit)
-        time_point = date2num(dt(2015, 11, 19, 1, 30), time_unit, CALENDAR)
-        expected_result = iris.coords.DimCoord(
-            [time_point], bounds=self.expected_bounds_hours,
-            standard_name='time', units=time_unit)
-        result = CubeCombiner.expand_bounds(
-            self.cubelist[0], self.cubelist, 'time', 'mid')
-        self.assertEqual(result.coord('time'), expected_result)
-        self.assertEqual(result.coord('time').dtype, np.float32)
-
-    def test_basic_time_upper(self):
-        """Test that expand_bound produces sensible bounds
-        when given arg 'upper'"""
-        time_point = np.around(date2num(dt(2015, 11, 19, 3), TIME_UNIT,
-                                        CALENDAR)).astype(np.int64)
-        expected_result = iris.coords.DimCoord(
-            [time_point], bounds=self.expected_bounds_seconds,
-            standard_name='time', units=TIME_UNIT)
-        result = CubeCombiner.expand_bounds(
-            self.cubelist[0], self.cubelist, 'time', 'upper')
-        self.assertEqual(result.coord('time'), expected_result)
-
-    def test_basic_no_time_bounds(self):
-        """Test that it creates appropriate bounds if there are no time bounds
-        """
-        for cube in self.cubelist:
-            cube.coord('time').bounds = None
-
-        time_point = np.around(date2num(dt(2015, 11, 19, 2), TIME_UNIT,
-                                        CALENDAR)).astype(np.int64)
-        time_bounds = [
-            np.around(date2num(dt(2015, 11, 19, 1), TIME_UNIT,
-                               CALENDAR)).astype(np.int64),
-            np.around(date2num(dt(2015, 11, 19, 3), TIME_UNIT,
-                               CALENDAR)).astype(np.int64)]
-        expected_result = iris.coords.DimCoord(
-            time_point, bounds=time_bounds,
-            standard_name='time', units=TIME_UNIT)
-
-        result = CubeCombiner.expand_bounds(
-            self.cubelist[0], self.cubelist, 'time', 'mid')
-        self.assertEqual(result.coord('time'), expected_result)
-
-    def test_fails_with_multi_point_coord(self):
-        """Test that if an error is raised if a coordinate with more than
-        one point is given"""
-        emsg = 'the expand bounds function should only be used on a'
-        with self.assertRaisesRegex(ValueError, emsg):
-            CubeCombiner.expand_bounds(
-                self.cubelist[0], self.cubelist, 'latitude', 'mid')
-
-
-class Test_combine(IrisTest):
-
-    """Test the combine method."""
+class set_up_cubes(IrisTest):
+    """Set up a common set of test cubes for subsequent test classes."""
 
     def setUp(self):
         """ Set up cubes for testing. """
-        self.cube1 = create_cube_with_threshold()
-        data = np.zeros((1, 2, 2, 2), dtype=np.float32)
-        data[0, 0, :, :] = 0.1
-        data[0, 1, :, :] = 0.4
-        self.cube2 = create_cube_with_threshold(data=data)
-        data2 = np.zeros((1, 2, 2, 2), dtype=np.float32)
-        data2[0, 0, :, :] = 0.1
-        data2[0, 1, :, :] = 0.8
-        self.cube3 = create_cube_with_threshold(data=data2)
+        data = np.full((1, 2, 2), 0.5, dtype=np.float32)
+        self.cube1 = set_up_probability_cube(
+            data, np.array([0.001], dtype=np.float32),
+            variable_name="lwe_thickness_of_precipitation_amount",
+            time=datetime(2015, 11, 19, 0),
+            time_bounds=(datetime(2015, 11, 18, 23),
+                         datetime(2015, 11, 19, 0)),
+            frt=datetime(2015, 11, 18, 22),
+            attributes={'attribute_to_update': 'first_value'})
+
+        data = np.full((1, 2, 2), 0.6, dtype=np.float32)
+        self.cube2 = set_up_probability_cube(
+            data, np.array([0.001], dtype=np.float32),
+            variable_name="lwe_thickness_of_precipitation_amount",
+            time=datetime(2015, 11, 19, 1),
+            time_bounds=(datetime(2015, 11, 19, 0),
+                         datetime(2015, 11, 19, 1)),
+            frt=datetime(2015, 11, 18, 22),
+            attributes={'attribute_to_update': 'first_value'})
+
+        data = np.full((1, 2, 2), 0.1, dtype=np.float32)
+        self.cube3 = set_up_probability_cube(
+            data, np.array([0.001], dtype=np.float32),
+            variable_name="lwe_thickness_of_precipitation_amount",
+            time=datetime(2015, 11, 19, 1),
+            time_bounds=(datetime(2015, 11, 19, 0),
+                         datetime(2015, 11, 19, 1)),
+            frt=datetime(2015, 11, 18, 22),
+            attributes={'attribute_to_update': 'first_value'})
+
+
+class Test_combine(set_up_cubes):
+
+    """Test the combine method."""
 
     def test_basic(self):
         """Test that the function returns a Cube. """
         operation = '*'
         plugin = CubeCombiner(operation)
-        cube1 = self.cube1
-        cube2 = cube1.copy()
-        result = plugin.combine(cube1, cube2, operation)
+        result = plugin.combine(self.cube1, self.cube2)
         self.assertIsInstance(result, Cube)
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.25
-        expected_data[0, 1, :, :] = 0.36
+        expected_data = np.full((1, 2, 2), 0.3, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_add(self):
         """Test combine adds the cubes correctly. """
         operation = '+'
         plugin = CubeCombiner(operation)
-        result = plugin.combine(self.cube1, self.cube2,
-                                operation)
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.6
-        expected_data[0, 1, :, :] = 1.0
+        result = plugin.combine(self.cube1, self.cube2)
+        expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_minus(self):
         """Test combine minus the cubes correctly. """
         operation = '-'
         plugin = CubeCombiner(operation)
-        result = plugin.combine(self.cube1, self.cube2,
-                                operation)
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.4
-        expected_data[0, 1, :, :] = 0.2
+        result = plugin.combine(self.cube1, self.cube2)
+        expected_data = np.full((1, 2, 2), -0.1, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_max(self):
         """Test combine finds the max of the cubes correctly."""
         operation = 'max'
         plugin = CubeCombiner(operation)
-        result = plugin.combine(self.cube1, self.cube3,
-                                operation)
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.5
-        expected_data[0, 1, :, :] = 0.8
+        result = plugin.combine(self.cube1, self.cube2)
+        expected_data = np.full((1, 2, 2), 0.6, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_min(self):
         """Test combine finds the min of the cubes correctly."""
         operation = 'min'
         plugin = CubeCombiner(operation)
-        result = plugin.combine(self.cube1, self.cube3,
-                                operation)
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.1
-        expected_data[0, 1, :, :] = 0.6
+        result = plugin.combine(self.cube1, self.cube2)
+        expected_data = np.full((1, 2, 2), 0.5, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_mean(self):
         """Test that the function adds the cubes correctly for mean."""
         operation = '+'
         plugin = CubeCombiner(operation)
-        result = plugin.combine(self.cube1, self.cube3,
-                                operation)
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.6
-        expected_data[0, 1, :, :] = 1.4
+        result = plugin.combine(self.cube1, self.cube2)
+        expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
 
-class Test_process(IrisTest):
+class Test_process(set_up_cubes):
 
     """Test the plugin combines the cubelist into a cube."""
-
-    def setUp(self):
-        """ Set up cubes for testing. """
-        self.cube1 = create_cube_with_threshold()
-        data = np.zeros((1, 2, 2, 2), dtype=np.float32)
-        data[0, 0, :, :] = 0.1
-        data[0, 1, :, :] = 0.4
-        self.cube2 = create_cube_with_threshold(data=data)
-        data2 = np.zeros((1, 2, 2, 2), dtype=np.float32)
-        data2[0, 0, :, :] = 0.9
-        data2[0, 1, :, :] = 0.2
-        self.cube3 = create_cube_with_threshold(data=data2)
 
     def test_basic(self):
         """Test that the plugin returns a Cube. """
         plugin = CubeCombiner('+')
-        cubelist = iris.cube.CubeList([self.cube1, self.cube1])
+        cubelist = iris.cube.CubeList([self.cube1, self.cube2])
         result = plugin.process(cubelist, 'new_cube_name')
         self.assertIsInstance(result, Cube)
         self.assertEqual(result.name(), 'new_cube_name')
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[:, 0, :, :] = 1.0
-        expected_data[:, 1, :, :] = 1.2
+        expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_mean(self):
         """Test that the plugin calculates the mean correctly. """
-        plugin = CubeCombiner('mean')
+        plugin = CubeCombiner('add')
         cubelist = iris.cube.CubeList([self.cube1, self.cube2])
         result = plugin.process(cubelist, 'new_cube_name')
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[:, 0, :, :] = 0.3
-        expected_data[:, 1, :, :] = 0.5
+        expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)
         self.assertEqual(result.name(), 'new_cube_name')
         self.assertArrayAlmostEqual(result.data, expected_data)
+
+    def test_bounds_expansion(self):
+        """Test that the plugin calculates the sum of the input cubes
+        correctly and expands the requested coordinate bounds in the
+        resulting output."""
+        plugin = CubeCombiner('mean')
+        expanded_coord = {'time': 'upper'}
+        cubelist = iris.cube.CubeList([self.cube1, self.cube2])
+        result = plugin.process(cubelist, 'new_cube_name',
+                                expanded_coord=expanded_coord)
+        expected_data = np.full((1, 2, 2), 0.55, dtype=np.float32)
+        self.assertEqual(result.name(), 'new_cube_name')
+        self.assertArrayAlmostEqual(result.data, expected_data)
+        self.assertEqual(result.coord('time').points[0], 1447894800)
+        self.assertArrayEqual(result.coord('time').bounds,
+                              [[1447887600, 1447894800]])
 
     def test_mean_multi_cube(self):
         """Test that the plugin calculates the mean for three cubes. """
@@ -320,30 +208,54 @@ class Test_process(IrisTest):
                                        self.cube2,
                                        self.cube3])
         result = plugin.process(cubelist, 'new_cube_name')
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[:, 0, :, :] = 0.5
-        expected_data[:, 1, :, :] = 0.4
+        expected_data = np.full((1, 2, 2), 0.4, dtype=np.float32)
         self.assertEqual(result.name(), 'new_cube_name')
         self.assertArrayAlmostEqual(result.data, expected_data)
 
-    @ManageWarnings(record=True)
-    def test_warnings_on(self, warning_list=None):
-        """Test that the plugin raises warnings and updates metadata. """
-        plugin = CubeCombiner('-', warnings_on=True)
-        cubelist = iris.cube.CubeList([self.cube1, self.cube1])
-        attributes = {'source': 'new_model'}
-        warning_msg = "Adding or updating attribute"
-        expected_data = np.zeros((1, 2, 2, 2))
-        expected_data[0, 0, :, :] = 0.0
-        expected_data[0, 1, :, :] = 0.0
+    def test_exception_for_cube_passed_in(self):
+        """Test that the plugin raises an exception if something other than a
+        cubelist is passed in."""
+        plugin = CubeCombiner('-')
+        msg = "Expecting data to be an instance of"
+
+        with self.assertRaisesRegex(TypeError, msg):
+            plugin.process(self.cube1, 'new_cube_name')
+
+    def test_exception_for_single_entry_cubelist(self):
+        """Test that the plugin raises an exception if a cubelist containing
+        only one cube is passed in."""
+        plugin = CubeCombiner('-')
+        msg = "Expecting 2 or more cubes in cube_list"
+
+        cubelist = iris.cube.CubeList([self.cube1])
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin.process(cubelist, 'new_cube_name')
+
+    def test_revised_coords(self):
+        """Test that the plugin passes through the relevant dictionary to
+        modify a coordinate and that these modifications are present in the
+        returned cube."""
+        plugin = CubeCombiner('mean')
+        revised_coords = {'lwe_thickness_of_precipitation_amount': {
+            'points': [2.0]}}
+        cubelist = iris.cube.CubeList([self.cube1, self.cube2])
         result = plugin.process(cubelist, 'new_cube_name',
-                                revised_attributes=attributes)
-        self.assertTrue(any(item.category == UserWarning
-                            for item in warning_list))
-        self.assertTrue(any(warning_msg in str(item)
-                            for item in warning_list))
-        self.assertEqual(result.name(), 'new_cube_name')
-        self.assertArrayAlmostEqual(result.data, expected_data)
+                                revised_coords=revised_coords)
+        self.assertEqual(
+            result.coord('lwe_thickness_of_precipitation_amount').points[0],
+            2.0)
+
+    def test_revised_attributes(self):
+        """Test that the plugin passes through the relevant dictionary to
+        modify an attribute and that these modifications are present in the
+        returned cube."""
+        plugin = CubeCombiner('mean')
+        revised_attributes = {'attribute_to_update': 'second_value'}
+        cubelist = iris.cube.CubeList([self.cube1, self.cube2])
+        result = plugin.process(cubelist, 'new_cube_name',
+                                revised_attributes=revised_attributes)
+        self.assertEqual(result.attributes['attribute_to_update'],
+                         'second_value')
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/cube_combiner/test_CubeCombiner.py
+++ b/lib/improver/tests/cube_combiner/test_CubeCombiner.py
@@ -178,10 +178,10 @@ class Test_process(set_up_cubes):
 
     def test_mean(self):
         """Test that the plugin calculates the mean correctly. """
-        plugin = CubeCombiner('add')
+        plugin = CubeCombiner('mean')
         cubelist = iris.cube.CubeList([self.cube1, self.cube2])
         result = plugin.process(cubelist, 'new_cube_name')
-        expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)
+        expected_data = np.full((1, 2, 2), 0.55, dtype=np.float32)
         self.assertEqual(result.name(), 'new_cube_name')
         self.assertArrayAlmostEqual(result.data, expected_data)
 
@@ -189,12 +189,12 @@ class Test_process(set_up_cubes):
         """Test that the plugin calculates the sum of the input cubes
         correctly and expands the requested coordinate bounds in the
         resulting output."""
-        plugin = CubeCombiner('mean')
+        plugin = CubeCombiner('add')
         expanded_coord = {'time': 'upper'}
         cubelist = iris.cube.CubeList([self.cube1, self.cube2])
         result = plugin.process(cubelist, 'new_cube_name',
                                 expanded_coord=expanded_coord)
-        expected_data = np.full((1, 2, 2), 0.55, dtype=np.float32)
+        expected_data = np.full((1, 2, 2), 1.1, dtype=np.float32)
         self.assertEqual(result.name(), 'new_cube_name')
         self.assertArrayAlmostEqual(result.data, expected_data)
         self.assertEqual(result.coord('time').points[0], 1447894800)

--- a/lib/improver/tests/utilities/cube_manipulation/test_expand_bounds.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_expand_bounds.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Unit tests for the function "cube_manipulation.expand_bounds".
+"""
+import unittest
+from datetime import datetime as dt
+import numpy as np
+from cf_units import date2num
+
+import iris
+from iris.tests import IrisTest
+
+from improver.utilities.cube_manipulation import expand_bounds
+from improver.tests.set_up_test_cubes import set_up_variable_cube
+
+TIME_UNIT = 'seconds since 1970-01-01 00:00:00'
+CALENDAR = 'gregorian'
+
+
+class Test_expand_bounds(IrisTest):
+
+    """Test expand_bounds function"""
+
+    def setUp(self):
+        """Set up a cubelist for testing"""
+
+        data = 275.5*np.ones((3, 3), dtype=np.float32)
+        frt = dt(2015, 11, 19, 0)
+        time_points = [dt(2015, 11, 19, 1), dt(2015, 11, 19, 3)]
+        time_bounds = [[dt(2015, 11, 19, 0), dt(2015, 11, 19, 2)],
+                       [dt(2015, 11, 19, 1), dt(2015, 11, 19, 3)]]
+
+        self.cubelist = iris.cube.CubeList([])
+        for tpoint, tbounds in zip(time_points, time_bounds):
+            cube = set_up_variable_cube(
+                data, frt=frt, time=tpoint, time_bounds=tbounds)
+            self.cubelist.append(cube)
+
+        self.expected_bounds_seconds = [
+            date2num(dt(2015, 11, 19, 0), TIME_UNIT,
+                     CALENDAR).astype(np.int64),
+            date2num(dt(2015, 11, 19, 3), TIME_UNIT,
+                     CALENDAR).astype(np.int64)]
+
+        self.expected_bounds_hours = [
+            date2num(dt(2015, 11, 19, 0), 'hours since 1970-01-01 00:00:00',
+                     CALENDAR),
+            date2num(dt(2015, 11, 19, 3), 'hours since 1970-01-01 00:00:00',
+                     CALENDAR)]
+
+    def test_basic_time_mid(self):
+        """Test that expand_bound produces sensible bounds
+        when given arg 'mid' for times in seconds"""
+        time_point = np.around(date2num(dt(2015, 11, 19, 1, 30), TIME_UNIT,
+                                        CALENDAR)).astype(np.int64)
+        expected_result = iris.coords.DimCoord(
+            [time_point], bounds=self.expected_bounds_seconds,
+            standard_name='time', units=TIME_UNIT)
+        result = expand_bounds(
+            self.cubelist[0], self.cubelist, {'time': 'mid'})
+        self.assertEqual(result.coord('time'), expected_result)
+        self.assertEqual(result.coord('time').dtype, np.int64)
+
+    def test_time_mid_data_precision(self):
+        """Test that expand_bound does not escalate precision when input is
+        of dtype int32"""
+        expected_result = iris.coords.DimCoord(
+            np.array([5400], dtype=np.int32),
+            bounds=np.array([0, 10800], dtype=np.int32),
+            standard_name='forecast_period', units='seconds')
+        result = expand_bounds(
+            self.cubelist[0], self.cubelist, {'forecast_period': 'mid'})
+        self.assertEqual(result.coord('forecast_period'), expected_result)
+        self.assertEqual(result.coord('forecast_period').dtype, np.int32)
+
+    def test_float_time_mid(self):
+        """Test that expand_bound produces sensible bounds
+        when given arg 'mid' for times in hours"""
+        time_unit = 'hours since 1970-01-01 00:00:00'
+        for cube in self.cubelist:
+            cube.coord("time").convert_units(time_unit)
+        time_point = date2num(dt(2015, 11, 19, 1, 30), time_unit, CALENDAR)
+        expected_result = iris.coords.DimCoord(
+            [time_point], bounds=self.expected_bounds_hours,
+            standard_name='time', units=time_unit)
+        result = expand_bounds(
+            self.cubelist[0], self.cubelist, {'time': 'mid'})
+        self.assertEqual(result.coord('time'), expected_result)
+        self.assertEqual(result.coord('time').dtype, np.float32)
+
+    def test_basic_time_upper(self):
+        """Test that expand_bound produces sensible bounds
+        when given arg 'upper'"""
+        time_point = np.around(date2num(dt(2015, 11, 19, 3), TIME_UNIT,
+                                        CALENDAR)).astype(np.int64)
+        expected_result = iris.coords.DimCoord(
+            [time_point], bounds=self.expected_bounds_seconds,
+            standard_name='time', units=TIME_UNIT)
+        result = expand_bounds(
+            self.cubelist[0], self.cubelist, {'time': 'upper'})
+        self.assertEqual(result.coord('time'), expected_result)
+
+    def test_multiple_coordinate_expanded(self):
+        """Test that expand_bound produces sensible bounds when more than one
+        coordinate is operated on, in this case expanding both the time and
+        forecast period coordinates."""
+        time_point = np.around(date2num(dt(2015, 11, 19, 3), TIME_UNIT,
+                                        CALENDAR)).astype(np.int64)
+        expected_result_time = iris.coords.DimCoord(
+            [time_point], bounds=self.expected_bounds_seconds,
+            standard_name='time', units=TIME_UNIT)
+        expected_result_fp = iris.coords.DimCoord(
+            [10800], bounds=[0, 10800],
+            standard_name='forecast_period', units='seconds')
+
+        result = expand_bounds(self.cubelist[0], self.cubelist,
+                               {'time': 'upper',
+                                'forecast_period': 'upper'})
+        self.assertEqual(result.coord('time'), expected_result_time)
+        self.assertEqual(result.coord('forecast_period'), expected_result_fp)
+
+        self.assertEqual(result.coord('time').dtype, np.int64)
+
+    def test_basic_no_time_bounds(self):
+        """Test that it creates appropriate bounds if there are no time bounds
+        """
+        for cube in self.cubelist:
+            cube.coord('time').bounds = None
+
+        time_point = np.around(date2num(dt(2015, 11, 19, 2), TIME_UNIT,
+                                        CALENDAR)).astype(np.int64)
+        time_bounds = [
+            np.around(date2num(dt(2015, 11, 19, 1), TIME_UNIT,
+                               CALENDAR)).astype(np.int64),
+            np.around(date2num(dt(2015, 11, 19, 3), TIME_UNIT,
+                               CALENDAR)).astype(np.int64)]
+        expected_result = iris.coords.DimCoord(
+            time_point, bounds=time_bounds,
+            standard_name='time', units=TIME_UNIT)
+
+        result = expand_bounds(
+            self.cubelist[0], self.cubelist, {'time': 'mid'})
+        self.assertEqual(result.coord('time'), expected_result)
+
+    def test_fails_with_multi_point_coord(self):
+        """Test that if an error is raised if a coordinate with more than
+        one point is given"""
+        emsg = 'the expand bounds function should only be used on a'
+        with self.assertRaisesRegex(ValueError, emsg):
+            expand_bounds(
+                self.cubelist[0], self.cubelist, {'latitude': 'mid'})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -159,7 +159,7 @@ def check_precision_loss(dtype, data, precision=5):
     may be lossy if changing from 64 bit to 32 bit floats, but changes at this
     precision are not captured here by design.
 
-    If the conversion is lossless (to the defined precision) this fuction
+    If the conversion is lossless (to the defined precision) this function
     returns True. If there is loss, the function returns False.
 
     .. See the documentation for examples of where such loss is important.

--- a/lib/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/lib/improver/wind_calculations/wind_gust_diagnostic.py
@@ -226,7 +226,7 @@ class WindGustDiagnostic(object):
 
         # Calculate wind-gust diagnostic using CubeCombiner
         plugin = CubeCombiner('max')
-        result = plugin.combine(req_cube_gust, req_cube_ws, 'max')
+        result = plugin.combine(req_cube_gust, req_cube_ws)
 
         # Update metadata
         result = self.update_metadata_after_max(result,


### PR DESCRIPTION
Factored out expand_bounds into cube_manipulation utilities. Rewrote CubeCombiner unit tests to match current standards (having checked the originals passed after the refactoring first).

This change allows me to use the expand bounds component of CubeCombiner in isolation without needing the plugin itself. I have also slightly rejigged the implementation such that expand_bounds can handle the modification of multiple coordinates, whereas previously this was achieved using a loop external to the function (in CubeCombiner.process).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)