### PR TITLE
IMPRO-983: Psychrometric unit tests

### DIFF
--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -39,7 +39,6 @@ from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
     FallingSnowLevel)
-
 from improver.tests.set_up_test_cubes import (set_up_variable_cube,
                                               add_coordinate)
 

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -443,8 +443,7 @@ class Test_process(IrisTest):
     def setUp(self):
         """Set up orography and land-sea mask cubes. Also create temperature,
         pressure, and relative humidity cubes that contain multiple height
-        levels.
-        """
+        levels."""
 
         data = np.ones((3, 3), dtype=np.float32)
         relh_data = np.ones((3, 3), dtype=np.float32) * 0.65

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -32,6 +32,7 @@
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 
 from cf_units import Unit
 import iris
@@ -39,10 +40,9 @@ from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
     FallingSnowLevel)
-from improver.tests.ensemble_calibration.ensemble_calibration.\
-    helper_functions import set_up_cube
-from improver.tests.utilities.test_mathematical_operations import (
-    set_up_height_cube)
+
+from improver.tests.set_up_test_cubes import (set_up_variable_cube,
+                                              add_coordinate)
 
 
 class Test__repr__(IrisTest):
@@ -448,49 +448,45 @@ class Test_process(IrisTest):
         temp_vals = [278.0, 280.0, 285.0, 286.0]
         pressure_vals = [93856.0, 95034.0, 96216.0, 97410.0]
 
-        data = np.ones((2, 1, 3, 3))
-        relh_data = np.ones((2, 1, 3, 3)) * 0.65
+        data = np.ones((3, 3), dtype=np.float32)
+        relh_data = np.ones((3, 3), dtype=np.float32) * 0.65
 
-        temperature = set_up_cube(data, 'air_temperature', 'K',
-                                  realizations=np.array([0, 1]))
-        relative_humidity = set_up_cube(relh_data, 'relative_humidity', '%',
-                                        realizations=np.array([0, 1]))
-        pressure = set_up_cube(data, 'air_pressure', 'Pa',
-                               realizations=np.array([0, 1]))
-        self.height_points = np.array([5., 195., 200.])
-        self.temperature_cube = set_up_height_cube(
-            self.height_points, cube=temperature)
-        self.relative_humidity_cube = (
-            set_up_height_cube(self.height_points, cube=relative_humidity))
-        self.pressure_cube = set_up_height_cube(
-            self.height_points, cube=pressure)
+        self.height_points = [5., 195., 200.]
+        height_attribute = {"positive": "up"}
+
+        self.orog = set_up_variable_cube(
+            data, name='surface_altitude', units='m', spatial_grid='equalarea')
+        self.land_sea = set_up_variable_cube(
+            data, name='land_binary_mask', units=1, spatial_grid='equalarea')
+
+        temperature = set_up_variable_cube(data, spatial_grid='equalarea')
+        temperature = add_coordinate(temperature, [0, 1], 'realization')
+        self.temperature_cube = add_coordinate(
+            temperature, self.height_points, 'height', coord_units='m')
+        self.temperature_cube.coord('height').attributes = height_attribute
+
+        relative_humidity = set_up_variable_cube(
+            relh_data, name='relative_humidity', units='%',
+            spatial_grid='equalarea')
+        relative_humidity = add_coordinate(
+            relative_humidity, [0, 1], 'realization')
+        self.relative_humidity_cube = add_coordinate(
+            relative_humidity, self.height_points, 'height', coord_units='m')
+        self.relative_humidity_cube.coord('height').attributes = height_attribute
+
+        pressure = set_up_variable_cube(
+            data, name='air_pressure', units='Pa', spatial_grid='equalarea')
+        pressure = add_coordinate(pressure, [0, 1], 'realization')
+        self.pressure_cube = add_coordinate(
+            pressure, self.height_points, 'height', coord_units='m')
+        self.pressure_cube.coord('height').attributes = height_attribute
+
         for i in range(0, 3):
             self.temperature_cube.data[i, ::] = temp_vals[i+1]
             self.pressure_cube.data[i, ::] = pressure_vals[i+1]
             # Add hole in middle of data.
-            self.temperature_cube.data[i, :, :, 1, 1] = temp_vals[i]
-            self.pressure_cube.data[i, :, :, 1, 1] = pressure_vals[i]
-
-        x_coord = iris.coords.DimCoord(np.linspace(-2000, 2000, 3),
-                                       'projection_x_coordinate', units='m')
-        y_coord = iris.coords.DimCoord(np.linspace(-2000, 2000, 3),
-                                       'projection_y_coordinate', units='m')
-        self.orog = iris.cube.Cube(np.ones((3, 3)),
-                                   standard_name='surface_altitude', units='m')
-        self.land_sea = iris.cube.Cube(np.ones((3, 3)),
-                                       standard_name='land_binary_mask',
-                                       units='m')
-        cubes = [self.temperature_cube, self.relative_humidity_cube,
-                 self.pressure_cube]
-        for cube in cubes:
-            cube.remove_coord("latitude")
-            cube.remove_coord("longitude")
-            cube.add_dim_coord(x_coord, 3)
-            cube.add_dim_coord(y_coord, 4)
-        cubes = [self.orog, self.land_sea]
-        for cube in cubes:
-            cube.add_dim_coord(x_coord, 0)
-            cube.add_dim_coord(y_coord, 1)
+            self.temperature_cube.data[i, :, 1, 1] = temp_vals[i]
+            self.pressure_cube.data[i, :, 1, 1] = pressure_vals[i]
 
     def test_basic(self):
         """Test that process returns a cube with the right name and units."""
@@ -498,7 +494,7 @@ class Test_process(IrisTest):
         result = FallingSnowLevel().process(
             self.temperature_cube, self.relative_humidity_cube,
             self.pressure_cube, self.orog, self.land_sea)
-        expected = np.ones((2, 3, 3)) * 66.88732723
+        expected = np.ones((2, 3, 3), dtype=np.float32) * 66.88566
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "falling_snow_level_asl")
         self.assertEqual(result.units, Unit('m'))
@@ -507,7 +503,7 @@ class Test_process(IrisTest):
     def test_data(self):
         """Test that the falling snow level process returns a cube
         containing the expected data when points at sea-level."""
-        expected = np.ones((2, 3, 3)) * 65.88732723
+        expected = np.ones((2, 3, 3), dtype=np.float32) * 65.88566
         orog = self.orog
         orog.data = orog.data * 0.0
         orog.data[1, 1] = 100.0

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -32,7 +32,6 @@
 import unittest
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 from cf_units import Unit
 import iris

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -471,7 +471,8 @@ class Test_process(IrisTest):
             relative_humidity, [0, 1], 'realization')
         self.relative_humidity_cube = add_coordinate(
             relative_humidity, self.height_points, 'height', coord_units='m')
-        self.relative_humidity_cube.coord('height').attributes = height_attribute
+        self.relative_humidity_cube.coord('height').attributes = (
+            height_attribute)
 
         pressure = set_up_variable_cube(
             data, name='air_pressure', units='Pa', spatial_grid='equalarea')

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -444,9 +444,6 @@ class Test_process(IrisTest):
     def setUp(self):
         """Set up cubes."""
 
-        temp_vals = [278.0, 280.0, 285.0, 286.0]
-        pressure_vals = [93856.0, 95034.0, 96216.0, 97410.0]
-
         data = np.ones((3, 3), dtype=np.float32)
         relh_data = np.ones((3, 3), dtype=np.float32) * 0.65
 
@@ -461,8 +458,8 @@ class Test_process(IrisTest):
         temperature = set_up_variable_cube(data, spatial_grid='equalarea')
         temperature = add_coordinate(temperature, [0, 1], 'realization')
         self.temperature_cube = add_coordinate(
-            temperature, self.height_points, 'height', coord_units='m')
-        self.temperature_cube.coord('height').attributes = height_attribute
+            temperature, self.height_points, 'height', coord_units='m',
+            attributes=height_attribute)
 
         relative_humidity = set_up_variable_cube(
             relh_data, name='relative_humidity', units='%',
@@ -470,17 +467,19 @@ class Test_process(IrisTest):
         relative_humidity = add_coordinate(
             relative_humidity, [0, 1], 'realization')
         self.relative_humidity_cube = add_coordinate(
-            relative_humidity, self.height_points, 'height', coord_units='m')
-        self.relative_humidity_cube.coord('height').attributes = (
-            height_attribute)
+            relative_humidity, self.height_points, 'height', coord_units='m',
+            attributes=height_attribute)
 
         pressure = set_up_variable_cube(
             data, name='air_pressure', units='Pa', spatial_grid='equalarea')
         pressure = add_coordinate(pressure, [0, 1], 'realization')
         self.pressure_cube = add_coordinate(
-            pressure, self.height_points, 'height', coord_units='m')
-        self.pressure_cube.coord('height').attributes = height_attribute
+            pressure, self.height_points, 'height', coord_units='m',
+            attributes=height_attribute)
 
+        # Assign different temperatures and pressures to each height.
+        temp_vals = [278.0, 280.0, 285.0, 286.0]
+        pressure_vals = [93856.0, 95034.0, 96216.0, 97410.0]
         for i in range(0, 3):
             self.temperature_cube.data[i, ::] = temp_vals[i+1]
             self.pressure_cube.data[i, ::] = pressure_vals[i+1]

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_FallingSnowLevel.py
@@ -441,7 +441,10 @@ class Test_process(IrisTest):
     """Test the FallingSnowLevel processing works"""
 
     def setUp(self):
-        """Set up cubes."""
+        """Set up orography and land-sea mask cubes. Also create temperature,
+        pressure, and relative humidity cubes that contain multiple height
+        levels.
+        """
 
         data = np.ones((3, 3), dtype=np.float32)
         relh_data = np.ones((3, 3), dtype=np.float32) * 0.65

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_Utilities.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_Utilities.py
@@ -40,6 +40,8 @@ from cf_units import Unit
 from improver.psychrometric_calculations.psychrometric_calculations import (
     Utilities)
 
+from improver.tests.set_up_test_cubes import set_up_variable_cube
+
 
 class Test_Utilities(IrisTest):
 
@@ -58,6 +60,19 @@ class Test_Utilities(IrisTest):
         mixing_ratio = Cube([0.1, 0.2, 0.3], long_name='humidity_mixing_ratio',
                             units='1',
                             dim_coords_and_dims=[(longitude, 0)])
+
+
+        data = np.array([[260., 270., 280.]], dtype=np.float32)
+        temperature = set_up_variable_cube(data)
+        data = np.array([[60., 70., 80.]], dtype=np.float32)
+        relative_humidity = set_up_variable_cube(
+            data, name='relative_humidity', units='%')
+        data = np.array([[1.E5, 9.9E4, 9.8E4]], dtype=np.float32)
+        pressure = set_up_variable_cube(
+            data, name='air_pressure', units='Pa')
+        data = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+        mixing_ratio = set_up_variable_cube(
+            data, name='humidity_mixing_ratio', units='1')
 
         self.temperature = temperature
         self.pressure = pressure
@@ -83,9 +98,9 @@ class Test_specific_heat_of_moist_air(Test_Utilities):
 
     def test_basic(self):
         """Basic calculation of some moist air specific heat capacities."""
-        expected = [1089.5, 1174., 1258.5]
+        expected = [[1089.499979, 1174.000017, 1258.50001]]
         result = Utilities.specific_heat_of_moist_air(self.mixing_ratio)
-        self.assertArrayEqual(result.data, expected)
+        self.assertArrayAlmostEqual(result.data, expected)
         self.assertEqual(result.units, Unit('J kg-1 K-1'))
 
 
@@ -96,9 +111,9 @@ class Test_latent_heat_of_condensation(Test_Utilities):
 
     def test_basic(self):
         """Basic calculation of some latent heats of condensation."""
-        expected = [2531771., 2508371., 2484971.]
+        expected = [[2531770.999107, 2508371.000223, 2484971.000223]]
         result = Utilities.latent_heat_of_condensation(self.temperature)
-        self.assertArrayEqual(result.data, expected)
+        self.assertArrayAlmostEqual(result.data, expected)
         self.assertEqual(result.units, Unit('J kg-1'))
 
 
@@ -109,12 +124,12 @@ class Test_calculate_enthalpy(Test_Utilities):
 
     def test_basic(self):
         """Basic calculation of some enthalpies."""
-        specific_heat = self.pressure.copy(data=[1089.5, 1174., 1258.5])
+        specific_heat = self.pressure.copy(data=[[1089.5, 1174., 1258.5]])
         specific_heat.units = 'J kg-1 K-1'
-        latent_heat = self.pressure.copy(data=[2531771., 2508371., 2484971.])
+        latent_heat = self.pressure.copy(data=[[2531771., 2508371., 2484971.]])
         latent_heat.units = 'J kg-1'
 
-        expected = [536447.1, 818654.2, 1097871.3]
+        expected = [[536447.103773,  818654.207476, 1097871.329623]]
         result = Utilities.calculate_enthalpy(
             self.mixing_ratio, specific_heat, latent_heat, self.temperature)
 
@@ -130,12 +145,12 @@ class Test_calculate_d_enthalpy_dt(Test_Utilities):
 
     def test_basic(self):
         """Basic calculation of some enthalpy gradients."""
-        specific_heat = self.pressure.copy(data=[1089.5, 1174., 1258.5])
+        specific_heat = self.pressure.copy(data=[[1089.5, 1174., 1258.5]])
         specific_heat.units = 'J kg-1 K-1'
-        latent_heat = self.pressure.copy(data=[2531771., 2508371., 2484971.])
+        latent_heat = self.pressure.copy(data=[[2531771., 2508371., 2484971.]])
         latent_heat.units = 'J kg-1'
 
-        expected = [21631.19827498, 38569.57448917, 52448.13601681]
+        expected = [[21631.198581, 38569.575046, 52448.138051]]
         result = Utilities.calculate_d_enthalpy_dt(
             self.mixing_ratio, specific_heat, latent_heat, self.temperature)
 
@@ -152,7 +167,7 @@ class Test_saturation_vapour_pressure_goff_gratch(Test_Utilities):
         """Basic calculation of some saturated vapour pressures."""
         result = Utilities.saturation_vapour_pressure_goff_gratch(
             self.temperature)
-        expected = [195.64190713, 469.67078994, 990.94206073]
+        expected = [[195.6419, 469.67078, 990.9421]]
 
         np.testing.assert_allclose(result.data, expected, rtol=1.e-5)
         self.assertEqual(result.units, Unit('Pa'))

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_Utilities.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_Utilities.py
@@ -50,34 +50,17 @@ class Test_Utilities(IrisTest):
     def setUp(self):
         """Set up the initial conditions for tests."""
 
-        longitude = DimCoord([0, 10, 20], 'longitude', units='degrees')
-        temperature = Cube([260., 270., 280.], 'air_temperature', units='K',
-                           dim_coords_and_dims=[(longitude, 0)])
-        pressure = Cube([1.E5, 9.9E4, 9.8E4], 'air_pressure', units='Pa',
-                        dim_coords_and_dims=[(longitude, 0)])
-        relative_humidity = Cube([60, 70, 80], 'relative_humidity', units='%',
-                                 dim_coords_and_dims=[(longitude, 0)])
-        mixing_ratio = Cube([0.1, 0.2, 0.3], long_name='humidity_mixing_ratio',
-                            units='1',
-                            dim_coords_and_dims=[(longitude, 0)])
-
-
         data = np.array([[260., 270., 280.]], dtype=np.float32)
-        temperature = set_up_variable_cube(data)
+        self.temperature = set_up_variable_cube(data)
         data = np.array([[60., 70., 80.]], dtype=np.float32)
-        relative_humidity = set_up_variable_cube(
+        self.relative_humidity = set_up_variable_cube(
             data, name='relative_humidity', units='%')
         data = np.array([[1.E5, 9.9E4, 9.8E4]], dtype=np.float32)
-        pressure = set_up_variable_cube(
+        self.pressure = set_up_variable_cube(
             data, name='air_pressure', units='Pa')
         data = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
-        mixing_ratio = set_up_variable_cube(
+        self.mixing_ratio = set_up_variable_cube(
             data, name='humidity_mixing_ratio', units='1')
-
-        self.temperature = temperature
-        self.pressure = pressure
-        self.relative_humidity = relative_humidity
-        self.mixing_ratio = mixing_ratio
 
 
 class Test__repr__(IrisTest):

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperature.py
@@ -137,7 +137,7 @@ class Test_pressure_correct_svp(Test_WetBulbTemperature):
         """Basic pressure correction of water vapour SVPs to give SVPs in
         air."""
         svp = self.pressure.copy(data=[[197.41815, 474.1368, 999.5001]])
-        expected = [[ 199.265975,  476.293096, 1006.391004]]
+        expected = [[199.265975, 476.293096, 1006.391004]]
         result = WetBulbTemperature().pressure_correct_svp(
             svp, self.temperature, self.pressure)
 

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperature.py
@@ -43,8 +43,7 @@ from improver.psychrometric_calculations.psychrometric_calculations import (
     WetBulbTemperature)
 from improver.utilities.warnings_handler import ManageWarnings
 
-from improver.tests.set_up_test_cubes import (set_up_variable_cube,
-                                              add_coordinate)
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 
 IGNORED_MESSAGES = ["Wet bulb temperatures are being calculated"]
 WARNING_TYPES = [UserWarning]

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
@@ -64,7 +64,13 @@ class Test_process(Test_WetBulbTemperature):
 
     """Test the calculation of the wet bulb temperature integral from
     temperature, pressure, and relative humidity information using the
