### PR TITLE
Impro 1347 global attributes: PR 1 of 3

### DIFF
--- a/lib/improver/cli/standardise.py
+++ b/lib/improver/cli/standardise.py
@@ -308,7 +308,8 @@ def process(output_data, target_grid=None, source_landsea=None,
         target_grid_attributes = (
             {k: v for (k, v) in target_grid.attributes.items()
              if 'mosg__' in k or 'institution' in k})
-        amend_metadata(output_data, attributes=target_grid_attributes)
+        output_data = amend_metadata(
+            output_data, attributes=target_grid_attributes)
     # Change metadata only option:
     # if output file path and json metadata file specified,
     # change the metadata

--- a/lib/improver/metadata/attributes.py
+++ b/lib/improver/metadata/attributes.py
@@ -58,13 +58,17 @@ DATASET_ATTRIBUTES = {
 def set_product_attributes(cube, product):
     """
     Set attributes on an output cube of type matching a key string in the
-    DATASET_ATTRIBUTES dictionary.  Modifies cube in place.
+    DATASET_ATTRIBUTES dictionary.
 
     Args:
         cube (iris.cube.Cube):
             Cube containing product data
         product (str):
             String describing product type
+
+    Returns:
+        updated_cube (iris.cube.Cube):
+            Cube with updated attributes
     """
     try:
         original_title = cube.attributes["title"]
@@ -72,7 +76,8 @@ def set_product_attributes(cube, product):
         original_title = ""
 
     try:
-        amend_metadata(cube, attributes=DATASET_ATTRIBUTES[product])
+        updated_cube = amend_metadata(
+            cube, attributes=DATASET_ATTRIBUTES[product])
     except KeyError:
         options = list(DATASET_ATTRIBUTES.keys())
         raise ValueError(
@@ -80,7 +85,10 @@ def set_product_attributes(cube, product):
                 product, options))
 
     if STANDARD_GRID_TITLE_STRING in original_title:
-        cube.attributes["title"] += " on {}".format(STANDARD_GRID_TITLE_STRING)
+        updated_cube.attributes["title"] += " on {}".format(
+            STANDARD_GRID_TITLE_STRING)
+
+    return updated_cube
 
 
 def update_spot_title_attribute(cube):

--- a/lib/improver/metadata/attributes.py
+++ b/lib/improver/metadata/attributes.py
@@ -120,7 +120,7 @@ def update_spot_title_attribute(cube):
         # try regular expression matching
         regex = re.compile(
             '(?P<field>.*?)'  # description of field
-            '( on )'       # expected joining statement
+            '( on )'          # expected joining statement
             '(?P<grid>.*?)')  # eg STANDARD_GRID_TITLE_STRING
         title_regex = regex.match(cube.attributes["title"])
 

--- a/lib/improver/metadata/attributes.py
+++ b/lib/improver/metadata/attributes.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Module defining attributes for IMPROVER blended data and the nowcast
+"""
+
+import re
+import warnings
+
+from improver.utilities.cube_metadata import amend_metadata
+
+
+STANDARD_GRID_TITLE_STRING = "UK 2 km Standard Grid"
+SPOT_TITLE_STRING = "UK Spot Values"
+
+DATASET_ATTRIBUTES = {
+    "nowcast": {
+        "source": "IMPROVER",
+        "title": "MONOW Extrapolation Nowcast",
+        "institution": "Met Office"
+    },
+    "multi-model blend": {
+        "source": "IMPROVER",
+        "title": "IMPROVER Post-Processed Multi-Model Blend",
+        "institution": "Met Office"
+    }
+}
+
+
+def set_product_attributes(cube, product):
+    """
+    Set attributes on an output cube of type matching a key string in the
+    DATASET_ATTRIBUTES dictionary.  Modifies cube in place.
+
+    Args:
+        cube (iris.cube.Cube):
+            Cube containing product data
+        product (str):
+            String describing product type
+    """
+    try:
+        original_title = cube.attributes["title"]
+    except KeyError:
+        original_title = ""
+
+    try:
+        amend_metadata(cube, attributes=DATASET_ATTRIBUTES[product])
+    except KeyError:
+        options = list(DATASET_ATTRIBUTES.keys())
+        raise ValueError(
+            "product '{}' not available (options: {})".format(
+                product, options))
+
+    if STANDARD_GRID_TITLE_STRING in original_title:
+        cube.attributes["title"] += " on {}".format(STANDARD_GRID_TITLE_STRING)
+
+
+def update_spot_title_attribute(cube):
+    """
+    Update the "title" attribute on a spot data cube IF there is an existing
+    attribute of the form "<description>_on_<grid>" or containing the UK
+    standard grid definition string.  Modifies cube in place.
+
+    Args:
+        cube (iris.cube.Cube):
+            Spot data cube
+    """
+    regex = re.compile(
+        '(?P<desc>)'   # title describing field
+        '( on )'       # expected joining statement
+        '(?P<grid>)')  # eg STANDARD_GRID_TITLE_STRING
+    try:
+        title_regex = regex.match(cube.attributes["title"])
+    except KeyError:
+        # if there is no original title, we cannot update it sensibly
+        return
+
+    if title_regex is None:
+        # try a straight replacement
+        if STANDARD_GRID_TITLE_STRING in cube.attributes["title"]:
+            new_title = cube.attributes["title"].replace(
+                STANDARD_GRID_TITLE_STRING, SPOT_TITLE_STRING)
+            cube.attributes["title"] = new_title
+        else:
+            # if title does not match expected pattern we cannot update it
+            # sensibly - raise a warning here
+            warnings.warn(
+                "'title' attribute does not match expected pattern - "
+                "unable to replace grid description")
+            return
+    else:
+        cube.attributes["title"] = (
+            title_regex.group(1) + title_regex.group(2) + SPOT_TITLE_STRING)

--- a/lib/improver/metadata/constants/attributes.py
+++ b/lib/improver/metadata/constants/attributes.py
@@ -30,7 +30,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """
 Module defining attributes for IMPROVER blended data, nowcasts and spot
-forecasts
+forecasts.
+
+This module is exclusively for attributes which are NOT dependent on the
+centre running the IMPROVER code.  Other attributes can be user-defined
+through configurable dictionary arguments.
 """
 
 STANDARD_GRID_TITLE_STRING = "UK 2 km Standard Grid"

--- a/lib/improver/metadata/constants/attributes.py
+++ b/lib/improver/metadata/constants/attributes.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Module defining attributes for IMPROVER blended data and the nowcast
+"""
+
+STANDARD_GRID_TITLE_STRING = "UK 2 km Standard Grid"
+UK_SPOT_TITLE_STRING = "UK Spot Values"
+GLOBAL_SPOT_TITLE_STRING = "Spot Values"
+
+DATASET_ATTRIBUTES = {
+    "nowcast": {
+        "source": "IMPROVER",
+        "title": "MONOW Extrapolation Nowcast",
+        "institution": "Met Office"
+    },
+    "multi-model blend": {
+        "source": "IMPROVER",
+        "title": "IMPROVER Post-Processed Multi-Model Blend",
+        "institution": "Met Office"
+    }
+}
+

--- a/lib/improver/metadata/constants/attributes.py
+++ b/lib/improver/metadata/constants/attributes.py
@@ -29,7 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """
-Module defining attributes for IMPROVER blended data and the nowcast
+Module defining attributes for IMPROVER blended data, nowcasts and spot
+forecasts
 """
 
 STANDARD_GRID_TITLE_STRING = "UK 2 km Standard Grid"
@@ -48,4 +49,3 @@ DATASET_ATTRIBUTES = {
         "institution": "Met Office"
     }
 }
