### PR TITLE
Update precipitation accumulation plugin to support overlapping periods

### DIFF
--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -209,9 +209,12 @@ def main(argv=None):
 
     # calculate accumulations if required
     if args.accumulation_fidelity > 0:
+        lead_times = (
+            np.arange(0, args.max_lead_time + 1, args.lead_time_interval))
         plugin = Accumulation(
             accumulation_units=args.accumulation_units,
-            accumulation_period=args.accumulation_period * 60)
+            accumulation_period=args.accumulation_period * 60,
+            forecast_periods=lead_times * 60)
         accumulation_cubes = plugin.process(forecast_cubes)
 
         # return accumulation cubes

--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -113,6 +113,12 @@ def main(argv=None):
         " calculate these accumulations. This interval must be a factor of"
         " the lead_time_interval.")
     accumulation_args.add_argument(
+        "--accumulation_period", type=int, default=15,
+        help="The period over which the accumulation is calculated (mins). "
+        "Only full accumulation periods will be computed, so if the "
+        "lead times are shorter than the accumulation period than these "
+        "lead times will not be calculated.")
+    accumulation_args.add_argument(
         "--accumulation_units", type=str, default='m',
         help="Desired units in which the accumulations should be expressed,"
         "e.g. mm")
@@ -203,8 +209,9 @@ def main(argv=None):
 
     # calculate accumulations if required
     if args.accumulation_fidelity > 0:
-        plugin = Accumulation(accumulation_units=args.accumulation_units,
-                              accumulation_period=args.lead_time_interval * 60)
+        plugin = Accumulation(
+            accumulation_units=args.accumulation_units,
+            accumulation_period=args.accumulation_period * 60)
         accumulation_cubes = plugin.process(forecast_cubes)
 
         # return accumulation cubes

