### PR TITLE
Impro1286 check and fail

### DIFF
--- a/lib/improver/nowcasting/accumulation.py
+++ b/lib/improver/nowcasting/accumulation.py
@@ -38,8 +38,7 @@ import numpy as np
 
 import iris
 from improver.utilities.cube_manipulation import expand_bounds
-from improver.utilities.cube_units import (enforce_coordinate_units_and_dtypes,
-                                           enforce_diagnostic_units_and_dtypes)
+from improver.utilities.cube_units import enforce_units_and_dtypes
 
 
 class Accumulation:
@@ -135,12 +134,10 @@ class Accumulation:
                 divisible by the time interval.
 
         """
-        # Standardise inputs to expected units.
-        cubes = enforce_coordinate_units_and_dtypes(
-            cubes, ['time', 'forecast_reference_time', 'forecast_period'],
-            inplace=False)
-
-        enforce_diagnostic_units_and_dtypes(cubes)
+        # Standardise inputs to expected units
+        cubes = enforce_units_and_dtypes(
+            cubes, coords=['time', 'forecast_reference_time',
+                           'forecast_period'])
 
         # Sort cubes into time order and calculate intervals.
         cubes, times = self.sort_cubes_by_time(cubes)

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -108,7 +108,7 @@ class Test_enforce_units_and_dtypes(IrisTest):
     def test_data_units_fail(self):
         """Test error is raised when enforce=False"""
         self.data_cube.convert_units('Fahrenheit')
-        msg = "Units Fahrenheit of air_temperature cube do not conform"
+        msg = "does not conform"
         with self.assertRaisesRegex(ValueError, msg):
             cube_units.enforce_units_and_dtypes(self.data_cube, enforce=False)
 
@@ -116,7 +116,7 @@ class Test_enforce_units_and_dtypes(IrisTest):
         """Test error is raised when enforce=False"""
         self.probability_cube.coord(
             'air_temperature').convert_units('Fahrenheit')
-        msg = "Units Fahrenheit of coordinate air_temperature on probability_"
+        msg = "does not conform"
         with self.assertRaisesRegex(ValueError, msg):
             cube_units.enforce_units_and_dtypes(
                 self.probability_cube, enforce=False)
@@ -140,7 +140,7 @@ class Test_enforce_units_and_dtypes(IrisTest):
         """Test error is raised when enforce=False"""
         self.percentile_cube.data = (
             self.percentile_cube.data.astype(np.float64))
-        msg = "of air_temperature cube does not conform"
+        msg = "does not conform"
         with self.assertRaisesRegex(ValueError, msg):
             cube_units.enforce_units_and_dtypes(
                 self.percentile_cube, enforce=False)
@@ -149,7 +149,7 @@ class Test_enforce_units_and_dtypes(IrisTest):
         """Test error is raised when enforce=False"""
         self.percentile_cube.coord('percentile').points = (
             self.percentile_cube.coord('percentile').points.astype(np.int32))
-        msg = "of coordinate percentile on air_temperature cube"
+        msg = "does not conform"
         with self.assertRaisesRegex(ValueError, msg):
             cube_units.enforce_units_and_dtypes(
                 self.percentile_cube, enforce=False)
@@ -399,6 +399,7 @@ class Test__enforce_coordinate_units_and_dtypes(IrisTest):
 
         coord = 'number_of_fish'
         cube = self.cube
+        cube.coord('projection_x_coordinate').rename(coord)
 
         msg = "'number_of_fish' not defined in units.py"
         with self.assertRaisesRegex(KeyError, msg):

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -166,6 +166,27 @@ class Test_enforce_units_and_dtypes(IrisTest):
         self.assertEqual(result[0].coord('percentile').dtype, np.float32)
         self.assertEqual(result[1].coord('air_temperature').units, 'K')
 
+    def test_subset_of_coordinates(self):
+        """Test function can enforce on a selected subset of coordinates and
+        leave all others unchanged"""
+        self.percentile_cube.coord('percentile').points = (
+            self.percentile_cube.coord('percentile').points.astype(np.int32))
+        self.percentile_cube.coord('time').convert_units(
+            'hours since 1970-01-01 00:00:00')
+        self.probability_cube.coord(
+            'air_temperature').convert_units('Fahrenheit')
+        self.probability_cube.coord('forecast_period').convert_units('h')
+
+        result = cube_units.enforce_units_and_dtypes(
+            [self.percentile_cube, self.probability_cube],
+            coords=["time", "forecast_period"])
+        self.assertEqual(result[0].coord('percentile').dtype, np.int32)
+        self.assertEqual(
+            result[0].coord('time').units, 'seconds since 1970-01-01 00:00:00')
+        self.assertEqual(
+            result[1].coord('air_temperature').units, 'Fahrenheit')
+        self.assertEqual(result[1].coord('forecast_period').units, 's')
+
 
 class Test__find_dict_key(IrisTest):
     """Test method to find suitable substring keys in dictionary"""

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -191,7 +191,7 @@ class Test_enforce_units_and_dtypes(IrisTest):
             result[1].coord('air_temperature').units, 'Fahrenheit')
         self.assertEqual(result[1].coord('forecast_period').units, 's')
 
-    def test_quantity_available(self):
+    def test_quantity_unavailable(self):
         """Test error raised if the named quantity is not listed in the
         dictionary standard"""
         self.data_cube.rename("number_of_fish")
@@ -199,6 +199,17 @@ class Test_enforce_units_and_dtypes(IrisTest):
         msg = "Name 'number_of_fish' is not uniquely defined in units.py"
         with self.assertRaisesRegex(KeyError, msg):
             cube_units.enforce_units_and_dtypes(self.data_cube)
+
+    def test_multiple_errors(self):
+        """Test a list of errors is correctly caught and re-raised"""
+        self.data_cube.convert_units('Fahrenheit')
+        self.probability_cube.coord(
+            'air_temperature').convert_units('Fahrenheit')
+        msg = ("The following errors were raised during processing:\n"
+               "air_temperature with units Fahrenheit and datatype ")
+        with self.assertRaisesRegex(ValueError, msg):
+            cube_units.enforce_units_and_dtypes(
+                [self.data_cube, self.probability_cube], enforce=False)
 
 
 class LimitedDictTest(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -126,6 +126,8 @@ class Test_enforce_units_and_dtypes(IrisTest):
         self.data_cube.data = self.data_cube.data.astype(np.float64)
         result, = cube_units.enforce_units_and_dtypes(self.data_cube)
         self.assertEqual(result.dtype, np.float32)
+        # check input is unchanged
+        self.assertEqual(self.data_cube.dtype, np.float64)
 
     def test_coord_datatype_enforce(self):
         """Test coordinate datatypes are enforced (using substring processing)
@@ -135,6 +137,8 @@ class Test_enforce_units_and_dtypes(IrisTest):
              self.data_cube.coord(test_coord).points.astype(np.float64))
         result, = cube_units.enforce_units_and_dtypes(self.data_cube)
         self.assertEqual(result.coord(test_coord).dtype, np.int64)
+        # check input is unchanged
+        self.assertEqual(self.data_cube.coord(test_coord).dtype, np.float64)
 
     def test_data_datatype_fail(self):
         """Test error is raised when enforce=False"""
