### PR TITLE
IMPRO-1295: Optical flow bug fixes

### DIFF
--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -696,8 +696,8 @@ class OpticalFlow(object):
         try:
             cube1 = cube1.copy()
             cube2 = cube2.copy()
-#            cube1.convert_units('mm/hr')
-#            cube2.convert_units('mm/hr')
+            cube1.convert_units('mm/hr')
+            cube2.convert_units('mm/hr')
         except ValueError:
             msg = ('Input data are in units that cannot be converted to mm/hr '
                    'which are the required units for use with optical flow.')

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -231,8 +231,9 @@ class OpticalFlow(object):
         the data field is not an exact multiple of "boxsize".
 
         Note that the weights calculated below are valid for precipitation
-        rates in mm/hr. This is a result of the constant 0.8 that is used;
-        see equation 8. in Bowler et al. 2004.
+        rates in mm/hr. This is a result of the constant 0.8 that is used,
+        noting that in the source paper a value of 0.75 is used; see equation
+        8. in Bowler et al. 2004.
 
         Args:
             field (np.ndarray):

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -703,10 +703,10 @@ class OpticalFlow(object):
             cube2 = cube2.copy()
             cube1.convert_units('mm/hr')
             cube2.convert_units('mm/hr')
-        except ValueError:
+        except ValueError as err:
             msg = ('Input data are in units that cannot be converted to mm/hr '
                    'which are the required units for use with optical flow.')
-            raise ValueError(msg)
+            raise ValueError(msg) from err
 
         # check time difference is positive
         time1 = (cube1.coord("time").units).num2date(

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -749,10 +749,12 @@ class OpticalFlow(object):
         data2 = next(cube2.slices([cube2.coord(axis='y'),
                                    cube2.coord(axis='x')])).data
 
-        # fill the mask with 0 values so fill_values are not spread into the
+        # fill any mask with 0 values so fill_values are not spread into the
         # domain when smoothing the fields.
-        data1 = data1.filled(0)
-        data2 = data2.filled(0)
+        if np.ma.is_masked(data1):
+            data1 = data1.filled(0)
+        if np.ma.is_masked(data2):
+            data2 = data2.filled(0)
 
         # if input arrays have no non-zero values, set velocities to zero here
         # and raise a warning

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -749,8 +749,8 @@ class OpticalFlow(object):
         data2 = next(cube2.slices([cube2.coord(axis='y'),
                                    cube2.coord(axis='x')])).data
 
-        # fill the mask with 0 values so erroneous values are not spread into
-        # the domain when smoothing the fields.
+        # fill the mask with 0 values so fill_values are not spread into the
+        # domain when smoothing the fields.
         data1 = data1.filled(0)
         data2 = data2.filled(0)
 

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -230,6 +230,10 @@ class OpticalFlow(object):
         1 and 2.  The final boxes in the list will be smaller if the size of
         the data field is not an exact multiple of "boxsize".
 
+        Note that the weights calculated below are valid for precipitation
+        rates in mm/hr. This is a result of the constant 0.8 that is used;
+        see equation 8. in Bowler et al. 2004.
+
         Args:
             field (np.ndarray):
                 Input field (partial derivative)

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -202,7 +202,7 @@ class OpticalFlow(object):
                 np.diff(data, axis=axis), axis=1-axis)
             outdata.append(diffs)
         smoothed_diffs = np.zeros(
-            [self.shape[0]+1, self.shape[1]+1], dtype=np.float64)
+            [self.shape[0]+1, self.shape[1]+1], dtype=np.float32)
         smoothed_diffs[1:-1, 1:-1] = 0.5*(outdata[0] + outdata[1])
         return self.interp_to_midpoint(smoothed_diffs)
 