--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -210,7 +210,8 @@ def main(argv=None):
     # calculate accumulations if required
     if args.accumulation_fidelity > 0:
         lead_times = (
-            np.arange(0, args.max_lead_time + 1, args.lead_time_interval))
+            np.arange(args.lead_time_interval, args.max_lead_time + 1,
+                      args.lead_time_interval))
         plugin = Accumulation(
             accumulation_units=args.accumulation_units,
             accumulation_period=args.accumulation_period * 60,

--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -115,9 +115,9 @@ def main(argv=None):
     accumulation_args.add_argument(
         "--accumulation_period", type=int, default=15,
         help="The period over which the accumulation is calculated (mins). "
-        "Only full accumulation periods will be computed, so if the "
-        "lead times are shorter than the accumulation period than these "
-        "lead times will not be calculated.")
+        "Only full accumulation periods will be computed. At lead times "
+        "that are shorter than the accumulation period, no accumulation "
+        "output will be produced.")
     accumulation_args.add_argument(
         "--accumulation_units", type=str, default='m',
         help="Desired units in which the accumulations should be expressed,"

--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -228,11 +228,6 @@ class Accumulation:
                 Cubelist that defines the cubes used to calculate
                 the accumulations.
 
-        Warns:
-            Warning: The provided cubes result in a partial period given the
-                specified accumulation_period, i.e. the number of cubes is
-                insufficient to give a set of complete periods. Only complete
-                periods will be returned.
         """
         # If the input is a numpy array, get the integer value from the array
         # for use in the constraint.

--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -215,7 +215,6 @@ class Accumulation:
         """
         fp_point = cube.coord("forecast_period").points[0]
         if fp_point not in self.forecast_periods:
-            print("Not calculating accumulations for {}".format(fp_point))
             return None, None
         end_point, = iris_time_to_datetime(cube.coord("time"))
         start_point = (

--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -232,7 +232,8 @@ class Accumulation:
             return None
         return cube_subset
 
-    def _calculate_accumulation(self, cube_subset, time_interval):
+    @staticmethod
+    def _calculate_accumulation(cube_subset, time_interval):
         """Calculate the accumulation for the requested accumulation period
         by finding the subset of cubes from the input cubelist that are
         within the accumulation period, based on the input cube defining the
@@ -266,7 +267,8 @@ class Accumulation:
                              time_interval * 0.5)
         return accumulation
 
-    def _set_metadata(self, cube_subset):
+    @staticmethod
+    def _set_metadata(cube_subset):
         """Set the metadata on the accumulation cube. This includes
         expanding the bounds to cover the accumulation period with the
         point within the time and forecast_period coordinates recorded as the

--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -193,8 +193,8 @@ class Accumulation:
                 Cubelist containing all the rates cubes that will be used
                 to calculate the accumulation.
             forecast_period (int):
-                Forecast period matching the upper bound of the accumulation
-                period.
+                Forecast period in seconds matching the upper bound of the
+                accumulation period.
             integral (int)
                 Integer value based on how many times the accumulation
                 period is divisible by the time interval. This therefore
@@ -212,13 +212,9 @@ class Accumulation:
                 insufficient to give a set of complete periods. Only complete
                 periods will be returned.
         """
-        constr = iris.Constraint(forecast_period=forecast_period)
-        cube, = cubes.extract(constr)
-        end_point, = iris_time_to_datetime(cube.coord("time"))
-        start_point = (
-            end_point - timedelta(seconds=int(self.accumulation_period)))
+        start_point = forecast_period - self.accumulation_period
         constr = iris.Constraint(
-            time=lambda cell: start_point <= cell.point <= end_point)
+            forecast_period=lambda fp: start_point <= fp <= forecast_period)
 
         cube_subset = cubes.extract(constr)
 

--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -34,10 +34,12 @@ accumulations from advected radar fields. It is also possible to create longer
 accumulations from shorter intervals.
 """
 import warnings
+from datetime import timedelta
 import numpy as np
 
 import iris
 from improver.utilities.cube_manipulation import expand_bounds
+from improver.utilities.temporal import iris_time_to_datetime
 from improver.utilities.cube_units import (enforce_coordinate_units_and_dtypes,
                                            enforce_diagnostic_units_and_dtypes)
 
@@ -50,11 +52,12 @@ class Accumulation:
     used to construct the accumulation period requested when possible, and
     cubes of this desired period are then returned.
     """
-    def __init__(self, accumulation_units='m', accumulation_period=None):
+    def __init__(self, accumulation_units='m', accumulation_period=None,
+                 forecast_periods=None):
         """
         Initialise the plugin.
 
-        Args:
+        Kwargs:
             accumulation_units (str):
                 The physical units in which the accumulation should be
                 returned. The default is metres.
@@ -64,9 +67,14 @@ class Accumulation:
                 cubes. The default is None, in which case an accumulation is
                 calculated across the span of time covered by the input rates
                 cubes.
+            forecast_periods (list):
+                The forecast periods that define the end of an accumulation
+                period.
+
         """
         self.accumulation_units = accumulation_units
         self.accumulation_period = accumulation_period
+        self.forecast_periods = forecast_periods
 
     def __repr__(self):
         """Represent the plugin instance as a string."""
@@ -96,35 +104,37 @@ class Accumulation:
         cubes = iris.cube.CubeList(np.array(cubes)[time_sorted])
         return cubes, times
 
-    def _get_period_sets(self, time_interval, cubes):
-        """
-        Return sub-sets of the input cube list that will be used to construct
-        the accumulation period specified by self.accumulation_period.
+    def _check_inputs(self):
+        # Standardise inputs to expected units.
+        cubes = enforce_coordinate_units_and_dtypes(
+            cubes, ['time', 'forecast_reference_time', 'forecast_period'],
+            inplace=False)
+        enforce_diagnostic_units_and_dtypes(cubes)
 
-        Args:
-            time_interval (int):
-                The time interval between the input precipitation rate cubes in
-                seconds.
-            cubes (list):
-                The input precitation rate cubes.
-        Returns:
-            cube_subsets (list of lists):
-                A list containing lists which comprise the rates cubes required
-                to construct a sequence of accumulation cubes that match the
-                period given by self.accumulation_period. If
-                self.accumulation_period is None then the whole list of cubes
-                is returned to give one accumulation across the whole set.
-        Raises:
-            ValueError: Accumulation period cannot be created from time
-                        intervals of input cubes.
-        """
-        # If no accumulation period is provided, calculate accumulation across
-        # all provided cubes.
+        # Sort cubes into time order and calculate intervals.
+        cubes, times = self.sort_cubes_by_time(cubes)
+
+        try:
+            time_interval, = np.unique(np.diff(times, axis=0))
+        except ValueError:
+            msg = ("Accumulation is designed to work with "
+                   "rates cubes at regular time intervals. Cubes "
+                   "provided are unevenly spaced in time; time intervals are "
+                   "{}.".format(np.diff(times, axis=0)))
+            raise ValueError(msg)
+
         if self.accumulation_period is None:
-            return [cubes]
+            # If no accumulation period is specified, assume that the input
+            # cubes will be used to construct a single accumulation period.
+            self.accumulation_period, = (
+                cubes[-1].coord("forecast_period").points)
 
-        fraction, cube_subset = np.modf(self.accumulation_period /
-                                        time_interval)
+        if self.forecast_periods is None:
+            self.forecast_periods = [
+                cube.coord("forecast_period").points for cube in cubes]
+
+        fraction, integral = np.modf(self.accumulation_period /
+                                     time_interval)
 
         if fraction != 0:
             msg = ("The specified accumulation period ({}) is not divisible "
@@ -134,22 +144,46 @@ class Accumulation:
                        self.accumulation_period, time_interval))
             raise ValueError(msg)
 
-        cube_subset = int(cube_subset)
+    def _calculate_accumulations(self, cube, integral):
+        fp_point = cube.coord("forecast_period").points[0]
+        if fp_point not in self.forecast_periods:
+            return None
+        end_point, = iris_time_to_datetime(cube.coord("time"))
+        start_point = (
+            end_point - timedelta(seconds=int(self.accumulation_period)))
+        constr = iris.Constraint(
+            time=lambda cell: start_point <= cell.point <= end_point)
 
-        # We expect 1 more rates cubes than accumulations cubes, if we have
-        # more or less, a targetted accumulation_period will be incomplete.
-        unused_cubes = int(len(cubes) % cube_subset)
-        if unused_cubes != 1 and cube_subset != 1:
-            msg = ("The provided cubes result in a partial period given the "
-                   "specified accumulation_period, i.e. the number of cubes "
-                   "is insufficient to give a set of complete periods. Only "
-                   "complete periods will be returned.")
+        cube_subset = cubes.extract(constr)
+
+        if len(cube_subset) != int(integral + 1):
+            print("Only complete periods")
+            msg = (
+                "The provided cubes result in a partial period given the "
+                "specified accumulation_period, i.e. the number of cubes "
+                "is insufficient to give a set of complete periods. Only "
+                "complete periods will be returned.")
             warnings.warn(msg)
+            return None
 
-        cube_subsets = []
-        for index in range(0, len(cubes) - unused_cubes, cube_subset):
-            cube_subsets.append(cubes[index:index + cube_subset + 1])
-        return cube_subsets
+        accumulation = 0.
+        # Accumulations are calculated using the mean precipitation rate
+        # calculated from the rates cubes that bookend the desired period.
+        iterator = zip(cube_subset[0:-1], cube_subset[1:])
+        for start_cube, end_cube in iterator:
+            accumulation += ((start_cube.data + end_cube.data) *
+                             time_interval * 0.5)
+        return accumulation
+
+    def _set_metadata(self, rate_cubes):
+        cube_name = 'lwe_thickness_of_precipitation_amount'
+        accumulation_cube = expand_bounds(
+            cube_subset[0].copy(),
+            iris.cube.CubeList(cube_subset),
+            expanded_coords={'time': 'upper', 'forecast_period': 'upper'})
+        accumulation_cube.rename(cube_name)
+        accumulation_cube.units = 'm'
+        return accumulation_cube
 
     def process(self, cubes):
         """
@@ -168,47 +202,14 @@ class Accumulation:
                 the accumulation periods are determined by plugin argument
                 accumulation_period.
         """
-        # Standardise inputs to expected units.
-        cubes = enforce_coordinate_units_and_dtypes(
-            cubes, ['time', 'forecast_reference_time', 'forecast_period'],
-            inplace=False)
-        enforce_diagnostic_units_and_dtypes(cubes)
-
-        # Sort cubes into time order and calculate intervals.
-        cubes, times = self.sort_cubes_by_time(cubes)
-        try:
-            time_interval, = np.unique(np.diff(times, axis=0))
-        except ValueError:
-            msg = ("Accumulation is designed to work with "
-                   "rates cubes at regular time intervals. Cubes "
-                   "provided are unevenly spaced in time; time intervals are "
-                   "{}.".format(np.diff(times, axis=0)))
-            raise ValueError(msg)
-
-        cube_subsets = self._get_period_sets(time_interval, cubes)
+        self._check_inputs(cubes)
 
         accumulation_cubes = iris.cube.CubeList()
-        for cube_subset in cube_subsets:
-            # Handle accumulation periods equal to the rates cube time interval
-            # in which case the last subset does not get used.
-            if len(cube_subset) == 1:
+        for cube in cubes:
+            accumulation = self._calculate_accumulations(cube, integral)
+            if accumulation is None:
                 continue
-
-            accumulation = 0.
-            # Accumulations are calculated using the mean precipitation rate
-            # calculated from the rates cubes that bookend the desired period.
-            iterator = zip(cube_subset[0:-1], cube_subset[1:])
-            for start_cube, end_cube in iterator:
-                accumulation += ((start_cube.data + end_cube.data) *
-                                 time_interval * 0.5)
-
-            cube_name = 'lwe_thickness_of_precipitation_amount'
-            accumulation_cube = expand_bounds(
-                cube_subset[0],
-                iris.cube.CubeList(cube_subset),
-                expanded_coords={'time': 'upper', 'forecast_period': 'upper'})
-            accumulation_cube.rename(cube_name)
-            accumulation_cube.units = 'm'
+            self.set_metadata(cube)
 
             # Calculate new data and insert into cube.
             accumulation_cube.data = accumulation

--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -34,12 +34,10 @@ accumulations from advected radar fields. It is also possible to create longer
 accumulations from shorter intervals.
 """
 import warnings
-from datetime import timedelta
 import numpy as np
 
 import iris
 from improver.utilities.cube_manipulation import expand_bounds
-from improver.utilities.temporal import iris_time_to_datetime
 from improver.utilities.cube_units import (enforce_coordinate_units_and_dtypes,
                                            enforce_diagnostic_units_and_dtypes)
 

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -235,7 +235,8 @@ class Test__check_inputs(rate_cube_set_up):
         expected_time_interval = 60
         expected_integral = 20
         expected_cubes = self.cubes.copy()
-        [cube.convert_units("m/s") for cube in expected_cubes]
+        for cube in expected_cubes:
+            cube.convert_units("m/s")
         accumulation_period = 20*60
         forecast_periods = [15]
         plugin = Accumulation(accumulation_period=accumulation_period,
@@ -386,6 +387,7 @@ class Test_process(rate_cube_set_up):
     """Tests the process method results in the expected outputs."""
 
     def setUp(self):
+        """Set up forecast periods used for testing."""
         super().setUp()
         self.forecast_periods = [
             cube.coord("forecast_period").points for cube in self.cubes[1:]]

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -304,10 +304,10 @@ class Test__get_cube_subsets(rate_cube_set_up):
             " accumulation_period, i.e. the number of cubes is insufficient to"
             " give a set of complete periods. Only complete periods will be"
             " returned.")
-        upper_bound_fp = self.cubes[5].coord("forecast_period").points
-        integral = 0
+        upper_bound_fp = self.cubes[8].coord("forecast_period").points
+        integral = 10
         plugin = Accumulation(
-            accumulation_period=5*60,
+            accumulation_period=10*60,
             forecast_periods=np.array([5])*60)
         result = plugin._get_cube_subsets(
             self.cubes, upper_bound_fp, integral)
@@ -324,10 +324,12 @@ class Test__calculate_accumulation(rate_cube_set_up):
 
     def test_basic(self):
         """Check the calculations of the accumulations, where an accumulation
-        is constructed from the cube subset by using 50% of the precipitation
-        rates cubes that bookend the accumulation period and 100% of the
-        precipitation rates cubes that are fully within the accumulation
-        period."""
+        is computed by finding the mean rate between each adjacent pair of
+        cubes within the cube_subset and multiplying this mean rate by the
+        time_interval, in order to compute an accumulation. In this case,
+        as the cube_subset only contains a pair of cubes, then the
+        accumulation from this pair will be the same as the total accumulation.
+        """
         expected_t0 = np.array([
             [0.015, 0.03, 0.03, 0.03, 0.03, 0.06, 0.09, 0.09, 0.09, 0.09],
             [0.015, 0.03, 0.03, 0.03, 0.03, np.nan, np.nan, 0.09, 0.09, 0.09],

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -188,7 +188,8 @@ class Test__check_inputs(rate_cube_set_up):
         expected_time_interval = 60
         expected_integral = 10
         expected_cubes = self.cubes.copy()
-        [cube.convert_units("m/s") for cube in expected_cubes]
+        for cube in expected_cubes:
+            cube.convert_units("m/s")
         cubes, time_interval, integral = (
             Accumulation()._check_inputs(self.cubes))
         self.assertEqual(cubes, expected_cubes)
@@ -202,7 +203,8 @@ class Test__check_inputs(rate_cube_set_up):
         expected_time_interval = 60
         expected_integral = 60
         expected_cubes = self.cubes.copy()
-        [cube.convert_units("m/s") for cube in expected_cubes]
+        for cube in expected_cubes:
+            cube.convert_units("m/s")
         accumulation_period = 60*60
         plugin = Accumulation(accumulation_period=accumulation_period)
         cubes, time_interval, integral = plugin._check_inputs(self.cubes)
@@ -218,7 +220,8 @@ class Test__check_inputs(rate_cube_set_up):
         expected_time_interval = 60
         expected_integral = 10
         expected_cubes = self.cubes.copy()
-        [cube.convert_units("m/s") for cube in expected_cubes]
+        for cube in expected_cubes:
+            cube.convert_units("m/s")
         forecast_periods = [60]
         plugin = Accumulation(forecast_periods=forecast_periods)
         cubes, time_interval, integral = plugin._check_inputs(self.cubes)

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -442,8 +442,6 @@ class Test_process(rate_cube_set_up):
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
         plugin = Accumulation(accumulation_units='mm')
-        for acube in self.cubes:
-            print("acube = ", acube.coord("time"))
         result = plugin.process(self.cubes)
 
         self.assertArrayAlmostEqual(result[0].data, expected_t0)

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -233,6 +233,32 @@ class Test__get_period_sets(rate_cube_set_up):
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
 
+    @ManageWarnings(record=True)
+    def test_raises_warning_when_no_cubes_returned(self, warning_list=None):
+        """Test function raises a warning when the accumulation period
+        requested is larger than the time range available from the input cubes.
+        In this test the accumulation period is 60 minutes, but the total span
+        of rates cubes covers 10 minutes, resulting
+        in no complete periods available. This test checks that a warning is
+        raised to highlight that only complete periods are returned."""
+
+        time_interval = 60
+        warning_msg = (
+            "The provided cubes result in a partial period given the specified"
+            " accumulation_period, i.e. the number of cubes is insufficient to"
+            " give a set of complete periods. Only complete periods will be"
+            " returned.")
+
+        expected = []
+        plugin = Accumulation(accumulation_period=60*60)
+        result = plugin._get_period_sets(time_interval, self.cubes)
+
+        self.assertListEqual(result, expected)
+        self.assertTrue(any(item.category == UserWarning
+                            for item in warning_list))
+        self.assertTrue(any(warning_msg in str(item)
+                            for item in warning_list))
+
     def test_raises_exception_for_impossible_aggregation(self):
         """Test function raises an exception when attempting to create an
         accumulation_period that cannot be created from the input cubes."""

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -284,27 +284,13 @@ class Test__get_cube_subsets(rate_cube_set_up):
         used for each accumulation period is expected to consist of 5 + 1
         cubes, so the integral is 5."""
         expected_cube_subset = self.cubes[:6]
-        upper_bound_cube = self.cubes[5]
+        upper_bound_fp, = self.cubes[5].coord("forecast_period").points
         integral = 5
         plugin = Accumulation(
             accumulation_period=5*60,
             forecast_periods=np.array([5])*60)
         result = plugin._get_cube_subsets(
-            self.cubes, upper_bound_cube, integral)
-        self.assertEqual(expected_cube_subset, result)
-
-    def test_not_a_desired_forecast_period(self):
-        """Test that if the forecast period of the upper bound cube is
-        not within the list of requested forecast periods, then the
-        subset of cubes returned is equal to None."""
-        expected_cube_subset = None
-        upper_bound_cube = self.cubes[-1]
-        integral = None
-        plugin = Accumulation(
-            accumulation_period=5*60,
-            forecast_periods=np.array([11])*60)
-        result = plugin._get_cube_subsets(
-            self.cubes, upper_bound_cube, integral)
+            self.cubes, upper_bound_fp, integral)
         self.assertEqual(expected_cube_subset, result)
 
     @ManageWarnings(record=True)
@@ -318,13 +304,13 @@ class Test__get_cube_subsets(rate_cube_set_up):
             " accumulation_period, i.e. the number of cubes is insufficient to"
             " give a set of complete periods. Only complete periods will be"
             " returned.")
