### PR TITLE
Change load_cube to allowed None to be returned if no filepath.

### DIFF
--- a/lib/improver/cli/apply_emos_coefficients.py
+++ b/lib/improver/cli/apply_emos_coefficients.py
@@ -49,7 +49,6 @@ from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GenerateProbabilitiesFromMeanAndVariance,
     RebadgePercentilesAsRealizations,
     ResamplePercentiles)
-from improver.utilities.cli_utilities import load_cube_or_none
 from improver.utilities.cube_checker import find_percentile_coordinate
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -137,7 +136,7 @@ def main(argv=None):
 
     # Load Cubes
     current_forecast = load_cube(args.forecast_filepath)
-    coeffs = load_cube_or_none(args.coefficients_filepath)
+    coeffs = load_cube(args.coefficients_filepath, return_none=True)
     # Process Cube
     result = process(current_forecast, coeffs, args.num_realizations,
                      args.random_ordering, args.random_seed,

--- a/lib/improver/cli/apply_emos_coefficients.py
+++ b/lib/improver/cli/apply_emos_coefficients.py
@@ -136,7 +136,7 @@ def main(argv=None):
 
     # Load Cubes
     current_forecast = load_cube(args.forecast_filepath)
-    coeffs = load_cube(args.coefficients_filepath, return_none=True)
+    coeffs = load_cube(args.coefficients_filepath, allow_none=True)
     # Process Cube
     result = process(current_forecast, coeffs, args.num_realizations,
                      args.random_ordering, args.random_seed,

--- a/lib/improver/cli/nbhood.py
+++ b/lib/improver/cli/nbhood.py
@@ -36,8 +36,7 @@ from improver.constants import DEFAULT_PERCENTILES
 from improver.nbhood.nbhood import (
     GeneratePercentilesFromANeighbourhood, NeighbourhoodProcessing)
 from improver.nbhood.recursive_filter import RecursiveFilter
-from improver.utilities.cli_utilities import (load_cube_or_none,
-                                              radius_or_radii_and_lead)
+from improver.utilities.cli_utilities import radius_or_radii_and_lead
 from improver.utilities.pad_spatial import remove_cube_halo
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -211,9 +210,11 @@ def main(argv=None):
 
     # Load Cube
     cube = load_cube(args.input_filepath)
-    mask_cube = load_cube_or_none(args.input_mask_filepath)
-    alphas_x_cube = load_cube_or_none(args.input_filepath_alphas_x_cube)
-    alphas_y_cube = load_cube_or_none(args.input_filepath_alphas_y_cube)
+    mask_cube = load_cube(args.input_mask_filepath, return_none=True)
+    alphas_x_cube = load_cube(args.input_filepath_alphas_x_cube,
+                              return_none=True)
+    alphas_y_cube = load_cube(args.input_filepath_alphas_y_cube,
+                              return_none=True)
 
     # Process Cube
     result = process(cube, args.neighbourhood_output,

--- a/lib/improver/cli/nbhood.py
+++ b/lib/improver/cli/nbhood.py
@@ -210,11 +210,11 @@ def main(argv=None):
 
     # Load Cube
     cube = load_cube(args.input_filepath)
-    mask_cube = load_cube(args.input_mask_filepath, return_none=True)
+    mask_cube = load_cube(args.input_mask_filepath, allow_none=True)
     alphas_x_cube = load_cube(args.input_filepath_alphas_x_cube,
-                              return_none=True)
+                              allow_none=True)
     alphas_y_cube = load_cube(args.input_filepath_alphas_y_cube,
-                              return_none=True)
+                              allow_none=True)
 
     # Process Cube
     result = process(cube, args.neighbourhood_output,

--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -41,8 +41,7 @@ from improver.nowcasting.forecasting import CreateExtrapolationForecast
 from improver.nowcasting.accumulation import Accumulation
 from improver.utilities.filename import generate_file_name
 from improver.utilities.load import load_cube
-from improver.utilities.cli_utilities import (load_cube_or_none,
-                                              load_json_or_none)
+from improver.utilities.cli_utilities import load_json_or_none
 from improver.utilities.save import save_netcdf
 from improver.wind_calculations.wind_components import ResolveWindComponents
 
@@ -136,8 +135,8 @@ def main(argv=None):
 
     # load files and initialise advection plugin
     input_cube = load_cube(args.input_filepath)
-    orographic_enhancement_cube = load_cube_or_none(
-        args.orographic_enhancement_filepaths)
+    orographic_enhancement_cube = load_cube(
+        args.orographic_enhancement_filepaths, return_none=True)
 
     speed_cube = direction_cube = ucube = vcube = None
     if (upath and vpath) and not (spath or dpath):

--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -136,7 +136,7 @@ def main(argv=None):
     # load files and initialise advection plugin
     input_cube = load_cube(args.input_filepath)
     orographic_enhancement_cube = load_cube(
-        args.orographic_enhancement_filepaths, return_none=True)
+        args.orographic_enhancement_filepaths, allow_none=True)
 
     speed_cube = direction_cube = ucube = vcube = None
     if (upath and vpath) and not (spath or dpath):

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -41,9 +41,8 @@ from improver.nowcasting.forecasting import CreateExtrapolationForecast
 from improver.nowcasting.optical_flow import OpticalFlow
 from improver.nowcasting.utilities import ApplyOrographicEnhancement
 from improver.utilities.filename import generate_file_name
-from improver.utilities.load import load_cubelist
-from improver.utilities.cli_utilities import (load_cube_or_none,
-                                              load_json_or_none)
+from improver.utilities.load import load_cubelist, load_cube
+from improver.utilities.cli_utilities import load_json_or_none
 from improver.utilities.save import save_netcdf
 
 
@@ -107,7 +106,7 @@ def main(argv=None):
     # Load Cubes and JSON.
     metadata_dict = load_json_or_none(args.json_file)
     original_cube_list = load_cubelist(args.input_filepaths)
-    oe_cube = load_cube_or_none(args.orographic_enhancement_filepaths)
+    oe_cube = load_cube(args.orographic_enhancement_filepaths, return_none=True)
 
     # Process
     forecast_cubes, u_and_v_mean = process(

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -106,7 +106,8 @@ def main(argv=None):
     # Load Cubes and JSON.
     metadata_dict = load_json_or_none(args.json_file)
     original_cube_list = load_cubelist(args.input_filepaths)
-    oe_cube = load_cube(args.orographic_enhancement_filepaths, return_none=True)
+    oe_cube = load_cube(args.orographic_enhancement_filepaths,
+                        return_none=True)
 
     # Process
     forecast_cubes, u_and_v_mean = process(

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -107,7 +107,7 @@ def main(argv=None):
     metadata_dict = load_json_or_none(args.json_file)
     original_cube_list = load_cubelist(args.input_filepaths)
     oe_cube = load_cube(args.orographic_enhancement_filepaths,
-                        return_none=True)
+                        allow_none=True)
 
     # Process
     forecast_cubes, u_and_v_mean = process(

--- a/lib/improver/cli/percentiles_to_realizations.py
+++ b/lib/improver/cli/percentiles_to_realizations.py
@@ -35,7 +35,6 @@
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     RebadgePercentilesAsRealizations, ResamplePercentiles, EnsembleReordering)
 from improver.argparser import ArgParser
-from improver.utilities.cli_utilities import load_cube_or_none
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
@@ -152,7 +151,8 @@ def main(argv=None):
                 [int(num) for num in args.realization_numbers])
 
     cube = load_cube(args.input_filepath)
-    raw_forecast = load_cube_or_none(args.raw_forecast_filepath)
+    raw_forecast = load_cube(args.raw_forecast_filepath,
+                             return_none=True)
 
     # Process Cube
     result_cube = process(cube, raw_forecast, args.no_of_percentiles,

--- a/lib/improver/cli/percentiles_to_realizations.py
+++ b/lib/improver/cli/percentiles_to_realizations.py
@@ -151,8 +151,7 @@ def main(argv=None):
                 [int(num) for num in args.realization_numbers])
 
     cube = load_cube(args.input_filepath)
-    raw_forecast = load_cube(args.raw_forecast_filepath,
-                             return_none=True)
+    raw_forecast = load_cube(args.raw_forecast_filepath, allow_none=True)
 
     # Process Cube
     result_cube = process(cube, raw_forecast, args.no_of_percentiles,

--- a/lib/improver/cli/probabilities_to_realizations.py
+++ b/lib/improver/cli/probabilities_to_realizations.py
@@ -119,7 +119,7 @@ def main(argv=None):
     cube = load_cube(args.input_filepath)
     raw_forecast = None
     if args.reordering:
-        raw_forecast = load_cube(args.raw_forecast_filepath, return_none=True)
+        raw_forecast = load_cube(args.raw_forecast_filepath, allow_none=True)
         if raw_forecast is None:
             message = ("You must supply a raw forecast filepath if using the "
                        "reordering option.")

--- a/lib/improver/cli/probabilities_to_realizations.py
+++ b/lib/improver/cli/probabilities_to_realizations.py
@@ -36,7 +36,6 @@ from improver.argparser import ArgParser
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GeneratePercentilesFromProbabilities, RebadgePercentilesAsRealizations,
     EnsembleReordering)
-from improver.utilities.cli_utilities import load_cube_or_none
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
@@ -120,7 +119,7 @@ def main(argv=None):
     cube = load_cube(args.input_filepath)
     raw_forecast = None
     if args.reordering:
-        raw_forecast = load_cube_or_none(args.raw_forecast_filepath)
+        raw_forecast = load_cube(args.raw_forecast_filepath, return_none=True)
         if raw_forecast is None:
             message = ("You must supply a raw forecast filepath if using the "
                        "reordering option.")

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -88,9 +88,9 @@ def main(argv=None):
 
     # Load Cubes.
     cube = load_cube(args.input_filepath)
-    mask_cube = load_cube(args.input_mask_filepath, return_none=True)
-    alphas_x_cube = load_cube(args.input_filepath_alphas_x, return_none=True)
-    alphas_y_cube = load_cube(args.input_filepath_alphas_y, return_none=True)
+    mask_cube = load_cube(args.input_mask_filepath, allow_none=True)
+    alphas_x_cube = load_cube(args.input_filepath_alphas_x, allow_none=True)
+    alphas_y_cube = load_cube(args.input_filepath_alphas_y, allow_none=True)
     # Process Cube
     result = process(cube, mask_cube, alphas_x_cube, alphas_y_cube,
                      args.alpha_x, args.alpha_y, args.iterations, args.re_mask)

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -34,7 +34,6 @@
 from improver.argparser import ArgParser
 
 from improver.nbhood.recursive_filter import RecursiveFilter
-from improver.utilities.cli_utilities import load_cube_or_none
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
 
@@ -89,9 +88,9 @@ def main(argv=None):
 
     # Load Cubes.
     cube = load_cube(args.input_filepath)
-    mask_cube = load_cube_or_none(args.input_mask_filepath)
-    alphas_x_cube = load_cube_or_none(args.input_filepath_alphas_x)
-    alphas_y_cube = load_cube_or_none(args.input_filepath_alphas_y)
+    mask_cube = load_cube(args.input_mask_filepath, return_none=True)
+    alphas_x_cube = load_cube(args.input_filepath_alphas_x, return_none=True)
+    alphas_y_cube = load_cube(args.input_filepath_alphas_y, return_none=True)
     # Process Cube
     result = process(cube, mask_cube, alphas_x_cube, alphas_y_cube,
                      args.alpha_x, args.alpha_y, args.iterations, args.re_mask)

--- a/lib/improver/cli/spot_extract.py
+++ b/lib/improver/cli/spot_extract.py
@@ -44,8 +44,7 @@ from improver.percentile import PercentileConverter
 from improver.spotdata.apply_lapse_rate import SpotLapseRateAdjust
 from improver.spotdata.neighbour_finding import NeighbourSelection
 from improver.spotdata.spot_extraction import SpotExtraction
-from improver.utilities.cli_utilities import (load_json_or_none,
-                                              load_cube_or_none)
+from improver.utilities.cli_utilities import load_json_or_none
 from improver.utilities.cube_checker import find_percentile_coordinate
 from improver.utilities.cube_extraction import extract_subcube
 from improver.utilities.cube_metadata import amend_metadata
@@ -154,7 +153,8 @@ def main(argv=None):
     # Load Cube and JSON.
     neighbour_cube = load_cube(args.neighbour_filepath)
     diagnostic_cube = load_cube(args.diagnostic_filepath)
-    lapse_rate_cube = load_cube_or_none(args.temperature_lapse_rate_filepath)
+    lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath,
+                                return_none=True)
     metadata_dict = load_json_or_none(args.metadata_json)
 
     # Process Cube

