### PR TITLE
Impro 983 cube manipulation

### DIFF
--- a/lib/improver/tests/utilities/cube_manipulation/test_build_coordinate.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_build_coordinate.py
@@ -41,17 +41,11 @@ from iris.coord_systems import TransverseMercator
 from iris.coords import AuxCoord, DimCoord
 from iris.tests import IrisTest
 
-from improver.tests.ensemble_calibration.ensemble_calibration. \
-    helper_functions import set_up_temperature_cube
 from improver.utilities.cube_manipulation import build_coordinate
 
 
 class Test_build_coordinate(IrisTest):
     """Test the build_coordinate utility."""
-
-    def setUp(self):
-        """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
 
     def test_basic(self):
         """Test that the utility returns a coord."""

--- a/lib/improver/tests/utilities/cube_manipulation/test_clip_cube_data.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_clip_cube_data.py
@@ -38,8 +38,8 @@ import numpy as np
 from iris.cube import Cube
 from iris.tests import IrisTest
 
-from improver.utilities.cube_manipulation import clip_cube_data
 from improver.tests.set_up_test_cubes import set_up_variable_cube
+from improver.utilities.cube_manipulation import clip_cube_data
 
 
 class Test_clip_cube_data(IrisTest):

--- a/lib/improver/tests/utilities/cube_manipulation/test_clip_cube_data.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_clip_cube_data.py
@@ -33,15 +33,13 @@ Unit tests for the function "cube_manipulation.clip_cube_data".
 """
 
 import unittest
+import numpy as np
 
 from iris.cube import Cube
 from iris.tests import IrisTest
 
-from improver.tests.ensemble_calibration.ensemble_calibration.\
-    helper_functions import (
-        set_up_temperature_cube,
-        set_up_probability_above_threshold_temperature_cube)
 from improver.utilities.cube_manipulation import clip_cube_data
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 
 
 class Test_clip_cube_data(IrisTest):
@@ -49,11 +47,18 @@ class Test_clip_cube_data(IrisTest):
 
     def setUp(self):
         """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
-        self.minimum_value = self.cube.data.min()
-        self.maximum_value = self.cube.data.max()
-        self.processed_cube = self.cube.copy(
-            data=self.cube.data*2.0 - self.cube.data.mean())
+        data = np.array(
+            [[[226.15, 237.4, 248.65],
+              [259.9, 271.15, 282.4],
+              [293.65, 304.9, 316.15]],
+             [[230.15, 241.4, 252.65],
+              [263.9, 275.15, 286.4],
+              [297.65, 308.9, 320.15]]], dtype=np.float32)
+        cube = set_up_variable_cube(data)
+        self.minimum_value = cube.data.min()
+        self.maximum_value = cube.data.max()
+        self.processed_cube = cube.copy(
+            data=cube.data*2.0 - cube.data.mean())
 
     def test_basic(self):
         """Test that the utility returns a cube."""
@@ -63,25 +68,13 @@ class Test_clip_cube_data(IrisTest):
 
     def test_clipping(self):
         """Test that the utility clips the processed cube to the same limits
-        as the input cube."""
+        as the input cube when slicing over multiple x-y planes"""
         result = clip_cube_data(self.processed_cube,
                                 self.minimum_value, self.maximum_value)
         self.assertEqual(result.data.min(), self.minimum_value)
         self.assertEqual(result.data.max(), self.maximum_value)
-
-    def test_clipping_slices(self):
-        """Test that the utility clips the processed cube to the same limits
-        as the input cube, and that it does this when slicing over multiple
-        x-y planes."""
-        cube = set_up_probability_above_threshold_temperature_cube()
-        minimum_value = cube.data.min()
-        maximum_value = cube.data.max()
-        processed_cube = cube.copy(data=cube.data*2.0 - cube.data.mean())
-        result = clip_cube_data(processed_cube, minimum_value, maximum_value)
-        self.assertEqual(result.data.min(), minimum_value)
-        self.assertEqual(result.data.max(), maximum_value)
-        self.assertEqual(result.attributes, processed_cube.attributes)
-        self.assertEqual(result.cell_methods, processed_cube.cell_methods)
+        self.assertEqual(result.attributes, self.processed_cube.attributes)
+        self.assertEqual(result.cell_methods, self.processed_cube.cell_methods)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/cube_manipulation/test_compare_attributes.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_compare_attributes.py
@@ -38,8 +38,7 @@ import iris
 import numpy as np
 from iris.tests import IrisTest
 
