### PR TITLE
IMPRO-1003 sort out default weights plugins & blending CLI options

### DIFF
--- a/lib/improver/blending/calculate_weights_and_blend.py
+++ b/lib/improver/blending/calculate_weights_and_blend.py
@@ -49,7 +49,7 @@ class WeightAndBlend():
     """
     def __init__(self, blend_coord, wts_calc_method,
                  weighting_coord=None, wts_dict=None,
-                 y0val=None, ynval=None, cval=None):
+                 y0val=None, ynval=None, cval=None, inverse_ordering=False):
         """
         Initialise central parameters
 
@@ -72,6 +72,10 @@ class WeightAndBlend():
                 Relative weight of last file for default linear weights plugin
             cval (float):
                 Parameter for default non-linear weights plugin
+            inverse_ordering (bool):
+                Option to invert weighting order for non-linear weights plugin
+                so that higher blend coordinate values get higher weights (eg
+                if cycle blending over forecast reference time).
         """
         self.blend_coord = blend_coord
         self.wts_calc_method = wts_calc_method
@@ -84,7 +88,10 @@ class WeightAndBlend():
             self.y0val = y0val
             self.ynval = ynval
         elif self.wts_calc_method == "nonlinear":
+            # the default cval is set here rather than in the CLI arguments
+            # in order to check for invalid argument combinations
             self.cval = cval if cval else 0.85
+            self.inverse_ordering = inverse_ordering
         else:
             raise ValueError(
                 "Weights calculation method '{}' unrecognised".format(
@@ -103,15 +110,12 @@ class WeightAndBlend():
             weights (iris.cube.Cube):
                 Cube containing 1D array of weights for blending
         """
-        # calculate blending weights
         if self.wts_calc_method == "dict":
-            # get dictionary access
             if "model" in self.blend_coord:
                 config_coord = "model_configuration"
             else:
                 config_coord = self.blend_coord
 
-            # calculate linear weights from dictionary
             weights = ChooseWeightsLinear(
                 self.weighting_coord, self.wts_dict,
                 config_coord_name=config_coord).process(cube)
@@ -122,10 +126,8 @@ class WeightAndBlend():
                     cube, self.blend_coord)
 
         elif self.wts_calc_method == "nonlinear":
-            # this is set here rather than in the CLI arguments in order to
-            # check for invalid argument combinations
             weights = ChooseDefaultWeightsNonLinear(self.cval).process(
-                cube, self.blend_coord)
+                cube, self.blend_coord, inverse_ordering=self.inverse_ordering)
 
         return weights
 

--- a/lib/improver/blending/calculate_weights_and_blend.py
+++ b/lib/improver/blending/calculate_weights_and_blend.py
@@ -88,9 +88,7 @@ class WeightAndBlend():
             self.y0val = y0val
             self.ynval = ynval
         elif self.wts_calc_method == "nonlinear":
