### PR TITLE
Add intersphinx mapping to improve readthedocs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -387,7 +387,13 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'https://docs.python.org/': None,
+    'https://scitools.org.uk/iris/docs/latest/': None,
+    'https://scitools.org.uk/cartopy/docs/latest/': None,
+    'https://scitools.org.uk/cf-units/docs/latest/': None,
+    'https://docs.scipy.org/doc/numpy/': None,
+}
 
 # Get napoleon to document constructor methods.
 napoleon_include_init_with_doc = True

--- a/lib/improver/blending/weights.py
+++ b/lib/improver/blending/weights.py
@@ -58,7 +58,7 @@ class WeightsUtilities:
         """Ensures all weights add up to one.
 
             Args:
-                weights (numpy.array):
+                weights (numpy.ndarray):
                     array of weights
 
             Keyword Args:
@@ -68,7 +68,7 @@ class WeightsUtilities:
                     array is used for the normalisation.
 
             Returns:
-                normalised_weights (numpy.array):
+                normalised_weights (numpy.ndarray):
                     array of weights where sum = 1.0
 
             Raises:
@@ -95,9 +95,9 @@ class WeightsUtilities:
             Args:
                 cube (iris.cube.Cube):
                     The cube that is being blended over blending_coord.
-                weights (numpy.array):
+                weights (numpy.ndarray):
                     Array of weights
-                blending_coord (string):
+                blending_coord (str):
                     Name of the coordinate over which the weights will be used
                     to blend data, e.g. across model name when grid blending.
             Returns:

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -454,7 +454,7 @@ def lat_lon_determine(cube):
             A diagnostic cube to examine for coordinate system.
 
     Returns:
-        trg_crs (cartopy.crs/None):
+        trg_crs (cartopy.crs.CRS or None):
             Coordinate system of the diagnostic cube in a cartopy format unless
             it is already a latitude/longitude grid, in which case None is
             returned.
@@ -473,7 +473,7 @@ def lat_lon_transform(trg_crs, latitude, longitude):
     grid into an alternative projection defined by trg_crs.
 
     Args:
-        trg_crs (cartopy.crs/None):
+        trg_crs (cartopy.crs.CRS or None):
             Target coordinate system in cartopy format or None.
 
         latitude (float):

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -55,14 +55,14 @@ def cycletime_to_datetime(cycletime, cycletime_format="%Y%m%dT%H%MZ"):
     """Convert a string representating the cycletime of the
     format YYYYMMDDTHHMMZ into a datetime object.
 
-     Args:
-         cycletime (string):
-             A cycletime that can be converted into a datetime using the
-             cycletime_format supplied.
+    Args:
+        cycletime (string):
+            A cycletime that can be converted into a datetime using the
+            cycletime_format supplied.
 
-     Keyword Args:
-         cycletime_format (str):
-             String containing the desired format for the cycletime.
+    Keyword Args:
+        cycletime_format (str):
+            String containing the desired format for the cycletime.
     Returns:
         datetime:
             A correctly formatted datetime object.

--- a/lib/improver/uv_index.py
+++ b/lib/improver/uv_index.py
@@ -61,16 +61,16 @@ def calculate_uv_index(uv_upward, uv_downward, scale_factor=3.6):
         uv_index (iris.cube.Cube):
             A cube of the calculated UV index.
 
-    Raises: ValueError
-        If uv_upward is not named correctly.
-        If uv_downward is not named correctly.
-        If units do not match.
+    Raises:
+        ValueError: If uv_upward is not named correctly.
+        ValueError: If uv_downward is not named correctly.
+        ValueError: If units do not match.
 
     References:
-    Turner, E.C, Manners, J. Morcette, C. J, O'Hagan, J. B,
-    & Smedley, A.R.D. (2017): Toward a New UV Index Diagnostic
-    in the Met Office's Forecast Model. Journal of Advances in
-    Modeling Earth Systems 9, 2654-2671.
+        Turner, E.C, Manners, J. Morcette, C. J, O'Hagan, J. B,
+        & Smedley, A.R.D. (2017): Toward a New UV Index Diagnostic
+        in the Met Office's Forecast Model. Journal of Advances in
+        Modeling Earth Systems 9, 2654-2671.
 
     """
     if uv_upward.name() != 'surface_upwelling_ultraviolet_flux_in_air':


### PR DESCRIPTION
Description
Add intersphinx mappings, so that links will be created between our documentation on readthedocs and the underlying modules. I've also made a few minor docstring edits, as part of testing the intersphinx mappings and when looking at how the docstrings are displayed on readthedocs.

Note that it seems like `numpy` should be used in the docstrings, rather than `np`, so that the mapping works as intended.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

