### PR TITLE
Unused vars

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -121,11 +121,9 @@ class MergeCubesForWeightedBlending():
         if ("model" in self.blend_coord and
                 self.weighting_coord is not None and
                 "forecast_period" in self.weighting_coord):
-            if cycletime is None:
-                cycletime = find_latest_cycletime(cubelist)
-            else:
-                cycletime = cycletime_to_datetime(cycletime)
-            cubelist = unify_forecast_reference_time(cubelist, cycletime)
+            cycletime = (find_latest_cycletime(cubelist) if cycletime is None
+                         else cycletime_to_datetime(cycletime))
+            unify_forecast_reference_time(cubelist, cycletime)
 
     def _create_model_coordinates(self, cubelist):
         """
@@ -858,7 +856,7 @@ class WeightedBlendAcrossWholeDimension:
             raise TypeError(msg)
 
         if not cube.coords(self.coord):
-            msg = ('Coordinate to be collapsed not found in cube.')
+            msg = 'Coordinate to be collapsed not found in cube.'
             raise CoordinateNotFoundError(msg)
 
         coord_dim = cube.coord_dims(self.coord)
@@ -871,7 +869,7 @@ class WeightedBlendAcrossWholeDimension:
         cube = sort_coord_in_cube(cube, self.coord, order="ascending")
         if weights is not None:
             if not weights.coords(self.coord):
-                msg = ('Coordinate to be collapsed not found in weights cube.')
+                msg = 'Coordinate to be collapsed not found in weights cube.'
                 raise CoordinateNotFoundError(msg)
             weights = sort_coord_in_cube(weights, self.coord,
                                          order="ascending")

--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -294,7 +294,7 @@ def process(input_cube, u_cube, v_cube, speed_cube, direction_cube,
 
     # extrapolate input data to required lead times
     forecast_cubes = iris.cube.CubeList()
-    for i, lead_time in enumerate(lead_times):
+    for lead_time in lead_times:
         forecast_cubes.append(
             forecast_plugin.extrapolate(leadtime_minutes=lead_time))
 

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -241,7 +241,7 @@ def process(original_cube_list, orographic_enhancement_cube=None,
             orographic_enhancement_cube=orographic_enhancement_cube,
             metadata_dict=metadata_dict)
         # extrapolate input data to required lead times
-        for i, lead_time in enumerate(lead_times):
+        for lead_time in lead_times:
             forecast_cubes.append(forecast_plugin.extrapolate(
                 leadtime_minutes=lead_time))
 

--- a/lib/improver/feels_like_temperature.py
+++ b/lib/improver/feels_like_temperature.py
@@ -240,7 +240,6 @@ def calculate_feels_like_temperature(temperature, wind_speed,
 
     t_data = temperature.data
     feels_like_temperature_data = np.zeros(t_data.shape, dtype=np.float32)
-    alpha = np.zeros(t_data.shape)
 
     # if temperature < 10 degrees Celsius:
     feels_like_temperature_data[t_data < 10] = wind_chill.data[t_data < 10]
@@ -249,8 +248,7 @@ def calculate_feels_like_temperature(temperature, wind_speed,
     # calculate weighting and blend between wind chill index
     # and Steadman equation
     alpha = (t_data-10.0)/10.0
-    temp_flt = (
-        alpha*apparent_temperature.data + ((1-alpha)*wind_chill.data))
+    temp_flt = (alpha*apparent_temperature.data + ((1-alpha)*wind_chill.data))
     t_data_between = (t_data >= 10) & (t_data <= 20)
     feels_like_temperature_data[t_data_between] = temp_flt[t_data_between]
 

--- a/lib/improver/nowcasting/lightning.py
+++ b/lib/improver/nowcasting/lightning.py
@@ -256,7 +256,6 @@ class NowcastLightning(object):
         new_cube_list = iris.cube.CubeList([])
         # Loop over required forecast validity times
         for cube_slice in cube.slices_over('time'):
-            this_point = cube_slice.coord('time').points[0]
             this_time = iris_time_to_datetime(
                 cube_slice.coord('time').copy())[0]
             lightning_rate_slice = lightning_rate_cube.extract(

--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -418,7 +418,6 @@ class NeighbourSelection:
                 the grid point indices of its nearest neighbour as per the
                 imposed constraints.
         """
-        index_nodes = []
         # Check if we are dealing with a global grid.
         self.global_coordinate_system = orography.coord(axis='x').circular
 

--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -373,7 +373,6 @@ class NeighbourSelection:
                        self.node_limit, self.search_radius))
             warnings.warn(msg)
 
-        distance = distance[valid_indices]
         indices = indices[valid_indices]
 
         # Calculate the difference in height between the spot site

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -138,7 +138,6 @@ class Test__recycle_raw_ensemble_realizations(IrisTest):
         equals the length of the realizations, check that the points of the
         realization coordinate is as expected.
         """
-        data = [0, 1, 2]
         data = np.array([[[[4., 4.625, 5.25],
                            [5.875, 6.5, 7.125],
                            [7.75, 8.375, 9.]]],

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -146,8 +146,6 @@ def save_netcdf(cubelist, filename):
     if isinstance(cubelist, iris.cube.Cube):
         cubelist = [cubelist]
 
-    chunksizes = None
-    xy_chunksizes = [None, None]
     for cube in cubelist:
         check_cube_not_float64(cube)
         _order_cell_methods(cube)


### PR DESCRIPTION
# Unused Variables

Here are a selection of unsed variables

- blending/weighted_blend
    - Unused asignment on mutable cubelist
- cli/nowcast_extrapolate
    - unused index with an enumerate()
- cli/nowcast_optical_flow
    - unused index with an enumerate()
- feels_like_temperature
    - alpha is assigned to later without use
- nowcasting/lighting
    - entire line does nothing
- spotdata/neighbour_finding
    - distance is never used
    - `index_nodes = []` is assigned to later before being used.

//TODO
- tests/ensemble_coupla_coupling/ensemble_coupla_coupling/test_EnsembleReordering
    - declares data then declares it again
- tests/set_up_test_cubes
    - time_bounds is never used.
- utilities/save
    - chunksize and xy_chunksize are assigned again before use.



Testing:
 - [x] Ran tests and they passed OK