@@ -219,7 +219,7 @@ class OpticalFlow(object):
         """
         tdiff = self.data2 - self.data1
         smoothed_diffs = np.zeros(
-            [self.shape[0]+1, self.shape[1]+1], dtype=np.float64)
+            [self.shape[0]+1, self.shape[1]+1], dtype=np.float32)
         smoothed_diffs[1:-1, 1:-1] = self.interp_to_midpoint(tdiff)
         return self.interp_to_midpoint(smoothed_diffs)
 
@@ -254,7 +254,7 @@ class OpticalFlow(object):
                     (self.data2[i:i+self.boxsize, j:j+self.boxsize]).sum())
                 weight = 1. - np.exp(-1.*weight/0.8)
                 weights.append(weight)
-        weights = np.array(weights, dtype=np.float64)
+        weights = np.array(weights, dtype=np.float32)
         weights[weights < 0.01] = 0
         return boxes, weights
 
@@ -274,7 +274,7 @@ class OpticalFlow(object):
         grid_data = np.repeat(np.repeat(box_data, self.boxsize, axis=0),
                               self.boxsize, axis=1)
         grid_data = grid_data[:self.shape[0],
-                              :self.shape[1]].astype(np.float64)
+                              :self.shape[1]].astype(np.float32)
         return grid_data
 
     @staticmethod
@@ -365,7 +365,7 @@ class OpticalFlow(object):
         # define kernel for neighbour weighting
         neighbour_kernel = (np.array([[0.5, 1, 0.5],
                                       [1.0, 0, 1.0],
-                                      [0.5, 1, 0.5]])/6.).astype(np.float64)
+                                      [0.5, 1, 0.5]])/6.).astype(np.float32)
 
         # smooth input data and weights fields
         vel_neighbour = scipy.ndimage.convolve(weights*vel_iter,
@@ -532,8 +532,8 @@ class OpticalFlow(object):
         # (c) Reshape displacement arrays to match array of subbox points
         newshape = [int((self.shape[0]-1)/self.boxsize) + 1,
                     int((self.shape[1]-1)/self.boxsize) + 1]
-        umat = np.array(velocity[0], dtype=np.float64).reshape(newshape)
-        vmat = np.array(velocity[1], dtype=np.float64).reshape(newshape)
+        umat = np.array(velocity[0], dtype=np.float32).reshape(newshape)
+        vmat = np.array(velocity[1], dtype=np.float32).reshape(newshape)
         weights = box_weights.reshape(newshape)
 
         # (d) Check for extreme advection displacements (over a significant
@@ -724,7 +724,7 @@ class OpticalFlow(object):
         # calculate smoothing radius in grid square units
         new_coord = cube1.coord(axis='x').copy()
         new_coord.convert_units('km')
-        grid_length_km = np.float64(np.diff((new_coord).points)[0])
+        grid_length_km = np.float32(np.diff((new_coord).points)[0])
         data_smoothing_radius = \
             int(data_smoothing_radius_km / grid_length_km)
 
@@ -761,15 +761,15 @@ class OpticalFlow(object):
             msg = ("No non-zero data in input fields: setting optical flow "
                    "velocities to zero")
             warnings.warn(msg)
-            ucomp = np.zeros(data1.shape, dtype=np.float64)
-            vcomp = np.zeros(data2.shape, dtype=np.float64)
+            ucomp = np.zeros(data1.shape, dtype=np.float32)
+            vcomp = np.zeros(data2.shape, dtype=np.float32)
         else:
             # calculate dimensionless displacement between the two input fields
             ucomp, vcomp = self.process_dimensionless(data1, data2, 1, 0,
                                                       data_smoothing_radius)
             # convert displacements to velocities in metres per second
             for vel in [ucomp, vcomp]:
-                vel *= np.float64(1000.*grid_length_km)
+                vel *= np.float32(1000.*grid_length_km)
                 vel /= cube_time_diff.total_seconds()
 
         # create velocity output cubes based on metadata from later input cube

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -664,6 +664,36 @@ class Test_process(IrisTest):
             np.mean(ucube.data), -2.1719084)
         self.assertAlmostEqual(np.mean(vcube.data), 2.1719084)
 
+    def test_values_with_precip_rate_in_m_per_s(self):
+        """Test velocity values are as expected (in m/s) when the input
+        precipitation rates are in units of m/s rather than the expected
+        mm/hr."""
+        self.cube1.convert_units('m s-1')
+        self.cube2.convert_units('m s-1')
+        ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
+        self.assertAlmostEqual(
+            np.mean(ucube.data), -2.1719084)
+        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084)
+
+    def test_error_for_unconvertable_units(self):
+        """Test that an exception is raised if the input precipitation cubes
+        have units that cannot be converted to mm/hr."""
+        self.cube1.units = 'm'
+        self.cube2.units = 'm'
+
+        msg = "Input data are in units that cannot be converted to mm/hr"
+        with self.assertRaisesRegex(ValueError, msg):
+            _, _ = self.plugin.process(self.cube1, self.cube2, boxsize=3)
+
+    def test_input_cubes_unchanged(self):
+        """Test the input precipitation rate cubes are unchanged by use in the
+        optical flow plugin."""
+        cube1_ref = self.cube1.copy()
+        cube2_ref = self.cube2.copy()
+        ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
+        self.assertEqual(self.cube1, cube1_ref)
+        self.assertEqual(self.cube2, cube2_ref)
+
     def test_decrease_time_interval(self):
         """Test that decreasing the time interval between radar frames below
         15 minutes does not alter the smoothing radius. To test this the time

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -701,8 +701,8 @@ class Test_process(IrisTest):
         data2[:2, :] = 1.0E36
         data2[:, :2] = 1.0E36
 
-        masked1 = data=np.ma.MaskedArray(self.cube1.data, mask=mask)
-        masked2 = data=np.ma.MaskedArray(self.cube2.data, mask=mask)
+        masked1 = np.ma.MaskedArray(self.cube1.data, mask=mask)
+        masked2 = np.ma.MaskedArray(self.cube2.data, mask=mask)
 
         masked_cube1 = self.cube1.copy(data=masked1)
         masked_cube2 = self.cube2.copy(data=masked2)

--- a/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -738,7 +738,7 @@ class Test_process(IrisTest):
         optical flow plugin."""
         cube1_ref = self.cube1.copy()
         cube2_ref = self.cube2.copy()
-        ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
+        _, _ = self.plugin.process(self.cube1, self.cube2, boxsize=3)
         self.assertEqual(self.cube1, cube1_ref)
         self.assertEqual(self.cube2, cube2_ref)
 


### PR DESCRIPTION
Addresses a problem in which a constant which should only be used with quantities in mm/hr was being used with other units. This is achieved by enforcing mm/hr as the working units of optical flow precip rates.

Additionally this PR also changes the treatment of masked points by setting their values to zero. This avoids the spreading of fill values across the domain which was causing the optical flow code to perform poorly when calculating velocities; it was returning only nans when working in mm/hr as the 1E36 fill values were increased by the unit conversion to a value beyond the float32 limit.

Among the new unit tests added is one that involves masked data which is included to capture the behaviour described.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)