### PR TITLE
Between thresholds plugin

### DIFF
--- a/lib/improver/between_thresholds.py
+++ b/lib/improver/between_thresholds.py
@@ -28,8 +28,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""
-Plugin to calculate probabilities of occurrence between specified thresholds
+"""Plugin to calculate probabilities of occurrence between specified thresholds
 """
 
 import iris
@@ -103,9 +102,9 @@ class OccurrenceBetweenThresholds(object):
         for t_range in self.threshold_ranges:
             t_range.sort()
             lower_constraint = iris.Constraint(coord_values={
-                thresh_coord: lambda t: isclose(t.point, t_range[0])}))
+                thresh_coord: lambda t: isclose(t.point, t_range[0])})
             upper_constraint = iris.Constraint(coord_values={
-                thresh_coord: lambda t: isclose(t.point, t_range[1])}))
+                thresh_coord: lambda t: isclose(t.point, t_range[1])})
             constraints.append([lower_constraint, upper_constraint])
         return constraints
 
@@ -145,7 +144,7 @@ class OccurrenceBetweenThresholds(object):
             between_thresholds_data = (
                 upper_cube.data-lower_cube.data)*multiplier
             between_thresholds_cube = upper_cube.copy(between_thresholds_data)
-            
+
             # add threshold coordinate bounds
             lower_threshold = lower_cube.coord(thresh_coord.name()).points[0]
             upper_threshold = upper_cube.coord(thresh_coord.name()).points[0]
@@ -157,6 +156,6 @@ class OccurrenceBetweenThresholds(object):
         output_cube = cubelist.merge()
         output_cube.rename(
             'probability_of_{}_between_thresholds'.format(
-            extract_diagnostic_name(cube)))
+                extract_diagnostic_name(cube)))
 
         return output_cube

