### PR TITLE
IMPRO-1287 - bugfix for day max / night min

### DIFF
--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -79,7 +79,7 @@ DEFAULT_UNITS = {
     "pressure": {"unit": "Pa"},
     "temperature": {"unit": "K"},
     "temperature_at_screen_level_daytime_max": {"unit": "K"},
-    "temperature_at_screen_level_daytime_min": {"unit": "K"},
+    "temperature_at_screen_level_nighttime_min": {"unit": "K"},
     "thickness": {"unit": "m"},
     "ultraviolet_flux": {"unit": "W m-2"},
     "ultraviolet_index": {"unit": "1"},

--- a/lib/improver/units.py
+++ b/lib/improver/units.py
@@ -78,6 +78,8 @@ DEFAULT_UNITS = {
     "precipitation_rate": {"unit": "m s-1"},
     "pressure": {"unit": "Pa"},
     "temperature": {"unit": "K"},
+    "temperature_at_screen_level_daytime_max": {"unit": "K"},
+    "temperature_at_screen_level_daytime_min": {"unit": "K"},
     "thickness": {"unit": "m"},
     "ultraviolet_flux": {"unit": "W m-2"},
     "ultraviolet_index": {"unit": "1"},


### PR DESCRIPTION
Added missing unit definitions for day time max temperature and night time min temperature.

Testing:
 - [x] Ran tests and they passed OK