-        upper_bound_cube = self.cubes[5]
+        upper_bound_fp = self.cubes[5].coord("forecast_period").points
         integral = 0
         plugin = Accumulation(
             accumulation_period=5*60,
             forecast_periods=np.array([5])*60)
         result = plugin._get_cube_subsets(
-            self.cubes, upper_bound_cube, integral)
+            self.cubes, upper_bound_fp, integral)
         self.assertEqual(expected_cube_subset, result)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -177,7 +177,6 @@ class Test_sort_cubes_by_time(rate_cube_set_up):
         self.assertArrayEqual(times, expected)
 
 
-
 class Test__check_inputs(rate_cube_set_up):
 
     """Test the _check_inputs method."""
@@ -263,7 +262,6 @@ class Test__check_inputs(rate_cube_set_up):
     def test_raises_exception_for_impossible_aggregation(self):
         """Test function raises an exception when attempting to create an
         accumulation_period that cannot be created from the input cubes."""
-
 
         plugin = Accumulation(accumulation_period=119)
         msg = "The specified accumulation period "
@@ -368,7 +366,7 @@ class Test__set_metadata(rate_cube_set_up):
         expected_units = Unit("m")
         expected_time_point = [datetime.datetime(2017, 11, 10, 4, 10)]
         expected_time_bounds = [(datetime.datetime(2017, 11, 10, 4, 0),
-                            datetime.datetime(2017, 11, 10, 4, 10))]
+                                 datetime.datetime(2017, 11, 10, 4, 10))]
         expected_fp_point = 600
         expected_fp_bounds = [[0, 600]]
         result = Accumulation()._set_metadata(self.cubes)

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -186,31 +186,26 @@ class Test__check_inputs(rate_cube_set_up):
         returned. Also test that the returned list of cubes has the
         expected units."""
         expected_time_interval = 60
-        expected_integral = 10
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
             cube.convert_units("m/s")
-        cubes, time_interval, integral = (
-            Accumulation()._check_inputs(self.cubes))
+        cubes, time_interval = Accumulation()._check_inputs(self.cubes)
         self.assertEqual(cubes, expected_cubes)
         self.assertEqual(time_interval, expected_time_interval)
-        self.assertEqual(integral, expected_integral)
 
     def test_specify_accumulation_period(self):
         """Test that the expected time interval and integral value is
         returned when the accumulation period is specified. Also test that the
         returned list of cubes has the expected units."""
         expected_time_interval = 60
-        expected_integral = 60
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
             cube.convert_units("m/s")
         accumulation_period = 60*60
         plugin = Accumulation(accumulation_period=accumulation_period)
-        cubes, time_interval, integral = plugin._check_inputs(self.cubes)
+        cubes, time_interval = plugin._check_inputs(self.cubes)
         self.assertEqual(cubes, expected_cubes)
         self.assertEqual(time_interval, expected_time_interval)
-        self.assertEqual(integral, expected_integral)
         self.assertEqual(plugin.accumulation_period, accumulation_period)
 
     def test_specify_forecast_period(self):
@@ -218,16 +213,14 @@ class Test__check_inputs(rate_cube_set_up):
         returned when the forecast periods are specified. Also test that the
         returned list of cubes has the expected units."""
         expected_time_interval = 60