--- a/lib/improver/between_thresholds.py
+++ b/lib/improver/between_thresholds.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Plugin to calculate probabilities of occurrence between specified thresholds
+"""
+
+import iris
+import numpy as np
+
+from iris.exceptions import CoordinateNotFoundError
+
+from improver.utilities.cube_checker import find_threshold_coordinate
+from improver.utilities.cube_metadata import extract_diagnostic_name
+
+
+class OccurrenceBetweenThresholds(object):
+    """Calculate the probability of occurrence between thresholds"""
+
+    def __init__(self, threshold_ranges):
+        """
+        Initialise the class
+
+        Args:
+            threshold_ranges (list):
+                List of 2-item iterables specifying thresholds between which
+                probabilities should be calculated
+        """
+        self.threshold_ranges = threshold_ranges
+
+    @staticmethod
+    def _get_multiplier(thresh_coord):
+        """
+        Check whether the cube contains "above" or "below" threshold
+        probabilities.  For "above", the probability of occurrence between
+        thresholds is the difference between probabilities at the higher
+        and lower thresholds: P(higher) - P(lower).  For "below" it is the
+        inverse of this: P(lower) - P(higher), which is implemented by
+        multiplying the difference by -1.
+
+        Args:
+            thresh_coord (iris.coords.DimCoord):
+                Threshold-type coordinate from the input cube
+
+        Returns:
+            multiplier (float):
+                1. or -1.
+
+        Raises:
+            ValueError: If the spp__relative_to_threshold attribute is
+                not recognised
+        """
+        if thresh_coord.attributes['spp__relative_to_threshold'] == 'above':
+            multiplier = 1.
+        elif thresh_coord.attributes['spp__relative_to_threshold'] == 'below':
+            multiplier = -1.
+        else:
+            raise ValueError('Input cube must contain probabilities of '
+                             'occurrence above or below threshold')
+        return multiplier
+
+    def _construct_constraints(self, thresh_coord):
+        """
+        Construct iris constraints to extract from the input cube
+
+        Args:
+            thresh_coord (iris.coords.DimCoord):
+                Threshold coordinate from the input cube
+
+        Returns:
+            constraints (list):
+                List of 2-item iterables containing iris constraints for
+                the lower and upper thresholds to be extracted
+        """
+        constraints = []
+        for t_range in self.threshold_ranges:
+            t_range.sort()
+            lower_constraint = iris.Constraint(coord_values={
+                thresh_coord: lambda t: isclose(t.point, t_range[0])}))
+            upper_constraint = iris.Constraint(coord_values={
+                thresh_coord: lambda t: isclose(t.point, t_range[1])}))
+            constraints.append([lower_constraint, upper_constraint])
+        return constraints
+
+    def process(self, cube):
+        """
+        Calculate probabilities between thresholds for the input cube
+
+        Args:
+            cube (iris.cube.Cube):
+                Probability cube containing thresholded data (above or below)
+
+        Returns:
+            output_cube (iris.cube.Cube):
+                Cube containing probability of occurrence between thresholds
+        """
+        # if cube has no threshold-type coordinate, raise an error
+        try:
+            thresh_coord = find_threshold_coordinate(cube)
+        except CoordinateNotFoundError:
+            raise ValueError('Input cube has no threshold-type coordinate')
+
+        # if cube contains below threshold probabilities, need to multiply
+        # difference by -1
+        multiplier = self._get_multiplier(thresh_coord)
+
+        # generate constraints from threshold-type coordinate
+        constraints = self._construct_constraints(thresh_coord)
+
+        # generate "between thresholds" fields
+        cubelist = iris.cube.CubeList([])
+        for constraint in constraints:
+            # extract cube slices
+            lower_cube = cube.extract(constraint[0])
+            upper_cube = cube.extract(constraint[1])
+
+            # construct difference cube
+            between_thresholds_data = (
+                upper_cube.data-lower_cube.data)*multiplier
+            between_thresholds_cube = upper_cube.copy(between_thresholds_data)
+            
+            # add threshold coordinate bounds
+            lower_threshold = lower_cube.coord(thresh_coord.name()).points[0]
+            upper_threshold = upper_cube.coord(thresh_coord.name()).points[0]
+            between_thresholds.coord(thresh_coord.name()).bounds = (
+                [lower_threshold, upper_threshold])
+
+            cubelist.append(between_thresholds_cube)
+
+        output_cube = cubelist.merge()
+        output_cube.rename(
+            'probability_of_{}_between_thresholds'.format(
+            extract_diagnostic_name(cube)))
+
+        return output_cube

--- a/lib/improver/between_thresholds.py
+++ b/lib/improver/between_thresholds.py
@@ -145,7 +145,7 @@ class OccurrenceBetweenThresholds(object):
         for (lower_cube, upper_cube) in self.cube_slices:
             # construct difference cube
             between_thresholds_data = (
-                lower_cube.data-upper_cube.data)*multiplier
+                lower_cube.data - upper_cube.data) * multiplier
             between_thresholds_cube = upper_cube.copy(between_thresholds_data)
 
             # add threshold coordinate bounds

--- a/lib/improver/tests/between_thresholds/test_between_thresholds.py
+++ b/lib/improver/tests/between_thresholds/test_between_thresholds.py
@@ -147,16 +147,17 @@ class Test_process(IrisTest):
         """Test error if cube doesn't contain the required thresholds"""
         threshold_ranges = [[10, 100], [1000, 30000]]
         plugin = OccurrenceBetweenThresholds(threshold_ranges, 'm')
-        msg = ('visibility threshold 10 is not available\n'
-               'visibility threshold 30000 is not available')
+        msg = ('visibility threshold 10 m is not available\n'
+               'visibility threshold 30000 m is not available')
         with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.vis_cube)
 
     def test_threshold_matching_tolerance(self):
         """Test threshold matching succeeds for absolute values close to
         zero"""
-        self.temp_cube.coord('air_temperature').points = [
-            272.15, 273.15, 274.15, 275.15]
+        new_thresholds = np.array(
+            [272.15, 273.15, 274.15, 275.15], dtype=np.float32)
+        self.temp_cube.coord('air_temperature').points = new_thresholds
         threshold_ranges = [[-1, 0], [0, 2]]
         expected_data = np.array([
             [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]],

--- a/lib/improver/tests/between_thresholds/test_between_thresholds.py
+++ b/lib/improver/tests/between_thresholds/test_between_thresholds.py
@@ -67,7 +67,7 @@ class Test_process(IrisTest):
             [[0.8, 0.7, 0.6], [0.7, 0.6, 0.5], [0.6, 0.5, 0.4]],
             [[0.1, 0.2, 0.3], [0.0, 0.1, 0.2], [0.0, 0.0, 0.1]]],
             dtype=np.float32)
