### PR TITLE
IMPRO-1397: Extract subcube made to work with float32 values

### DIFF
--- a/lib/improver/tests/utilities/test_cube_constraints.py
+++ b/lib/improver/tests/utilities/test_cube_constraints.py
@@ -70,6 +70,20 @@ class Test_create_sorted_lambda_constraint(IrisTest):
         result_cube = self.precip_cube.extract(result)
         self.assertArrayAlmostEqual(result_cube.data, self.expected_data)
 
+    def test_non_default_tolerance(self):
+        """Test that a constraint is created, if the input coordinates are
+        made more fuzzy by use of a non-standard tolerance. The default
+        tolerance is 1.0E-7, here we make it large enough to extract all the
+        available thresholds using two bounds; this is testing an extreme
+        not a desirable use case."""
+        values = [0.03, 0.6]
+        result = create_sorted_lambda_constraint(
+            self.coord_name, values, tolerance=0.9)
+        self.assertIsInstance(result, iris.Constraint)
+        self.assertEqual(list(result._coord_values.keys()), [self.coord_name])
+        result_cube = self.precip_cube.extract(result)
+        self.assertArrayAlmostEqual(result_cube.data, self.precip_cube.data)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -241,7 +241,7 @@ class Test_parse_constraint_list(IrisTest):
 
     def test_string_constraint(self):
         """ Test that a string constraint results in a simple iris constraint,
-        not a lamba function. This is created via the literal_eval ValueError.
+        not a lambda function. This is created via the literal_eval ValueError.
         """
         constraints = ["percentile=kittens"]
         result, _ = parse_constraint_list(constraints)

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -44,6 +44,9 @@ from improver.utilities.cube_extraction import (
     create_range_constraint, apply_extraction, extract_subcube,
     is_complex_parsing_required, create_constraint, parse_constraint_list)
 
+from improver.tests.set_up_test_cubes import (set_up_probability_cube,
+                                              construct_xy_coords)
+
 
 def islambda(function):
     """
@@ -74,18 +77,15 @@ def set_up_precip_probability_cube():
                      [[0.03, 0.04, 0.01],
                       [0.02, 0.02, 0.00],
                       [0.01, 0.00, 0.00]]], dtype=np.float32)
-
     MMH_TO_MS = 0.001 / 3600.
-    threshold = DimCoord(
-        MMH_TO_MS * np.array([0.03, 0.1, 1.0], dtype=np.float32),
-        long_name="precipitation_rate", units="m s-1", var_name="threshold")
-    ycoord = DimCoord(np.arange(3), "projection_y_coordinate", units="km")
-    xcoord = DimCoord(np.arange(3), "projection_x_coordinate", units="km")
 
-    cube = iris.cube.Cube(
-        data, long_name="probability_of_precipitation_rate_above_threshold",
-        dim_coords_and_dims=[(threshold, 0), (ycoord, 1),
-                             (xcoord, 2)], units="1")
+    cube = set_up_probability_cube(
+        data, MMH_TO_MS * np.array([0.03, 0.1, 1.0], dtype=np.float32),
+        variable_name="precipitation_rate",
+        threshold_units="m s-1", spatial_grid="equalarea")
+    cube.coord(axis='x').points = np.arange(3, dtype=np.float32)
+    cube.coord(axis='y').points = np.arange(3, dtype=np.float32)
+
     return cube
 
 
@@ -410,7 +410,7 @@ class Test_extract_subcube(IrisTest):
         constraints)."""
         constraints = ["precipitation_rate=[0.03,0.1]",
                        "projection_y_coordinate=[1,2]"]
-        precip_units = ["mm h-1", "km"]
+        precip_units = ["mm h-1", "m"]
         expected = self.precip_cube[0:2, 1:, :]
         result = extract_subcube(self.precip_cube, constraints,
                                  units=precip_units)
@@ -422,7 +422,7 @@ class Test_extract_subcube(IrisTest):
         multiple constraints)."""
         constraints = ["precipitation_rate=[0.03:0.1]",
                        "projection_y_coordinate=[1:2]"]
-        precip_units = ["mm h-1", "km"]
+        precip_units = ["mm h-1", "m"]
         expected = self.precip_cube[0:2, 1:, :]
         result = extract_subcube(self.precip_cube, constraints,
                                  units=precip_units)
@@ -434,7 +434,7 @@ class Test_extract_subcube(IrisTest):
         syntax."""
         constraints = ["precipitation_rate=[0.03,0.1]",
                        "projection_y_coordinate=[1:2]"]
