### PR TITLE
Calculate grid length

### DIFF
--- a/lib/improver/blending/calculate_weights_and_blend.py
+++ b/lib/improver/blending/calculate_weights_and_blend.py
@@ -144,9 +144,9 @@ class WeightAndBlend():
                 Updated 3D cube of spatially-varying weights
         """
         check_if_grid_is_equal_area(cube)
-        grid_cells_x, _ = convert_distance_into_number_of_grid_cells(
+        grid_cells = convert_distance_into_number_of_grid_cells(
             cube, fuzzy_length, int_grid_cells=False)
-        SpatialWeightsPlugin = SpatiallyVaryingWeightsFromMask(grid_cells_x)
+        SpatialWeightsPlugin = SpatiallyVaryingWeightsFromMask(grid_cells)
         weights = SpatialWeightsPlugin.process(cube, weights, self.blend_coord)
         return weights
 

--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -207,8 +207,9 @@ class CircularNeighbourhood(object):
 
         # Check that the cube has an equal area grid.
         check_if_grid_is_equal_area(cube)
-        ranges = convert_distance_into_number_of_grid_cells(
+        grid_cells_x = convert_distance_into_number_of_grid_cells(
             cube, radius, max_distance_in_grid_cells=MAX_RADIUS_IN_GRID_CELLS)
+        ranges = (grid_cells_x, grid_cells_x)
         cube = self.apply_circular_kernel(cube, ranges)
         return cube
 
@@ -417,8 +418,9 @@ class GeneratePercentilesFromACircularNeighbourhood(object):
         # Check that the cube has an equal area grid.
         check_if_grid_is_equal_area(cube)
         # Take data array and identify X and Y axes indices
-        ranges_tuple = convert_distance_into_number_of_grid_cells(
+        grid_cells_x = convert_distance_into_number_of_grid_cells(
             cube, radius, max_distance_in_grid_cells=MAX_RADIUS_IN_GRID_CELLS)
+        ranges_tuple = (grid_cells_x, grid_cells_x)
         ranges_xy = np.array(ranges_tuple)
         kernel = circular_kernel(ranges_xy, ranges_tuple, weighted_mode=False)
         # Loop over each 2D slice to reduce memory demand and derive

--- a/lib/improver/nbhood/square_kernel.py
+++ b/lib/improver/nbhood/square_kernel.py
@@ -360,7 +360,7 @@ class SquareNeighbourhood(object):
         Apply neighbourhood processing consisting of the following steps:
 
         1. Pad a halo around the input cube to allow vectorised
-           neighbourhooding at edgepoints.l
+           neighbourhooding at edgepoints.
         2. Cumulate the array along the x and y axes.
         3. Apply neighbourhood processing to the cumulated array.
 

--- a/lib/improver/nbhood/square_kernel.py
+++ b/lib/improver/nbhood/square_kernel.py
@@ -360,7 +360,7 @@ class SquareNeighbourhood(object):
         Apply neighbourhood processing consisting of the following steps:
 
         1. Pad a halo around the input cube to allow vectorised
-           neighbourhooding at edgepoints.
+           neighbourhooding at edgepoints.l
         2. Cumulate the array along the x and y axes.
         3. Apply neighbourhood processing to the cumulated array.
 
@@ -483,10 +483,11 @@ class SquareNeighbourhood(object):
         # original_data * mask array.
         original_attributes = cube.attributes
         original_methods = cube.cell_methods
-        grid_cells_x, grid_cells_y = (
+        grid_cells_x = (
             convert_distance_into_number_of_grid_cells(
                 cube, radius,
                 max_distance_in_grid_cells=MAX_RADIUS_IN_GRID_CELLS))
+        grid_cells_y = grid_cells_x
         result_slices = iris.cube.CubeList()
         for cube_slice in cube.slices([cube.coord(axis='y'),
                                        cube.coord(axis='x')]):

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -404,7 +404,7 @@ class Test_run(IrisTest):
     def test_single_point_lat_long(self):
         """Test behaviour for a single grid cell on lat long grid."""
         cube = set_up_cube_lat_long()
-        msg = "Invalid grid: projection_x/y coords required"
+        msg = "points are not equally spaced"
         radius = 6000.
         with self.assertRaisesRegex(ValueError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(cube, radius)

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -404,7 +404,7 @@ class Test_run(IrisTest):
     def test_single_point_lat_long(self):
         """Test behaviour for a single grid cell on lat long grid."""
         cube = set_up_cube_lat_long()
-        msg = "points are not equally spaced"
+        msg = "Unable to convert from Unit"
         radius = 6000.
         with self.assertRaisesRegex(ValueError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(cube, radius)

--- a/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/lib/improver/tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -404,7 +404,7 @@ class Test_run(IrisTest):
     def test_single_point_lat_long(self):
         """Test behaviour for a single grid cell on lat long grid."""
         cube = set_up_cube_lat_long()
-        msg = "Unable to convert from Unit"
+        msg = "Unable to convert from"
         radius = 6000.
         with self.assertRaisesRegex(ValueError, msg):
             GeneratePercentilesFromACircularNeighbourhood().run(cube, radius)

--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -185,7 +185,8 @@ class Test_calculate_grid_spacing(IrisTest):
     def test_cube_not_equal_area(self):
         """Test ValueError if cube is not equal area"""
         cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32))
-        with self.assertRaises(ValueError):
+        msg = "points are not equally spaced"
+        with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(cube)
 
 
@@ -235,14 +236,6 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
         result = convert_distance_into_number_of_grid_cells(
             self.cube, self.DISTANCE)
         self.assertEqual(result, 3)
-
-    def test_error_lat_lon_grid(self):
-        """Test behaviour for a single grid cell on lat long grid."""
-        cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32))
-        msg = "points are not equally spaced"
-        with self.assertRaisesRegex(ValueError, msg):
-            convert_distance_into_number_of_grid_cells(
-                cube, self.DISTANCE)
 
     def test_error_negative_distance(self):
         """Test behaviour with a non-zero point with negative range."""
@@ -315,17 +308,6 @@ class Test_convert_number_of_grid_cells_into_distance(IrisTest):
         expected_result = 4000.0
         self.assertAlmostEqual(result_radius, expected_result)
         self.assertIs(type(expected_result), float)
-
-    def test_not_equal_areas(self):
-        """
-        Check it raises an error when the input is not an equal areas grid.
-        """
-        self.cube.remove_coord("projection_x_coordinate")
-        self.cube.add_dim_coord(
-            DimCoord(np.linspace(200.0, 600.0, 3),
-                     'projection_x_coordinate', units='m'), 0)
-        with self.assertRaises(ValueError):
-            convert_number_of_grid_cells_into_distance(self.cube, 2)
 
     def test_check_different_input_radius(self):
         """Check it works for different input values."""

--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -317,7 +317,6 @@ class Test_convert_number_of_grid_cells_into_distance(IrisTest):
         """
         Check it raises an error when the input is not an equal areas grid.
         """
-
         self.cube.remove_coord("projection_x_coordinate")
         self.cube.add_dim_coord(
             DimCoord(np.linspace(200.0, 600.0, 3),

--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -244,7 +244,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
     def test_single_point_range_negative(self):
         """Test behaviour with a non-zero point with negative range."""
         distance = -1.0 * self.DISTANCE
-        msg = "Distance of -6100.0m gives a negative cell extent"
+        msg = "Please specify a positive distance in metres"
         with self.assertRaisesRegex(ValueError, msg):
             convert_distance_into_number_of_grid_cells(
                 self.cube, distance)

--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -347,10 +347,18 @@ class Test_check_if_grid_is_equal_area(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             check_if_grid_is_equal_area(cube)
 
+    def test_still_fails_with_override(self):
+        """Test that a lat/lon cube still fails when 'require_equal_xy_spacing'
+        is set to False"""
+        cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32))
+        msg = "points are not equally spaced"
+        with self.assertRaisesRegex(ValueError, msg):
+            check_if_grid_is_equal_area(cube, require_equal_xy_spacing=False)
+
     def test_non_equal_xy_spacing(self):
         """Test that the cubes have an equal areas grid."""
         self.cube.coord(axis='x').points = 2*self.cube.coord(axis='x').points
-        msg = "Grid does not have equal spacing"
+        msg = "Grid does not have equal spacing in x and y"
         with self.assertRaisesRegex(ValueError, msg):
             check_if_grid_is_equal_area(self.cube)
 

--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -47,8 +47,10 @@ from iris.time import PartialDateTime
 
 from improver.tests.nbhood.nbhood.test_BaseNeighbourhoodProcessing import (
     set_up_cube, set_up_cube_lat_long)
+from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.spatial import (
-    check_if_grid_is_equal_area, convert_distance_into_number_of_grid_cells,
+    check_if_grid_is_equal_area, calculate_grid_spacing,
+    convert_distance_into_number_of_grid_cells,
     convert_number_of_grid_cells_into_distance,
     lat_lon_determine, lat_lon_transform, transform_grid_to_lat_lon,
     get_nearest_coords)
@@ -149,6 +151,35 @@ class Test_common_functions(IrisTest):
         self.data_indices = data_indices
         self.ancillary_data = ancillary_data
         self.additional_data = additional_data
+
+
+class Test_calculate_grid_spacing(IrisTest):
+    """Test the calculate_grid_spacing function"""
+
+    def setUp(self):
+        """Set up an equal area cube"""
+        self.cube = set_up_variable_cube(
+            np.ones((5, 5), dtype=np.float32), spatial_grid='equalarea')
+
+    def test_basic(self):
+        """Test correct answer is returned from an equal area grid"""
+        result = calculate_grid_spacing(self.cube)
+        self.assertAlmostEqual(result, 200000.0)
+
+    def test_units(self):
+        """Test correct answer is returned for coordinates in km"""
+        for axis in ['x', 'y']:
+            self.cube.coord(axis=axis).convert_units('km')
+        result = calculate_grid_spacing(self.cube)
+        self.assertAlmostEqual(result, 200000.0)
+        for axis in ['x', 'y']:
+            self.assertEqual(self.cube.coord(axis=axis).units, 'km')
+
+    def test_cube_not_equal_area(self):
+        """Test ValueError if cube is not equal area"""
+        cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32))
+        with self.assertRaises(ValueError):
+            calculate_grid_spacing(cube)
 
 
 class Test_convert_distance_into_number_of_grid_cells(IrisTest):

--- a/lib/improver/utilities/pad_spatial.py
+++ b/lib/improver/utilities/pad_spatial.py
@@ -115,12 +115,12 @@ def create_cube_with_halo(cube, halo_radius):
         halo_cube (iris.cube.Cube):
             New cube defining the halo-padded grid (data set to zero)
     """