-from improver.tests.ensemble_calibration.ensemble_calibration. \
-    helper_functions import set_up_temperature_cube
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import compare_attributes
 from improver.utilities.warnings_handler import ManageWarnings
 
@@ -49,17 +48,13 @@ class Test_compare_attributes(IrisTest):
 
     def setUp(self):
         """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
-        self.cube_ukv = self.cube.extract(iris.Constraint(realization=1))
-        self.cube_ukv.remove_coord('realization')
-        self.cube_ukv.attributes['mosg__grid_type'] = 'standard'
-        self.cube_ukv.attributes['mosg__model_configuration'] = 'uk_det'
-        self.cube_ukv.attributes['mosg__grid_domain'] = 'uk_extended'
-        self.cube_ukv.attributes['mosg__grid_version'] = '1.1.0'
-        self.cube.attributes['mosg__grid_type'] = 'standard'
-        self.cube.attributes['mosg__model_configuration'] = 'uk_ens'
-        self.cube.attributes['mosg__grid_domain'] = 'uk_extended'
-        self.cube.attributes['mosg__grid_version'] = '1.2.0'
+        data = 275*np.ones((3, 3, 3), dtype=np.float32)
+        self.cube = set_up_variable_cube(
+            data, standard_grid_metadata='uk_ens',
+            attributes={'mosg__grid_version': '1.2.0'})
+        self.cube_ukv = set_up_variable_cube(
+            data[0], standard_grid_metadata='uk_det',
+            attributes={'mosg__grid_version': '1.1.0'})
 
     def test_basic(self):
         """Test that the utility returns a list and have no differences."""

--- a/lib/improver/tests/utilities/cube_manipulation/test_compare_coords.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_compare_coords.py
@@ -38,14 +38,13 @@ import iris
 import numpy as np
 from cf_units import Unit
 from iris.coords import AuxCoord, DimCoord
-from iris.tests import IrisTest
 
 from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import compare_coords
 from improver.utilities.warnings_handler import ManageWarnings
 
 
-class Test_compare_coords(IrisTest):
+class Test_compare_coords(unittest.TestCase):
     """Test the compare_coords utility."""
 
     def setUp(self):
@@ -75,7 +74,7 @@ class Test_compare_coords(IrisTest):
         warning_msg = "Only a single cube so no differences will be found "
         self.assertTrue(any(warning_msg in str(item)
                             for item in warning_list))
-        self.assertAlmostEqual(result, [])
+        self.assertEqual(result, [])
 
     def test_first_cube_has_extra_dimension_coordinates(self):
         """Test for comparing coordinate between cubes, where the first
@@ -138,6 +137,7 @@ class Test_compare_coords(IrisTest):
         self.assertEqual(result[1]["model"]["coord"], self.extra_aux_coord)
         self.assertEqual(result[1]["model"]["data_dims"], None)
         self.assertEqual(result[1]["model"]["aux_dims"], 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/utilities/cube_manipulation/test_compare_coords.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_compare_coords.py
@@ -52,7 +52,8 @@ class Test_compare_coords(unittest.TestCase):
         data = 275*np.ones((3, 3, 3), dtype=np.float32)
         self.cube = set_up_variable_cube(data)
         self.extra_dim_coord = DimCoord(
-            [5.0], standard_name="height", units="m")
+            np.array([5.0], dtype=np.float32),
+            standard_name="height", units="m")
         self.extra_aux_coord = AuxCoord(
             ['uk_det', 'uk_ens', 'gl_ens'], long_name='model', units='no_unit')
 

--- a/lib/improver/tests/utilities/cube_manipulation/test_compare_coords.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_compare_coords.py
@@ -40,8 +40,6 @@ from cf_units import Unit
 from iris.coords import AuxCoord, DimCoord
 from iris.tests import IrisTest
 
-#from improver.tests.ensemble_calibration.ensemble_calibration. \
-#    helper_functions import set_up_temperature_cube
 from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import compare_coords
 from improver.utilities.warnings_handler import ManageWarnings