-        precip_units = ["mm h-1", "km"]
+        precip_units = ["mm h-1", "m"]
         expected = self.precip_cube[0:2, 1:, :]
         result = extract_subcube(self.precip_cube, constraints,
                                  units=precip_units)

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -35,7 +35,6 @@ import collections
 
 import iris
 import numpy as np
-from iris.coords import DimCoord
 from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
 
@@ -44,8 +43,7 @@ from improver.utilities.cube_extraction import (
     create_range_constraint, apply_extraction, extract_subcube,
     is_complex_parsing_required, create_constraint, parse_constraint_list)
 
-from improver.tests.set_up_test_cubes import (set_up_probability_cube,
-                                              construct_xy_coords)
+from improver.tests.set_up_test_cubes import set_up_probability_cube
 
 
 def islambda(function):

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -142,9 +142,9 @@ class Test_create_constraint(IrisTest):
     comparisons."""
 
     def setUp(self):
-        class generic():
-            point = 10
-        self.cell = generic
+        """Set up a coordinate that can be modified and used to test the
+        lambda functions that are created for floating point values."""
+        self.crd = iris.coords.AuxCoord([10], long_name='a_coordinate')
 
     def test_with_string_type(self):
         """Test that an extraction that is to match a string is not changed
@@ -166,26 +166,26 @@ class Test_create_constraint(IrisTest):
         """Test that an extraction that is to match a float results in the
         creation of a lambda function."""
         value = 10.0
-        self.cell.point = value
         result = create_constraint(value)
         self.assertTrue(islambda(result))
-        self.assertTrue(result(self.cell))
-        self.cell.point = 20.
-        self.assertFalse(result(self.cell))
+
+        crd = self.crd.copy(points=value)
+        self.assertTrue(result(crd.cell(0)))
+        crd = self.crd.copy(points=20)
+        self.assertFalse(result(crd.cell(0)))
 
     def test_with_float_type_multiple_values(self):
         """Test that an extraction that is to match a float results in the
         creation of a lambda function."""
         value = [10.0, 20.0]
-        self.cell.point = value
         result = create_constraint(value)
         self.assertTrue(islambda(result))
