### PR TITLE
Alter default model_id_attr argument for weighted blending

### DIFF
--- a/lib/improver/cli/weighted_blending.py
+++ b/lib/improver/cli/weighted_blending.py
@@ -81,8 +81,8 @@ def main(argv=None):
                         default=None,
                         help='The name of the netCDF file attribute to be '
                              'used to identify the source model for '
-                             'multi-model blends. Default assumes Met Office '
-                             'model metadata. Must be present on all input '
+                             'multi-model blends. Default is None. '
+                             'Must be present on all input '
                              'files if blending over models.')
     parser.add_argument('--spatial_weights_from_mask',
                         action='store_true', default=False,

--- a/lib/improver/cli/weighted_blending.py
+++ b/lib/improver/cli/weighted_blending.py
@@ -78,7 +78,7 @@ def main(argv=None):
                         'will take the latest available forecast reference '
                         'time from the input cubes supplied.')
     parser.add_argument('--model_id_attr', metavar='MODEL_ID_ATTR', type=str,
-                        default="mosg__model_configuration",
+                        default=None,
                         help='The name of the netCDF file attribute to be '
                              'used to identify the source model for '
                              'multi-model blends. Default assumes Met Office '

--- a/tests/improver-weighted-blending/01-help.bats
+++ b/tests/improver-weighted-blending/01-help.bats
@@ -83,8 +83,8 @@ optional arguments:
   --model_id_attr MODEL_ID_ATTR
                         The name of the netCDF file attribute to be used to
                         identify the source model for multi-model blends.
-                        Default assumes Met Office model metadata. Must be
-                        present on all input files if blending over models.
+                        Default is None. Must be present on all input files if
+                        blending over models.
   --spatial_weights_from_mask
                         If set this option will result in the generation of
                         spatially varying weights based on the masks of the

--- a/tests/improver-weighted-blending/09-model_blending.bats
+++ b/tests/improver-weighted-blending/09-model_blending.bats
@@ -38,7 +38,7 @@
   # Run weighted blending with linear weights for two input files and check it
   # passes.
   run improver weighted-blending 'model_configuration' \
-      --ynval 1 --y0val 1 \
+      --ynval 1 --y0val 1 --model_id_attr mosg__model_configuration \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/ukv_input.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/enuk_input.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/11-weights_from_dict.bats
+++ b/tests/improver-weighted-blending/11-weights_from_dict.bats
@@ -40,6 +40,7 @@
   run improver weighted-blending --wts_calc_method 'dict' \
       --wts_dict "$IMPROVER_ACC_TEST_DIR/weighted_blending/weights_from_dict/input_dict.json" \
       --weighting_coord 'forecast_period' 'model_configuration' \
+      --model_id_attr mosg__model_configuration \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/ukv_input.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/model/enuk_input.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/12-percentile_weights_from_dict.bats
+++ b/tests/improver-weighted-blending/12-percentile_weights_from_dict.bats
@@ -39,6 +39,7 @@
   run improver weighted-blending --wts_calc_method 'dict' \
       --wts_dict "$IMPROVER_ACC_TEST_DIR/weighted_blending/weights_from_dict/input_dict.json" \
       --weighting_coord 'forecast_period' 'model_configuration' \
+      --model_id_attr mosg__model_configuration \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/percentile_weights_from_dict/ukv_input.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/percentile_weights_from_dict/enuk_input.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/16-spatial_model_blending.bats
+++ b/tests/improver-weighted-blending/16-spatial_model_blending.bats
@@ -38,6 +38,7 @@
   # Run weighted blending with ukvx and nowcast data using spatial weights
   run improver weighted-blending 'model_configuration' \
       --ynval 1 --y0val 1 --spatial_weights_from_mask \
+      --model_id_attr mosg__model_configuration \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/ukvx_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/18-spatial_model_blending_no_fuzzy.bats
+++ b/tests/improver-weighted-blending/18-spatial_model_blending_no_fuzzy.bats
@@ -38,6 +38,7 @@
   # Run weighted blending with ukvx and nowcast data using spatial weights and no spatial fuzziness
   run improver weighted-blending 'model_configuration' \
       --ynval 1 --y0val 1 --spatial_weights_from_mask --fuzzy_length 1 \
+      --model_id_attr mosg__model_configuration \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/nowcast_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/spatial_weights/ukvx_data/20181129T1000Z-PT0002H00M-lwe_precipitation_rate.nc" \
       "$TEST_DIR/output.nc"

--- a/tests/improver-weighted-blending/19-three_model_blending.bats
+++ b/tests/improver-weighted-blending/19-three_model_blending.bats
@@ -39,6 +39,7 @@
   run improver weighted-blending 'model_configuration' \
       --spatial_weights_from_mask --wts_calc_method 'dict' \
       --weighting_coord forecast_period --cycletime 20190101T0300Z \
+      --model_id_attr mosg__model_configuration \
       --wts_dict $IMPROVER_ACC_TEST_DIR/weighted_blending/three_models/blending-weights-preciprate.json \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/three_models/enukxhrly/20190101T0400Z-PT0004H00M-precip_rate.nc" \
       "$IMPROVER_ACC_TEST_DIR/weighted_blending/three_models/nc/20190101T0400Z-PT0001H00M-precip_rate.nc" \


### PR DESCRIPTION
Description
Alter the model_id_attr argument to have None as a default and update the relevant CLI tests accordingly.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