-        expected_integral = 10
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
             cube.convert_units("m/s")
         forecast_periods = [600]
         plugin = Accumulation(forecast_periods=forecast_periods)
-        cubes, time_interval, integral = plugin._check_inputs(self.cubes)
+        cubes, time_interval = plugin._check_inputs(self.cubes)
         self.assertEqual(cubes, expected_cubes)
         self.assertEqual(time_interval, expected_time_interval)
-        self.assertEqual(integral, expected_integral)
         self.assertEqual(plugin.forecast_periods, forecast_periods)
 
     def test_specify_accumulation_period_and_forecast_period(self):
@@ -236,7 +229,6 @@ class Test__check_inputs(rate_cube_set_up):
         specified. Also test that the returned list of cubes has the expected
         units."""
         expected_time_interval = 60
-        expected_integral = 20
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
             cube.convert_units("m/s")
@@ -244,10 +236,9 @@ class Test__check_inputs(rate_cube_set_up):
         forecast_periods = np.array([15])*60
         plugin = Accumulation(accumulation_period=accumulation_period,
                               forecast_periods=forecast_periods)
-        cubes, time_interval, integral = plugin._check_inputs(self.cubes)
+        cubes, time_interval = plugin._check_inputs(self.cubes)
         self.assertEqual(cubes, expected_cubes)
         self.assertEqual(time_interval, expected_time_interval)
-        self.assertEqual(integral, expected_integral)
 
     def test_raises_exception_for_unevenly_spaced_cubes(self):
         """Test function raises an exception if the input cubes are not

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -182,9 +182,8 @@ class Test__check_inputs(rate_cube_set_up):
     """Test the _check_inputs method."""
 
     def test_basic(self):
