### PR TITLE
Spot-extract altered to accept percentiles as floats

### DIFF
--- a/lib/improver/cli/spot_extract.py
+++ b/lib/improver/cli/spot_extract.py
@@ -114,7 +114,7 @@ def main(argv=None):
         "provided a warning is raised and all leading dimensions are included "
         "in the returned spot-data cube.")
     percentile_group.add_argument(
-        "--extract_percentiles", default=None, nargs='+', type=int,
+        "--extract_percentiles", default=None, nargs='+', type=float,
         help="If set to a percentile value or a list of percentile values, "
         "data corresponding to those percentiles will be returned. For "
         "example setting '--extract_percentiles 25 50 75' will result in the "

--- a/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
+++ b/tests/improver-spot-extract/17-extract_percentile_deterministic_input.bats
@@ -43,7 +43,7 @@
   echo "status = ${status}"
   [[ "$status" -eq 0 ]]
   read -d '' expected <<'__TEXT__' || true
-UserWarning: Diagnostic cube is not a known probabilistic type. The [50] percentile could not be extracted. Extracting data from the cube including any leading dimensions.
+UserWarning: Diagnostic cube is not a known probabilistic type. The [50.0] percentile could not be extracted. Extracting data from the cube including any leading dimensions.
 __TEXT__
   [[ "$output" =~ "$expected" ]]
 


### PR DESCRIPTION
The spot-extract CLI has to date required that the requested percentiles for extraction be integers. This may not always be desirable and changing the option to float is straightforward.

Testing:
 - [x] Ran tests and they passed OK