-        plugin = OccurrenceBetweenThresholds(threshold_ranges, 'K')
+        plugin = OccurrenceBetweenThresholds(threshold_ranges.copy(), 'K')
         result = plugin.process(self.temp_cube)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(
@@ -85,7 +85,7 @@ class Test_process(IrisTest):
         expected_data = np.array(
             [[0.8, 0.7, 0.6], [0.7, 0.6, 0.5], [0.6, 0.5, 0.4]],
             dtype=np.float32)
-        plugin = OccurrenceBetweenThresholds(threshold_ranges, 'm')
+        plugin = OccurrenceBetweenThresholds(threshold_ranges.copy(), 'm')
         result = plugin.process(self.vis_cube)
         self.assertArrayAlmostEqual(result.data, expected_data)
         self.assertArrayAlmostEqual(

--- a/lib/improver/tests/between_thresholds/test_between_thresholds.py
+++ b/lib/improver/tests/between_thresholds/test_between_thresholds.py
@@ -152,6 +152,20 @@ class Test_process(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             plugin.process(self.vis_cube)
 
+    def test_threshold_matching_tolerance(self):
+        """Test threshold matching succeeds for absolute values close to
+        zero"""
+        self.temp_cube.coord('air_temperature').points = [
+            272.15, 273.15, 274.15, 275.15]
+        threshold_ranges = [[-1, 0], [0, 2]]
+        expected_data = np.array([
+            [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]],
+            [[0.9, 0.9, 0.9], [0.7, 0.7, 0.7], [0.6, 0.5, 0.5]]],
+            dtype=np.float32)
+        plugin = OccurrenceBetweenThresholds(threshold_ranges, 'degC')
+        result = plugin.process(self.temp_cube)
+        self.assertArrayAlmostEqual(result.data, expected_data)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/between_thresholds/test_between_thresholds.py
+++ b/lib/improver/tests/between_thresholds/test_between_thresholds.py
@@ -196,7 +196,7 @@ class Test_process(IrisTest):
         threshold_ranges = [[0.25, 0.5]]
         plugin = OccurrenceBetweenThresholds(threshold_ranges, 'mm h-1')
         result = plugin.process(self.precip_cube)
-        self.assertArrayAlmostEqual(result.data, expected_data)        
+        self.assertArrayAlmostEqual(result.data, expected_data)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/between_thresholds/test_between_thresholds.py
+++ b/lib/improver/tests/between_thresholds/test_between_thresholds.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests for the OccurrenceBetweenThresholds plugin"""
+
+import unittest
+import numpy as np
+
+import iris
+from iris.tests import IrisTest
+
+from improver.tests.set_up_test_cubes import set_up_probability_cube
+from improver.between_thresholds import OccurrenceBetweenThresholds
+
+
+class Test_process(IrisTest):
+    """Test the process method"""
+
+    def setUp(self):
+        """Set up a test cube with probability data"""
+        data = np.array([
+            [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+            [[0.9, 0.9, 0.9], [0.8, 0.8, 0.8], [0.7, 0.7, 0.7]],
+            [[0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3]],
+            [[0.0, 0.0, 0.0], [0.1, 0.1, 0.1], [0.1, 0.2, 0.2]]],
+            dtype=np.float32)
+        thresholds = np.array([279, 280, 281, 282], dtype=np.float32)
+        self.temp_cube = set_up_probability_cube(data, thresholds)
+
+        vis_thresholds = np.array([100, 1000, 5000, 10000], dtype=np.float32)
+        self.vis_cube = set_up_probability_cube(
+            np.flip(data, axis=0), vis_thresholds, variable_name='visibility',
+            threshold_units='m', spp__relative_to_threshold='below')
+
+    def test_above_threshold(self):
+        """Test values from an "above threshold" cube"""
+        threshold_ranges = [[280, 281], [281, 282]]
+        plugin = OccurrenceBetweenThresholds(threshold_ranges)
+        result = plugin.process(self.temp_cube)
+        print(result)
+
+
+
+
+
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Plugin to calculate a "between_thresholds" cube from above or below thresholded probabilities.

The question of whether threshold points should be at the top, bottom or midrange of the bounds has been asked but not answered yet.  In the meantime I've written the plugin to have the upper threshold point and bounds spanning the range between which probabilities are specified.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
