### PR TITLE
Fix use of 'is' for comparison of strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ below:
 * Tomasz Trzeciak (Met Office, UK)
 * Mark Worsfold (Met Office, UK)
 * Bruno P. Kinoshita (NIWA, NZ)
+* Tom Gale (Bureau of Meteorology, Australia)
 
 (All contributors on GitHub are identifiable with email addresses in the
 version control logs or otherwise.)

--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -170,10 +170,11 @@ class CircularNeighbourhood(object):
         self.kernel = circular_kernel(fullranges, ranges,
                                       self.weighted_mode)
         # Smooth the data by applying the kernel.
-        if self.sum_or_fraction is "fraction":
-            total_area = np.sum(self.kernel)
-        elif self.sum_or_fraction is "sum":
+        if self.sum_or_fraction == "sum":
             total_area = 1.0
+        else:
+            # sum_or_fraction is in fraction mode
+            total_area = np.sum(self.kernel)
 
         cube.data = scipy.ndimage.filters.correlate(
             data, self.kernel, mode='nearest') / total_area


### PR DESCRIPTION
Python strings should be compared using `==` to check string equality, rather than `is` which checks object identity. Fix an instance of this problem in the neighbourhood circular kernel code.
Also re-structured the if-elif to avoid `total_area` may not be defined before use later in the function.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [x] If a new developer, signed up to CLA
