### PR TITLE
Removed blending mode option from blending CLIs and tests

### DIFF
--- a/lib/improver/cli/blend_adjacent_points.py
+++ b/lib/improver/cli/blend_adjacent_points.py
@@ -80,11 +80,6 @@ def main(argv=None):
                         'be used when time and forecast_period share a '
                         'dimension: ie when all files provided are from the '
                         'same forecast cycle.')
-    parser.add_argument('weighting_mode', metavar='WEIGHTED_BLEND_MODE',
-                        choices=['weighted_mean'],
-                        help='The method used in the weighted blend. '
-                             '"weighted_mean": calculate a normal weighted'
-                             ' mean across the coordinate.')
     parser.add_argument('input_filepaths', metavar='INPUT_FILES', nargs="+",
                         help='Paths to input NetCDF files including and '
                              'surrounding the central_point.')

--- a/lib/improver/cli/weighted_blending.py
+++ b/lib/improver/cli/weighted_blending.py
@@ -96,11 +96,6 @@ def main(argv=None):
                              ' we are blending. The spatial weights are'
                              ' calculated using the'
                              ' SpatiallyVaryingWeightsFromMask plugin.')
-    parser.add_argument('weighting_mode', metavar='WEIGHTED_BLEND_MODE',
-                        choices=['weighted_mean'],
-                        help='The method used in the weighted blend. '
-                             '"weighted_mean": calculate a normal weighted'
-                             ' mean across the coordinate.')
 
     parser.add_argument('input_filepaths', metavar='INPUT_FILES',
                         nargs="+",

--- a/tests/improver-blend-adjacent-points/00-null.bats
+++ b/tests/improver-blend-adjacent-points/00-null.bats
@@ -39,8 +39,8 @@ usage: improver blend-adjacent-points [-h] [--profile]
                                       --width TRIANGLE_WIDTH
                                       [--blend_time_using_forecast_period]
                                       COORDINATE_TO_BLEND_OVER CENTRAL_POINT
-                                      WEIGHTED_BLEND_MODE INPUT_FILES
-                                      [INPUT_FILES ...] OUTPUT_FILE
+                                      INPUT_FILES [INPUT_FILES ...]
+                                      OUTPUT_FILE
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-blend-adjacent-points/01-help.bats
+++ b/tests/improver-blend-adjacent-points/01-help.bats
@@ -39,8 +39,8 @@ usage: improver blend-adjacent-points [-h] [--profile]
                                       --width TRIANGLE_WIDTH
                                       [--blend_time_using_forecast_period]
                                       COORDINATE_TO_BLEND_OVER CENTRAL_POINT
-                                      WEIGHTED_BLEND_MODE INPUT_FILES
-                                      [INPUT_FILES ...] OUTPUT_FILE
+                                      INPUT_FILES [INPUT_FILES ...]
+                                      OUTPUT_FILE
 
 Use the TriangularWeightedBlendAcrossAdjacentPoints to blend across a
 particular coordinate. It does not collapse the coordinate, but instead blends
@@ -56,9 +56,6 @@ positional arguments:
                         in the units of the units argument that is passed in.
                         This value should be a point on the coordinate for
                         blending over.
-  WEIGHTED_BLEND_MODE   The method used in the weighted blend.
-                        "weighted_mean": calculate a normal weighted mean
-                        across the coordinate.
   INPUT_FILES           Paths to input NetCDF files including and surrounding
                         the central_point.
   OUTPUT_FILE           The output path for the processed NetCDF.

--- a/tests/improver-blend-adjacent-points/02-basic_mean.bats
+++ b/tests/improver-blend-adjacent-points/02-basic_mean.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with weighted_mean mode and check it passes.
   run improver blend-adjacent-points 'forecast_period' '2' --units 'hours' \
-      --width 3.0 'weighted_mean' \
+      --width 3.0 \
       "$IMPROVER_ACC_TEST_DIR/blend-adjacent-points/basic_mean/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-blend-adjacent-points/03-time_bounds.bats
+++ b/tests/improver-blend-adjacent-points/03-time_bounds.bats
@@ -37,7 +37,7 @@
 
   # Run triangular time blending with matched time bounds and check it passes
   run improver blend-adjacent-points 'forecast_period' '4' --units 'hours' \
-      --width 2 'weighted_mean' \
+      --width 2 \
       "$IMPROVER_ACC_TEST_DIR/blend-adjacent-points/time_bounds/*wind_gust*.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-blend-adjacent-points/04-mismatched_bounds_ranges.bats
+++ b/tests/improver-blend-adjacent-points/04-mismatched_bounds_ranges.bats
@@ -36,7 +36,7 @@
 
   # Run triangular time blending with mismatched time bounds ranges and check it fails
   run improver blend-adjacent-points 'forecast_period' '2' --units 'hours' \
-      --width 3.0 'weighted_mean' --blend_time_using_forecast_period \
+      --width 3.0 --blend_time_using_forecast_period \
       "$IMPROVER_ACC_TEST_DIR/blend-adjacent-points/basic_mean/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 1 ]]

--- a/tests/improver-blend-adjacent-points/05-mismatched_args.bats
+++ b/tests/improver-blend-adjacent-points/05-mismatched_args.bats
@@ -36,7 +36,7 @@
 
   # Run triangular time blending with inappropriate arguments and check it fails
   run improver blend-adjacent-points 'model' '2' --units 'None' \
-      --width 3.0 'weighted_mean' --blend_time_using_forecast_period \
+      --width 3.0 --blend_time_using_forecast_period \
       "$IMPROVER_ACC_TEST_DIR/blend-adjacent-points/basic_mean/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 1 ]]

--- a/tests/improver-blend-adjacent-points/06-time.bats
+++ b/tests/improver-blend-adjacent-points/06-time.bats
@@ -35,8 +35,8 @@
   improver_check_skip_acceptance
 
   # Run triangular time blending and see what happens...
-  run improver blend-adjacent-points 'time' '1536908400' --units 'seconds since 1970-01-01 00:00:00' \
-      --width 7200 'weighted_mean' \
+  run improver blend-adjacent-points 'time' '1536908400' \
+      --units 'seconds since 1970-01-01 00:00:00' --width 7200 \
       "$IMPROVER_ACC_TEST_DIR/blend-adjacent-points/time_bounds/*wind_gust*.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 1 ]]

--- a/tests/improver-weighted-blending/00-null.bats
+++ b/tests/improver-weighted-blending/00-null.bats
@@ -45,8 +45,7 @@ usage: improver weighted-blending [-h] [--profile]
                                   [--cval NON_LINEAR_FACTOR]
                                   [--wts_dict WEIGHTS_DICTIONARY]
                                   [--weighting_coord WEIGHTING_COORD]
-                                  COORDINATE_TO_AVERAGE_OVER
-                                  WEIGHTED_BLEND_MODE INPUT_FILES
+                                  COORDINATE_TO_AVERAGE_OVER INPUT_FILES
                                   [INPUT_FILES ...] OUTPUT_FILE
 __TEXT__
   [[ "$output" =~ "$expected" ]]

--- a/tests/improver-weighted-blending/01-help.bats
+++ b/tests/improver-weighted-blending/01-help.bats
@@ -45,8 +45,7 @@ usage: improver weighted-blending [-h] [--profile]
                                   [--cval NON_LINEAR_FACTOR]
                                   [--wts_dict WEIGHTS_DICTIONARY]
                                   [--weighting_coord WEIGHTING_COORD]
-                                  COORDINATE_TO_AVERAGE_OVER
-                                  WEIGHTED_BLEND_MODE INPUT_FILES
+                                  COORDINATE_TO_AVERAGE_OVER INPUT_FILES
                                   [INPUT_FILES ...] OUTPUT_FILE
 
 Calculate the default weights to apply in weighted blending plugins using the
@@ -60,9 +59,6 @@ positional arguments:
   COORDINATE_TO_AVERAGE_OVER
                         The coordinate over which the blending will be
                         applied.
-  WEIGHTED_BLEND_MODE   The method used in the weighted blend.
-                        "weighted_mean": calculate a normal weighted mean
-                        across the coordinate.
   INPUT_FILES           Paths to input files to be blended.
   OUTPUT_FILE           The output path for the processed NetCDF.
 

--- a/tests/improver-weighted-blending/02-basic_nonlin.bats
+++ b/tests/improver-weighted-blending/02-basic_nonlin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/basic_nonlin/kgo.nc"
 
   # Run weighted blending with non linear weights and check it passes.
-  run improver weighted-blending --wts_calc_method 'nonlinear' 'forecast_reference_time' 'weighted_mean'\
+  run improver weighted-blending --wts_calc_method 'nonlinear' 'forecast_reference_time' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/03-basic_lin.bats
+++ b/tests/improver-weighted-blending/03-basic_lin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/basic_lin/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
+  run improver weighted-blending 'forecast_reference_time' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/04-bothoptions_fail.bats
+++ b/tests/improver-weighted-blending/04-bothoptions_fail.bats
@@ -32,7 +32,7 @@
 
 @test "weighted-blending invalid method" {
   # Run blending with linear and nonlinear: check it fails.
-  run improver weighted-blending --wts_calc_method 'linear nonlinear' 'time'  'weighted_mean'\
+  run improver weighted-blending --wts_calc_method 'linear nonlinear' 'time' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "NO_OUTPUT_FILE"
   [[ "${status}" -eq 2 ]]
@@ -49,8 +49,7 @@ usage: improver weighted-blending [-h] [--profile]
                                   [--cval NON_LINEAR_FACTOR]
                                   [--wts_dict WEIGHTS_DICTIONARY]
                                   [--weighting_coord WEIGHTING_COORD]
-                                  COORDINATE_TO_AVERAGE_OVER
-                                  WEIGHTED_BLEND_MODE INPUT_FILES
+                                  COORDINATE_TO_AVERAGE_OVER INPUT_FILES
                                   [INPUT_FILES ...] OUTPUT_FILE
 improver weighted-blending: error: argument --wts_calc_method: invalid choice: 'linear nonlinear' (choose from 'linear', 'nonlinear', 'dict')
 

--- a/tests/improver-weighted-blending/05-options_nonlin.bats
+++ b/tests/improver-weighted-blending/05-options_nonlin.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with non linear weights and sub-options and check it passes.
   run improver weighted-blending --wts_calc_method 'nonlinear' \
-      'forecast_reference_time' 'weighted_mean' --cval 1.0 \
+      'forecast_reference_time' --cval 1.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/06-options_lin.bats
+++ b/tests/improver-weighted-blending/06-options_lin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/options_lin/kgo.nc"
 
   # Run weighted blending with linear weights and suboptions: y0val and ynval. Check it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' --y0val 0.0 --ynval 4.0 \
+  run improver weighted-blending 'forecast_reference_time' --y0val 0.0 --ynval 4.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/07-invalid_args_lin_nonlin.bats
+++ b/tests/improver-weighted-blending/07-invalid_args_lin_nonlin.bats
@@ -33,7 +33,7 @@
 
 @test "weighted-blending linear invalid options" {
   # Run blending with linear weights calculation but nonlinear args: check it fails.
-  run improver weighted-blending 'time' 'weighted_mean' --ynval 1 --cval 0.5\
+  run improver weighted-blending 'time' --ynval 1 --cval 0.5\
       "NO_INPUT_FILE" \
       "NO_OUTPUT_FILE"
   [[ "${status}" -eq 2 ]]
@@ -50,8 +50,7 @@ usage: improver weighted-blending [-h] [--profile]
                                   [--cval NON_LINEAR_FACTOR]
                                   [--wts_dict WEIGHTS_DICTIONARY]
                                   [--weighting_coord WEIGHTING_COORD]
-                                  COORDINATE_TO_AVERAGE_OVER
-                                  WEIGHTED_BLEND_MODE INPUT_FILES
+                                  COORDINATE_TO_AVERAGE_OVER INPUT_FILES
                                   [INPUT_FILES ...] OUTPUT_FILE
 improver weighted-blending: error: Method: linear does not accept arguments: cval
 __TEXT__

--- a/tests/improver-weighted-blending/08-invalid_args_nonlin_lin.bats
+++ b/tests/improver-weighted-blending/08-invalid_args_nonlin_lin.bats
@@ -33,7 +33,7 @@
 
 @test "weighted-blending nonlinear invalid options" {
   # Run blending with non-linear weights calculation but linear args: check it fails.
-  run improver weighted-blending --wts_calc_method 'nonlinear' 'time' 'weighted_mean' --ynval 1 --y0val 0\
+  run improver weighted-blending --wts_calc_method 'nonlinear' 'time' --ynval 1 --y0val 0\
       "NO_INPUT_FILE" \
       "NO_OUTPUT_FILE"
   [[ "${status}" -eq 2 ]]
@@ -50,8 +50,7 @@ usage: improver weighted-blending [-h] [--profile]
                                   [--cval NON_LINEAR_FACTOR]
                                   [--wts_dict WEIGHTS_DICTIONARY]
                                   [--weighting_coord WEIGHTING_COORD]
-                                  COORDINATE_TO_AVERAGE_OVER
-                                  WEIGHTED_BLEND_MODE INPUT_FILES
+                                  COORDINATE_TO_AVERAGE_OVER INPUT_FILES
                                   [INPUT_FILES ...] OUTPUT_FILE
 improver weighted-blending: error: Method: non-linear does not accept arguments: y0val, ynval
 __TEXT__

--- a/tests/improver-weighted-blending/09-percentile_blending.bats
+++ b/tests/improver-weighted-blending/09-percentile_blending.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with non linear weights and sub-options and check it passes.
   run improver weighted-blending --wts_calc_method 'nonlinear' \
-      'forecast_reference_time' 'weighted_mean' --cval 1.0 \
+      'forecast_reference_time' --cval 1.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/percentiles/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/10-cycletime.bats
+++ b/tests/improver-weighted-blending/10-cycletime.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/cycletime/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
+  run improver weighted-blending 'forecast_reference_time' \
       --y0val 1.0 --ynval 4.0 --cycletime '20171129T0900Z'\
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/cycletime/input.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/11-model_blending.bats
+++ b/tests/improver-weighted-blending/11-model_blending.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with linear weights for two input files and check it
   # passes.
-  run improver weighted-blending 'model_configuration' 'weighted_mean' \
+  run improver weighted-blending 'model_configuration' \
       --ynval 1 --y0val 1 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/ukv_input.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/enuk_input.nc" \

--- a/tests/improver-weighted-blending/12-realization_collapse.bats
+++ b/tests/improver-weighted-blending/12-realization_collapse.bats
@@ -36,7 +36,7 @@
 
   # Run weighted blending with linear weights and check it passes,
   # after realization collapse.
-  run improver weighted-blending 'realization' 'weighted_mean' \
+  run improver weighted-blending 'realization' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/realizations/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/13-weights_from_dict.bats
+++ b/tests/improver-weighted-blending/13-weights_from_dict.bats
@@ -39,7 +39,7 @@
   # passes.
   run improver weighted-blending --wts_calc_method 'dict' \
       --wts_dict "$IMPROVER_ACC_TEST_DIR/weighted_blending/weights_from_dict/input_dict.json" \
-      --weighting_coord 'forecast_period' 'model_configuration' 'weighted_mean' \
+      --weighting_coord 'forecast_period' 'model_configuration' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/ukv_input.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/enuk_input.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/14-percentile_weights_from_dict.bats
+++ b/tests/improver-weighted-blending/14-percentile_weights_from_dict.bats
@@ -38,7 +38,7 @@
   # Run weighted blending with linear weights for two percentile input files
   run improver weighted-blending --wts_calc_method 'dict' \
       --wts_dict "$IMPROVER_ACC_TEST_DIR/weighted_blending/weights_from_dict/input_dict.json" \
-      --weighting_coord 'forecast_period' 'model_configuration' 'weighted_mean' \
+      --weighting_coord 'forecast_period' 'model_configuration' \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/percentile_weights_from_dict/ukv_input.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/percentile_weights_from_dict/enuk_input.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/15-accum_cycle_blend.bats
+++ b/tests/improver-weighted-blending/15-accum_cycle_blend.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/accum_cycle_blend/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
+  run improver weighted-blending 'forecast_reference_time' \
       $IMPROVER_ACC_TEST_DIR/weighted_blending/accum_cycle_blend/ukv_prob_accum_PT?H.nc \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/16-non_mo_model.bats
+++ b/tests/improver-weighted-blending/16-non_mo_model.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with linear weights for two input files and check it
   # passes.
-  run improver weighted-blending 'model_configuration' 'weighted_mean' \
+  run improver weighted-blending 'model_configuration' \
       --ynval 1 --y0val 1 \
       "$IMPROVER_ACC_TEST_DIR//weighted_blending/non_mo_model/non_mo_det.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/non_mo_model/non_mo_ens.nc" \

--- a/tests/improver-weighted-blending/17-nowcast_cycle_blending.bats
+++ b/tests/improver-weighted-blending/17-nowcast_cycle_blending.bats
@@ -37,7 +37,7 @@
 
   # Run weighted blending with linear weights for three input files and check
   # it passes.
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
+  run improver weighted-blending 'forecast_reference_time' \
       --ynval 1 --y0val 1 --spatial_weights_from_mask \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0003H00M-lwe_precipitation_rate.nc" \

--- a/tests/improver-weighted-blending/18-spatial_model_blending.bats
+++ b/tests/improver-weighted-blending/18-spatial_model_blending.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/spatial_weights/kgo/model.nc"
 
   # Run weighted blending with ukvx and nowcast data using spatial weights
-  run improver weighted-blending 'model_configuration' 'weighted_mean' \
+  run improver weighted-blending 'model_configuration' \
       --ynval 1 --y0val 1 --spatial_weights_from_mask \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/ukvx_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \

--- a/tests/improver-weighted-blending/19-nowcast_cycle_blending_no_fuzzy.bats
+++ b/tests/improver-weighted-blending/19-nowcast_cycle_blending_no_fuzzy.bats
@@ -36,8 +36,8 @@
   KGO="weighted_blending/spatial_weights/kgo/cycle_no_fuzzy.nc"
 
   # Run weighted blending between different nowcast files using spatial weights
-  run improver weighted-blending 'forecast_reference_time' 'weighted_mean' \
-      --ynval 1 --y0val 1 --spatial_weights_from_mask --fuzzy_length 1\
+  run improver weighted-blending 'forecast_reference_time' \
+      --ynval 1 --y0val 1 --spatial_weights_from_mask --fuzzy_length 1 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0003H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0004H00M-lwe_precipitation_rate.nc" \

--- a/tests/improver-weighted-blending/20-spatial_model_blending_no_fuzzy.bats
+++ b/tests/improver-weighted-blending/20-spatial_model_blending_no_fuzzy.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/spatial_weights/kgo/model_no_fuzzy.nc"
 
   # Run weighted blending with ukvx and nowcast data using spatial weights and no spatial fuzziness
-  run improver weighted-blending 'model_configuration' 'weighted_mean' \
+  run improver weighted-blending 'model_configuration' \
       --ynval 1 --y0val 1 --spatial_weights_from_mask --fuzzy_length 1 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/ukvx_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \

--- a/tests/improver-weighted-blending/21-three_model_blending.bats
+++ b/tests/improver-weighted-blending/21-three_model_blending.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/three_models/kgo.nc"
 
   # Run weighted blending with ukvx and nowcast data using spatial weights
-  run improver weighted-blending 'model_configuration' 'weighted_mean' \
+  run improver weighted-blending 'model_configuration' \
       --spatial_weights_from_mask --wts_calc_method 'dict' \
       --weighting_coord forecast_period --cycletime 20190101T0300Z \
       --wts_dict $IMPROVER_ACC_TEST_DIR/weighted_blending/three_models/blending-weights-preciprate.json \


### PR DESCRIPTION
Follow-up from #804

This should be merged at the same time as the associated suite change: https://github.com/MetOffice/improver_suite/pull/336

Testing:
 - [x] Ran tests and they passed OK