-    process function. Integration is calculated in the vertical."""
+    process function. Integration is calculated in the vertical.
+
+    The wet bulb temperature calculated at each level, and the difference in
+    height between the levels are used to calculate an integrated wet bulb
+    temperature. This is used to ascertain the degree of melting that initially
+    frozen precipitation undergoes.
+    """
 
     def setUp(self):
         """Set up cubes."""

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
@@ -42,12 +42,8 @@ from improver.psychrometric_calculations.psychrometric_calculations import (
     WetBulbTemperatureIntegral)
 from improver.tests.psychrometric_calculations.psychrometric_calculations.\
     test_WetBulbTemperature import Test_WetBulbTemperature
-from improver.utilities.warnings_handler import ManageWarnings
 
 from improver.tests.set_up_test_cubes import add_coordinate
-
-IGNORED_MESSAGES = ["Wet bulb temperatures are being calculated"]
-WARNING_TYPES = [UserWarning]
 
 
 class Test__repr__(IrisTest):
@@ -89,8 +85,6 @@ class Test_process(Test_WetBulbTemperature):
             self.pressure, self.height_points, 'height', coord_units='m',
             attributes=height_attribute)
 
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_basic(self):
         """Test that the wet bulb temperature integral returns a cube
         with the expected name."""
@@ -104,8 +98,6 @@ class Test_process(Test_WetBulbTemperature):
         self.assertEqual(wb_temp.name(), "wet_bulb_temperature")
         self.assertEqual(wb_temp.units, Unit('celsius'))
 
