### PR TITLE
IMPRO-1381: Ensure recreated ensemble numbers are of type int32

### DIFF
--- a/lib/improver/tests/utilities/test_GenerateTimeLaggedEnsemble.py
+++ b/lib/improver/tests/utilities/test_GenerateTimeLaggedEnsemble.py
@@ -71,7 +71,8 @@ class Test_process(IrisTest):
         realizations = iris.cube.CubeList()
         for i in range(3):
             realization = input_cube.copy()
-            realization.coord("realization").points = np.array(i)
+            realization.coord("realization").points = np.array(
+                i, dtype=np.int32)
             realizations.append(realization)
         self.input_cube = realizations.merge_cube()
         # Create a second cube from a later forecast with a different set of
@@ -81,7 +82,8 @@ class Test_process(IrisTest):
             self.input_cube2.coord("forecast_reference_time").points[0] + 1)
         self.input_cube2.coord("forecast_period").points = np.array(
             self.input_cube2.coord("forecast_period").points[0] - 1)
-        self.input_cube2.coord("realization").points = np.array([3, 4, 5])
+        self.input_cube2.coord("realization").points = np.array(
+            [3, 4, 5], dtype=np.int32)
         # Put the two cubes in a cubelist ready to use in the plugin.
         self.input_cubelist = iris.cube.CubeList(
             [self.input_cube, self.input_cube2])
@@ -97,7 +99,7 @@ class Test_process(IrisTest):
             self.input_cubelist)
         expected_forecast_period = np.array(3)
         expected_forecast_ref_time = np.array([402292.])
-        expected_realizations = np.array([0, 1, 2, 3, 4, 5])
+        expected_realizations = [0, 1, 2, 3, 4, 5]
         self.assertArrayAlmostEqual(
             result.coord("forecast_period").points, expected_forecast_period)
         self.assertArrayAlmostEqual(
@@ -105,6 +107,8 @@ class Test_process(IrisTest):
             expected_forecast_ref_time)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, expected_realizations)
+        self.assertEqual(
+            result.coord("realization").dtype, np.int32)
 
     def test_cycletime(self):
         """Test that the expected metadata is correct with a different
@@ -113,7 +117,7 @@ class Test_process(IrisTest):
             self.input_cubelist)
         expected_forecast_period = np.array(1)
         expected_forecast_ref_time = np.array([402294.])
-        expected_realizations = np.array([0, 1, 2, 3, 4, 5])
+        expected_realizations = [0, 1, 2, 3, 4, 5]
         self.assertArrayAlmostEqual(
             result.coord("forecast_period").points, expected_forecast_period)
         self.assertArrayAlmostEqual(
@@ -121,16 +125,19 @@ class Test_process(IrisTest):
             expected_forecast_ref_time)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, expected_realizations)
+        self.assertEqual(
+            result.coord("realization").dtype, np.int32)
 
     def test_realizations(self):
         """Test that the expected metadata is correct with a different
            realizations"""
-        self.input_cube2.coord("realization").points = np.array([6, 7, 8])
+        self.input_cube2.coord("realization").points = np.array(
+            [6, 7, 8], dtype=np.int32)
         result = GenerateTimeLaggedEnsemble().process(
             self.input_cubelist)
         expected_forecast_period = np.array(3)
         expected_forecast_ref_time = np.array([402292.])
-        expected_realizations = np.array([0, 1, 2, 6, 7, 8])
+        expected_realizations = [0, 1, 2, 6, 7, 8]
         self.assertArrayAlmostEqual(
             result.coord("forecast_period").points, expected_forecast_period)
         self.assertArrayAlmostEqual(
@@ -138,6 +145,8 @@ class Test_process(IrisTest):
             expected_forecast_ref_time)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, expected_realizations)
+        self.assertEqual(
+            result.coord("realization").dtype, np.int32)
 
     def test_duplicate_realizations(self):
         """Test that the expected metadata is correct with different
@@ -148,7 +157,7 @@ class Test_process(IrisTest):
             self.input_cubelist)
         expected_forecast_period = np.array(3)
         expected_forecast_ref_time = np.array([402292.])