@@ -192,7 +196,7 @@ class Test_enforce_units_and_dtypes(IrisTest):
         dictionary standard"""
         self.data_cube.rename("number_of_fish")
         self.data_cube.units = "1"
-        msg = "Name 'number_of_fish' not defined in units.py"
+        msg = "Name 'number_of_fish' is not uniquely defined in units.py"
         with self.assertRaisesRegex(KeyError, msg):
             cube_units.enforce_units_and_dtypes(self.data_cube)
 
@@ -223,26 +227,28 @@ class Test__find_dict_key(LimitedDictTest):
 
     def test_match(self):
         """Test correct identification of single substring match"""
-        result = cube_units._find_dict_key("air_temperature", "")
+        result = cube_units._find_dict_key("air_temperature")
         self.assertEqual(result, "temperature")
 
     def test_probability_match(self):
         """Test the correct substring is returned for an IMPROVER-style
         probability cube name that matches multiple substrings"""
         result = cube_units._find_dict_key(
-            "probability_of_air_temperature_above_threshold", "")
+            "probability_of_air_temperature_above_threshold")
         self.assertEqual(result, "probability")
 
     def test_no_matches_error(self):
         """Test a KeyError is raised if there is no matching substring"""
+        msg = "Name 'kittens' is not uniquely defined in units.py"
         with self.assertRaises(KeyError):
-            cube_units._find_dict_key("kittens", "")
+            cube_units._find_dict_key("kittens")
 
     def test_multiple_matches_error(self):
         """Test a KeyError is raised if there are multiple matching substrings
         """
+        msg = "Name 'rainfall_rate' is not uniquely defined in units.py"
         with self.assertRaises(KeyError):
-            cube_units._find_dict_key("rainfall_rate", "")
+            cube_units._find_dict_key("rainfall_rate")
 
 
 class Test__get_required_units_and_dtype(LimitedDictTest):

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -229,7 +229,7 @@ class Test__find_dict_key(IrisTest):
             cube_units._find_dict_key("rainfall_rate", "")
 
 
-class Test_enforce_coordinate_units_and_dtypes(IrisTest):
+class Test__enforce_coordinate_units_and_dtypes(IrisTest):
 
     """Test the enforcement of coordinate units and data types."""
 
@@ -251,7 +251,7 @@ class Test_enforce_coordinate_units_and_dtypes(IrisTest):
         }
 
         cube_units.DEFAULT_UNITS = original_units
-        self.plugin = cube_units.enforce_coordinate_units_and_dtypes
+        self.plugin = cube_units._enforce_coordinate_units_and_dtypes
         self.cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32),
                                          spatial_grid='equalarea')
 
@@ -417,7 +417,7 @@ class Test_enforce_coordinate_units_and_dtypes(IrisTest):
                                       np.float64)
 
 
-class Test_enforce_diagnostic_units_and_dtypes(IrisTest):
+class Test__enforce_diagnostic_units_and_dtypes(IrisTest):
 
     """Test the enforcement of diagnostic units and data types."""
 
@@ -430,7 +430,7 @@ class Test_enforce_diagnostic_units_and_dtypes(IrisTest):
         }
 
         cube_units.DEFAULT_UNITS = original_units
-        self.plugin = cube_units.enforce_diagnostic_units_and_dtypes
+        self.plugin = cube_units._enforce_diagnostic_units_and_dtypes
         self.cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32),
                                          spatial_grid='equalarea')
 

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -204,9 +204,14 @@ class Test_enforce_units_and_dtypes(IrisTest):
         """Test a list of errors is correctly caught and re-raised"""
         self.data_cube.convert_units('Fahrenheit')
         self.probability_cube.coord(
-            'air_temperature').convert_units('Fahrenheit')
+            'air_temperature').convert_units('degC')
         msg = ("The following errors were raised during processing:\n"
-               "air_temperature with units Fahrenheit and datatype ")
+               "air_temperature with units Fahrenheit and datatype float32 "
+               "does not conform to expected standard \\(units K, datatype "
+               "\\<class 'numpy.float32'\\>\\)\n"
+               "air_temperature with units degC and datatype float32 "
+               "does not conform to expected standard \\(units K, datatype "
+               "\\<class 'numpy.float32'\\>\\)\n")
         with self.assertRaisesRegex(ValueError, msg):
             cube_units.enforce_units_and_dtypes(
                 [self.data_cube, self.probability_cube], enforce=False)

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -43,6 +43,23 @@ from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, set_up_probability_cube, set_up_percentile_cube)
 
 
+# limited item dictionary to point to in smaller tests
+TEST_DICT = {
+    "time": {
+        "unit": "seconds since 1970-01-01 00:00:00",
+        "dtype": np.int64},
+    "forecast_period": {
+        "unit": "seconds",
+        "dtype": np.int32},
+    "projection_x_coordinate": {"unit", "m"},
+    "percentile": {"unit": "%"},
+    "probability": {"unit": "1"},
+    "temperature": {"unit": "K"},
+    "rainfall": {"unit": "m s-1"},
+    "rate": {"unit": "m s-1"}
+}
+
+
 class Test_enforce_units_and_dtypes(IrisTest):
     """Test checking with option of enforcement or failure"""
 
@@ -194,16 +211,7 @@ class Test__find_dict_key(IrisTest):
     @staticmethod
     def setUp():
         """Redirect to dummy dictionary"""
-        cube_units.DEFAULT_UNITS = {
-            "time": {
-                "unit": "seconds since 1970-01-01 00:00:00",
-                "dtype": np.int64},
-            "percentile": {"unit": "%"},
-            "probability": {"unit": "1"},
-            "temperature": {"unit": "K"},
-            "rainfall": {"unit": "m s-1"},
-            "rate": {"unit": "m s-1"}
-        }
+        cube_units.DEFAULT_UNITS = TEST_DICT
 
     def test_match(self):
         """Test correct identification of single substring match"""
@@ -229,7 +237,29 @@ class Test__find_dict_key(IrisTest):
             cube_units._find_dict_key("rainfall_rate", "")
 
 
-class Test__check_units_and_dtypes(IrisTest):
+class Test__get_required_units_and_dtype(IrisTest):
+    """Test method to read requirements from dictionary"""
+
+    @staticmethod
+    def setUp():
+        """Redirect to dummy dictionary"""
+        cube_units.DEFAULT_UNITS = TEST_DICT
+
+    def test_match(self):
+        """Test correct requirements identified"""
+        result = cube_units._get_required_units_and_dtype("air_temperature")
+        self.assertEqual(result[0], "K")
+        self.assertEqual(result[1], np.float32)
+
+    def test_probability_match(self):
+        """Test correct requirements for probability (substring) diagnostic"""
+        result = cube_units._get_required_units_and_dtype(
+            "probability_of_air_temperature_above_threshold")
+        self.assertEqual(result[0], "1")
+        self.assertEqual(result[1], np.float32)
+
+
+class Test__check_units_and_dtype(IrisTest):
     """Test method to check object conformance"""
 
     def setUp(self):
@@ -262,32 +292,13 @@ class Test__check_units_and_dtypes(IrisTest):
         self.assertFalse(result)
 
 
-class Test__enforce_coordinate_units_and_dtypes(IrisTest):
-
-    """Test the enforcement of coordinate units and data types."""
+class Test__convert_coordinate_dtype(IrisTest):
+    """Test method to convert coordinate datatypes"""
 
     def setUp(self):
-        """Set up a cube to test."""
-        original_units = {
-            "time": {
-                "unit": "seconds since 1970-01-01 00:00:00",
-                "dtype": np.int64},
-            "forecast_reference_time": {
-                "unit": "seconds since 1970-01-01 00:00:00",
-                "dtype": np.int64},
-            "forecast_period": {
-                "unit": "seconds",
-                "dtype": np.int32},
-            "projection_x_coordinate": {
-                "unit": "m",
-                "dtype": np.float32}
-        }
-
-        cube_units.DEFAULT_UNITS = original_units
-        self.plugin = cube_units._enforce_coordinate_units_and_dtypes
+        """Set up cubes for testing"""
         self.cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32),
                                          spatial_grid='equalarea')
-
         self.cube_non_integer_intervals = set_up_variable_cube(
             np.ones((5, 5), dtype=np.float32), spatial_grid='equalarea',
             time=datetime(2017, 11, 10, 4, 30))
@@ -297,303 +308,71 @@ class Test__enforce_coordinate_units_and_dtypes(IrisTest):
     def test_time_coordinate_to_hours_valid(self):
         """Test that a cube with a validity time on the hour can be converted
         to integer hours."""
-
         target_units = "hours since 1970-01-01 00:00:00"
-        coord = 'time'
-        cube = self.cube
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
+        coord = self.cube.coord('time')
         expected = 419524
 
-        self.plugin([cube], [coord])
+        coord.convert_units(target_units)
+        cube_units._convert_coordinate_dtype(coord, np.int64)
 
-        self.assertEqual(cube.coord(coord).points[0], expected)
-        self.assertEqual(cube.coord(coord).units, target_units)
-        self.assertIsInstance(cube.coord(coord).points[0], np.int64)
+        self.assertEqual(coord.points[0], expected)
+        self.assertEqual(coord.units, target_units)
+        self.assertIsInstance(coord.points[0], np.int64)
 
     def test_time_coordinate_to_hours_invalid(self):
         """Test that a cube with a validity time on the half hour cannot be
         converted to integer hours."""
-
         target_units = "hours since 1970-01-01 00:00:00"
-        coord = 'time'
-        cube = self.cube_non_integer_intervals
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
+        coord = self.cube_non_integer_intervals.coord('time')
+        coord.convert_units(target_units)
 
         msg = ('Data type of coordinate "time" could not be'
                ' enforced without losing significant precision.')
         with self.assertRaisesRegex(ValueError, msg):
-            self.plugin([cube], [coord])
-
-    def test_time_coordinate_to_invalid_units(self):
-        """Test that a cube with time coordinate cannot be converted to an
-        incompatible units, e.g. metres."""
-
-        target_units = "m"
-        coord = 'time'
-        cube = self.cube
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
-
-        msg = 'time units cannot be converted to "m"'
-        with self.assertRaisesRegex(ValueError, msg):
-            self.plugin([cube], [coord])
+            cube_units._convert_coordinate_dtype(coord, np.int64)
 
     def test_time_coordinate_to_hours_float(self):
         """Test that a cube with a validity time on the half hour can be
         converted to float hours."""
-
         target_units = "hours since 1970-01-01 00:00:00"
-        coord = 'time'
-        cube = self.cube_non_integer_intervals
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[coord]['dtype'] = np.float64
+        coord = self.cube_non_integer_intervals.coord('time')
         expected = 419524.5
 
-        self.plugin([cube], [coord])
+        coord.convert_units(target_units)
+        cube_units._convert_coordinate_dtype(coord, np.float64)
 
-        self.assertEqual(cube.coord(coord).points[0], expected)
-        self.assertEqual(cube.coord(coord).units, target_units)
-        self.assertIsInstance(cube.coord(coord).points[0], np.float64)
-
-    def test_time_coordinate_hours_to_seconds_integer(self):
-        """Test that a cube with a validity time in units of hours can be
-        converted to integer seconds."""
-
-        target_units = "seconds since 1970-01-01 00:00:00"
-        coord = 'time'
-        cube = self.cube.copy()
-        cube.coord('time').convert_units("hours since 1970-01-01 00:00:00")
-        cube.coord('forecast_reference_time').convert_units(
-            "hours since 1970-01-01 00:00:00")
-        cube.coord('forecast_period').convert_units("hours")
-
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
-        expected = 1510286400
-
-        self.plugin([cube], [coord])
-
-        self.assertEqual(cube.coord(coord).points[0], expected)
-        self.assertEqual(cube.coord(coord).units, target_units)
-        self.assertIsInstance(cube.coord(coord).points[0], np.int64)
-
-    def test_basic_non_time_coordinate(self):
-        """Test that a cube with a grid at km intervals expressed in metres can
-        be converted to integer kilometres."""
-
-        target_units = "km"
-        coord = 'projection_x_coordinate'
-        cube = self.cube
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[coord]['dtype'] = np.int32
-        expected = [-400, -200, 0, 200, 400]
-
-        self.plugin([self.cube], [coord])
-
-        self.assertArrayEqual(cube.coord(coord).points, expected)
-        self.assertEqual(cube.coord(coord).units, target_units)
-        self.assertIsInstance(cube.coord(coord).points[0], np.int32)
-
-    def test_unavailable_coordinate(self):
-        """Test application of the function to a coordinate for which the
-        default units and data type are not defined, resulting in an
-        exception."""
-
-        coord = 'number_of_fish'
-        cube = self.cube
-        cube.coord('projection_x_coordinate').rename(coord)
-
-        msg = "'number_of_fish' not defined in units.py"
-        with self.assertRaisesRegex(KeyError, msg):
-            self.plugin([cube], [coord])
-
-    def test_return_changes_as_copy(self):
-        """Test that using the inplace=False keyword arg results in the input
-        cube remaining unchanged, and a new modified cube being returned."""
-
-        target_units = "hours since 1970-01-01 00:00:00"
-        coord = 'time'
-        cube = self.cube.copy()
-        cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
-        expected = 419524
-
-        result, = self.plugin([cube], [coord], inplace=False)
-
-        self.assertEqual(cube.coord(coord).points[0],
-                         self.cube.coord(coord).points[0],)
-        self.assertEqual(cube.coord(coord).units, self.cube.coord(coord).units)
-
-        self.assertEqual(result.coord(coord).points[0], expected)
-        self.assertEqual(result.coord(coord).units, target_units)
-        self.assertIsInstance(result.coord(coord).points[0], np.int64)
-
-    def test_multiple_cubes(self):
-        """Test that when a cube list is provided, all the cubes are modified
-        as expected."""
-
-        target_units = "hours since 1970-01-01 00:00:00"
-        coords = ['time', 'forecast_reference_time']
-        cubes = [self.cube, self.cube_non_integer_intervals]
-
-        for coord in coords:
-            cube_units.DEFAULT_UNITS[coord]['unit'] = target_units
-            cube_units.DEFAULT_UNITS[coord]['dtype'] = np.float64
-
-        expected = {'time': [419524, 419524.5],
-                    'forecast_reference_time': [419520, 419520]}
-
-        self.plugin(cubes, coords)
-
-        for coord in coords:
-            for index in range(2):
-                self.assertEqual(cubes[index].coord(coord).points[0],
-                                 expected[coord][index])
-                self.assertEqual(cubes[index].coord(coord).units, target_units)
-                self.assertIsInstance(cubes[index].coord(coord).points[0],
-                                      np.float64)
+        self.assertEqual(coord.points[0], expected)
+        self.assertEqual(coord.units, target_units)
+        self.assertIsInstance(coord.points[0], np.float64)
 
 
-class Test__enforce_diagnostic_units_and_dtypes(IrisTest):
-
-    """Test the enforcement of diagnostic units and data types."""
+class Test__convert_diagnostic_dtype(IrisTest):
+    """Test method to convert diagnostic (cube.data) datatypes"""
 
     def setUp(self):
-        """Set up a cube to test."""
-        original_units = {
-            "air_temperature": {
-                "unit": "K",
-                "dtype": np.float32},
-        }
-
-        cube_units.DEFAULT_UNITS = original_units
-        self.plugin = cube_units._enforce_diagnostic_units_and_dtypes
+        """Set up cubes for testing"""
         self.cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32),
                                          spatial_grid='equalarea')
-
         self.cube_non_integer_intervals = set_up_variable_cube(
             np.ones((5, 5), dtype=np.float32), spatial_grid='equalarea')
         self.cube_non_integer_intervals.data *= 1.5
 
     def test_temperature_to_integer_kelvin_valid(self):
         """Test that a cube with temperatures at whole kelvin intervals can
