### PR TITLE
Fix ResolveWindComponents calc_true_north_offset throwing away regridding result

### DIFF
--- a/lib/improver/tests/wind_calculations/wind_components/test_ResolveWindComponents.py
+++ b/lib/improver/tests/wind_calculations/wind_components/test_ResolveWindComponents.py
@@ -238,8 +238,8 @@ class Test_process(IrisTest):
         self.wind_direction_cube.rename("wind_from_direction")
         ucube, vcube = self.plugin.process(
             self.wind_speed_cube, self.wind_direction_cube)
-        self.assertTrue(np.allclose(ucube.data, expected_u, atol=1e-6))
-        self.assertTrue(np.allclose(vcube.data, expected_v, atol=1e-6))
+        self.assertArrayAllClose(ucube.data, expected_u, atol=1e-5)
+        self.assertArrayAllClose(vcube.data, expected_v, atol=1e-5)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/wind_calculations/wind_components/test_ResolveWindComponents.py
+++ b/lib/improver/tests/wind_calculations/wind_components/test_ResolveWindComponents.py
@@ -100,9 +100,9 @@ class Test_calc_true_north_offset(IrisTest):
         """Test that for UK National Grid coordinates the angle adjustments
         are sensible"""
         expected_result = np.array([
-            [3.012338, 2.635347, 2.258535, 1.881877, 1.505348],
-            [3.167531, 2.771182, 2.374997, 1.978951, 1.583021],
-            [3.310965, 2.896735, 2.482648, 2.068685, 1.654825]],
+            [2.651483, 2.386892, 2.122119, 1.857182, 1.592121],
+            [2.921058, 2.629620, 2.337963, 2.046132, 1.754138],
+            [3.223816, 2.902300, 2.580523, 2.258494, 1.936247]],
             dtype=np.float32)
         result = self.plugin.calc_true_north_offset(self.directions)
         self.assertArrayAlmostEqual(RAD_TO_DEG*result, expected_result)
@@ -169,14 +169,14 @@ class Test_process(IrisTest):
             wind_direction_data, "wind_to_direction", "degrees")
 
         self.expected_u = np.array([
-            [3.774919, 2.902824, 2.406847, 1.826062],
-            [4.683339, 3.386423, 2.456537, 2.374629],
-            [6.829466, 4.149148, 3.593584, 2.963243]], dtype=np.float32)
+            [3.804214, 2.917800, 2.410297, 1.822455],
+            [4.711193, 3.395639, 2.454748, 2.365005],
+            [6.844465, 4.144803, 3.580219, 2.943424]], dtype=np.float32)
 
         self.expected_v = np.array([
-            [-4.663688, -4.071071, -3.194854, -2.380230],
-            [-6.485857, -4.952993, -3.156806, -3.218872],
-            [-9.867035, -6.839924, -4.804805, -4.027306]], dtype=np.float32)
+            [-4.639823, -4.060351, -3.1922507, -2.382994],
+            [-6.465651, -4.946681, -3.1581972, -3.225949],
+            [-9.856638, -6.842559, -4.8147717, -4.041813]], dtype=np.float32)
 
     def test_basic(self):
         """Test plugin creates two output cubes with the correct metadata"""

--- a/lib/improver/wind_calculations/wind_components.py
+++ b/lib/improver/wind_calculations/wind_components.py
@@ -112,9 +112,10 @@ class ResolveWindComponents(object):
             ucube_truenorth, vcube_truenorth, reference_cube.coord_system())
 
         # unmask and regrid rotated winds onto reference_cube grid
-        for cube in [ucube, vcube]:
-            cube.data = cube.data.data
-            cube = cube.regrid(reference_cube, Linear())
+        ucube.data = ucube.data.data
+        ucube = ucube.regrid(reference_cube, Linear())
+        vcube.data = vcube.data.data
+        vcube = vcube.regrid(reference_cube, Linear())
 
         # ratio of u to v winds is the tangent of the angle which is the
         # true North to grid North rotation


### PR DESCRIPTION
The for loop near the end of `ResolveWindComponents` `calc_true_north_offset` method currently carries out regridding, but then throws away the regridded cube rather than assigning back to the `ucube` and `vcube` variables. This behaviour looks like it is not how the code is intended to work and is very likely to be a bug.

Testing:
Expected outputs in unit tests have been updated.
This change affects the KGO output files, and those will need to be updated separately outside this pull request.