-

--- a/lib/improver/metadata/set_attributes.py
+++ b/lib/improver/metadata/set_attributes.py
@@ -47,13 +47,14 @@ from improver.utilities.cube_metadata import amend_metadata
 def set_product_attributes(cube, product):
     """
     Set attributes on an output cube of type matching a key string in the
-    DATASET_ATTRIBUTES dictionary.
+    improver.metadata.constants.attributes.DATASET_ATTRIBUTES dictionary.
 
     Args:
         cube (iris.cube.Cube):
             Cube containing product data
         product (str):
-            String describing product type
+            String describing product type, which is a key in the
+            DATASET_ATTRIBUTES dictionary.
 
     Returns:
         updated_cube (iris.cube.Cube):
@@ -65,14 +66,15 @@ def set_product_attributes(cube, product):
         original_title = ""
 
     try:
-        updated_cube = amend_metadata(
-            cube, attributes=DATASET_ATTRIBUTES[product])
+        dataset_attributes = DATASET_ATTRIBUTES[product]
     except KeyError:
         options = list(DATASET_ATTRIBUTES.keys())
         raise ValueError(
             "product '{}' not available (options: {})".format(
                 product, options))
 
+    updated_cube = amend_metadata(
+        cube, attributes=dataset_attributes)
     if STANDARD_GRID_TITLE_STRING in original_title:
         updated_cube.attributes["title"] += " on {}".format(
             STANDARD_GRID_TITLE_STRING)
@@ -82,7 +84,7 @@ def set_product_attributes(cube, product):
 
 def _match_title(original_title):
     """