--- a/lib/improver/tests/utilities/cube_manipulation/test_concatenate_cubes.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_concatenate_cubes.py
@@ -83,10 +83,10 @@ class Test_concatenate_cubes(IrisTest):
         resulting data, if a CubeList containing non-identical cubes
         (different values for the time coordinate) is passed in as the input.
         """
-        cube3 = self.cube.copy()
-        cube3.transpose([1, 0, 2, 3])
+        cube = self.cube.copy()
+        cube.transpose([1, 0, 2, 3])
         expected_result = (
-            np.vstack([cube3.data, cube3.data]).transpose([1, 0, 2, 3]))
+            np.vstack([cube.data, cube.data]).transpose([1, 0, 2, 3]))
         cubelist = iris.cube.CubeList([self.cube, self.later_cube])
         result = concatenate_cubes(
             cubelist, coords_to_slice_over=["realization"])

--- a/lib/improver/tests/utilities/cube_manipulation/test_concatenate_cubes.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_concatenate_cubes.py
@@ -37,13 +37,13 @@ import unittest
 import iris
 import numpy as np
 from cf_units import Unit
+from datetime import datetime
 from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.exceptions import ConcatenateError
 from iris.tests import IrisTest
 
-from improver.tests.ensemble_calibration.ensemble_calibration. \
-    helper_functions import set_up_temperature_cube
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import concatenate_cubes
 
 
@@ -52,8 +52,15 @@ class Test_concatenate_cubes(IrisTest):
     """Test the concatenate_cubes utility."""
 
     def setUp(self):
-        """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
+        """Set up temperature cubes to test with."""
+        data = 275*np.ones((3, 3, 3), dtype=np.float32)
+        cube = set_up_variable_cube(data, time=datetime(2017, 9, 9, 11),
+                                    frt=datetime(2017, 9, 9, 6))
+        self.cube = iris.util.new_axis(cube, "time")
+        self.cube.transpose([1, 0, 2, 3])
+        self.later_cube = self.cube.copy()
+        self.later_cube.coord("time").points = (
+            self.later_cube.coord("time").points + 3600)
 
     def test_basic(self):
         """Test that the utility returns an iris.cube.Cube."""
@@ -76,21 +83,13 @@ class Test_concatenate_cubes(IrisTest):
         resulting data, if a CubeList containing non-identical cubes
         (different values for the time coordinate) is passed in as the input.
         """
-        cube1 = self.cube.copy()
-        cube2 = self.cube.copy()
-
         cube3 = self.cube.copy()
         cube3.transpose([1, 0, 2, 3])
         expected_result = (
             np.vstack([cube3.data, cube3.data]).transpose([1, 0, 2, 3]))
-
-        cube2.coord("time").points = np.array([1484028000], dtype=np.int64)
-
-        cubelist = iris.cube.CubeList([cube1, cube2])
-
+        cubelist = iris.cube.CubeList([self.cube, self.later_cube])
         result = concatenate_cubes(
             cubelist, coords_to_slice_over=["realization"])
-
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(expected_result, result.data)
 
@@ -146,18 +145,15 @@ class Test_concatenate_cubes(IrisTest):
         time coordinate, if a CubeList containing cubes with different
         timesteps is passed in as the input.
         """
-        cube1 = self.cube.copy()
-        cube2 = self.cube.copy()
-
-        cube2.coord("time").points = np.array([1484028000], dtype=np.int64)
-
-        cubelist = iris.cube.CubeList([cube1, cube2])
-
+        expected_time_points = [
+            self.cube.coord("time").points[0],
+            self.later_cube.coord("time").points[0]]
+        cubelist = iris.cube.CubeList([self.cube, self.later_cube])
         result = concatenate_cubes(
             cubelist, coords_to_slice_over=["time"])
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(
-            result.coord("time").points, [1484017200, 1484028000])
+            result.coord("time").points, expected_time_points)
 
     def test_cubelist_slice_over_realization_only(self):
         """
@@ -165,13 +161,7 @@ class Test_concatenate_cubes(IrisTest):
         realization coordinate, if a CubeList containing cubes with different
         realizations is passed in as the input.
         """