-        """Test that the expected time_interval and integral value is
-        returned. Also test that the returned list of cubes has the
-        expected units."""
+        """Test that the expected time_interval is returned and that the
+        returned list of cubes has the expected units."""
         expected_time_interval = 60
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
@@ -194,9 +193,9 @@ class Test__check_inputs(rate_cube_set_up):
         self.assertEqual(time_interval, expected_time_interval)
 
     def test_specify_accumulation_period(self):
-        """Test that the expected time interval and integral value is
-        returned when the accumulation period is specified. Also test that the
-        returned list of cubes has the expected units."""
+        """Test that the expected time interval is returned when the
+        accumulation period is specified. Also test that the returned list of
+        cubes has the expected units."""
         expected_time_interval = 60
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
@@ -209,9 +208,9 @@ class Test__check_inputs(rate_cube_set_up):
         self.assertEqual(plugin.accumulation_period, accumulation_period)
 
     def test_specify_forecast_period(self):
-        """Test that the expected time interval and integral value is
-        returned when the forecast periods are specified. Also test that the
-        returned list of cubes has the expected units."""
+        """Test that the expected time interval is returned when the forecast
+        periods are specified. Also test that the returned list of cubes has
+        the expected units."""
         expected_time_interval = 60
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
@@ -224,10 +223,9 @@ class Test__check_inputs(rate_cube_set_up):
         self.assertEqual(plugin.forecast_periods, forecast_periods)
 
     def test_specify_accumulation_period_and_forecast_period(self):