-        self.cell.point = value[0]
-        self.assertTrue(result(self.cell))
-        self.cell.point = value[1]
-        self.assertTrue(result(self.cell))
-        self.cell.point = 30.
-        self.assertFalse(result(self.cell))
+
+        crd = self.crd.copy(points=value)
+        self.assertTrue(result(crd.cell(0)))
+        self.assertTrue(result(crd.cell(1)))
+        crd = self.crd.copy(points=30.0)
+        self.assertFalse(result(crd.cell(0)))
 
 
 class Test_parse_constraint_list(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -44,6 +44,12 @@ from improver.utilities.cube_extraction import (
     is_complex_parsing_required, parse_constraint_list)
 
 
+def islambda(function):
+    LAMBDA = lambda:0
+    return (isinstance(function, type(LAMBDA)) and
+            function.__name__ == LAMBDA.__name__)
+
+
 def set_up_precip_probability_cube():
     """
     Set up a cube with spatial probabilities of precipitation at three
@@ -136,8 +142,8 @@ class Test_parse_constraint_list(IrisTest):
         self.assertCountEqual(
             list(result._coord_values.keys()), ["threshold", "percentile"])
         cdict = result._coord_values
-        self.assertEqual(cdict["percentile"], 10)
-        self.assertEqual(cdict["threshold"], 0.1)
+        self.assertEqual(cdict["percentile"], [10])
+        self.assertTrue(islambda(cdict["threshold"]))
         self.assertFalse(udict)
 
     def test_whitespace(self):
@@ -145,8 +151,8 @@ class Test_parse_constraint_list(IrisTest):
         constraints = ["percentile = 10", "threshold = 0.1"]
         result, _ = parse_constraint_list(constraints)
         cdict = result._coord_values
-        self.assertEqual(cdict["percentile"], 10)
-        self.assertEqual(cdict["threshold"], 0.1)
+        self.assertEqual(cdict["percentile"], [10])
+        self.assertTrue(islambda(cdict["threshold"]))
 
     def test_some_units(self):
         """ Test units list containing "None" elements is correctly parsed """
@@ -166,7 +172,7 @@ class Test_parse_constraint_list(IrisTest):
         constraints = ["threshold=[0.1,1.0]"]
         result, _ = parse_constraint_list(constraints)
         cdict = result._coord_values
-        self.assertEqual(cdict["threshold"], [0.1, 1.0])
+        self.assertTrue(islambda(cdict["threshold"]))
 
     def test_range_constraint(self):
         """ Test that a constraint passed in as a range is parsed correctly """

--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -159,7 +159,7 @@ class Test_create_constraint(IrisTest):
     def test_with_int_type(self):
         """Test that an extraction that is to match an integer results in the
         creation of a lambda function. This is done in case unit conversion
-        is applied, in which case the cube data may be converted inprecisely,
+        is applied, in which case the cube data may be converted imprecisely,
         e.g. 273.15K might become 1.0E-8C, which will not match a 0C constraint
         unless we use the lambda function to add some tolerance."""
         value = 10
@@ -173,7 +173,7 @@ class Test_create_constraint(IrisTest):
 
     def test_with_float_type(self):
         """Test that an extraction that is to match a float results in the
-        creation of a lambda function."""
+        creation of a lambda function which matches the expected values."""
         value = 10.0
         result = create_constraint(value)
         self.assertTrue(islambda(result))
@@ -186,8 +186,8 @@ class Test_create_constraint(IrisTest):
         self.assertFalse(result(crd.cell(0)))
 
     def test_with_float_type_multiple_values(self):
-        """Test that an extraction that is to match a float results in the
-        creation of a lambda function."""
+        """Test that an extraction that is to match multiple floats results in
+        the creation of a lambda function which matches the expected values."""
         value = [10.0, 20.0]
         result = create_constraint(value)
         self.assertTrue(islambda(result))
@@ -238,6 +238,17 @@ class Test_parse_constraint_list(IrisTest):
         self.assertTrue(cdict["percentile"](self.p_crd.cell(0)))
         self.assertTrue(islambda(cdict["threshold"]))
         self.assertTrue(cdict["threshold"](self.t_crd.cell(0)))
+
+    def test_string_constraint(self):
+        """ Test that a string constraint results in a simple iris constraint,
+        not a lamba function. This is created via the literal_eval ValueError.
+        """
+        constraints = ["percentile=kittens"]
+        result, _ = parse_constraint_list(constraints)
+        cdict = result._coord_values
+        self.assertFalse(islambda(cdict["percentile"]))
+        self.assertEqual(cdict["percentile"], "kittens")
+        self.assertIsInstance(cdict, dict)
 
     def test_some_units(self):
         """ Test units list containing "None" elements is correctly parsed """

--- a/lib/improver/utilities/cube_constraints.py
+++ b/lib/improver/utilities/cube_constraints.py
@@ -42,7 +42,10 @@ def create_sorted_lambda_constraint(coord_name, values, tolerance=1.0E-7):
 
     The created function uses float values. As a result, a small tolerance is
     used to spread the ends of the ranges to help with float equality
-    matching.
+    matching. Note that the relative tolerance will not affect values of zero.
+    Adding/subtracting an absolute tolerance is not done due to the
+    difficulty of selecting an appropriate value given the very small values
+    of precipitation rates expressed in m s-1.
 
     Args:
         coord_name (str):
@@ -52,7 +55,7 @@ def create_sorted_lambda_constraint(coord_name, values, tolerance=1.0E-7):
             of a range.
         tolerance (float):
             A relative tolerance value to ensure equivalence matching when
-            using float32 values.
+            using float32 values. Values of zero will be unchanged.
 
     Returns:
         constr (iris.Constraint):

--- a/lib/improver/utilities/cube_constraints.py
+++ b/lib/improver/utilities/cube_constraints.py
@@ -34,11 +34,15 @@
 import iris
 
 
-def create_sorted_lambda_constraint(coord_name, values):
+def create_sorted_lambda_constraint(coord_name, values, tolerance=1.0E-7):
     """
     Create a lambda constraint for a range. This formulation of specifying
     a lambda constraint has the benefit of not needing to hardcode the name
     for the coordinate, so that this can be determined at runtime.
+
+    The created function uses float values. As a result, a small tolerance is
+    used to spread the ends of the ranges to help with float equality
+    matching.
 
     Args:
         coord_name (str):
@@ -46,6 +50,9 @@ def create_sorted_lambda_constraint(coord_name, values):
         values (list):
             A list of two values that represent the inclusive end points
             of a range.
+        tolerance (float):
+            A relative tolerance value to ensure equivalence matching when
+            using float32 values.
 
     Returns:
         constr (iris.Constraint):
@@ -54,6 +61,8 @@ def create_sorted_lambda_constraint(coord_name, values):
     """
     values = [float(i) for i in values]
     values = sorted(values)
+    values[0] = (1. - tolerance) * values[0]
+    values[1] = (1. + tolerance) * values[1]
     constr = (
         iris.Constraint(
             coord_values={

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -32,6 +32,7 @@
 
 from ast import literal_eval
 
+import numpy as np
 import iris
 
 from improver.utilities.cube_constraints import create_sorted_lambda_constraint
@@ -76,6 +77,33 @@ def is_complex_parsing_required(value):
     else:
         complex_constraint = False
     return complex_constraint
+
+
+def create_constraint(value):
+    """
+    Constructs an appropriate contraint for matching numerical values is they
+    are floating point. If not, the original values are returned as a list
+    (even if they were single valued on entry).
+
+    Args:
+        value (float/int or list of float/int):
+            Contraint values that are being used to match against values in a
+            cube for the purposes of extracting elements of the cube.
+    Returns:
+        lambda function or list:
+            If the input value(s) are floating point this function returns a
+            lambda function that will enable for approximate matching to
+            ensure they can be matched to cube values. If the inputs are int
+            or non-numeric, they will be returned unchanged, except for single
+            values that will have become lists.
+    """
+    if not isinstance(value, list):
+        value = [value]
+
+    if np.issubdtype(np.array(value).dtype, np.float):
+        return lambda cell: any(np.isclose(cell.point, value))
+    else:
+        return value
 
 
 def parse_constraint_list(constraints, units=None):
@@ -129,9 +157,11 @@ def parse_constraint_list(constraints, units=None):
             complex_constraints.append(create_range_constraint(key, value))
         else:
             try:
-                simple_constraints_dict[key] = literal_eval(value)
+                typed_value = literal_eval(value)
             except ValueError:
                 simple_constraints_dict[key] = value
+            else:
+                simple_constraints_dict[key] = create_constraint(typed_value)
 
         if unit_val is not None and unit_val.capitalize() != 'None':
             units_dict[key] = unit_val.strip(' ')
@@ -144,6 +174,7 @@ def parse_constraint_list(constraints, units=None):
     constraints = simple_constraints
     for constr in complex_constraints:
         constraints = constraints & constr
+
     return constraints, units_dict
 
 

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -100,7 +100,7 @@ def create_constraint(value):
     if not isinstance(value, list):
         value = [value]
 
-    if np.issubdtype(np.array(value).dtype, np.floating):
+    if np.issubdtype(np.array(value).dtype, np.number):
         return lambda cell: any(np.isclose(cell.point, value))
     else:
         return value

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -100,7 +100,7 @@ def create_constraint(value):
     if not isinstance(value, list):
         value = [value]
 
-    if np.issubdtype(np.array(value).dtype, np.float):
+    if np.issubdtype(np.array(value).dtype, np.floating):
         return lambda cell: any(np.isclose(cell.point, value))
     else:
         return value

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -81,13 +81,13 @@ def is_complex_parsing_required(value):
 
 def create_constraint(value):
     """
-    Constructs an appropriate contraint for matching numerical values if they
+    Constructs an appropriate constraint for matching numerical values if they
     are floating point. If not, the original values are returned as a list
     (even if they were single valued on entry).
 
     Args:
         value (float/int or list of float/int):
-            Contraint values that are being used to match against values in a
+            Constraint values that are being used to match against values in a
             cube for the purposes of extracting elements of the cube.
     Returns:
         lambda function or list:

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -81,7 +81,7 @@ def is_complex_parsing_required(value):
 
 def create_constraint(value):
     """
-    Constructs an appropriate contraint for matching numerical values is they
+    Constructs an appropriate contraint for matching numerical values if they
     are floating point. If not, the original values are returned as a list
     (even if they were single valued on entry).
 


### PR DESCRIPTION
The extract_subcube code was written when we were still using float64 values. The precision of these values made float equivalence work in most instances. Now that we are using float32 coordinate and data values, float equivalence tends to fail and requires a small tolerance to be added.

The changes in this PR introduce a small amount of tolerance (relative to the value being compared) that lead float equivalence to work. This is achieved using numpy.close for single value matching, and by slightly expanding the range when using range matching.

Existing units tests were modified to use a cube with float32 data and coordinates. This required introducing some tolerance where the constraint was not created by the new function.

Note that the test_cube_extraction.py: Test_extract_subcube tests were previously not used as they were not prefixed with test_; these were enabled and fixed (the failures fixed are in master too if the tests are enabled, they are not affected by the changes made here).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)