-    halo_size_x, halo_size_y = convert_distance_into_number_of_grid_cells(
+    halo_size = convert_distance_into_number_of_grid_cells(
         cube, halo_radius)
 
     # create padded x- and y- coordinates
-    x_coord = pad_coord(cube.coord(axis='x'), halo_size_x, 'add')
-    y_coord = pad_coord(cube.coord(axis='y'), halo_size_y, 'add')
+    x_coord = pad_coord(cube.coord(axis='x'), halo_size, 'add')
+    y_coord = pad_coord(cube.coord(axis='y'), halo_size, 'add')
 
     halo_cube = iris.cube.Cube(
         np.zeros((len(y_coord.points), len(x_coord.points)), dtype=np.float32),
@@ -262,15 +262,15 @@ def remove_cube_halo(cube, halo_radius):
         result (iris.cube.Cube):
             New cube with the halo removed.
     """
-    halo_size_x, halo_size_y = convert_distance_into_number_of_grid_cells(
+    halo_size = convert_distance_into_number_of_grid_cells(
         cube, halo_radius)
 
     result_slices = iris.cube.CubeList()
     for cube_slice in cube.slices([cube.coord(axis='y'),
                                    cube.coord(axis='x')]):
         cube_halo = remove_halo_from_cube(cube_slice,
-                                          halo_size_x,
-                                          halo_size_y)
+                                          halo_size,
+                                          halo_size)
         result_slices.append(cube_halo)
     result = result_slices.merge_cube()
 

--- a/lib/improver/utilities/pad_spatial.py
+++ b/lib/improver/utilities/pad_spatial.py
@@ -115,12 +115,14 @@ def create_cube_with_halo(cube, halo_radius):
         halo_cube (iris.cube.Cube):
             New cube defining the halo-padded grid (data set to zero)
     """
-    halo_size = convert_distance_into_number_of_grid_cells(
-        cube, halo_radius)
+    halo_size_x = convert_distance_into_number_of_grid_cells(
+        cube, halo_radius, axis='x')
+    halo_size_y = convert_distance_into_number_of_grid_cells(
+        cube, halo_radius, axis='y')
 
     # create padded x- and y- coordinates
-    x_coord = pad_coord(cube.coord(axis='x'), halo_size, 'add')
-    y_coord = pad_coord(cube.coord(axis='y'), halo_size, 'add')
+    x_coord = pad_coord(cube.coord(axis='x'), halo_size_x, 'add')
+    y_coord = pad_coord(cube.coord(axis='y'), halo_size_y, 'add')
 
     halo_cube = iris.cube.Cube(
         np.zeros((len(y_coord.points), len(x_coord.points)), dtype=np.float32),
@@ -262,15 +264,17 @@ def remove_cube_halo(cube, halo_radius):
         result (iris.cube.Cube):
             New cube with the halo removed.
     """
-    halo_size = convert_distance_into_number_of_grid_cells(
-        cube, halo_radius)
+    halo_size_x = convert_distance_into_number_of_grid_cells(
+        cube, halo_radius, axis='x')
+    halo_size_y = convert_distance_into_number_of_grid_cells(
+        cube, halo_radius, axis='y')
 
     result_slices = iris.cube.CubeList()
     for cube_slice in cube.slices([cube.coord(axis='y'),
                                    cube.coord(axis='x')]):
         cube_halo = remove_halo_from_cube(cube_slice,
-                                          halo_size,
-                                          halo_size)
+                                          halo_size_x,
+                                          halo_size_y)
         result_slices.append(cube_halo)
     result = result_slices.merge_cube()
 

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -156,8 +156,8 @@ def convert_distance_into_number_of_grid_cells(
     def calculate_domain_extent(coord):
         """Calculates the coordinate extent in metres"""
         new_coord = coord.copy()
-        new_coord = coord.convert_units('metres')
-        return max(coord.points) - min(coord.points)
+        new_coord.convert_units('metres')
+        return max(new_coord.points) - min(new_coord.points)
 
     x_extent_metres = calculate_domain_extent(cube.coord(axis='x'))
     y_extent_metres = calculate_domain_extent(cube.coord(axis='y'))

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -154,8 +154,10 @@ def convert_distance_into_number_of_grid_cells(
     """
     d_error = "Distance of {}m".format(distance)
     zero_distance_error = ("{} gives zero cell extent".format(d_error))
-    if distance <= 0:
+    if distance == 0:
         raise ValueError(zero_distance_error)
+    if distance < 0:
+        raise ValueError("Please specify a positive distance in metres")
 
     # calculate grid spacing or raise error if cube is not equal area
     grid_spacing_metres = calculate_grid_spacing(cube)
@@ -176,20 +178,12 @@ def convert_distance_into_number_of_grid_cells(
                 d_error, max_distance_of_domain))
 
     # calculate distance in grid squares
-    # TODO abs here (as previously configured) means value error below cannot
-    # be reached; but NO abs here causes in failure in square_kernel unit tests
     grid_cells = distance / abs(grid_spacing_metres)
 
     if int_grid_cells:
         grid_cells = int(grid_cells)
         if grid_cells == 0:
             raise ValueError(zero_distance_error)
-
-    if grid_cells < 0:
-        # TODO this error cannot be reached.  Is this a problem?
-        raise ValueError(
-            "{} gives a negative cell extent - check coordinate "
-            "ordering".format(d_error))
 
     if max_distance_in_grid_cells is not None:
         if grid_cells > max_distance_in_grid_cells:

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -56,9 +56,9 @@ def check_if_grid_is_equal_area(cube):
         cube (iris.cube.Cube):
             Cube with coordinates that will be cMAhecked.
     Raises:
-        ValueError: Coordinate points are not equally spaced (from
-            calculate_grid_spacing)
-        ValueError: Point spacing is not equal for the two spatial axes
+        ValueError: If coordinate points are not equally spaced along either
+            axis (from calculate_grid_spacing)
+        ValueError: If point spacing is not equal for the two spatial axes
     """
     xdiff = calculate_grid_spacing(cube, axis='x')
     ydiff = calculate_grid_spacing(cube, axis='y')
@@ -77,7 +77,7 @@ def calculate_grid_spacing(cube, axis='x'):
             Axis ('x' or 'y') to use in determining grid spacing
 
     Returns:
-        gridlength (float):
+        (float):
             Grid spacing in metres
 
     Raises:
@@ -102,7 +102,8 @@ def convert_distance_into_number_of_grid_cells(
         cube, distance, max_distance_in_grid_cells=None, int_grid_cells=True):
     """
     Return the number of grid cells in the x and y direction based on the
-    input distance in metres.
+    input distance in metres.  Requires an equal-area grid on which the spacing
+    is equal in the x- and y- directions.
 
     Args:
         cube (iris.cube.Cube):
@@ -110,7 +111,7 @@ def convert_distance_into_number_of_grid_cells(
             calculating the number of grid cells in the x and y direction,
             which equates to the requested distance in the x and y direction.
         distance (float):
-            Distance in metres.
+            Distance in metres.  Must be positive.
         max_distance_in_grid_cells (int or None):
             Maximum distance in grid cells.  Defaults to None, which bypasses
             the check.
@@ -128,19 +129,13 @@ def convert_distance_into_number_of_grid_cells(
                 distance in metres.
 
     Raises:
-        ValueError:
-            If the projection is not "equal area" (proxied by projection_x/y
-            spatial coordinate names).
+        ValueError: If a negative distance is provided
+        ValueError: If the projection is not equal-area
         ValueError:
             If the distance in grid cells is larger than the maximum dimension
             of the rectangular domain (measured across the diagonal).  Needed
             for neighbourhood processing.
-        ValueError:
-            If the distance in grid cells is zero.
-        ValueError:
-            If the distance in grid cells is negative.  (Assuming the distance
-            argument is positive, this indicates one or more spatial axes are
-            not correctly ordered.)
+        ValueError: If the distance in grid cells is zero.
         Value Error:
             If max_distance_in_grid_cells is set and the distance in grid cells
             exceeds this value.  Needed for neighbourhood processing.
@@ -157,6 +152,7 @@ def convert_distance_into_number_of_grid_cells(
     grid_spacing_metres = calculate_grid_spacing(cube)
 
     # check required distance isn't greater than the size of the domain
+    # (note: this implicitly assumes equal x- and y-spacing)
     def calculate_domain_extent(coord):
         """Calculates the coordinate extent in metres"""
         new_coord = coord.copy()
@@ -198,14 +194,14 @@ def convert_number_of_grid_cells_into_distance(cube, grid_points):
             The iris cube that the number of grid points for the radius
             refers to.
         grid_points (int):
-            The number of grid points you want to convert.
+            The number of grid points to convert.
     Returns:
         radius_in_metres (float):
             The radius in metres.
     """
     check_if_grid_is_equal_area(cube)
-    x_diff = calculate_grid_spacing(cube)
-    radius_in_metres = x_diff*grid_points
+    spacing = calculate_grid_spacing(cube)
+    radius_in_metres = spacing*grid_points
     return radius_in_metres
 
 

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -84,6 +84,27 @@ def check_if_grid_is_equal_area(cube):
         raise ValueError(msg)
 
 
+def calculate_grid_spacing(cube):
+    """
+    Returns the grid spacing of an equal-area cube
+
+    Args:
+        cube (iris.cube.Cube):
+            Cube of data on equal area grid
+
+    Returns:
+        gridlength (float):
+            Grid spacing in metres
+
+    Raises:
+        ValueError: If cube is not equal-area
+    """
+    check_if_grid_is_equal_area(cube)
+    coord = cube.coord(axis='x').copy()
+    coord.convert_units("m")
+    return np.diff(coord.points)[0]
+
+
 def convert_distance_into_number_of_grid_cells(
         cube, distance, max_distance_in_grid_cells=None, int_grid_cells=True):
     """
@@ -183,10 +204,7 @@ def convert_number_of_grid_cells_into_distance(cube, grid_points):
         radius_in_metres (float):
             The radius in metres.
     """
-    check_if_grid_is_equal_area(cube)
-    cube.coord("projection_x_coordinate").convert_units("m")
-    x_diff = np.diff(cube.coord("projection_x_coordinate").points)[0]
-    # Make sure the radius isn't exactly on a grid box boundary.
+    x_diff = calculate_grid_spacing(cube)
     radius_in_metres = x_diff*grid_points
     return radius_in_metres
 


### PR DESCRIPTION
Added function to calculate grid length from equally-spaced spatial coordinates tidied up some mess in spatial functions, largely around `convert_distance_to_grid_cells`.  Further refactoring work is required in neighbourhood processing applications.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