-        be converted to integer kelvin. Precision checking is invoked here to
-        ensure the change of data type does not result in a loss of
-        information."""
-
-        target_units = "kelvin"
-        diagnostic = "air_temperature"
-        cube = self.cube
-        cube_units.DEFAULT_UNITS[diagnostic]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[diagnostic]['dtype'] = np.int32
+        be converted to integer kelvin"""
         expected = np.ones((5, 5), dtype=np.int32)
-
-        self.plugin([cube])
-
-        self.assertArrayEqual(cube.data, expected)
-        self.assertEqual(cube.units, target_units)
-        self.assertEqual(cube.data.dtype, np.int32)
+        cube_units._convert_diagnostic_dtype(self.cube, np.int32)
+        self.assertArrayEqual(self.cube.data, expected)
+        self.assertEqual(self.cube.data.dtype, np.int32)
 
     def test_temperature_to_integer_kelvin_invalid(self):
         """Test that a cube with temperatures not at whole kelvin intervals
-        cannot be converted to integer kelvin. Precision checking is invoked
-        here to ensure the change of data type does not result in a loss of
-        information; in this case it does and raises an exception."""
-
-        target_units = "kelvin"
-        diagnostic = "air_temperature"
-        cube = self.cube_non_integer_intervals
-        cube_units.DEFAULT_UNITS[diagnostic]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[diagnostic]['dtype'] = np.int32
-
+        cannot be converted to integer kelvin"""
         msg = ('Data type of diagnostic "air_temperature" could not be'
                ' enforced without losing significant precision.')
         with self.assertRaisesRegex(ValueError, msg):
-            self.plugin([cube])
-
-    def test_temperature_to_invalid_units(self):
-        """Test that a cube with temperatures in kelvin cannot be converted
-        so incompatible units, e.g. metres."""
-
-        target_units = "m"
-        diagnostic = "air_temperature"
-        cube = self.cube
-        cube_units.DEFAULT_UNITS[diagnostic]['unit'] = target_units
-
-        msg = ('Data type of diagnostic "air_temperature" could not be'
-               ' enforced without losing significant precision.')
-        msg = 'air_temperature units cannot be converted to "m"'
-        with self.assertRaisesRegex(ValueError, msg):
-            self.plugin([cube])
-
-    def test_unavailable_diagnostic(self):
-        """Test application of the function to a cube for which the default
-        units and data type are not defined, resulting in an exception."""
-
-        cube = self.cube
-        cube.rename('number_of_fish')
-
-        msg = "'number_of_fish' not defined in units.py"
-        with self.assertRaisesRegex(KeyError, msg):
-            self.plugin([cube])
-
-    def test_return_changes_as_copy(self):
-        """Test that using the inplace=False keyword arg results in the input
-        cube remaining unchanged, and a new modified cube being returned. In
-        this test the temperature are converted to Celsius to make the change
-        clear."""
-
-        target_units = "celsius"
-        diagnostic = "air_temperature"
-        cube = self.cube.copy()
-        cube_units.DEFAULT_UNITS[diagnostic]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[diagnostic]['dtype'] = np.float32
-        expected = np.full((5, 5), -272.15, dtype=np.float32)
-
-        result, = self.plugin([cube], inplace=False)
-
-        self.assertArrayEqual(cube.data, self.cube.data)
-        self.assertEqual(cube.units, self.cube.units)
-
-        self.assertArrayEqual(result.data, expected)
-        self.assertEqual(result.units, target_units)
-        self.assertEqual(result.data.dtype, np.float32)
-
-    def test_temperature_to_float_celsius_valid(self):
-        """Test that a cube with temperatures at whole kelvin intervals stored
-        as integers can be converted to float Celsius, changing units and data
-        type, whilst checking precision is not lost."""
-
-        target_units = "celsius"
-        diagnostic = "air_temperature"
-        cube = self.cube.copy(data=self.cube.data.astype(np.int))
-        cube_units.DEFAULT_UNITS[diagnostic]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[diagnostic]['dtype'] = np.float32
-        expected = np.full((5, 5), -272.15, dtype=np.float32)
-
-        self.plugin([cube])
-
-        self.assertArrayEqual(cube.data, expected)
-        self.assertEqual(cube.units, target_units)
-        self.assertEqual(cube.data.dtype, np.float32)
-
-    def test_multiple_cubes(self):
-        """Test that when a cube list is provided, all the cubes are modified
-        as expected."""
-
-        target_units = "kelvin"
-        diagnostic = "air_temperature"
-        cubes = [self.cube, self.cube_non_integer_intervals]
-
-        cube_units.DEFAULT_UNITS[diagnostic]['unit'] = target_units
-        cube_units.DEFAULT_UNITS[diagnostic]['dtype'] = np.float64
-
-        expected = [np.ones((5, 5), dtype=np.float64),
-                    np.full((5, 5), 1.5, dtype=np.float64)]
-
-        self.plugin(cubes)
-
-        for index in range(2):
-            self.assertArrayEqual(cubes[index].data, expected[index])
-            self.assertEqual(cubes[index].units, target_units)
-            self.assertEqual(cubes[index].data.dtype, np.float64)
+            cube_units._convert_diagnostic_dtype(
+                self.cube_non_integer_intervals, np.int32)
 
 
 class Test_check_precision_loss(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -43,23 +43,6 @@ from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, set_up_probability_cube, set_up_percentile_cube)
 
 
-# limited item dictionary to point to in smaller tests
-TEST_DICT = {
-    "time": {
-        "unit": "seconds since 1970-01-01 00:00:00",
-        "dtype": np.int64},
-    "forecast_period": {
-        "unit": "seconds",
-        "dtype": np.int32},
-    "projection_x_coordinate": {"unit", "m"},
-    "percentile": {"unit": "%"},
-    "probability": {"unit": "1"},
-    "temperature": {"unit": "K"},
-    "rainfall": {"unit": "m s-1"},
-    "rate": {"unit": "m s-1"}
-}
-
-
 class Test_enforce_units_and_dtypes(IrisTest):
     """Test checking with option of enforcement or failure"""
 
@@ -203,6 +186,18 @@ class Test_enforce_units_and_dtypes(IrisTest):
         self.assertEqual(
             result[1].coord('air_temperature').units, 'Fahrenheit')
         self.assertEqual(result[1].coord('forecast_period').units, 's')
+
+
+# limited item dictionary to point to in smaller tests
+TEST_DICT = {
+    "time": {
+        "unit": "seconds since 1970-01-01 00:00:00",
+        "dtype": np.int64},
+    "probability": {"unit": "1"},
+    "temperature": {"unit": "K"},
+    "rainfall": {"unit": "m s-1"},
+    "rate": {"unit": "m s-1"}
+}
 
 
 class Test__find_dict_key(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -240,14 +240,14 @@ class Test__find_dict_key(LimitedDictTest):
     def test_no_matches_error(self):
         """Test a KeyError is raised if there is no matching substring"""
         msg = "Name 'kittens' is not uniquely defined in units.py"
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(KeyError, msg):
             cube_units._find_dict_key("kittens")
 
     def test_multiple_matches_error(self):
         """Test a KeyError is raised if there are multiple matching substrings
         """
         msg = "Name 'rainfall_rate' is not uniquely defined in units.py"
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(KeyError, msg):
             cube_units._find_dict_key("rainfall_rate")
 
 

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -197,25 +197,29 @@ class Test_enforce_units_and_dtypes(IrisTest):
             cube_units.enforce_units_and_dtypes(self.data_cube)
 
 
-# limited item dictionary to point to in smaller tests
-TEST_DICT = {
-    "time": {
-        "unit": "seconds since 1970-01-01 00:00:00",
-        "dtype": np.int64},
-    "probability": {"unit": "1"},
-    "temperature": {"unit": "K"},
-    "rainfall": {"unit": "m s-1"},
-    "rate": {"unit": "m s-1"}
-}
+class LimitedDictTest(IrisTest):
+    """Set up limited item dictionary to point to in smaller tests"""
+
+    def setUp(self):
+        """Define dictionary"""
+        self.units_dict = {
+            "time": {
+                "unit": "seconds since 1970-01-01 00:00:00",
+                "dtype": np.int64},
+            "probability": {"unit": "1"},
+            "temperature": {"unit": "K"},
+            "rainfall": {"unit": "m s-1"},
+            "rate": {"unit": "m s-1"}
+        }
 
 
-class Test__find_dict_key(IrisTest):
+class Test__find_dict_key(LimitedDictTest):
     """Test method to find suitable substring keys in dictionary"""
 
-    @staticmethod
-    def setUp():
+    def setUp(self):
         """Redirect to dummy dictionary"""
-        cube_units.DEFAULT_UNITS = TEST_DICT
+        super().setUp()
+        cube_units.DEFAULT_UNITS = self.units_dict
 
     def test_match(self):
         """Test correct identification of single substring match"""
@@ -232,7 +236,7 @@ class Test__find_dict_key(IrisTest):
     def test_no_matches_error(self):
         """Test a KeyError is raised if there is no matching substring"""
         with self.assertRaises(KeyError):
-            cube_units._find_dict_key("snowfall", "")
+            cube_units._find_dict_key("kittens", "")
 
     def test_multiple_matches_error(self):
         """Test a KeyError is raised if there are multiple matching substrings