-            # the default cval is set here rather than in the CLI arguments
-            # in order to check for invalid argument combinations
-            self.cval = cval if cval else 0.85
+            self.cval = cval
             self.inverse_ordering = inverse_ordering
         else:
             raise ValueError(

--- a/lib/improver/blending/weights.py
+++ b/lib/improver/blending/weights.py
@@ -59,7 +59,7 @@ class WeightsUtilities:
         """Ensures all weights add up to one.
 
             Args:
-                weights (numpy.array):
+                weights (numpy.ndarray):
                     array of weights
 
             Keyword Args:
@@ -69,7 +69,7 @@ class WeightsUtilities:
                     array is used for the normalisation.
 
             Returns:
-                normalised_weights (numpy.array):
+                normalised_weights (numpy.ndarray):
                     array of weights where sum = 1.0
 
             Raises:
@@ -96,9 +96,9 @@ class WeightsUtilities:
             Args:
                 cube (iris.cube.Cube):
                     The cube that is being blended over blending_coord.
-                weights (numpy.array):
+                weights (numpy.ndarray):
                     Array of weights
-                blending_coord (string):
+                blending_coord (str):
                     Name of the coordinate over which the weights will be used
                     to blend data, e.g. across model name when grid blending.
             Returns:
@@ -485,9 +485,9 @@ class ChooseDefaultWeightsLinear:
         Set up for calculating default weights using linear function.
 
         Args:
-            y0val (int / float):
+            y0val (int or float):
                 Relative weight of first point.  Must be positive.
-            ynval (int / float):
+            ynval (int or float):
                 Relative weight of last point.
         """
         if y0val is None or ynval is None:
@@ -510,7 +510,7 @@ class ChooseDefaultWeightsLinear:
                     Number of weights to create.
 
             Returns:
-                weights (numpy.array):
+                weights (numpy.ndarray):
                     array of weights, sum of all weights = 1.0
         """
         # Special case num_of_weights == 1 i.e. Scalar coordinate.
@@ -539,7 +539,7 @@ class ChooseDefaultWeightsLinear:
         Args:
             cube (iris.cube.Cube):
                 Cube to blend across the coord.
-            coord_name (string):
+            coord_name (str):
                 Name of coordinate in the cube to be blended.
 
         Returns:
@@ -604,7 +604,7 @@ class ChooseDefaultWeightsNonLinear:
                 Number of weights to create
 
         Returns:
-            weights (numpy.array):
+            weights (numpy.ndarray):
                 Normalised array of weights
         """
         weights_list = []
@@ -623,7 +623,7 @@ class ChooseDefaultWeightsNonLinear:
         Args:
             cube (iris.cube.Cube):
                 Cube to be blended across the coord.
-            coord_name (string):
+            coord_name (str):
                 Name of coordinate in the cube to be blended.
 
         Kwargs:
@@ -702,7 +702,7 @@ class ChooseDefaultWeightsTriangular:
         """Create triangular weights.
 
             Args:
-                coord_vals (numpy array):
+                coord_vals (numpy.ndarray):
                     An array of coordinate values that we want to calculate
                     weights for.
                 midpoint (float):
@@ -711,7 +711,7 @@ class ChooseDefaultWeightsTriangular:
                     The width of the triangular function from the centre point.
 
             Returns:
-                weights (numpy.array):
+                weights (numpy.ndarray):
                     array of weights, sum of all weights should equal 1.0.
         """
 
@@ -757,7 +757,7 @@ class ChooseDefaultWeightsTriangular:
             Args:
                 cube (iris.cube.Cube):
                     Cube to blend across the coord.
-                coord_name (string):
+                coord_name (str):
                     Name of coordinate in the cube to be blended.
                 midpoint (float):
                     The centre point of the triangular function.  This is

--- a/lib/improver/blending/weights.py
+++ b/lib/improver/blending/weights.py
@@ -585,6 +585,10 @@ class ChooseDefaultWeightsNonLinear:
         Raises:
             ValueError: an inappropriate value of cval is input.
         """
+        if cval is None:
+            raise ValueError('cval is a required argument to the '
+                             'ChooseDefaultWeightsNonLinear plugin')
+
         if cval <= 0.0 or cval > 1.0:
             msg = ('cval must be greater than 0.0 and less '
                    'than or equal to 1.0 cval = {}'.format(cval))

--- a/lib/improver/tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
+++ b/lib/improver/tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
@@ -141,7 +141,8 @@ class Test__calculate_blending_weights(IrisTest):
         self.assertArrayAlmostEqual(weights.data, 0.25*np.ones((4,)))
 
     def test_default_nonlinear(self):
-        """Test non-linear weighting over forecast reference time"""
+        """Test non-linear weighting over forecast reference time, where the
+        earlier cycle has a higher weighting"""
         data = np.ones((3, 3, 3), dtype=np.float32)
         thresholds = np.array([276, 277, 278], dtype=np.float32)
         ukv_cube_earlier = set_up_probability_cube(
@@ -152,13 +153,27 @@ class Test__calculate_blending_weights(IrisTest):
             [ukv_cube_later, ukv_cube_earlier]).merge_cube()
 
         plugin = WeightAndBlend("forecast_reference_time", "nonlinear")
-
-        # Note this is the default behaviour for the nonlinear weights plugin,
-        # whereby the earlier cycle has greater weight than the later cycle.
-        # TODO this should be reconsidered
         weights = plugin._calculate_blending_weights(cube)
         self.assertArrayAlmostEqual(
             weights.data, np.array([0.5405405, 0.45945945]))
+
+    def test_default_nonlinear_inverse(self):
+        """Test non-linear weighting over forecast reference time in reverse
+        order, so that the more recent cycle has a higher weighting"""
+        data = np.ones((3, 3, 3), dtype=np.float32)
+        thresholds = np.array([276, 277, 278], dtype=np.float32)
+        ukv_cube_earlier = set_up_probability_cube(
+            data, thresholds, time=dt(2018, 9, 10, 7), frt=dt(2018, 9, 10, 3))
+        ukv_cube_later = set_up_probability_cube(
+            data, thresholds, time=dt(2018, 9, 10, 7), frt=dt(2018, 9, 10, 4))
+        cube = iris.cube.CubeList(
+            [ukv_cube_later, ukv_cube_earlier]).merge_cube()
+
+        plugin = WeightAndBlend(
+            "forecast_reference_time", "nonlinear", inverse_ordering=True)
+        weights = plugin._calculate_blending_weights(cube)
+        self.assertArrayAlmostEqual(
+            weights.data, np.array([0.45945945, 0.5405405]))
 
     def test_dict(self):
         """Test dictionary option for model blending with non-equal weights"""

--- a/lib/improver/tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
+++ b/lib/improver/tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
@@ -152,7 +152,8 @@ class Test__calculate_blending_weights(IrisTest):
         cube = iris.cube.CubeList(
             [ukv_cube_later, ukv_cube_earlier]).merge_cube()
 
-        plugin = WeightAndBlend("forecast_reference_time", "nonlinear")
+        plugin = WeightAndBlend(
+            "forecast_reference_time", "nonlinear", cval=0.85)
         weights = plugin._calculate_blending_weights(cube)
         self.assertArrayAlmostEqual(
             weights.data, np.array([0.5405405, 0.45945945]))
@@ -170,7 +171,8 @@ class Test__calculate_blending_weights(IrisTest):
             [ukv_cube_later, ukv_cube_earlier]).merge_cube()
 
         plugin = WeightAndBlend(
-            "forecast_reference_time", "nonlinear", inverse_ordering=True)
+            "forecast_reference_time", "nonlinear", cval=0.85,
+            inverse_ordering=True)
         weights = plugin._calculate_blending_weights(cube)
         self.assertArrayAlmostEqual(
             weights.data, np.array([0.45945945, 0.5405405]))

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -48,9 +48,9 @@ from improver.tests.set_up_test_cubes import (
 class Test__init__(IrisTest):
     """Test the __init__ method."""
 
-    def test_default_y0val_and_ynval(self):
-        """Test default values of y0val and ynval are set correctly."""
-        plugin = LinearWeights()
+    def test_basic(self):
+        """Test values of y0val and ynval are set correctly"""
+        plugin = LinearWeights(y0val=20.0, ynval=2.0)
         self.assertEqual(plugin.y0val, 20.0)
         self.assertEqual(plugin.ynval, 2.0)
 
@@ -58,7 +58,7 @@ class Test__init__(IrisTest):
         """Test it raises a Value Error if y0val less than zero. """
         msg = ('y0val must be a float >= 0.0')
         with self.assertRaisesRegex(ValueError, msg):
-            LinearWeights(y0val=-10.0)
+            LinearWeights(y0val=-10.0, ynval=2.0)
 
 
 class Test_linear_weights(IrisTest):
@@ -66,12 +66,12 @@ class Test_linear_weights(IrisTest):
 
     def test_basic(self):
         """Test that the function returns an array of weights"""
-        result = LinearWeights().linear_weights(3)
+        result = LinearWeights(y0val=20.0, ynval=2.0).linear_weights(3)
         self.assertIsInstance(result, np.ndarray)
 
     def test_returns_correct_values_num_of_weights_one(self):
         """Test it returns the correct values, method is proportional"""
-        result = LinearWeights().linear_weights(1)
+        result = LinearWeights(y0val=20.0, ynval=2.0).linear_weights(1)
         expected_result = np.array([1.0])
         self.assertArrayAlmostEqual(result, expected_result)
 
@@ -112,19 +112,19 @@ class Test_process(IrisTest):
 
     def test_basic(self):
         """Test that the plugin returns a cube of weights. """
-        plugin = LinearWeights()
+        plugin = LinearWeights(y0val=20.0, ynval=2.0)
         result = plugin.process(self.cube, self.coord_name)
         self.assertIsInstance(result, iris.cube.Cube)
 
     def test_array_sum_equals_one(self):
         """Test that the resulting weights add up to one. """
-        plugin = LinearWeights()
+        plugin = LinearWeights(y0val=20.0, ynval=2.0)
         result = plugin.process(self.cube, self.coord_name)
         self.assertAlmostEqual(result.data.sum(), 1.0)
 
     def test_fails_input_not_a_cube(self):
         """Test it raises a Value Error if not supplied with a cube. """
-        plugin = LinearWeights()
+        plugin = LinearWeights(y0val=20.0, ynval=2.0)
         notacube = 0.0
         msg = ('The first argument must be an instance of '
                'iris.cube.Cube')
@@ -136,13 +136,13 @@ class Test_process(IrisTest):
         self.cube.add_aux_coord(
             AuxCoord(1, long_name='scalar_coord', units='no_unit'))
         coord = self.cube.coord("scalar_coord")
-        plugin = LinearWeights()
+        plugin = LinearWeights(y0val=20.0, ynval=2.0)
         result = plugin.process(self.cube, coord)
         self.assertArrayAlmostEqual(result.data, np.array([1.0]))
 
     def test_works_defaults_used(self):
         """Test it works if defaults used. """
-        plugin = LinearWeights()
+        plugin = LinearWeights(y0val=20.0, ynval=2.0)
         result = plugin.process(self.cube, self.coord_name)
         expected_result = np.array([0.90909091, 0.09090909])
         self.assertArrayAlmostEqual(result.data, expected_result)

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
@@ -56,7 +56,7 @@ class Test__init__(IrisTest):
         """Test plugin raises an error if cval is None"""
         msg = 'cval is a required argument'
         with self.assertRaisesRegex(ValueError, msg):
-            result = NonLinearWeights(None)
+            NonLinearWeights(None)
 
     def test_fails_cval_set_wrong(self):
         """Test it fails if cval is negative or greater than 1"""

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
@@ -52,9 +52,15 @@ class Test__init__(IrisTest):
         result = NonLinearWeights(0.85)
         self.assertAlmostEqual(result.cval, 0.85)
 
+    def test_fails_cval_not_set(self):
+        """Test plugin raises an error if cval is None"""
+        msg = 'cval is a required argument'
+        with self.assertRaisesRegex(ValueError, msg):
+            result = NonLinearWeights(None)
+
     def test_fails_cval_set_wrong(self):
         """Test it fails if cval is negative or greater than 1"""
-        msg = ('cval must be greater than 0.0')
+        msg = 'cval must be greater than 0.0'
         with self.assertRaisesRegex(ValueError, msg):
             NonLinearWeights(-0.1)
         with self.assertRaisesRegex(ValueError, msg):
@@ -124,7 +130,7 @@ class Test_process(IrisTest):
 
     def test_works_with_default_cval(self):
         """Test it works with default cval. """
-        plugin = NonLinearWeights(0.85)
+        plugin = NonLinearWeights(cval=0.85)
         result = plugin.process(self.cube, self.coord_name)
         expected_result = np.array([0.54054054, 0.45945946])
         self.assertArrayAlmostEqual(result.data, expected_result)
@@ -133,7 +139,7 @@ class Test_process(IrisTest):
         """Test inverting the order of the input cube produces inverted weights
         order, with the cube and weights cube still matching in dimensions"""
         reference_cube = self.cube.copy()
-        plugin = NonLinearWeights(0.85)
+        plugin = NonLinearWeights(cval=0.85)
         result = plugin.process(
             self.cube, self.coord_name, inverse_ordering=True)
         expected_result = np.array([0.45945946, 0.54054054])

--- a/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
@@ -75,7 +75,7 @@ class Test_nonlinear_weights(IrisTest):
         result = NonLinearWeights(0.85).nonlinear_weights(3)
         self.assertIsInstance(result, np.ndarray)
 
-    def test_returns_correct_values(self):
+    def test_values(self):
         """Test it returns the correct values for num_of_weights 6, cval 0.6"""
         result = NonLinearWeights(0.6).nonlinear_weights(6)
         expected_result = np.array([0.41957573, 0.25174544,
@@ -119,8 +119,8 @@ class Test_process(IrisTest):
         with self.assertRaisesRegex(TypeError, msg):
             plugin.process(notacube, self.coord_name)
 
-    def test_works_if_scalar_coord(self):
-        """Test it works if scalar coordinate. """
+    def test_scalar_coord(self):
+        """Test it works if blend coordinate is scalar. """
         self.cube.add_aux_coord(
             AuxCoord(1, long_name='scalar_coord', units='no_unit'))
         coord = self.cube.coord("scalar_coord")
@@ -128,16 +128,16 @@ class Test_process(IrisTest):
         result = plugin.process(self.cube, coord)
         self.assertArrayAlmostEqual(result.data, np.array([1.0]))
 
-    def test_works_with_default_cval(self):
-        """Test it works with default cval. """
+    def test_values(self):
+        """Test weights values. """
         plugin = NonLinearWeights(cval=0.85)
         result = plugin.process(self.cube, self.coord_name)
         expected_result = np.array([0.54054054, 0.45945946])
         self.assertArrayAlmostEqual(result.data, expected_result)
 
-    def test_works_with_default_cval_inverse_ordering(self):
+    def test_values_inverse_ordering(self):
         """Test inverting the order of the input cube produces inverted weights
-        order, with the cube and weights cube still matching in dimensions"""
+        order, with the cube and weights cube still matching in dimensions. """
         reference_cube = self.cube.copy()
         plugin = NonLinearWeights(cval=0.85)
         result = plugin.process(
@@ -153,14 +153,14 @@ class Test_process(IrisTest):
             result.coord(self.coord_name).points,
             reference_cube.coord(self.coord_name).points)
 
-    def test_works_with_cval_equal_one(self):
+    def test_cval_equal_one(self):
         """Test it works with cval = 1.0, i.e. equal weights. """
         plugin = NonLinearWeights(cval=1.0)
         result = plugin.process(self.cube, self.coord_name)
         expected_result = np.array([0.5, 0.5])
         self.assertArrayAlmostEqual(result.data, expected_result)
 
-    def test_works_with_larger_num(self):
+    def test_larger_num(self):
         """Test it works with larger num_of_vals. """
         plugin = NonLinearWeights(cval=0.5)
         cubenew = add_coordinate(

--- a/tests/improver-weighted-blending/02-basic_nonlin.bats
+++ b/tests/improver-weighted-blending/02-basic_nonlin.bats
@@ -36,7 +36,8 @@
   KGO="weighted_blending/basic_nonlin/kgo.nc"
 
   # Run weighted blending with non linear weights and check it passes.
-  run improver weighted-blending --wts_calc_method 'nonlinear' 'forecast_reference_time' \
+  run improver weighted-blending --wts_calc_method 'nonlinear' \
+      'forecast_reference_time' --cval 0.85 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/03-basic_lin.bats
+++ b/tests/improver-weighted-blending/03-basic_lin.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/basic_lin/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'forecast_reference_time' \
+  run improver weighted-blending 'forecast_reference_time' --y0val 20.0 --ynval 2.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/basic_lin/multiple_probabilities_rain_*H.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/12-realization_collapse.bats
+++ b/tests/improver-weighted-blending/12-realization_collapse.bats
@@ -36,7 +36,7 @@
 
   # Run weighted blending with linear weights and check it passes,
   # after realization collapse.
-  run improver weighted-blending 'realization' \
+  run improver weighted-blending 'realization' --y0val=20.0 --ynval=2.0 \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/realizations/input.nc" \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-weighted-blending/15-accum_cycle_blend.bats
+++ b/tests/improver-weighted-blending/15-accum_cycle_blend.bats
@@ -36,7 +36,7 @@
   KGO="weighted_blending/accum_cycle_blend/kgo.nc"
 
   # Run weighted blending with linear weights and check it passes.
-  run improver weighted-blending 'forecast_reference_time' \
+  run improver weighted-blending 'forecast_reference_time' --y0val=20.0 --ynval=2.0 \
       $IMPROVER_ACC_TEST_DIR/weighted_blending/accum_cycle_blend/ukv_prob_accum_PT?H.nc \
       "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]


### PR DESCRIPTION
Removed defaults from both `ChooseDefaultWeights` plugins.  Added re-ordering option to non-linear weights plugin (not required for linear as user has all the options!).  Updated CLI tests for weighted blending so that they work.  A later PR will change the CLI tests to do something sensible, and remove any tests that are no longer required.

Description

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
