### PR TITLE
No compression for CLI test ouputs

### DIFF
--- a/lib/improver/tests/utilities/test_save.py
+++ b/lib/improver/tests/utilities/test_save.py
@@ -28,21 +28,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+# pylint: disable=E1136
 """Unit tests for saving functionality."""
 
 import os
-import netCDF4
 import unittest
 from unittest import mock
-
-import numpy as np
 from subprocess import call
 from tempfile import mkdtemp
 
+import numpy as np
+from netCDF4 import Dataset
 import iris
 from iris.coords import CellMethod
 from iris.tests import IrisTest
-from netCDF4 import Dataset
 
 from improver.utilities.load import load_cube
 from improver.utilities.save import (
@@ -191,7 +190,7 @@ class Test_save_netcdf(IrisTest):
 
         # Default expected to be compressed.
         save_netcdf(self.cube, self.filepath)
-        cube = netCDF4.Dataset(self.filepath)
+        cube = Dataset(self.filepath)
         var = cube.variables['air_temperature']
         compressed = var.filters().get('complevel', False)
 
@@ -205,7 +204,7 @@ class Test_save_netcdf(IrisTest):
         # Environment variable should prevent compression.
         with mock.patch.dict(os.environ, {'SAVE_COMPRESSED': 'False'}):
             save_netcdf(self.cube, self.filepath)
-        cube = netCDF4.Dataset(self.filepath)
+        cube = Dataset(self.filepath)
         var = cube.variables['air_temperature']
         compressed = var.filters().get('complevel', False)
 

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -38,10 +38,6 @@ import iris
 
 from improver.utilities.cube_checker import check_cube_not_float64
 
-# To avoid compression in acceptance tests SAVE_COMPRESSED=False exported to
-# environment. Defaults True if not set.
-SAVE_COMPRESSED = ast.literal_eval(os.getenv("SAVE_COMPRESSED", "True"))
-
 
 def _append_metadata_cube(cubelist, global_keys):
     """ Create a metadata cube associated with statistical
@@ -148,6 +144,10 @@ def save_netcdf(cubelist, filename):
     Raises:
         warning if cubelist contains cubes of varying dimensions.
     """
+    # To avoid compression SAVE_COMPRESSED=False can be exported to the
+    # environment. Defaults True if not set.
+    save_compressed = ast.literal_eval(os.getenv("SAVE_COMPRESSED", "True"))
+
     if isinstance(cubelist, iris.cube.Cube):
         cubelist = [cubelist]
 
@@ -181,5 +181,5 @@ def save_netcdf(cubelist, filename):
     cubelist = _append_metadata_cube(cubelist, global_keys)
     iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys,
                                  complevel=1, shuffle=True,
-                                 zlib=SAVE_COMPRESSED,
+                                 zlib=save_compressed,
                                  chunksizes=chunksizes)

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -30,11 +30,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for saving netcdf cubes with desired attribute types."""
 
+import os
+import ast
 import cf_units
 import warnings
 import iris
 
 from improver.utilities.cube_checker import check_cube_not_float64
+
+# To avoid compression in acceptance tests SAVE_COMPRESSED=False exported to
+# environment. Defaults True if not set.
+SAVE_COMPRESSED = ast.literal_eval(os.getenv("SAVE_COMPRESSED", "True"))
 
 
 def _append_metadata_cube(cubelist, global_keys):
@@ -174,5 +180,6 @@ def save_netcdf(cubelist, filename):
 
     cubelist = _append_metadata_cube(cubelist, global_keys)
     iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys,
-                                 complevel=1, shuffle=True, zlib=True,
+                                 complevel=1, shuffle=True,
+                                 zlib=SAVE_COMPRESSED,
                                  chunksizes=chunksizes)

--- a/tests/bin/bats
+++ b/tests/bin/bats
@@ -61,6 +61,9 @@ export PATH="$BATS_LIBEXEC:$PATH"
 # tests on different machines. Some CLI test results exhibit precision level
 # sensitivity to the number of threads.
 export OMP_NUM_THREADS=1
+# Environment variable used to turn off compression in save wrapper.
+# SAVE_COMPRESSED="False", results not compressed, tests run faster.
+export SAVE_COMPRESSED="False"
 
 options=()
 arguments=()


### PR DESCRIPTION
This PR proposes a simple method for turning off compression in the save wrapper using an imported environment variable. This will enable us to run the CLI tests without compression, which speeds them up by a factor of more than 2 (essentially reclaiming lost speed).

Note that a particular pylint check has been disabled for the test_save.py file as there is currently a bug in pylint which does not seem to be being fixed very rapidly: https://github.com/PyCQA/pylint/issues/1498

Testing:
 - [x] Ran tests and they passed OK