-    Match a title string to a regular expression
+    Match a title string to the expected regular expression pattern
 
     Args:
         original_title (str):
@@ -90,7 +92,8 @@ def _match_title(original_title):
 
     Returns:
         match (re.Match object or None):
-            Match to expected regular expression pattern
+            Match to expected regular expression pattern, or None if the
+            string does not match the pattern
     """
     regex = re.compile(
         '(?P<field>.*?)'  # description of field

--- a/lib/improver/metadata/set_attributes.py
+++ b/lib/improver/metadata/set_attributes.py
@@ -29,7 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """
-Module setting attributes for IMPROVER blended data and the nowcast
+Module setting attributes for IMPROVER blended data, nowcasts and spot
+forecasts
 """
 
 import re
@@ -136,8 +137,8 @@ def update_spot_title_attribute(cube):
             return
         else:
             if "UK" in original_title:
-                cube.attributes["title"] = (
-                    title_regex.group('field') + ' ' + UK_SPOT_TITLE_STRING)
+                cube.attributes["title"] = '{} {}'.format(
+                    title_regex.group('field'), UK_SPOT_TITLE_STRING)
             else:
-                cube.attributes["title"] = (
-                    title_regex.group('field') + ' ' + GLOBAL_SPOT_TITLE_STRING)
+                cube.attributes["title"] = '{} {}'.format(
+                    title_regex.group('field'), GLOBAL_SPOT_TITLE_STRING)

--- a/lib/improver/metadata/set_attributes.py
+++ b/lib/improver/metadata/set_attributes.py
@@ -89,7 +89,7 @@ def _match_title(original_title):
             Value of "title" attribute on an input cube
 
     Returns:
-        match (str or None):
+        match (re.Match object or None):
             Match to expected regular expression pattern
     """
     regex = re.compile(
@@ -136,7 +136,8 @@ def update_spot_title_attribute(cube):
                 "unable to replace grid description")
             return
         else:
-            if "UK" in original_title:
+            grid_descriptor = '{}'.format(title_regex.group('grid'))
+            if "UK" in grid_descriptor:
                 cube.attributes["title"] = '{} {}'.format(
                     title_regex.group('field'), UK_SPOT_TITLE_STRING)
             else:

--- a/lib/improver/metadata/set_attributes.py
+++ b/lib/improver/metadata/set_attributes.py
@@ -96,9 +96,9 @@ def _match_title(original_title):
             string does not match the pattern
     """
     regex = re.compile(
-        '(?P<field>.*?)'  # description of field
-        '( on )'          # expected joining statement
-        '(?P<grid>.*?)')  # eg STANDARD_GRID_TITLE_STRING
+        '(?P<field>.*)'  # description of field
+        '( on )'         # expected joining statement
+        '(?P<grid>.*)')  # eg STANDARD_GRID_TITLE_STRING
     return regex.match(original_title)
 
 

--- a/lib/improver/tests/metadata/test_attributes.py
+++ b/lib/improver/tests/metadata/test_attributes.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Tests for the improver.metadata.attributes module
+"""
+
+import unittest
+import numpy as np
+
+from improver.metadata.attributes import (
+    set_product_attributes, update_spot_title_attribute)
+from improver.tests.set_up_test_cubes import set_up_variable_cube
+
+
+class Test_set_product_attributes(unittest.TestCase):
+    """Test the set_product_attributes function"""
+
+    def setUp(self):
+        """Set up a dummy cube"""
+        attributes = {
+            "source": "Met Office Unified Model",
+            "title": "MOGREPS-UK Temperature Forecast "
+                     "on UK 2 km Standard Grid"}
+        self.cube = set_up_variable_cube(
+            278*np.ones((5, 5), dtype=np.float32),
+            attributes=attributes)
+
+        self.blend_descriptor = "IMPROVER Post-Processed Multi-Model Blend"
+        self.nowcast_descriptor = "MONOW Extrapolation Nowcast"
+        self.grid_descriptor = " on UK 2 km Standard Grid"
+
+    def test_blend(self):
+        """Test cube is modified in place"""
+        expected_title = self.blend_descriptor + self.grid_descriptor
+        set_product_attributes(self.cube, "multi-model blend")
+        attrs = self.cube.attributes
+        self.assertEqual(attrs["source"], "IMPROVER")
+        self.assertEqual(attrs["title"], expected_title)
+        self.assertEqual(attrs["institution"], "Met Office")
+
+    def test_nowcast(self):
+        """Test nowcast attributes"""
+        expected_title = self.nowcast_descriptor + self.grid_descriptor
+        set_product_attributes(self.cube, "nowcast")
+        attrs = self.cube.attributes
+        self.assertEqual(attrs["source"], "IMPROVER")
+        self.assertEqual(attrs["title"], expected_title)
+        self.assertEqual(attrs["institution"], "Met Office")        
+
+    def test_no_grid_descriptor(self):
+        """Test blended cube only has grid descriptor where appropriate"""
+        self.cube.attributes["title"] = "MOGREPS-UK Temperature Forecast"
+        set_product_attributes(self.cube, "multi-model blend")
+        self.assertEqual(self.cube.attributes["title"], self.blend_descriptor)
+
+    def test_error_invalid_product(self):
+        """Test error when product is not recognised"""
+        msg = "product 'unknown product' not available"
+        with self.assertRaisesRegex(ValueError, msg):
+            set_product_attributes(self.cube, "unknown product")
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/metadata/test_attributes.py
+++ b/lib/improver/tests/metadata/test_attributes.py
@@ -58,10 +58,10 @@ class Test_set_product_attributes(unittest.TestCase):
         self.grid_descriptor = " on UK 2 km Standard Grid"
 
     def test_blend(self):
-        """Test cube is modified in place"""
+        """Test blended attributes"""
         expected_title = self.blend_descriptor + self.grid_descriptor
-        set_product_attributes(self.cube, "multi-model blend")
-        attrs = self.cube.attributes
+        result = set_product_attributes(self.cube, "multi-model blend")
+        attrs = result.attributes
         self.assertEqual(attrs["source"], "IMPROVER")
         self.assertEqual(attrs["title"], expected_title)
         self.assertEqual(attrs["institution"], "Met Office")
@@ -69,17 +69,17 @@ class Test_set_product_attributes(unittest.TestCase):
     def test_nowcast(self):
         """Test nowcast attributes"""
         expected_title = self.nowcast_descriptor + self.grid_descriptor
-        set_product_attributes(self.cube, "nowcast")
-        attrs = self.cube.attributes
+        result = set_product_attributes(self.cube, "nowcast")
+        attrs = result.attributes
         self.assertEqual(attrs["source"], "IMPROVER")
         self.assertEqual(attrs["title"], expected_title)
-        self.assertEqual(attrs["institution"], "Met Office")        
+        self.assertEqual(attrs["institution"], "Met Office")
 
     def test_no_grid_descriptor(self):
         """Test blended cube only has grid descriptor where appropriate"""
         self.cube.attributes["title"] = "MOGREPS-UK Temperature Forecast"