-        cube1 = self.cube.copy()
-        cube2 = self.cube.copy()
-
-        cube2.coord("time").points = np.int64(1484028000)
-
-        cubelist = iris.cube.CubeList([cube1, cube2])
-
+        cubelist = iris.cube.CubeList([self.cube, self.later_cube])
         result = concatenate_cubes(
             cubelist, coords_to_slice_over=["realization"])
         self.assertIsInstance(result, Cube)
@@ -186,39 +176,26 @@ class Test_concatenate_cubes(IrisTest):
         This makes sure that the forecast_reference_time from the input cubes
         is maintained within the output cube, after concatenation.
         """
-        cube1 = self.cube.copy()
-        cube2 = self.cube.copy()
-
-        cube2.coord("time").points = np.array([1484028000], dtype=np.int64)
-        time_origin = "seconds since 1970-01-01 00:00:00"
-        calendar = "gregorian"
-        tunit = Unit(time_origin, calendar)
-        cube1.add_aux_coord(
-            DimCoord([1484017200], "forecast_reference_time", units=tunit))
-        cube2.add_aux_coord(
-            DimCoord([1484028000], "forecast_reference_time", units=tunit))
-        cubelist = iris.cube.CubeList([cube1, cube2])
-
+        self.later_cube.coord("forecast_reference_time").points = (
+            self.later_cube.coord("forecast_reference_time").points + 3600)
+        expected_frt_points = [
+            self.cube.coord("forecast_reference_time").points[0],
+            self.later_cube.coord("forecast_reference_time").points[0]]
+        cubelist = iris.cube.CubeList([self.cube, self.later_cube])
         result = concatenate_cubes(
             cubelist, coordinates_for_association=["forecast_reference_time"])
         self.assertArrayAlmostEqual(
             result.coord("forecast_reference_time").points,
-            [1484017200, 1484028000])
+            expected_frt_points)
 
     def test_cubelist_different_var_names(self):
         """
         Test that the utility returns an iris.cube.Cube, if a CubeList
         containing non-identical cubes is passed in as the input.
         """
-        cube1 = self.cube.copy()
-        cube2 = self.cube.copy()
-        cube2.coord("time").points = np.int64(1484028000)
-
-        cube1.coord("time").var_name = "time_0"
-        cube2.coord("time").var_name = "time_1"
-
-        cubelist = iris.cube.CubeList([cube1, cube2])
-
+        self.cube.coord("time").var_name = "time_0"
+        self.later_cube.coord("time").var_name = "time_1"
+        cubelist = iris.cube.CubeList([self.cube, self.later_cube])
         result = concatenate_cubes(cubelist)
         self.assertIsInstance(result, Cube)
 

--- a/lib/improver/tests/utilities/cube_manipulation/test_equalise_cube_attributes.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_equalise_cube_attributes.py
@@ -50,16 +50,7 @@ class Test_equalise_cube_attributes(IrisTest):
 
     def setUp(self):
         """Use temperature cube to test with."""
-        data = np.array([[[226.15, 237.40, 248.65],
-                          [259.90, 271.15, 282.40],
-                          [293.65, 304.90, 316.15]],
-                         [[230.15, 241.40, 252.65],
-                          [263.90, 275.15, 286.40],
-                          [297.65, 308.90, 320.15]],
-                         [[232.15, 243.40, 254.65],
-                          [265.90, 277.15, 288.40],
-                          [299.65, 310.90, 322.15]]], dtype=np.float32)
-
+        data = 278*np.ones((3, 3, 3), dtype=np.float32)
         cube_attrs = {"history": "2017-01-18T08:59:53: StaGE Decoupler",
                       "unknown_attribute": "1"}
         self.cube = set_up_variable_cube(

--- a/lib/improver/tests/utilities/cube_manipulation/test_merge_cubes.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_merge_cubes.py
@@ -52,16 +52,7 @@ class Test_merge_cubes(IrisTest):
 
     def setUp(self):
         """Use temperature cube to test with."""
-
-        data = np.array([[[226.15, 237.4, 248.65],
-                          [259.9, 271.15, 282.4],
-                          [293.65, 304.9, 316.15]],
-                         [[230.15, 241.4, 252.65],
-                          [263.9, 275.15, 286.4],
-                          [297.65, 308.9, 320.15]],
-                         [[232.15, 243.4, 254.65],
-                          [265.9, 277.15, 288.4],
-                          [299.65, 310.9, 322.15]]], dtype=np.float32)
+        data = 277*np.ones((3, 3, 3), dtype=np.float32)
 
         # set up a MOGREPS-UK cube with 7 hour forecast period
         time_point = dt(2015, 11, 23, 7)

--- a/lib/improver/tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
@@ -39,8 +39,7 @@ import numpy as np
 from iris.coords import AuxCoord
 from iris.tests import IrisTest
 
-from improver.tests.utilities.test_mathematical_operations import (
-    set_up_height_cube)
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import sort_coord_in_cube
 from improver.utilities.warnings_handler import ManageWarnings
 
@@ -49,34 +48,38 @@ class Test_sort_coord_in_cube(IrisTest):
     """Class to test the sort_coord_in_cube function."""
 
     def setUp(self):
-        """Set up a cube."""
-        self.ascending_height_points = np.array([5., 10., 20.])
-        cube = set_up_height_cube(self.ascending_height_points)[:, 0, :, :, :]
-        data = np.zeros(cube.shape)
-        data[0] = np.ones(cube[0].shape, dtype=np.int32)
-        data[1] = np.full(cube[1].shape, 2, dtype=np.int32)
-        data[2] = np.full(cube[2].shape, 3, dtype=np.int32)
-        cube.data = data
-        self.ascending_cube = cube
-        descending_cube = cube.copy()
-        self.descending_height_points = np.array([20., 10., 5.])
-        descending_cube.coord("height").points = self.descending_height_points
-        self.descending_cube = descending_cube
+        """Set up ascending and descending cubes"""
+        self.ascending_height_points = np.array(
+            [5., 10., 20.], dtype=np.float32)
+        self.descending_height_points = np.flip(self.ascending_height_points)
+
+        data = np.array(
+            [np.ones((3, 3)), 2*np.ones((3, 3)), 3*np.ones((3, 3))],
+            dtype=np.float32)
+        self.ascending_cube = set_up_variable_cube(data)
+        self.ascending_cube.coord("realization").rename("height")
+        self.ascending_cube.coord("height").points = (
+            self.ascending_height_points)
+        self.ascending_cube.coord("height").units = "m"
+
+        self.descending_cube = self.ascending_cube.copy()
+        self.descending_cube.coord("height").points = (
+            self.descending_height_points)
 
     def test_ascending_then_ascending(self):
         """Test that the sorting successfully sorts the cube based
         on the points within the given coordinate. The points in the resulting
         cube should now be in ascending order."""
         expected_data = np.array(
-            [[[[1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00]]],
-             [[[2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00]]],
-             [[[3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00]]]])
+            [[[1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00]],
+             [[2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00]],
+             [[3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00]]])
         coord_name = "height"
         result = sort_coord_in_cube(self.ascending_cube, coord_name)
         self.assertIsInstance(result, iris.cube.Cube)
@@ -94,15 +97,15 @@ class Test_sort_coord_in_cube(IrisTest):
         """Test that the above sorting is successful when an AuxCoord is
         used."""
         expected_data = np.array(
-            [[[[1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00]]],
-             [[[2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00]]],
-             [[[3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00]]]])
+            [[[1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00]],
+             [[2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00]],
+             [[3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00]]])
         coord_name = "height_aux"
         height_coord = self.ascending_cube.coord('height')
         height_coord_index, = self.ascending_cube.coord_dims('height')
@@ -122,15 +125,15 @@ class Test_sort_coord_in_cube(IrisTest):
         on the points within the given coordinate. The points in the resulting
         cube should now be in descending order."""
         expected_data = np.array(
-            [[[[3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00]]],
-             [[[2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00]]],
-             [[[1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00]]]])
+            [[[3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00]],
+             [[2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00]],
+             [[1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00]]])
         coord_name = "height"
         result = sort_coord_in_cube(
             self.ascending_cube, coord_name, order="descending")
