### PR TITLE
Return uncalibrated forecast if no EMOS coefficients are provided

### DIFF
--- a/lib/improver/cli/apply_emos_coefficients.py
+++ b/lib/improver/cli/apply_emos_coefficients.py
@@ -33,6 +33,8 @@
 Statistics (EMOS), otherwise known as Non-homogeneous Gaussian
 Regression (NGR)."""
 
+import warnings
+
 import numpy as np
 
 from iris.exceptions import CoordinateNotFoundError
@@ -208,6 +210,9 @@ def process(current_forecast, coeffs, num_realizations=None,
 
     """
     if coeffs is None:
+        msg = ("There are no coefficients provided for calibration. The "
+               "uncalibrated forecast will be returned.")
+        warnings.warn(msg)
         return current_forecast
 
     original_current_forecast = current_forecast.copy()

--- a/lib/improver/cli/apply_emos_coefficients.py
+++ b/lib/improver/cli/apply_emos_coefficients.py
@@ -47,6 +47,7 @@ from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GenerateProbabilitiesFromMeanAndVariance,
     RebadgePercentilesAsRealizations,
     ResamplePercentiles)
+from improver.utilities.cli_utilities import load_cube_or_none
 from improver.utilities.cube_checker import find_percentile_coordinate
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -75,8 +76,8 @@ def main(argv=None):
              'probabilities or percentiles.')
     parser.add_argument(
         'coefficients_filepath',
-        metavar='COEFFICIENTS_FILEPATH',
-        help='A path to an input NetCDF file containing the '
+        metavar='COEFFICIENTS_FILEPATH', nargs='?',
+        help='(Optional) A path to an input NetCDF file containing the '
              'coefficients used for calibration.')
     parser.add_argument(
         'output_filepath', metavar='OUTPUT_FILEPATH',
@@ -132,7 +133,7 @@ def main(argv=None):
 
     # Load Cubes
     current_forecast = load_cube(args.forecast_filepath)
-    coeffs = load_cube(args.coefficients_filepath)
+    coeffs = load_cube_or_none(args.coefficients_filepath)
     # Process Cube
     result = process(current_forecast, coeffs, args.num_realizations,
                      args.random_ordering, args.random_seed,
@@ -156,8 +157,8 @@ def process(current_forecast, coeffs, num_realizations=None,
         current_forecast (iris.cube.Cube):
             A Cube containing the forecast to be calibrated. The input format
             could be either realizations, probabilities or percentiles.
-        coeffs (iris.cube.Cube):
-            A cube containing the coefficients used for calibration.
+        coeffs (iris.cube.Cube or None):
+            A cube containing the coefficients used for calibration or None.
 
     Keyword Args:
         num_realizations (numpy.int32):
@@ -206,6 +207,9 @@ def process(current_forecast, coeffs, num_realizations=None,
             num_realizations are given.
 
     """
+    if coeffs is None:
+        return current_forecast
+
     original_current_forecast = current_forecast.copy()
     try:
         find_percentile_coordinate(current_forecast)

--- a/tests/improver-apply-emos-coefficients/00-null.bats
+++ b/tests/improver-apply-emos-coefficients/00-null.bats
@@ -40,7 +40,8 @@
                                         [--ecc_bounds_warning]
                                         [--predictor_of_mean PREDICTOR_OF_MEAN]
                                         FORECAST_FILEPATH
-                                        COEFFICIENTS_FILEPATH OUTPUT_FILEPATH
+                                        [COEFFICIENTS_FILEPATH]
+                                        OUTPUT_FILEPATH
 "
   [[ "$output" =~ "$expected" ]]
 }

--- a/tests/improver-apply-emos-coefficients/01-help.bats
+++ b/tests/improver-apply-emos-coefficients/01-help.bats
@@ -56,7 +56,8 @@ positional arguments:
                         realizations, probabilities or percentiles.
   COEFFICIENTS_FILEPATH
                         (Optional) A path to an input NetCDF file containing
-                        the coefficients used for calibration.
+                        the coefficients used for calibration. If this file is
+                        not provided the input forecast is returned unchanged.
   OUTPUT_FILEPATH       The output path for the processed NetCDF
 
 optional arguments:

--- a/tests/improver-apply-emos-coefficients/01-help.bats
+++ b/tests/improver-apply-emos-coefficients/01-help.bats
@@ -41,7 +41,8 @@ usage: improver apply-emos-coefficients [-h] [--profile]
                                         [--ecc_bounds_warning]
                                         [--predictor_of_mean PREDICTOR_OF_MEAN]
                                         FORECAST_FILEPATH
-                                        COEFFICIENTS_FILEPATH OUTPUT_FILEPATH
+                                        [COEFFICIENTS_FILEPATH]
+                                        OUTPUT_FILEPATH
 
 Apply coefficients for Ensemble Model Output Statistics (EMOS), otherwise
 known as Non-homogeneous Gaussian Regression (NGR). The supported input
@@ -54,8 +55,8 @@ positional arguments:
                         to be calibrated. The input format could be either
                         realizations, probabilities or percentiles.
   COEFFICIENTS_FILEPATH
-                        A path to an input NetCDF file containing the
-                        coefficients used for calibration.
+                        (Optional) A path to an input NetCDF file containing
+                        the coefficients used for calibration.
   OUTPUT_FILEPATH       The output path for the processed NetCDF
 
 optional arguments:

--- a/tests/improver-apply-emos-coefficients/10-no_coefficients.bats
+++ b/tests/improver-apply-emos-coefficients/10-no_coefficients.bats
@@ -42,9 +42,17 @@
       "$TEST_DIR/output.nc" --random_seed 0
   [[ "$status" -eq 0 ]]
 
+  # Check for warning
+  read -d '' expected <<'__TEXT__' || true
+UserWarning: There are no coefficients provided for calibration
+__TEXT__
+
+  [[ "$output" =~ "$expected" ]]
+
   improver_check_recreate_kgo "output.nc" $KGO
 
   # Run nccmp to compare the output and kgo realizations and check it passes.
   improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
+
 }

--- a/tests/improver-apply-emos-coefficients/10-no_coefficients.bats
+++ b/tests/improver-apply-emos-coefficients/10-no_coefficients.bats
@@ -31,23 +31,15 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "apply-emos-coefficients using non-default predictor 'realizations'" {
+@test "apply-emos-coefficients for diagnostic with assumed gaussian distribution" {
   improver_check_skip_acceptance
-  if python -c "import statsmodels" &> /dev/null; then
-      COEFFS="estimate-emos-coefficients/realizations/with_statsmodels_kgo.nc"
-      KGO="ensemble-calibration/realizations/with_statsmodels_kgo.nc"
-  else
-      COEFFS="estimate-emos-coefficients/realizations/without_statsmodels_kgo.nc"
-      KGO="ensemble-calibration/realizations/without_statsmodels_kgo.nc"
-  fi
+  KGO="ensemble-calibration/gaussian/input.nc"
 
   # Apply EMOS coefficients to calibrate the input forecast
   # and check that the calibrated forecast matches the kgo.
   run improver apply-emos-coefficients \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
-      "$IMPROVER_ACC_TEST_DIR/$COEFFS" \
-      "$TEST_DIR/output.nc" \
-      --predictor_of_mean 'realizations' --random_seed 0
+      "$TEST_DIR/output.nc" --random_seed 0
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-apply-emos-coefficients/11-wrong_coefficients.bats
+++ b/tests/improver-apply-emos-coefficients/11-wrong_coefficients.bats
@@ -31,28 +31,22 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "apply-emos-coefficients when no coefficients provided"  {
+@test "apply-emos-coefficients when coefficients cube is wrong" {
   improver_check_skip_acceptance
-  KGO="ensemble-calibration/gaussian/input.nc"
 
-  # Apply EMOS coefficients to calibrate the input forecast
-  # and check that the calibrated forecast matches the kgo.
+  # Check value error raised when coefficients filepath does not contain
+  # a coefficients cube.
   run improver apply-emos-coefficients \
       "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
+      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
       "$TEST_DIR/output.nc" --random_seed 0
-  [[ "$status" -eq 0 ]]
-
-  # Check for warning
+  [[ "$status" -eq 1 ]]
+  # Check for error
   read -d '' expected <<'__TEXT__' || true
-UserWarning: There are no coefficients provided for calibration
+ValueError: The current coefficients cube does not have the name 'emos_coefficients'
 __TEXT__
 
   [[ "$output" =~ "$expected" ]]
 
-  improver_check_recreate_kgo "output.nc" $KGO
-
-  # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
-      "$IMPROVER_ACC_TEST_DIR/$KGO"
 
 }

--- a/tests/improver-apply-emos-coefficients/12-wrong_forecast_input.bats
+++ b/tests/improver-apply-emos-coefficients/12-wrong_forecast_input.bats
@@ -31,28 +31,22 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "apply-emos-coefficients when no coefficients provided"  {
+@test "apply-emos-coefficients when input forecast cube is a coefficients cube" {
   improver_check_skip_acceptance
   KGO="ensemble-calibration/gaussian/input.nc"
 
-  # Apply EMOS coefficients to calibrate the input forecast
-  # and check that the calibrated forecast matches the kgo.
+  # Check it raises an error when there input forecast cube is a
+  # coefficients cube.
   run improver apply-emos-coefficients \
-      "$IMPROVER_ACC_TEST_DIR/ensemble-calibration/gaussian/input.nc" \
+  "$IMPROVER_ACC_TEST_DIR/estimate-emos-coefficients/gaussian/kgo.nc" \
+  "$IMPROVER_ACC_TEST_DIR/estimate-emos-coefficients/gaussian/kgo.nc" \
       "$TEST_DIR/output.nc" --random_seed 0
-  [[ "$status" -eq 0 ]]
-
-  # Check for warning
+  [[ "$status" -eq 1 ]]
+  # Check for error
   read -d '' expected <<'__TEXT__' || true
-UserWarning: There are no coefficients provided for calibration
+ValueError: The current forecast cube has the name 'emos_coefficients'
 __TEXT__
 
   [[ "$output" =~ "$expected" ]]
-
-  improver_check_recreate_kgo "output.nc" $KGO
-
-  # Run nccmp to compare the output and kgo realizations and check it passes.
-  improver_compare_output_lower_precision "$TEST_DIR/output.nc" \
-      "$IMPROVER_ACC_TEST_DIR/$KGO"
 
 }


### PR DESCRIPTION
Description
Amendment to the apply-emos-coefficients CLI, so that the coefficients filepath is an optional positional argument, so that if this filepath is not supplied then the uncalibrated forecast is returned.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