-    @ManageWarnings(
-        ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def test_data(self):
         """Test that the wet bulb temperature integral returns a cube
         containing the expected data."""
@@ -113,9 +105,9 @@ class Test_process(Test_WetBulbTemperature):
             [[[0.0, 0.0, 608.1063]],
              [[0.0, 0.0, 912.1595]]], dtype=np.float32)
         expected_wb_temp = np.array(
-            [[[-90.00001, -13.266943, 60.81063]],
-             [[-90.00001, -13.266943, 60.81063]],
-             [[-90.00001, -13.266943, 60.81063]]], dtype=np.float32)
+            [[[-88.15, -13.266943, 60.81063]],
+             [[-88.15, -13.266943, 60.81063]],
+             [[-88.15, -13.266943, 60.81063]]], dtype=np.float32)
         wb_temp, wb_temp_int = WetBulbTemperatureIntegral().process(
             self.temperature_cube, self.relative_humidity_cube,
             self.pressure_cube)

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
@@ -78,18 +78,16 @@ class Test_process(Test_WetBulbTemperature):
         height_attribute = {"positive": "up"}
 
         self.temperature_cube = add_coordinate(
-            self.temperature, self.height_points, 'height', coord_units='m')
-        self.temperature_cube.coord('height').attributes = height_attribute
+            self.temperature, self.height_points, 'height', coord_units='m',
+            attributes=height_attribute)
 
         self.relative_humidity_cube = add_coordinate(
             self.relative_humidity, self.height_points, 'height',
-            coord_units='m')
-        self.relative_humidity_cube.coord('height').attributes = (
-            height_attribute)
+            coord_units='m', attributes=height_attribute)
 
         self.pressure_cube = add_coordinate(
-            self.pressure, self.height_points, 'height', coord_units='m')
-        self.pressure_cube.coord('height').attributes = height_attribute
+            self.pressure, self.height_points, 'height', coord_units='m',
+            attributes=height_attribute)
 
     @ManageWarnings(
         ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)