--- a/lib/improver/cli/spot_extract.py
+++ b/lib/improver/cli/spot_extract.py
@@ -154,7 +154,7 @@ def main(argv=None):
     neighbour_cube = load_cube(args.neighbour_filepath)
     diagnostic_cube = load_cube(args.diagnostic_filepath)
     lapse_rate_cube = load_cube(args.temperature_lapse_rate_filepath,
-                                return_none=True)
+                                allow_none=True)
     metadata_dict = load_json_or_none(args.metadata_json)
 
     # Process Cube

--- a/lib/improver/cli/wind_downscaling.py
+++ b/lib/improver/cli/wind_downscaling.py
@@ -117,9 +117,9 @@ def main(argv=None):
     sigma = load_cube(args.sigma_filepath)
     target_orog = load_cube(args.target_orog_filepath)
     standard_orog = load_cube(args.standard_orog_filepath)
-    height_levels = load_cube(args.height_levels_filepath, return_none=True)
+    height_levels = load_cube(args.height_levels_filepath, allow_none=True)
     veg_roughness_cube = load_cube(args.veg_roughness_filepath,
-                                   return_none=True)
+                                   allow_none=True)
 
     # Process Cube
     wind_speed = process(wind_speed, silhouette_roughness, sigma, target_orog,

--- a/lib/improver/cli/wind_downscaling.py
+++ b/lib/improver/cli/wind_downscaling.py
@@ -38,7 +38,6 @@ import numpy as np
 import iris
 from iris.exceptions import CoordinateNotFoundError
 
-from improver.utilities.cli_utilities import load_cube_or_none
 from improver.wind_calculations import wind_downscaling
 from improver.utilities.load import load_cube
 from improver.utilities.save import save_netcdf
@@ -118,8 +117,9 @@ def main(argv=None):
     sigma = load_cube(args.sigma_filepath)
     target_orog = load_cube(args.target_orog_filepath)
     standard_orog = load_cube(args.standard_orog_filepath)
-    height_levels = load_cube_or_none(args.height_levels_filepath)
-    veg_roughness_cube = load_cube_or_none(args.veg_roughness_filepath)
+    height_levels = load_cube(args.height_levels_filepath, return_none=True)
+    veg_roughness_cube = load_cube(args.veg_roughness_filepath,
+                                   return_none=True)
 
     # Process Cube
     wind_speed = process(wind_speed, silhouette_roughness, sigma, target_orog,

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -236,7 +236,7 @@ class Test_apply_extraction(IrisTest):
         with self.assertRaises(CoordinateNotFoundError):
             apply_extraction(self.precip_cube, constraint_dict, units_dict)
 
-    def test_return_none(self):
+    def test_allow_none(self):
         """ Test function returns None rather than raising an error where
         no subcubes match the required constraints, when unit conversion is
         required """

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -221,11 +221,12 @@ class Test_load_cube(IrisTest):
         self.assertTrue(result.has_lazy_data())
 
     def test_none_file_with_allow_none(self):
-        """Test that return none works with None as filepath."""
+        """Test that with None as filepath and allow_none, it returns None."""
         self.assertIsNone(load_cube(None, allow_none=True))
 
     def test_none_file_without_allow_none(self):
-        """Test that without allow_none it raises an TypeError with None as filepath."""
+        """Test that with None as filepath as without allow_none,
+         it raises a TypeError."""
         with self.assertRaises(TypeError):
             load_cube(None)
 

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -220,12 +220,12 @@ class Test_load_cube(IrisTest):
         result = load_cube(self.filepath)
         self.assertTrue(result.has_lazy_data())
 
-    def test_none_file_with_return_none(self):
+    def test_none_file_with_allow_none(self):
         """Test that return none works with None as filepath."""
-        self.assertIsNone(load_cube(None, return_none=True))
+        self.assertIsNone(load_cube(None, allow_none=True))
 
-    def test_none_file_without_return_none(self):
-        """Test that without return_none it raises an with None as filepath."""
+    def test_none_file_without_allow_none(self):
+        """Test that without allow_none it raises an with None as filepath."""
         with self.assertRaises(TypeError):
             load_cube(None)
 

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -225,7 +225,7 @@ class Test_load_cube(IrisTest):
         self.assertIsNone(load_cube(None, allow_none=True))
 
     def test_none_file_without_allow_none(self):
-        """Test that without allow_none it raises an with None as filepath."""
+        """Test that without allow_none it raises an TypeError with None as filepath."""
         with self.assertRaises(TypeError):
             load_cube(None)
 

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -220,12 +220,12 @@ class Test_load_cube(IrisTest):
         result = load_cube(self.filepath)
         self.assertTrue(result.has_lazy_data())
 
-    def test_return_none(self):
+    def test_none_file_with_return_none(self):
         """Test that return none works with None as filepath."""
         self.assertIsNone(load_cube(None, return_none=True))
 
-    def test_return_none(self):
-        """Test that return none works with None as filepath."""
+    def test_none_file_without_return_none(self):
+        """Test that without return_none it raises an with None as filepath."""
         with self.assertRaises(TypeError):
             load_cube(None)
 

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -220,6 +220,15 @@ class Test_load_cube(IrisTest):
         result = load_cube(self.filepath)
         self.assertTrue(result.has_lazy_data())
 
+    def test_return_none(self):
+        """Test that return none works with None as filepath."""
+        self.assertIsNone(load_cube(None, return_none=True))
+
+    def test_return_none(self):
+        """Test that return none works with None as filepath."""
+        with self.assertRaises(TypeError):
+            load_cube(None)
+
 
 class Test_load_cubelist(IrisTest):
 

--- a/lib/improver/tests/utilities/test_load.py
+++ b/lib/improver/tests/utilities/test_load.py
@@ -225,7 +225,7 @@ class Test_load_cube(IrisTest):
         self.assertIsNone(load_cube(None, allow_none=True))
 
     def test_none_file_without_allow_none(self):
-        """Test that with None as filepath as without allow_none,
+        """Test that with None as filepath and without allow_none,
          it raises a TypeError."""
         with self.assertRaises(TypeError):
             load_cube(None)

--- a/lib/improver/utilities/cli_utilities.py
+++ b/lib/improver/utilities/cli_utilities.py
@@ -30,24 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Provides support utilities for cli scripts."""
 
-from improver.utilities.load import load_cube
 import json
-
-
-def load_cube_or_none(file_path):
-    """If there is a filepath, loads a cube and returns it, else returns None.
-
-    Args:
-        file_path (str):
-            File path to the file to load as a cube.
-
-    Returns:
-        (iris.cube.Cube):
-            A loaded cube.
-            or
-            None
-    """
-    return load_cube(file_path) if file_path else None
 
 
 def load_json_or_none(file_path):

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -56,7 +56,7 @@ def load_cube(filepath, constraints=None, no_lazy_load=False,
             cube into memory. This can increase performance at the cost of
             memory. If False (default) then lazy load.
         return_none (bool):
-            If True, when the filepath is None returns None.
+            If True, when the filepath is None, returns None.
             If False, normal error handling applies.
             Default is False.
 

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -39,7 +39,7 @@ from improver.utilities.cube_manipulation import (
 
 
 def load_cube(filepath, constraints=None, no_lazy_load=False,
-              return_none=False):
+              allow_none=False):
     """Load the filepath provided using Iris into a cube.
 
     Args:
@@ -55,7 +55,7 @@ def load_cube(filepath, constraints=None, no_lazy_load=False,
             If True, bypass cube deferred (lazy) loading and load the whole
             cube into memory. This can increase performance at the cost of
             memory. If False (default) then lazy load.
-        return_none (bool):
+        allow_none (bool):
             If True, when the filepath is None, returns None.
             If False, normal error handling applies.
             Default is False.
@@ -65,7 +65,7 @@ def load_cube(filepath, constraints=None, no_lazy_load=False,
             Cube that has been loaded from the input filepath given the
             constraints provided.
     """
-    if filepath is None and return_none:
+    if filepath is None and allow_none:
         return None
     # Remove metadata prefix cube if present
     constraints = iris.Constraint(

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -38,7 +38,8 @@ from improver.utilities.cube_manipulation import (
     enforce_coordinate_ordering, merge_cubes)
 
 
-def load_cube(filepath, constraints=None, no_lazy_load=False):
+def load_cube(filepath, constraints=None, no_lazy_load=False,
+              return_none=False):
     """Load the filepath provided using Iris into a cube.
 
     Args:
@@ -50,16 +51,21 @@ def load_cube(filepath, constraints=None, no_lazy_load=False):
             This can be in the form of an iris.Constraint or could be a string
             that is intended to match the name of the cube.
             The default is None.
-        no_lazy_load (bool)
+        no_lazy_load (bool):
             If True, bypass cube deferred (lazy) loading and load the whole
             cube into memory. This can increase performance at the cost of
             memory. If False (default) then lazy load.
+        return_none (bool):
+            If True, when the filepath is None returns None.
+            If False, normal error handling applies.
 
     Returns:
         cube (iris.cube.Cube):
             Cube that has been loaded from the input filepath given the
             constraints provided.
     """
+    if filepath is None and return_none:
+        return None
     # Remove metadata prefix cube if present
     constraints = iris.Constraint(
         cube_func=lambda cube: cube.long_name != 'prefixes') & constraints

--- a/lib/improver/utilities/load.py
+++ b/lib/improver/utilities/load.py
@@ -58,6 +58,7 @@ def load_cube(filepath, constraints=None, no_lazy_load=False,
         return_none (bool):
             If True, when the filepath is None returns None.
             If False, normal error handling applies.
+            Default is False.
 
     Returns:
         cube (iris.cube.Cube):


### PR DESCRIPTION
The CLI's often need to optionally load cubes. This means that the cubes can be either Nonetype or a Cube. 
This move the responsibility of that to a bool kwarg rather than extra if statements throughout the CLI's.

This has taken a single check at the start of the load function and a refactor across 10 CLI's.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)