-        """Test that the expected time interval and integral value is
-        returned when the accumulation period and forecast periods are
-        specified. Also test that the returned list of cubes has the expected
-        units."""
+        """Test that the expected time interval is returned when the
+        accumulation period and forecast periods are specified. Also test that
+        the returned list of cubes has the expected units."""
         expected_time_interval = 60
         expected_cubes = self.cubes.copy()
         for cube in expected_cubes:
@@ -288,8 +286,7 @@ class Test__get_cube_subsets(rate_cube_set_up):
     def test_basic(self):
         """Test that the subset of cubes that are within the accumulation
         period are correctly identified. In this case, the subset of cubes
-        used for each accumulation period is expected to consist of 5 + 1
-        cubes, so the integral is 5."""
+        used for each accumulation period is expected to consist of 6 cubes."""
         expected_cube_subset = self.cubes[:6]
         upper_bound_fp, = self.cubes[5].coord("forecast_period").points
         plugin = Accumulation(

--- a/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
+++ b/lib/improver/tests/nowcasting/accumulation/test_Accumulation.py
@@ -181,7 +181,7 @@ class Test__get_period_sets(rate_cube_set_up):
         result = plugin._get_period_sets(time_interval, self.cubes)
         self.assertIsInstance(result, list)
 
-    def test_returns_expected_cubes(self, warning_list=None):
+    def test_returns_expected_cubes(self):
         """Test function returns lists containing the expected cubes for each
         period. In this test all the cubes are used as the total time span of
         precipitation rates cubes is divisible by the requested accumulation