-        set_product_attributes(self.cube, "multi-model blend")
-        self.assertEqual(self.cube.attributes["title"], self.blend_descriptor)
+        result = set_product_attributes(self.cube, "multi-model blend")
+        self.assertEqual(result.attributes["title"], self.blend_descriptor)
 
     def test_error_invalid_product(self):
         """Test error when product is not recognised"""

--- a/lib/improver/tests/metadata/test_set_attributes.py
+++ b/lib/improver/tests/metadata/test_set_attributes.py
@@ -118,7 +118,7 @@ class Test_update_spot_title_attribute(unittest.TestCase):
             "MOGREPS-G Temperature Forecast on Global Grid")
         expected_title = "MOGREPS-G Temperature Forecast Spot Values"
         update_spot_title_attribute(self.cube)
-        self.assertEqual(self.cube.attributes["title"], self.expected_title)
+        self.assertEqual(self.cube.attributes["title"], expected_title)
 
     def test_no_title(self):
         """Test no change is made to an input cube with no title"""

--- a/lib/improver/tests/metadata/test_set_attributes.py
+++ b/lib/improver/tests/metadata/test_set_attributes.py
@@ -35,7 +35,7 @@ Tests for the improver.metadata.attributes module
 import unittest
 import numpy as np
 
-from improver.metadata.attributes import (
+from improver.metadata.set_attributes import (
     set_product_attributes, update_spot_title_attribute)
 from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.warnings_handler import ManageWarnings
@@ -109,6 +109,14 @@ class Test_update_spot_title_attribute(unittest.TestCase):
         """Test function recognises other grid specifications"""
         self.cube.attributes["title"] = (
             "MOGREPS-UK Temperature Forecast on Other Grid")
+        update_spot_title_attribute(self.cube)
+        self.assertEqual(self.cube.attributes["title"], self.expected_title)
+
+    def test_global_grid(self):
+        """Test function responds correctly to a non-UK grid"""
+        self.cube.attributes["title"] = (
+            "MOGREPS-G Temperature Forecast on Global Grid")
+        expected_title = "MOGREPS-G Temperature Forecast Spot Values"
         update_spot_title_attribute(self.cube)
         self.assertEqual(self.cube.attributes["title"], self.expected_title)
 

--- a/lib/improver/tests/metadata/test_set_attributes.py
+++ b/lib/improver/tests/metadata/test_set_attributes.py
@@ -36,7 +36,7 @@ import unittest
 import numpy as np
 
 from improver.metadata.set_attributes import (
-    set_product_attributes, update_spot_title_attribute)
+    set_product_attributes, _match_title, update_spot_title_attribute)
 from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.warnings_handler import ManageWarnings
 
@@ -88,6 +88,20 @@ class Test_set_product_attributes(unittest.TestCase):
             set_product_attributes(self.cube, "unknown product")
 
 
+class Test__match_title(unittest.TestCase):
+    """Test the _match_title function"""
+
+    def test_basic(self):
+        """Test pattern matching is working as expected"""
+        expected_field = "MOGREPS-UK Temperature Forecast"
+        expected_grid = "UK 2 km Standard Grid"
+        original_title = (
+            "MOGREPS-UK Temperature Forecast on UK 2 km Standard Grid")
+        result = _match_title(original_title)
+        self.assertEqual(result.group("field"), expected_field)
+        self.assertEqual(result.group("grid"), expected_grid)
+
+
 class Test_update_spot_title_attribute(unittest.TestCase):
     """Test the update_spot_title_attribute function"""
 
@@ -105,14 +119,6 @@ class Test_update_spot_title_attribute(unittest.TestCase):
         update_spot_title_attribute(self.cube)
         self.assertEqual(self.cube.attributes["title"], self.expected_title)
 