--- a/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
+++ b/lib/improver/tests/psychrometric_calculations/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
@@ -73,7 +73,9 @@ class Test_process(Test_WetBulbTemperature):
     """
 
     def setUp(self):
-        """Set up cubes."""
+        """Set up temperature, pressure, and relative humidity cubes that
+        contain multiple height levels; in this case the values of these
+        diagnostics are identical on each level."""
         super().setUp()
 
         self.height_points = np.array([5., 10., 20.])

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -390,7 +390,8 @@ def set_up_probability_cube(data, thresholds, variable_name='air_temperature',
 
 
 def add_coordinate(incube, coord_points, coord_name, coord_units=None,
-                   dtype=np.float32, order=None, is_datetime=False):
+                   dtype=np.float32, order=None, is_datetime=False,
+                   attributes=None):
     """
     Function to duplicate a sample cube with an additional coordinate to create
     a cubelist. The cubelist is merged to create a single cube, which can be
@@ -420,6 +421,8 @@ def add_coordinate(incube, coord_points, coord_name, coord_units=None,
             list of datetime objects and need converting.  In this case the
             "coord_units" argument is overridden and the time points provided
             in seconds.  The "dtype" argument is overridden and set to int64.
+        attributes (dict):
+            Optional coordinate attributes.
 
     Returns:
         iris.cube.Cube:
@@ -448,7 +451,7 @@ def add_coordinate(incube, coord_points, coord_name, coord_units=None,
         temp_cube = cube.copy()
         temp_cube.add_aux_coord(
             DimCoord(np.array([val], dtype=dtype), long_name=coord_name,
-                     units=coord_units))
+                     units=coord_units, attributes=attributes))
 
         # recalculate forecast period if time or frt have been updated
         if is_datetime and "time" in coord_name:

--- a/lib/improver/tests/test_set_up_test_cubes.py
+++ b/lib/improver/tests/test_set_up_test_cubes.py
@@ -403,6 +403,17 @@ class test_add_coordinate(IrisTest):
         self.assertEqual(result.coord('height').dtype, np.float32)
         self.assertEqual(result.coord('height').units, self.height_unit)
 
+    def test_adding_coordinate_with_attribute(self):
+        """Test addition of a leading height coordinate with an appropriate
+        attribute."""
+        height_attribute = {"positive": "up"}
+        result = add_coordinate(
+            self.input_cube, self.height_points, 'height',
+            coord_units=self.height_unit, attributes=height_attribute)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertEqual(result.coord_dims('height'), (0,))
+        self.assertEqual(result.coord('height').attributes, height_attribute)
+
     def test_reorder(self):
         """Test new coordinate can be placed in different positions"""
         input_cube = set_up_variable_cube(np.ones((4, 3, 4), dtype=np.float32))


### PR DESCRIPTION
This PR updates the psychrometric units tests to use the centralised utility for setting up cubes. It might be good to add/modify the create cube with height levels functionality, but for now I have removed the use of this (let's discuss).

The use of float32 data in the tests led to the recently merged modifications to the SVP table, and also results in small changes to many of the tests results.

Testing:
 - [x] Ran tests and they passed OK