### PR TITLE
IMPRO1361 timezone bugs

### DIFF
--- a/lib/improver/tests/utilities/test_TemporalInterpolation.py
+++ b/lib/improver/tests/utilities/test_TemporalInterpolation.py
@@ -32,7 +32,6 @@
 
 import os
 import datetime
-import time
 import unittest
 from datetime import timedelta
 
@@ -44,12 +43,6 @@ from iris.tests import IrisTest
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.utilities.temporal_interpolation import TemporalInterpolation
-
-
-def set_utc():
-    """Enforce time zone to UTC regardless of local time zone"""
-    os.environ['TZ'] = 'UTC'
-    time.tzset()
 
 
 class Test__init__(IrisTest):
@@ -426,7 +419,7 @@ class Test_solar_interpolation(IrisTest):
     def test_solar_interpolation(self):
         """Test interpolating using solar method works correctly."""
 
-        expected_time = (self.time_0 + timedelta(hours=2)).timestamp()
+        expected_time = [1509523200]
         expected_fp = 2 * 3600
         plugin = TemporalInterpolation(interpolation_method='solar',
                                        times=[self.time_mid])
@@ -442,7 +435,7 @@ class Test_solar_interpolation(IrisTest):
         """Test interpolating using solar method with len(shape) >= 3
          works correctly."""
 
-        expected_time = (self.time_0 + timedelta(hours=2)).timestamp()
+        expected_time = [1509523200]
         expected_fp = 2 * 3600
         plugin = TemporalInterpolation(interpolation_method='solar',
                                        times=[self.time_mid])
@@ -463,7 +456,6 @@ class Test_daynight_interpolation(IrisTest):
 
     def setUp(self):
         """Set up the test inputs spanning sunrise."""
-        set_utc()
         self.time_0 = datetime.datetime(2017, 11, 1, 6)
         self.time_mid = datetime.datetime(2017, 11, 1, 8)
         self.npoints = 10
@@ -510,7 +502,7 @@ class Test_daynight_interpolation(IrisTest):
         expected_data = np.ones((self.npoints, self.npoints))*4
         index = np.where(self.daynight_mask == 0)
         expected_data[index] = 0.0
-        expected_time = (self.time_0 + timedelta(hours=2)).timestamp()
+        expected_time = [1509523200]
         expected_fp = 2 * 3600
         plugin = TemporalInterpolation(interpolation_method='daynight',
                                        times=[self.time_mid])
@@ -530,7 +522,7 @@ class Test_daynight_interpolation(IrisTest):
         expected_data_grid[index] = 0.0
         expected_data = np.repeat(expected_data_grid[np.newaxis, :, :],
                                   3, axis=0)
-        expected_time = (self.time_0 + timedelta(hours=2)).timestamp()
+        expected_time = [1509523200]
         expected_fp = 2 * 3600
         plugin = TemporalInterpolation(interpolation_method='daynight',
                                        times=[self.time_mid])
@@ -575,7 +567,7 @@ class Test_process(IrisTest):
         06Z November 11th 2017."""
 
         expected_data = np.ones((self.npoints, self.npoints)) * 4
-        expected_time = (self.time_0 + timedelta(hours=3)).timestamp()
+        expected_time = [1509516000]
         expected_fp = 3 * 3600
         result, = TemporalInterpolation(interval_in_minutes=180).process(
             self.cube_time_0, self.cube_time_1)
@@ -597,7 +589,7 @@ class Test_process(IrisTest):
             self.cube_time_0, self.cube_time_1)
         for i, cube in enumerate(result):
             expected_data = np.ones((self.npoints, self.npoints)) * i + 2
-            expected_time = (self.time_0 + timedelta(hours=(i+1))).timestamp()
+            expected_time = [1509508800 + i * 3600]
 
             self.assertArrayAlmostEqual(expected_data, cube.data)
             self.assertArrayAlmostEqual(
@@ -616,7 +608,7 @@ class Test_process(IrisTest):
         result, = TemporalInterpolation(times=[self.time_extra]).process(
             self.cube_time_0, self.cube_time_1)
         expected_data = np.ones((self.npoints, self.npoints)) * 4
-        expected_time = self.time_extra.timestamp()
+        expected_time = [1509516000]
         expected_fp = 3 * 3600
 
         self.assertArrayAlmostEqual(expected_data, result.data)
@@ -639,7 +631,7 @@ class Test_process(IrisTest):
                                        interpolation_method='solar')
         result, = plugin.process(self.cube_time_0,
                                  self.cube_time_1)
-        expected_time = self.time_extra.timestamp()
+        expected_time = [1509516000]
         expected_fp = 3 * 3600
 
         self.assertArrayAlmostEqual(
@@ -664,7 +656,7 @@ class Test_process(IrisTest):
         expected_data[:2, 7:] = 4.
         expected_data[2, 8:] = 4.
         expected_data[3, 9] = 4.
-        expected_time = self.time_extra.timestamp()
+        expected_time = [1509516000]
         expected_fp = 3 * 3600
 
         self.assertArrayAlmostEqual(expected_data, result.data)

--- a/lib/improver/tests/utilities/test_TemporalInterpolation.py
+++ b/lib/improver/tests/utilities/test_TemporalInterpolation.py
@@ -30,7 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for temporal utilities."""
 
-import os
 import datetime
 import unittest
 from datetime import timedelta

--- a/lib/improver/tests/utilities/test_TemporalInterpolation.py
+++ b/lib/improver/tests/utilities/test_TemporalInterpolation.py
@@ -30,7 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for temporal utilities."""
 
+import os
 import datetime
+import time
 import unittest
 from datetime import timedelta
 
@@ -42,6 +44,12 @@ from iris.tests import IrisTest
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.utilities.temporal_interpolation import TemporalInterpolation
+
+
+def set_utc():
+    """Enforce time zone to UTC regardless of local time zone"""
+    os.environ['TZ'] = 'UTC'
+    time.tzset()
 
 
 class Test__init__(IrisTest):
@@ -455,6 +463,7 @@ class Test_daynight_interpolation(IrisTest):
 
     def setUp(self):
         """Set up the test inputs spanning sunrise."""
+        set_utc()
         self.time_0 = datetime.datetime(2017, 11, 1, 6)
         self.time_mid = datetime.datetime(2017, 11, 1, 8)
         self.npoints = 10


### PR DESCRIPTION
The unit-tests in tests/utilities/test_TemporalInterpolation.py made use of the datetime.timestamp method without specifying a time-zone. This meant that the expected values defined in the unit-tests varied according to the locale of the machine running the tests.

After experimenting with setting time-zone information, I have replaced all these calls with hard-coded numbers, as used elsewhere in the IMPROVER unit-tests.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Ran tests with TZ='Australia/Melbourne' and they passed OK
