### PR TITLE
IMPRO-1312: Ensure SVP table useable with float32 temperature above max temperature

### DIFF
--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -306,8 +306,11 @@ class WetBulbTemperature(object):
             svp (iris.cube.Cube):
                 A cube of saturated vapour pressures (Pa).
         """
-        T_min = svp_table.T_MIN
+        # We subtract T_INCREMENT from T_MAX to get the upper bound to which we
+        # clip input temperatures. This ensures that we do not attempt an
+        # interpolation that requires a value beyond the SVP table maximum.
         T_max = svp_table.T_MAX - svp_table.T_INCREMENT
+        T_min = svp_table.T_MIN
         delta_T = svp_table.T_INCREMENT
         self.check_range(temperature, T_min, T_max)
         temperatures = temperature.data

--- a/lib/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/lib/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -307,7 +307,7 @@ class WetBulbTemperature(object):
                 A cube of saturated vapour pressures (Pa).
         """
         T_min = svp_table.T_MIN
-        T_max = svp_table.T_MAX
+        T_max = svp_table.T_MAX - svp_table.T_INCREMENT
         delta_T = svp_table.T_INCREMENT
         self.check_range(temperature, T_min, T_max)
         temperatures = temperature.data

--- a/lib/improver/psychrometric_calculations/svp_table.py
+++ b/lib/improver/psychrometric_calculations/svp_table.py
@@ -53,7 +53,7 @@ import numpy as np
 # These values describe the range in temperatures covered by the table and
 # the increments at which data points are given.
 T_MIN = 183.15
-T_MAX = 338.15
+T_MAX = 338.25
 T_INCREMENT = 0.1
 
 DATA = np.array([
@@ -367,5 +367,5 @@ DATA = np.array([
     2.338401e+04, 2.348988e+04, 2.359615e+04, 2.370283e+04, 2.380993e+04,
     2.391743e+04, 2.402534e+04, 2.413367e+04, 2.424241e+04, 2.435156e+04,
     2.446114e+04, 2.457113e+04, 2.468154e+04, 2.479237e+04, 2.490363e+04,
-    2.501530e+04
+    2.501530e+04, 2.512741e+04
 ])

--- a/lib/improver/tests/utilities/ancillary_creation/test_SaturatedVapourPressureTable.py
+++ b/lib/improver/tests/utilities/ancillary_creation/test_SaturatedVapourPressureTable.py
@@ -48,7 +48,7 @@ class Test__repr__(IrisTest):
         """Test that the __repr__ returns the expected string."""
         result = str(SaturatedVapourPressureTable())
         msg = ('<SaturatedVapourPressureTable: t_min: {}; t_max: {}; '
-               't_increment: {}>'.format(183.15, 338.15, 0.1))
+               't_increment: {}>'.format(183.15, 338.25, 0.1))
         self.assertEqual(result, msg)
 
 

--- a/lib/improver/utilities/ancillary_creation.py
+++ b/lib/improver/utilities/ancillary_creation.py
@@ -225,9 +225,16 @@ class SaturatedVapourPressureTable(object):
     Plugin to create a saturated vapour pressure lookup table.
     """
 
-    def __init__(self, t_min=183.15, t_max=338.15, t_increment=0.1):
+    def __init__(self, t_min=183.15, t_max=338.25, t_increment=0.1):
         """
-        Initialise class.
+        Create a table of saturated vapour pressures that can be interpolated
+        through to obtain an SVP value for any temperature within the range
+        t_min --> (t_max - t_increment).
+
+        The default min/max values create a table that provides SVP values
+        covering the temperature range -90C to +65.1C. Note that the last
+        bin is not used, so the SVP value corresponding to +65C is the highest
+        that will be used.
 
         Args:
             t_min (float):


### PR DESCRIPTION
The more exact answer provided to a simple calculation when using float32 means that we need an additional, but unused table entry to enable interpolation when temperatures are at the maximum temperature for which we want to use the table.
```
float64 --> 1549.9999999999995
float32 --> 1550.0
```
The calculation in float64 gave a rounded down index of 1549, and an interpolant of 1, meaning the value for the saturated vapour pressure would be equal to the value at index 1550. In float32 the index returned is 1550, and the interpolant is 0. However we still need the index+1 table position to keep our calculation general (rather than making a special case for this highest value). That is the purpose of this change.

See ticket and linked notebook for more discussion of the issue.

Testing:
 - [x] Ran tests and they passed OK