-        expected_realizations = np.array([0, 1, 2, 3, 4, 5])
+        expected_realizations = [0, 1, 2, 3, 4, 5]
         self.assertArrayAlmostEqual(
             result.coord("forecast_period").points, expected_forecast_period)
         self.assertArrayAlmostEqual(
@@ -156,6 +165,8 @@ class Test_process(IrisTest):
             expected_forecast_ref_time)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, expected_realizations)
+        self.assertEqual(
+            result.coord("realization").dtype, np.int32)
 
     def test_duplicate_realizations_more_input_cubes(self):
         """Test that the expected metadata is correct with different
@@ -174,7 +185,7 @@ class Test_process(IrisTest):
             input_cubelist)
         expected_forecast_period = np.array(2)
         expected_forecast_ref_time = np.array([402293.])
-        expected_realizations = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
+        expected_realizations = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         self.assertArrayAlmostEqual(
             result.coord("forecast_period").points, expected_forecast_period)
         self.assertArrayAlmostEqual(
@@ -182,6 +193,8 @@ class Test_process(IrisTest):
             expected_forecast_ref_time)
         self.assertArrayAlmostEqual(
             result.coord("realization").points, expected_realizations)
+        self.assertEqual(
+            result.coord("realization").dtype, np.int32)
 
     def test_attributes(self):
         """Test what happens if input cubes have different attributes"""
@@ -207,19 +220,22 @@ class Test_process(IrisTest):
         data = 275.*np.ones((3, 3, 3), dtype=np.float32)
         cycletime = dt(2019, 6, 24, 9)
         cube1 = set_up_variable_cube(
-            data, realizations=[15, 16, 17], time=cycletime,
-            frt=dt(2019, 6, 24, 8))
+            data, realizations=np.array([15, 16, 17], dtype=np.int32),
+            time=cycletime, frt=dt(2019, 6, 24, 8))
         cube2 = set_up_variable_cube(
-            data, realizations=[0, 18, 19], time=cycletime, frt=cycletime)
+            data, realizations=np.array([0, 18, 19], dtype=np.int32),
+            time=cycletime, frt=cycletime)
 
         expected_cube = set_up_variable_cube(
             275.*np.ones((6, 3, 3), dtype=np.float32),
-            realizations=[0, 15, 16, 17, 18, 19],
+            realizations=np.array([0, 15, 16, 17, 18, 19], dtype=np.int32),
             time=cycletime, frt=cycletime)
 
         input_cubelist = iris.cube.CubeList([cube1, cube2])
         result = GenerateTimeLaggedEnsemble().process(input_cubelist)
         self.assertEqual(result, expected_cube)
+        self.assertEqual(
+            result.coord("realization").dtype, np.int32)
 
 
 if __name__ == '__main__':

--- a/lib/improver/utilities/time_lagging.py
+++ b/lib/improver/utilities/time_lagging.py
@@ -100,7 +100,8 @@ class GenerateTimeLaggedEnsemble(object):
             for cube in cubelist:
                 n_realization = len(cube.coord("realization").points)
                 cube.coord("realization").points = np.arange(
-                    first_realization, first_realization + n_realization)
+                    first_realization, first_realization + n_realization,
+                    dtype=np.int32)
                 first_realization = first_realization + n_realization
 
         # slice over realization to deal with cases where direct concatenation

--- a/tests/improver-time-lagged-ensembles/05-renumbered_realizations.bats
+++ b/tests/improver-time-lagged-ensembles/05-renumbered_realizations.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "time-lagged-ensembles renumber non-unique realizations numbers" {
+  improver_check_skip_acceptance
+  KGO="time-lagged-ens/renumbered_realizations/kgo.nc"
+
+  # Run time-lagged-ensemble processing and check it passes.
+  run improver time-lagged-ensembles \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0005H00M-temperature_at_surface.nc" \
+      "$IMPROVER_ACC_TEST_DIR/time-lagged-ens/same_validity/20180924T1300Z-PT0005H00M-temperature_at_surface.nc" \
+      "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
The time lagging functionality within IMPROVER renumbers ensemble members when creating a time lag if there is not an existing unique number for each ensemble member. For example, lagging two MOGREPS-G cycles will result in this renumbering as both cycles include member 0.

This PR ensures that the newly created realization coordinate is of type int32, ensuring compliance with metadata, which is enforced by the save wrapper. A new test is added that would have captured this issue and ensures it is covered in case of future changes.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)