@@ -335,12 +335,13 @@ class Test_process(rate_cube_set_up):
     def test_does_not_use_incomplete_period_data(self):
         """Test function returns only 2 accumulation periods when a 4 minute
         aggregation period is used with 10 minutes of input data. The trailing
-        2 cubes are insufficient to create another period and so are disgarded.
+        2 cubes are insufficient to create another period and so are discarded.
         A warning is raised by the chunking function and has been tested above,
         so is ignored here.
         """
 
-        plugin = Accumulation(accumulation_period=240)
+        plugin = Accumulation(accumulation_period=240,
+                              forecast_periods=[240, 480])
         result = plugin.process(self.cubes)
         self.assertEqual(len(result), 2)
 
@@ -375,7 +376,8 @@ class Test_process(rate_cube_set_up):
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
-        plugin = Accumulation(accumulation_period=300, accumulation_units='mm')
+        plugin = Accumulation(accumulation_period=300, accumulation_units='mm',
+                              forecast_periods=[300, 600])
         result = plugin.process(self.cubes)
 
         self.assertArrayAlmostEqual(result[0].data, expected_t0)
@@ -440,6 +442,8 @@ class Test_process(rate_cube_set_up):
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
         plugin = Accumulation(accumulation_units='mm')
+        for acube in self.cubes:
+            print("acube = ", acube.coord("time"))
         result = plugin.process(self.cubes)
 
         self.assertArrayAlmostEqual(result[0].data, expected_t0)