@@ -148,15 +151,15 @@ class Test_sort_coord_in_cube(IrisTest):
         on the points within the given coordinate. The points in the resulting
         cube should now be in ascending order."""
         expected_data = np.array(
-            [[[[3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00]]],
-             [[[2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00]]],
-             [[[1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00]]]])
+            [[[3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00]],
+             [[2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00]],
+             [[1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00]]])
         coord_name = "height"
         result = sort_coord_in_cube(self.descending_cube, coord_name)
         self.assertIsInstance(result, iris.cube.Cube)
@@ -173,15 +176,15 @@ class Test_sort_coord_in_cube(IrisTest):
         on the points within the given coordinate. The points in the resulting
         cube should now be in descending order."""
         expected_data = np.array(
-            [[[[1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00]]],
-             [[[2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00]]],
-             [[[3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00]]]])
+            [[[1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00]],
+             [[2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00]],
+             [[3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00]]])
         coord_name = "height"
         result = sort_coord_in_cube(
             self.descending_cube, coord_name, order="descending")
@@ -199,17 +202,17 @@ class Test_sort_coord_in_cube(IrisTest):
         on the points within the given coordinate (latitude).
         The points in the resulting cube should now be in descending order."""
         expected_data = np.array(
-            [[[[1.00, 1.00, 1.00],
-               [1.00, 1.00, 1.00],
-               [6.00, 1.00, 1.00]]],
-             [[[2.00, 2.00, 2.00],
-               [2.00, 2.00, 2.00],
-               [6.00, 2.00, 2.00]]],
-             [[[3.00, 3.00, 3.00],
-               [3.00, 3.00, 3.00],
-               [6.00, 3.00, 3.00]]]])
-        self.ascending_cube.data[:, :, 0, 0] = 6.0
-        expected_points = np.array([45., 0., -45])
+            [[[1.00, 1.00, 1.00],
+              [1.00, 1.00, 1.00],
+              [6.00, 1.00, 1.00]],
+             [[2.00, 2.00, 2.00],
+              [2.00, 2.00, 2.00],
+              [6.00, 2.00, 2.00]],
+             [[3.00, 3.00, 3.00],
+              [3.00, 3.00, 3.00],
+              [6.00, 3.00, 3.00]]])
+        self.ascending_cube.data[:, 0, 0] = 6.0
+        expected_points = np.flip(self.ascending_cube.coord("latitude").points)
         coord_name = "latitude"
         result = sort_coord_in_cube(
             self.ascending_cube, coord_name, order="descending")
@@ -225,7 +228,7 @@ class Test_sort_coord_in_cube(IrisTest):
     def test_warn_raised_for_circular_coordinate(self, warning_list=None):
         """Test that a warning is successfully raised when circular
         coordinates are sorted."""
-        self.ascending_cube.data[:, :, 0, 0] = 6.0
+        self.ascending_cube.data[:, 0, 0] = 6.0
         coord_name = "latitude"
         self.ascending_cube.coord(coord_name).circular = True
         result = sort_coord_in_cube(

--- a/lib/improver/tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
@@ -53,10 +53,10 @@ class Test_sort_coord_in_cube(IrisTest):
             [5., 10., 20.], dtype=np.float32)
         self.descending_height_points = np.flip(self.ascending_height_points)
 
-        data = np.array(
+        self.data = np.array(
             [np.ones((3, 3)), 2*np.ones((3, 3)), 3*np.ones((3, 3))],
             dtype=np.float32)
-        self.ascending_cube = set_up_variable_cube(data)
+        self.ascending_cube = set_up_variable_cube(self.data)
         self.ascending_cube.coord("realization").rename("height")
         self.ascending_cube.coord("height").points = (
             self.ascending_height_points)
@@ -70,16 +70,7 @@ class Test_sort_coord_in_cube(IrisTest):
         """Test that the sorting successfully sorts the cube based
         on the points within the given coordinate. The points in the resulting
         cube should now be in ascending order."""
-        expected_data = np.array(
-            [[[1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00]],
-             [[2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00]],
-             [[3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00]]])
+        expected_data = self.data
         coord_name = "height"
         result = sort_coord_in_cube(self.ascending_cube, coord_name)
         self.assertIsInstance(result, iris.cube.Cube)
@@ -96,16 +87,7 @@ class Test_sort_coord_in_cube(IrisTest):
     def test_auxcoord(self):
         """Test that the above sorting is successful when an AuxCoord is
         used."""
-        expected_data = np.array(
-            [[[1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00]],
-             [[2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00]],
-             [[3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00]]])
+        expected_data = self.data
         coord_name = "height_aux"
         height_coord = self.ascending_cube.coord('height')
         height_coord_index, = self.ascending_cube.coord_dims('height')
@@ -124,16 +106,7 @@ class Test_sort_coord_in_cube(IrisTest):
         """Test that the sorting successfully sorts the cube based
         on the points within the given coordinate. The points in the resulting
         cube should now be in descending order."""
-        expected_data = np.array(
-            [[[3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00]],
-             [[2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00]],
-             [[1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00]]])
+        expected_data = np.flip(self.data)
         coord_name = "height"
         result = sort_coord_in_cube(
             self.ascending_cube, coord_name, order="descending")
@@ -150,16 +123,7 @@ class Test_sort_coord_in_cube(IrisTest):
         """Test that the sorting successfully sorts the cube based
         on the points within the given coordinate. The points in the resulting
         cube should now be in ascending order."""
-        expected_data = np.array(
-            [[[3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00]],
-             [[2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00]],
-             [[1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00]]])
+        expected_data = np.flip(self.data)
         coord_name = "height"
         result = sort_coord_in_cube(self.descending_cube, coord_name)
         self.assertIsInstance(result, iris.cube.Cube)
@@ -175,16 +139,7 @@ class Test_sort_coord_in_cube(IrisTest):
         """Test that the sorting successfully sorts the cube based
         on the points within the given coordinate. The points in the resulting
         cube should now be in descending order."""
-        expected_data = np.array(
-            [[[1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00],
-              [1.00, 1.00, 1.00]],
-             [[2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00],
-              [2.00, 2.00, 2.00]],
-             [[3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00],
-              [3.00, 3.00, 3.00]]])
+        expected_data = self.data
         coord_name = "height"
         result = sort_coord_in_cube(
             self.descending_cube, coord_name, order="descending")

--- a/lib/improver/tests/utilities/cube_manipulation/test_strip_var_names.py
+++ b/lib/improver/tests/utilities/cube_manipulation/test_strip_var_names.py
@@ -33,26 +33,26 @@ Unit tests for the function "cube_manipulation.strip_var_names".
 """
 
 import unittest