-    def test_other_grid(self):
-        """Test function recognises other grid specifications"""
-        self.cube.attributes["title"] = (
-            "MOGREPS-UK Temperature Forecast on Other Grid")
-        expected_title = "MOGREPS-UK Temperature Forecast Spot Values"
-        update_spot_title_attribute(self.cube)
-        self.assertEqual(self.cube.attributes["title"], expected_title)
-
     def test_global_grid(self):
         """Test function responds correctly to a non-UK grid"""
         self.cube.attributes["title"] = (
@@ -120,6 +126,21 @@ class Test_update_spot_title_attribute(unittest.TestCase):
         expected_title = "MOGREPS-G Temperature Forecast Spot Values"
         update_spot_title_attribute(self.cube)
         self.assertEqual(self.cube.attributes["title"], expected_title)
+
+    def test_other_grid(self):
+        """Test function responds correctly to an unknown grid"""
+        self.cube.attributes["title"] = (
+            "MOGREPS-UK Temperature Forecast on Other Grid")
+        expected_title = "MOGREPS-UK Temperature Forecast Spot Values"
+        update_spot_title_attribute(self.cube)
+        self.assertEqual(self.cube.attributes["title"], expected_title)
+
+    def test_other_uk_grid(self):
+        """Test function responds correctly to an unknown UK grid"""
+        self.cube.attributes["title"] = (
+            "MOGREPS-UK Temperature Forecast on Other UK Grid")
+        update_spot_title_attribute(self.cube)
+        self.assertEqual(self.cube.attributes["title"], self.expected_title)
 
     def test_no_title(self):
         """Test no change is made to an input cube with no title"""

--- a/lib/improver/tests/metadata/test_set_attributes.py
+++ b/lib/improver/tests/metadata/test_set_attributes.py
@@ -58,7 +58,7 @@ class Test_set_product_attributes(unittest.TestCase):
         self.grid_descriptor = " on UK 2 km Standard Grid"
 
     def test_blend(self):
-        """Test blended attributes"""
+        """Test blended attributes are correctly set"""
         expected_title = self.blend_descriptor + self.grid_descriptor
         result = set_product_attributes(self.cube, "multi-model blend")
         attrs = result.attributes
@@ -67,7 +67,7 @@ class Test_set_product_attributes(unittest.TestCase):
         self.assertEqual(attrs["institution"], "Met Office")
 
     def test_nowcast(self):
-        """Test nowcast attributes"""
+        """Test nowcast attributes are correctly set"""
         expected_title = self.nowcast_descriptor + self.grid_descriptor
         result = set_product_attributes(self.cube, "nowcast")
         attrs = result.attributes
@@ -109,8 +109,9 @@ class Test_update_spot_title_attribute(unittest.TestCase):
         """Test function recognises other grid specifications"""
         self.cube.attributes["title"] = (
             "MOGREPS-UK Temperature Forecast on Other Grid")
+        expected_title = "MOGREPS-UK Temperature Forecast Spot Values"
         update_spot_title_attribute(self.cube)
-        self.assertEqual(self.cube.attributes["title"], self.expected_title)
+        self.assertEqual(self.cube.attributes["title"], expected_title)
 
     def test_global_grid(self):
         """Test function responds correctly to a non-UK grid"""
@@ -125,6 +126,13 @@ class Test_update_spot_title_attribute(unittest.TestCase):
         self.cube.attributes.pop("title")
         update_spot_title_attribute(self.cube)
         self.assertNotIn("title", self.cube.attributes.keys())
+
+    def test_title_already_spot(self):
+        """Test no change is made to an input cube where the title contains
+        a spot-data-descriptive substring"""
+        self.cube.attributes["title"] = "Spot Values"
+        update_spot_title_attribute(self.cube)
+        self.assertEqual(self.cube.attributes["title"], "Spot Values")
 
     @ManageWarnings(record=True)
     def test_unexpected_title(self, warning_list=None):

--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """
-Module to contain the default units for use within IMPROVER.
+Module containing the default units and datatypes for use within IMPROVER.
 
 The DEFAULT_UNITS dictionary has the following form.
 


### PR DESCRIPTION
Changes:
- Added `improver.metadata` directory including `improver.metadata.attributes` with functions to update the level 1 nowcast, level 3 blended and any-level spot data attributes
- Fixed functions in `improver.utilities.cube_metadata` to return a cube without modifying the input cube
- Made appropriate functions in `improver.utilities.cube_metadata` private to that module, anticipating further rearrangement of the metadata modules in the next PR

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