--- a/tests/improver-nowcast-extrapolate/01-help.bats
+++ b/tests/improver-nowcast-extrapolate/01-help.bats
@@ -46,6 +46,7 @@ usage: improver nowcast-extrapolate [-h] [--profile]
                                     [--max_lead_time MAX_LEAD_TIME]
                                     [--lead_time_interval LEAD_TIME_INTERVAL]
                                     [--accumulation_fidelity ACCUMULATION_FIDELITY]
+                                    [--accumulation_period ACCUMULATION_PERIOD]
                                     [--accumulation_units ACCUMULATION_UNITS]
                                     INPUT_FILEPATH
 
@@ -111,6 +112,12 @@ Calculate accumulations from advected fields:
                         between advected fields that is used to calculate
                         these accumulations. This interval must be a factor of
                         the lead_time_interval.
+  --accumulation_period ACCUMULATION_PERIOD
+                        The period over which the accumulation is calculated
+                        (mins). Only full accumulation periods will be
+                        computed, so if the lead times are shorter than the
+                        accumulation period than these lead times will not be
+                        calculated.
   --accumulation_units ACCUMULATION_UNITS
                         Desired units in which the accumulations should be
                         expressed,e.g. mm

--- a/tests/improver-nowcast-extrapolate/01-help.bats
+++ b/tests/improver-nowcast-extrapolate/01-help.bats
@@ -115,9 +115,9 @@ Calculate accumulations from advected fields:
   --accumulation_period ACCUMULATION_PERIOD
                         The period over which the accumulation is calculated
                         (mins). Only full accumulation periods will be
-                        computed, so if the lead times are shorter than the
-                        accumulation period than these lead times will not be
-                        calculated.
+                        computed. At lead times that are shorter than the
+                        accumulation period, no accumulation output will be
+                        produced.
   --accumulation_units ACCUMULATION_UNITS
                         Desired units in which the accumulations should be
                         expressed,e.g. mm

--- a/tests/improver-nowcast-extrapolate/13-accumulation_period.bats
+++ b/tests/improver-nowcast-extrapolate/13-accumulation_period.bats
@@ -48,7 +48,8 @@
     --northward_advection "$VCOMP" \
     --orographic_enhancement_filepaths \
     "$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/$OE1" \
-    --accumulation_fidelity 5 --accumulation_period 30
+    --accumulation_fidelity 5 --accumulation_period 15 \
+    --lead_time_interval 5
   [[ "$status" -eq 0 ]]
 
   T0="20181103T1630Z-PT0000H30M-lwe_thickness_of_precipitation_amount.nc"

--- a/tests/improver-nowcast-extrapolate/13-accumulation_period.bats
+++ b/tests/improver-nowcast-extrapolate/13-accumulation_period.bats
@@ -48,7 +48,7 @@
     --northward_advection "$VCOMP" \
     --orographic_enhancement_filepaths \
     "$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/$OE1" \
-    --accumulation_fidelity 5 --accumulation_period 15 \
+    --accumulation_fidelity 5 --accumulation_period 30 \
     --lead_time_interval 5
   [[ "$status" -eq 0 ]]
 


### PR DESCRIPTION
Description
This PR is aimed at modifying the accumulation plugin to support overlapping periods. The changes are:
- nowcast_extrapolate.py - Add an `accumulation_period` CLI argument and pass this through to the accumulation period. 
- accumulation.py - Although there looks like a lot of changes, there is only a small amount of new code. The new code is predominately in _get_cube_subsets. Another change is to allow the specification of the `forecast_periods` required within the `__init__`. This allows a check for whether an accumulation period that ends at the specified forecast_period requires calculation. The rest of the changes mainly relate to putting things from `process` into methods, so that I could test the different sections more directly.
- test_accumulation.py - This has been updated, in line with the changes to `accumulation.py`. 
- 00-null.bats and 01-help.bats following the addition of the `accumulation_period` CLI argument.
- Addition of the 13-accumulation_period.bats, so as to test the `accumulation_period` CLI argument.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