@@ -241,13 +245,13 @@ class Test__find_dict_key(IrisTest):
             cube_units._find_dict_key("rainfall_rate", "")
 
 
-class Test__get_required_units_and_dtype(IrisTest):
+class Test__get_required_units_and_dtype(LimitedDictTest):
     """Test method to read requirements from dictionary"""
 
-    @staticmethod
-    def setUp():
+    def setUp(self):
         """Redirect to dummy dictionary"""
-        cube_units.DEFAULT_UNITS = TEST_DICT
+        super().setUp()
+        cube_units.DEFAULT_UNITS = self.units_dict
 
     def test_match(self):
         """Test correct requirements identified"""

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -187,6 +187,15 @@ class Test_enforce_units_and_dtypes(IrisTest):
             result[1].coord('air_temperature').units, 'Fahrenheit')
         self.assertEqual(result[1].coord('forecast_period').units, 's')
 
+    def test_quantity_available(self):
+        """Test error raised if the named quantity is not listed in the
+        dictionary standard"""
+        self.data_cube.rename("number_of_fish")
+        self.data_cube.units = "1"
+        msg = "Name 'number_of_fish' not defined in units.py"
+        with self.assertRaisesRegex(KeyError, msg):
+            cube_units.enforce_units_and_dtypes(self.data_cube)
+
 
 # limited item dictionary to point to in smaller tests
 TEST_DICT = {

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -367,7 +367,7 @@ class Test__enforce_coordinate_units_and_dtypes(IrisTest):
         coord = 'number_of_fish'
         cube = self.cube
 
-        msg = 'Coordinate number_of_fish not defined in units.py'
+        msg = "'number_of_fish' not defined in units.py"
         with self.assertRaisesRegex(KeyError, msg):
             self.plugin([cube], [coord])
 
@@ -496,7 +496,7 @@ class Test__enforce_diagnostic_units_and_dtypes(IrisTest):
         cube = self.cube
         cube.rename('number_of_fish')
 
-        msg = 'Diagnostic number_of_fish not defined in units.py'
+        msg = "'number_of_fish' not defined in units.py"
         with self.assertRaisesRegex(KeyError, msg):
             self.plugin([cube])
 

--- a/lib/improver/tests/utilities/test_cube_units.py
+++ b/lib/improver/tests/utilities/test_cube_units.py
@@ -229,6 +229,39 @@ class Test__find_dict_key(IrisTest):
             cube_units._find_dict_key("rainfall_rate", "")
 
 
+class Test__check_units_and_dtypes(IrisTest):
+    """Test method to check object conformance"""
+
+    def setUp(self):
+        """Set up test cube"""
+        self.cube = set_up_variable_cube(
+            data=275.*np.ones((3, 3), dtype=np.float32),
+            spatial_grid='equalarea')
+        self.coord = self.cube.coord('projection_x_coordinate')
+
+    def test_pass_cube(self):
+        """Test return value for compliant cube"""
+        result = cube_units._check_units_and_dtype(self.cube, 'K', np.float32)
+        self.assertTrue(result)
+
+    def test_fail_cube(self):
+        """Test return value for non-compliant cube"""
+        result = cube_units._check_units_and_dtype(
+            self.cube, 'degC', np.float32)
+        self.assertFalse(result)
+
+    def test_pass_coord(self):
+        """Test return value for compliant coordinate"""
+        result = cube_units._check_units_and_dtype(
+            self.coord, 'm', np.float32)
+        self.assertTrue(result)
+
+    def test_fail_coord(self):
+        """Test return value for non-compliant coordinate"""
+        result = cube_units._check_units_and_dtype(self.coord, 'm', np.int32)
+        self.assertFalse(result)
+
+
 class Test__enforce_coordinate_units_and_dtypes(IrisTest):
 
     """Test the enforcement of coordinate units and data types."""

--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -70,5 +70,6 @@ DEFAULT_UNITS = {
     "thickness": {"unit": "m"},
     "rainfall_rate": {"unit": "m s-1"},
     "lwe_snowfall_rate": {"unit": "m s-1"},
-    "lwe_precipitation_rate": {"unit": "m s-1"}
+    "lwe_precipitation_rate": {"unit": "m s-1"},
+    "lapse_rate": {"unit": "K m-1"}
 }

--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -62,10 +62,10 @@ DEFAULT_UNITS = {
     "projection_y_coordinate": {"unit": "m"},
     "percentile": {"unit": "%"},
     "probability": {"unit": "1"},
-    # standard diagnostics and suitable substrings
-    "temperature": {"unit": "K"},
-    "thickness": {"unit": "m"},
+    # standard diagnostics and suitable substrings (alphabetised for clarity)
     "fall_rate": {"unit": "m s-1"},
+    "lapse_rate": {"unit": "K m-1"},
     "precipitation_rate": {"unit": "m s-1"},
-    "lapse_rate": {"unit": "K m-1"}
+    "temperature": {"unit": "K"},
+    "thickness": {"unit": "m"}
 }

--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -48,17 +48,14 @@ The DEFAULT_UNITS dictionary has the following form.
 import numpy as np
 
 DEFAULT_UNITS = {
-    # time coordinates
+    # time coordinates and suitable substrings
     "time": {
-        "unit": "seconds since 1970-01-01 00:00:00",
-        "dtype": np.int64},
-    "forecast_reference_time": {
         "unit": "seconds since 1970-01-01 00:00:00",
         "dtype": np.int64},
     "forecast_period": {
         "unit": "seconds",
         "dtype": np.int32},
-    # other standard coordinates
+    # other standard coordinates and substrings
     "longitude": {"unit": "degrees"},
     "latitude": {"unit": "degrees"},
     "projection_x_coordinate": {"unit": "m"},
@@ -68,8 +65,7 @@ DEFAULT_UNITS = {
     # standard diagnostics and suitable substrings
     "temperature": {"unit": "K"},
     "thickness": {"unit": "m"},
-    "rainfall_rate": {"unit": "m s-1"},
-    "lwe_snowfall_rate": {"unit": "m s-1"},
-    "lwe_precipitation_rate": {"unit": "m s-1"},
+    "fall_rate": {"unit": "m s-1"},
+    "precipitation_rate": {"unit": "m s-1"},
     "lapse_rate": {"unit": "K m-1"}
 }

--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -38,15 +38,17 @@ The DEFAULT_UNITS dictionary has the following form.
 
 "unit": <str>
     The standard/default units for the coordinate or diagnostic
-    described by the key.
+    described by the key.  This is mandatory.
 "dtype": <dtype>
     The standard/default data type in which the coordinate points
-    or diagnostic values should be stored.
+    or diagnostic values should be stored.  This is optional; if
+    not set, float32 is assumed.
 """
 
 import numpy as np
 
 DEFAULT_UNITS = {
+    # time coordinates
     "time": {
         "unit": "seconds since 1970-01-01 00:00:00",
         "dtype": np.int64},
@@ -56,10 +58,17 @@ DEFAULT_UNITS = {
     "forecast_period": {
         "unit": "seconds",
         "dtype": np.int32},
-    "lwe_thickness_of_precipitation_amount": {
-        "unit": "m",
-        "dtype": np.float32},
-    "lwe_precipitation_rate": {
-        "unit": "m s-1",
-        "dtype": np.float32},
+    # other standard coordinates
+    "longitude": {"unit": "degrees"},
+    "latitude": {"unit": "degrees"},
+    "projection_x_coordinate": {"unit": "m"},
+    "projection_y_coordinate": {"unit": "m"},
+    "percentile": {"unit": "%"},
+    "probability": {"unit": "1"},
+    # standard diagnostics and suitable substrings
+    "temperature": {"unit": "K"},
+    "thickness": {"unit": "m"},
+    "rainfall_rate": {"unit": "m s-1"},
+    "lwe_snowfall_rate": {"unit": "m s-1"},
+    "lwe_precipitation_rate": {"unit": "m s-1"}
 }

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -75,10 +75,8 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
     if coords is not None:
         all_coords = list(set(coords))
     else:
-        all_coords = []
-        for cube in cubes:
-            all_coords.extend(
-                [coord.name() for coord in cube.coords()])
+        all_coords = [
+            coord.name() for cube in cubes for coord in cube.coords()]
         all_coords = list(set(all_coords))
     # modify the copied cubes in place
     _enforce_coordinate_units_and_dtypes(new_cubes, all_coords)

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -181,17 +181,17 @@ def enforce_coordinate_units_and_dtypes(cubes, coordinates, inplace=True):
 
     for cube in cubes:
         for coord_name in coordinates:
-
+            coord_key = coord_name
             try:
-                unit = DEFAULT_UNITS[coord_name]["unit"]
+                unit = DEFAULT_UNITS[coord_key]["unit"]
             except KeyError:
                 msg = "Coordinate {} not defined in units.py"
                 # hold the error and check for valid substrings
-                coord_name = _find_dict_key(coord_name, msg.format(coord_name))
-                unit = DEFAULT_UNITS[coord_name]["unit"]
+                coord_key = _find_dict_key(coord_key, msg.format(coord_key))
+                unit = DEFAULT_UNITS[coord_key]["unit"]
 
             try:
-                dtype = DEFAULT_UNITS[coord_name]["dtype"]
+                dtype = DEFAULT_UNITS[coord_key]["dtype"]
             except KeyError:
                 dtype = np.float32
 

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -98,7 +98,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
                 msg = msg.format(item.name(), item.units, item.dtype,
                                  units, dtype)
                 error_string += msg
-                continue
+            continue
 
         # attempt to convert units and record any errors
         try:

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -85,31 +85,31 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
         else:
             object_list.extend(cube.coords())
 
-    for obj in object_list:
-        units, dtype = _get_required_units_and_dtype(obj.name())
+    for item in object_list:
+        units, dtype = _get_required_units_and_dtype(item.name())
 
         if not enforce:
             # if not enforcing, throw an error if non-compliant
-            conforms = _check_units_and_dtype(obj, units, dtype)
+            conforms = _check_units_and_dtype(item, units, dtype)
             if not conforms:
                 msg = ('{} with units {} and datatype {} does not conform'
                        ' to expected standard (units {}, datatype {})')
-                msg = msg.format(obj.name(), obj.units, obj.dtype,
+                msg = msg.format(item.name(), item.units, item.dtype,
                                  units, dtype)
                 raise ValueError(msg)
 
         # convert units
         try:
-            obj.convert_units(units)
+            item.convert_units(units)
         except ValueError:
             msg = '{} units cannot be converted to "{}"'
-            raise ValueError(msg.format(obj.name(), units))
+            raise ValueError(msg.format(item.name(), units))
 
         # convert datatype
-        if isinstance(obj, iris.cube.Cube):
-            _convert_diagnostic_dtype(obj, dtype)
+        if isinstance(item, iris.cube.Cube):
+            _convert_diagnostic_dtype(item, dtype)
         else:
-            _convert_coordinate_dtype(obj, dtype)
+            _convert_coordinate_dtype(item, dtype)
 
     return iris.cube.CubeList(new_cubes)
 
@@ -245,103 +245,6 @@ def _convert_diagnostic_dtype(cube, dtype):
         msg = ('Data type of diagnostic "{}" could not be'
                ' enforced without losing significant precision.')
         raise ValueError(msg.format(cube.name()))
-
-
-def _enforce_coordinate_units_and_dtypes(cubes, coordinates, inplace=True):
-    """
-    Function to enforce standard units and data types as defined in units.py.
-    If undefined, the expected datatype is np.float32.
-
-    By default the cube units are changed in place, but setting inplace to
-    False will return a copy of the cubes, leaving the originals unchanged.
-
-    Args:
-        cubes (iris.cube.CubeList):
-            List of cubes on which to enforce coordinate units and data types.
-        coordinates (list):
-            List of coordinates for which units and dtypes should be enforced.
-            This is a list of coordinate names.
-    Keyword Args:
-        inplace (bool):
-            If True (default) the cubes are modified in place, if False this
-            function returns a modified copy of the cubes.
-    Returns:
-        cubes (iris.cube.CubeList or insitu):
-            The input cubes with units and data types of the chosen coordinates
-            set to match the definitions in units.py.
-    Raises:
-        KeyError: If coordinate to enforce is not defined in units.py
-        ValueError: If requested unit conversion is not possible.
-        ValueError: If a unit data type could not be converted without losing
-                    significant information (e.g. rounding time to the nearest
-                    hour when there are sub-hourly components).
-    """
-    if not inplace:
-        cubes = [cube.copy() for cube in cubes]
-
-    for cube in cubes:
-        for coord_name in coordinates:
-            try:
-                coord = cube.coord(coord_name)
-            except CoordinateNotFoundError:
-                continue
-
-            units, dtype = _get_required_units_and_dtype(coord_name)
-
-            try:
-                coord.convert_units(units)
-            except ValueError:
-                msg = '{} units cannot be converted to "{}"'
-                raise ValueError(msg.format(coord.name(), units))
-            else:
-                _convert_coordinate_dtype(coord, dtype)
-
-    if not inplace:
-        return cubes
-
-
-def _enforce_diagnostic_units_and_dtypes(cubes, inplace=True):
-    """
-    Function to enforce diagnostic units and data types as defined in units.py.
-    If undefined, the expected datatype is np.float32.
-
-    By default the diagnostic units are changed in place, but setting inplace
-    to False will return a copy of the cubes, leaving the originals unchanged.
-
-    Args:
-        cubes (iris.cube.CubeList):
-            List of cubes on which to enforce diagnostic units and data types.
-    Keyword Args:
-        inplace (bool):
-            If True (default) the cubes are modified in place, if False this
-            function returns a modified copy of the cubes.
-    Returns:
-        cubes (iris.cube.CubeList or insitu):
-            The input cubes with units and data types of the diagnostic
-            set to match the definitions in units.py.
-    Raises:
-        KeyError: If coordinate to enforce is not defined in units.py
-        ValueError: If requested unit conversion is not possible.
-        ValueError: If a unit data type could not be converted without losing
-                    significant information (e.g. removing significant
-                    fractional components when converting to integers).
-    """
-    if not inplace:
-        cubes = [cube.copy() for cube in cubes]
-
-    for cube in cubes:
-        units, dtype = _get_required_units_and_dtype(cube.name())
-
-        try:
-            cube.convert_units(units)
-        except ValueError:
-            msg = '{} units cannot be converted to "{}"'
-            raise ValueError(msg.format(cube.name(), units))
-        else:
-            _convert_diagnostic_dtype(cube, dtype)
-
-    if not inplace:
-        return cubes
 
 
 def check_precision_loss(dtype, data, precision=5):

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -79,7 +79,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
             all_coords.extend(
                 [coord.name() for coord in new_cubes[0].coords()])
         all_coords = list(set(all_coords))
-    # modify the copies cubes in place
+    # modify the copied cubes in place
     enforce_coordinate_units_and_dtypes(new_cubes, all_coords)
 
     if not enforce:

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -93,7 +93,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
             conforms = _check_units_and_dtype(item, units, dtype)
             if not conforms:
                 msg = ('{} with units {} and datatype {} does not conform'
-                       ' to expected standard (units {}, datatype {})')
+                       ' to expected standard (units {}, datatype {})\n')
                 msg = msg.format(item.name(), item.units, item.dtype,
                                  units, dtype)
                 raise ValueError(msg)

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -85,31 +85,31 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
         else:
             object_list.extend(cube.coords())
 
-    for object in object_list:
-        units, dtype = _get_required_units_and_dtype(object.name())
+    for obj in object_list:
+        units, dtype = _get_required_units_and_dtype(obj.name())
 
         if not enforce:
             # if not enforcing, throw an error if non-compliant
-            conforms = _check_units_and_dtype(object, units, dtype)
+            conforms = _check_units_and_dtype(obj, units, dtype)
             if not conforms:
                 msg = ('{} with units {} and datatype {} does not conform'
                        ' to expected standard (units {}, datatype {})')
-                msg = msg.format(object.name(), object.units, object.dtype,
+                msg = msg.format(obj.name(), obj.units, obj.dtype,
                                  units, dtype)
                 raise ValueError(msg)
 
         # convert units
         try:
-            object.convert_units(units)
+            obj.convert_units(units)
         except ValueError:
             msg = '{} units cannot be converted to "{}"'
-            raise ValueError(msg.format(object.name(), units))
+            raise ValueError(msg.format(obj.name(), units))
 
         # convert datatype
-        if isinstance(object, iris.cube.Cube):
-            _convert_diagnostic_dtype(object, dtype)
+        if isinstance(obj, iris.cube.Cube):
+            _convert_diagnostic_dtype(obj, dtype)
         else:
-            _convert_coordinate_dtype(object, dtype)
+            _convert_coordinate_dtype(obj, dtype)
 
     return iris.cube.CubeList(new_cubes)
 
@@ -160,7 +160,7 @@ def _get_required_units_and_dtype(key):
 
     Returns:
         units, dtype (tuple):
-            Tuple with string and type objectt identifying the required units
+            Tuple with string and type object identifying the required units
             and datatype
 
     Raises:
@@ -184,13 +184,13 @@ def _get_required_units_and_dtype(key):
     return unit, dtype
 
 
-def _check_units_and_dtype(object, units, dtype):
+def _check_units_and_dtype(obj, units, dtype):
     """
     Check whether the units and datatype of the input object conform
     to the standard given.
 
     Args:
-        object (iris.cube.Cube or iris.coords.Coord):
+        obj (iris.cube.Cube or iris.coords.Coord):
             Cube or coordinate to be checked
         units (str):
             Required units
@@ -201,10 +201,10 @@ def _check_units_and_dtype(object, units, dtype):
         bool:
             True if object conforms; False if not
     """
-    if Unit(object.units) != Unit(units):
+    if Unit(obj.units) != Unit(units):
         return False
 
-    if object.dtype != dtype:
+    if obj.dtype != dtype:
         return False
 
     return True

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -68,7 +68,8 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
     if isinstance(cubes, iris.cube.Cube):
         cubes = [cubes]
 
-    # make a copy of the input cube list
+    # return a new cube list from the inputs in which data units and datatypes
+    # have been enforced
     new_cubes = enforce_diagnostic_units_and_dtypes(cubes, inplace=False)
     # set up coordinates to check
     if coords is not None:
@@ -77,7 +78,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
         all_coords = []
         for cube in cubes:
             all_coords.extend(
-                [coord.name() for coord in new_cubes[0].coords()])
+                [coord.name() for coord in cube.coords()])
         all_coords = list(set(all_coords))
     # modify the copied cubes in place
     enforce_coordinate_units_and_dtypes(new_cubes, all_coords)
@@ -97,16 +98,16 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
                 try:
                     if cube.coord(coord).units != ref.coord(coord).units:
                         msg = ('Units {} of coordinate {} on {} cube do not '
-                               'conform to expected standard')
+                               'conform to expected standard {}')
                         raise ValueError(msg.format(
-                            cube.coord(coord).units, ref.coord(coord).name(),
-                            ref.name()))
+                            ref.coord(coord).units, ref.coord(coord).name(),
+                            ref.name(), cube.coord(coord).units))
                     if cube.coord(coord).dtype != ref.coord(coord).dtype:
                         msg = ('Datatype {} of coordinate {} on {} cube does '
-                               'not conform to expected standard')
+                               'not conform to expected standard {}')
                         raise ValueError(msg.format(
-                            cube.coord(coord).dtype, ref.coord(coord).name(),
-                            ref.name()))
+                            ref.coord(coord).dtype, ref.coord(coord).name(),
+                            ref.name(), cube.coord(coord).dtype))
                 except CoordinateNotFoundError:
                     pass
 
@@ -142,7 +143,7 @@ def _find_dict_key(input_key, error_msg):
         if key in input_key:
             matching_keys.append(key)
     if len(matching_keys) != 1:
-        raise KeyError(error_msg)
+        raise KeyError(error_msg, 'matching keys:', matching_keys)
 
     return matching_keys[0]
 

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -124,7 +124,7 @@ def _find_dict_key(input_key, error_msg):
         input_key (str):
             Key that didn't return an entry in DEFAULT_UNITS
         error_msg (str):
-            Error to raise if no matching item is not found
+            Error to raise if no unique match is found
 
     Returns:
         str: New key to identify required entry

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -70,7 +70,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
 
     # return a new cube list from the inputs in which data units and datatypes
     # have been enforced
-    new_cubes = enforce_diagnostic_units_and_dtypes(cubes, inplace=False)
+    new_cubes = _enforce_diagnostic_units_and_dtypes(cubes, inplace=False)
     # set up coordinates to check
     if coords is not None:
         all_coords = list(set(coords))
@@ -81,7 +81,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
                 [coord.name() for coord in cube.coords()])
         all_coords = list(set(all_coords))
     # modify the copied cubes in place
-    enforce_coordinate_units_and_dtypes(new_cubes, all_coords)
+    _enforce_coordinate_units_and_dtypes(new_cubes, all_coords)
 
     if not enforce:
         # check each cube against its counterpart and fail if changed
@@ -148,7 +148,7 @@ def _find_dict_key(input_key, error_msg):
     return matching_keys[0]
 
 
-def enforce_coordinate_units_and_dtypes(cubes, coordinates, inplace=True):
+def _enforce_coordinate_units_and_dtypes(cubes, coordinates, inplace=True):
     """
     Function to enforce standard units and data types as defined in units.py.
     If undefined, the expected datatype is np.float32.
@@ -216,7 +216,7 @@ def enforce_coordinate_units_and_dtypes(cubes, coordinates, inplace=True):
         return cubes
 
 
-def enforce_diagnostic_units_and_dtypes(cubes, inplace=True):
+def _enforce_diagnostic_units_and_dtypes(cubes, inplace=True):
     """
     Function to enforce diagnostic units and data types as defined in units.py.
     If undefined, the expected datatype is np.float32.

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -114,7 +114,7 @@ def enforce_units_and_dtypes(cubes, coords=None, enforce=True):
     return iris.cube.CubeList(new_cubes)
 
 
-def _find_dict_key(input_key, error_msg):
+def _find_dict_key(input_key):
     """
     If input_key is not in the DEFAULT_UNITS dict, test for substrings of
     input_key that are available.  This allows, for example, use of
@@ -124,8 +124,6 @@ def _find_dict_key(input_key, error_msg):
     Args:
         input_key (str):
             Key that didn't return an entry in DEFAULT_UNITS
-        error_msg (str):
-            Error to raise if no unique match is found
 
     Returns:
         str: New key to identify required entry
@@ -143,8 +141,9 @@ def _find_dict_key(input_key, error_msg):
         if key in input_key:
             matching_keys.append(key)
     if len(matching_keys) != 1:
-        msg = '{}, matching keys: {}'.format(error_msg, matching_keys)
-        raise KeyError(msg)
+        msg = ("Name '{}' is not uniquely defined in units.py; "
+               "matching keys: {}")
+        raise KeyError(msg.format(input_key, matching_keys))
 
     return matching_keys[0]
 
@@ -171,9 +170,8 @@ def _get_required_units_and_dtype(key):
     try:
         unit = DEFAULT_UNITS[key]["unit"]
     except KeyError:
-        msg = "Name '{}' not defined in units.py"
         # hold the error and check for valid substrings
-        key = _find_dict_key(key, msg.format(key))
+        key = _find_dict_key(key)
         unit = DEFAULT_UNITS[key]["unit"]
 
     try:

--- a/lib/improver/utilities/cube_units.py
+++ b/lib/improver/utilities/cube_units.py
@@ -31,6 +31,7 @@
 """ Provides support utilities for manipulating cube units."""
 
 import numpy as np
+from cf_units import Unit
 
 import iris
 from iris.exceptions import CoordinateNotFoundError
@@ -158,7 +159,8 @@ def _get_required_units_and_dtype(key):
 
     Returns:
         units, dtype (tuple):
-            Tuple of strings identifying the required units and datatype
+            Tuple with string and type objectt identifying the required units
+            and datatype
 
     Raises:
         KeyError:
@@ -179,6 +181,32 @@ def _get_required_units_and_dtype(key):
         dtype = np.float32
 
     return unit, dtype
+
+
+def _check_units_and_dtype(object, units, dtype):
+    """
+    Check whether the units and datatype of the input object conform
+    to the standard given.
+
+    Args:
+        object (iris.cube.Cube or iris.coords.Coord):
+            Cube or coordinate to be checked
+        units (str):
+            Required units
+        dtype (type):
+            Required datatype
+
+    Returns:
+        bool:
+            True if object conforms; False if not
+    """
+    if Unit(object.units) != Unit(units):
+        return False
+
+    if object.dtype != dtype:
+        return False
+
+    return True
 
 
 def _enforce_coordinate_units_and_dtypes(cubes, coordinates, inplace=True):


### PR DESCRIPTION
Adds functionality to the `cube_units` module to fail if cube data or coordinates do not conform to the expected units or types (new function).  Also:
- Added substring parsing for dataset and coordinate names
- Added some more entries to the `improver.units` module

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