+import numpy as np
 
 import iris
-from iris.tests import IrisTest
 
-from improver.tests.ensemble_calibration.ensemble_calibration. \
-    helper_functions import set_up_temperature_cube
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import strip_var_names
 
 
-class Test_strip_var_names(IrisTest):
+class Test_strip_var_names(unittest.TestCase):
 
     """Test the _slice_var_names utility."""
 
     def setUp(self):
         """Use temperature cube to test with."""
-        self.cube = set_up_temperature_cube()
+        data = 281*np.ones((3, 3, 3), dtype=np.float32)
+        self.cube = set_up_variable_cube(data)
+        self.cube.var_name = "air_temperature"
 
     def test_basic(self):
         """Test that the utility returns an iris.cube.CubeList."""
-        self.cube.var_name = "air_temperature"
         result = strip_var_names(self.cube)
         self.assertIsInstance(result, iris.cube.CubeList)
 
@@ -61,7 +61,6 @@ class Test_strip_var_names(IrisTest):
         Test that the utility returns an iris.cube.Cube with a
         var_name of None.
         """
-        self.cube.var_name = "air_temperature"
         result = strip_var_names(self.cube)
         self.assertIsNone(result[0].var_name, None)
 
@@ -79,10 +78,7 @@ class Test_strip_var_names(IrisTest):
 
     def test_cubelist(self):
         """Test that the utility returns an iris.cube.CubeList."""
-        cube1 = self.cube
-        cube2 = self.cube
-        cubes = iris.cube.CubeList([cube1, cube2])
-        self.cube.var_name = "air_temperature"
+        cubes = iris.cube.CubeList([self.cube, self.cube])
         result = strip_var_names(cubes)
         self.assertIsInstance(result, iris.cube.CubeList)
         for cube in result:


### PR DESCRIPTION
Partially addresses #742 

Migrated remaining cube manipulation utility unit tests to use the new cube setup functions.  Tidied up and reduced duplication.

Testing:
 - [x] Ran tests and they passed OK
