### PR TITLE
IMPRO-1323: ApplyCoefficientsFromEnsembleCalibration refactor

### DIFF
--- a/lib/improver/cli/apply_emos_coefficients.py
+++ b/lib/improver/cli/apply_emos_coefficients.py
@@ -273,9 +273,9 @@ def process(current_forecast, coeffs, num_realizations=None,
 
     # Apply coefficients as part of Ensemble Model Output Statistics (EMOS).
     ac = ApplyCoefficientsFromEnsembleCalibration(
-        current_forecast, coeffs,
         predictor_of_mean_flag=predictor_of_mean)
-    calibrated_predictor, calibrated_variance = ac.process()
+    calibrated_predictor, calibrated_variance = ac.process(
+        current_forecast, coeffs)
 
     # If input forecast is probabilities, convert output into probabilities.
     # If input forecast is percentiles, convert output into percentiles.

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -918,8 +918,8 @@ class ApplyCoefficientsFromEnsembleCalibration():
 
     def _get_calibrated_forecast_predictors_mean(self, optimised_coeffs):
         """
-        Function to get appropriately formatted forecast_predictors when the
-        predictor of mean used is the ensemble mean.
+        Function to get calibrated forecast_predictors when the predictor of
+        mean used is the ensemble mean.
 
         Args:
             optimised_coeffs (dict):
@@ -929,7 +929,7 @@ class ApplyCoefficientsFromEnsembleCalibration():
         Returns:
             (tuple) : tuple containing:
                 **predicted_mean** (numpy.ndarray):
-                    Calibrated mean value.
+                    Calibrated mean values in a flattened array.
                 **forecast_predictors** (iris.cube.Cube):
                     The forecast predictors, mean values taken by collapsing
                     the realization coordinate.
@@ -952,8 +952,14 @@ class ApplyCoefficientsFromEnsembleCalibration():
     def _get_calibrated_forecast_predictors_realizations(
             self, optimised_coeffs, forecast_vars):
         """
-        Function to get appropriately formatted forecast_predictors when the
-        predictor of mean used each realization separately.
+        Function to get calibrated forecast_predictors when the predictor of
+        mean is the mean of each distinct realization. The domain mean in a
+        given realization has been used to generate calibration coefficients,
+        such that each realization can be calibrated separately. These
+        calibrated realizations are then collapsed to give mean values at each
+        point in the domain.
+
+        used is specific to each realization
 
         Args:
             optimised_coeffs (dict):
@@ -966,7 +972,7 @@ class ApplyCoefficientsFromEnsembleCalibration():
         Returns:
             (tuple) : tuple containing:
                 **predicted_mean** (numpy.ndarray):
-                    Calibrated mean value.
+                    Calibrated mean values in a flattened array.
                 **calibrated_forecast_predictor** (iris.cube.Cube):
                     The forecast predictors, mean values taken by collapsing
                     the realization coordinate.
@@ -1000,7 +1006,10 @@ class ApplyCoefficientsFromEnsembleCalibration():
                                 calibrated_forecast_predictor,
                                 calibrated_forecast_var):
         """
-        Apply the calibration coefficients to the forecast data.
+        Reshape the calibrated_forecast_predictor to the original domain
+        dimensions. Apply the calibration coefficients to the forecast data
+        variance. Return both to give calibrated mean and variance in the
+        original domain dimensions.
 
         Args:
             optimised_coeffs (dict):

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -46,9 +46,9 @@ from improver.ensemble_calibration.ensemble_calibration_utilities import (
     convert_cube_data_to_2d, check_predictor_of_mean_flag,
     flatten_ignoring_masked_data)
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
+from improver.utilities.cube_checker import time_coords_match
 from improver.utilities.temporal import (
-    cycletime_to_datetime, datetime_to_cycletime, datetime_to_iris_time,
-    iris_time_to_datetime)
+    cycletime_to_datetime, datetime_to_iris_time, iris_time_to_datetime)
 
 
 class ContinuousRankedProbabilityScoreMinimisers():
@@ -873,13 +873,177 @@ class ApplyCoefficientsFromEnsembleCalibration():
     Class to apply the optimised EMOS coefficients to future dates.
 
     """
-    def __init__(
-            self, current_forecast, coefficients_cube,
-            predictor_of_mean_flag="mean"):
+    def __init__(self, predictor_of_mean_flag="mean"):
         """
         Create an ensemble calibration plugin that, for Nonhomogeneous Gaussian
         Regression, applies coefficients created using on historical forecasts
         and applies the coefficients to the current forecast.
+
+        Args:
+            predictor_of_mean_flag (str):
+                String to specify the input to calculate the calibrated mean.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
+        """
+        check_predictor_of_mean_flag(predictor_of_mean_flag)
+        self.predictor_of_mean_flag = predictor_of_mean_flag
+
+    def __repr__(self):
+        """Represent the configured plugin instance as a string."""
+        result = ('<ApplyCoefficientsFromEnsembleCalibration: '
+                  'predictor_of_mean_flag: {}>')
+        return result.format(self.predictor_of_mean_flag)
+
+    def _spatial_domain_match(self):
+        """
+        Check that the domain of the current forecast and coefficients cube
+        match.
+
+        Raises:
+            ValueError: If the domain information of the current_forecast and
+                coefficients_cube do not match.
+        """
+        msg = ("The domain along the {} axis given by the current forecast {} "
+               "does not match the domain given by the coefficients cube {}.")
+
+        for axis in ["x", "y"]:
+            current_forecast_points = [
+                self.current_forecast.coord(axis=axis).points[0],
+                self.current_forecast.coord(axis=axis).points[-1]]
+            if not np.allclose(current_forecast_points,
+                               self.coefficients_cube.coord(axis=axis).bounds):
+                raise ValueError(
+                    msg.format(axis, current_forecast_points,
+                               self.coefficients_cube.coord(axis=axis).bounds))
+
+    def _get_calibrated_forecast_predictors_mean(self, optimised_coeffs):
+        """
+        Function to get appropriately formated forecast_predictors when the
+        predictor of mean used is the ensemble mean.
+
+        Args:
+            optimised_coeffs (dict):
+                A dictionary containing the calibration coefficient names as
+                keys with their corresponding values.
+
+        Returns:
+            (tuple) : tuple containing:
+                **predicted_mean** (numpy.ndarray):
+                    Calibrated mean value.
+                **forecast_predictors** (iris.cube.Cube):
+                    The forecast predictors, mean values taken by collapsing
+                    the realization coordinate.
+        """
+        forecast_predictors = self.current_forecast.collapsed(
+            "realization", iris.analysis.MEAN)
+
+        # Calculate predicted mean = a + b*X, where X is the
+        # raw ensemble mean. In this case, b = beta.
+        a_and_b = [optimised_coeffs["alpha"], optimised_coeffs["beta"]]
+        forecast_predictor_flat = forecast_predictors.data.flatten()
+        col_of_ones = (
+            np.ones(forecast_predictor_flat.shape, dtype=np.float32))
+        ones_and_mean = (
+            np.column_stack((col_of_ones, forecast_predictor_flat)))
+        predicted_mean = np.dot(ones_and_mean, a_and_b)
+
+        return predicted_mean, forecast_predictors
+
+    def _get_calibrated_forecast_predictors_realizations(
+            self, optimised_coeffs, forecast_vars):
+        """
+        Function to get appropriately formated forecast_predictors when the
+        predictor of mean used each realization separately.
+
+        Args:
+            optimised_coeffs (dict):
+                A dictionary containing the calibration coefficient names as
+                keys with their corresponding values.
+            forecast_vars (iris.cube.Cube):
+                A cube of forecast predictor variance calculated across
+                realizations.
+
+        Returns:
+            (tuple) : tuple containing:
+                **predicted_mean** (numpy.ndarray):
+                    Calibrated mean value.
+                **calibrated_forecast_predictor** (iris.cube.Cube):
+                    The forecast predictors, mean values taken by collapsing
+                    the realization coordinate.
+        """
+        forecast_predictors = self.current_forecast
+
+        # Calculate predicted mean = a + b*X, where X is the
+        # raw ensemble mean. In this case, b = beta^2.
+        beta_values = np.array([], dtype=np.float32)
+        for key in optimised_coeffs.keys():
+            if key.startswith("beta"):
+                beta_values = np.append(beta_values, optimised_coeffs[key])
+        a_and_b = np.append(optimised_coeffs["alpha"], beta_values**2)
+        forecast_predictor_flat = (
+            convert_cube_data_to_2d(forecast_predictors))
+        forecast_var_flat = forecast_vars.data.flatten()
+        col_of_ones = np.ones(forecast_var_flat.shape, dtype=np.float32)
+        ones_and_predictor = (
+            np.column_stack((col_of_ones, forecast_predictor_flat)))
+        predicted_mean = np.dot(ones_and_predictor, a_and_b)
+        # Calculate mean of ensemble realizations, as only the
+        # calibrated ensemble mean will be returned.
+        calibrated_forecast_predictor = (
+            forecast_predictors.collapsed(
+                "realization", iris.analysis.MEAN))
+
+        return predicted_mean, calibrated_forecast_predictor
+
+    def calibrate_forecast_data(self, optimised_coeffs, predicted_mean,
+                                calibrated_forecast_predictor,
+                                calibrated_forecast_var):
+        """
+        Apply the calibration coefficients to the forecast data.
+
+        Args:
+            optimised_coeffs (dict):
+                A dictionary containing the calibration coefficient names as
+                keys with their corresponding values.
+            predicted_mean (numpy.ndarray):
+                Calibrated mean value.
+            calibrated_forecast_predictor (iris.cube.Cube):
+                The forecast predictors, mean values taken by collapsing
+                the realization coordinate.
+            forecast_vars (iris.cube.Cube):
+                A cube of forecast predictor variance calculated across
+                realizations.
+
+        Returns:
+            (tuple) : tuple containing:
+                **calibrated_forecast_predictor** (iris.cube.Cube):
+                    Cube containing the calibrated version of the
+                    ensemble predictor, either the ensemble mean or
+                    the ensemble realizations.
+                **calibrated_forecast_var** (iris.cube.Cube):
+                    Cube containing the calibrated version of the
+                    ensemble variance, either the ensemble mean or
+                    the ensemble realizations.
+        """
+        xlen = len(calibrated_forecast_predictor.coord(axis="x").points)
+        ylen = len(calibrated_forecast_predictor.coord(axis="y").points)
+
+        calibrated_forecast_predictor.data = (
+            np.reshape(predicted_mean, (ylen, xlen)))
+
+        # Calculating the predicted variance, based on the
+        # raw variance S^2, where predicted variance = c + dS^2,
+        # where c = (gamma)^2 and d = (delta)^2
+        calibrated_forecast_var.data = (
+            optimised_coeffs["gamma"]**2 +
+            optimised_coeffs["delta"]**2 * calibrated_forecast_var.data)
+
+        return calibrated_forecast_predictor, calibrated_forecast_var
+
+    def process(self, current_forecast, coefficients_cube):
+        """
+        Wrapping function to calculate the forecast predictor and forecast
+        variance prior to applying coefficients to the current forecast.
 
         Args:
             current_forecast (iris.cube.Cube):
@@ -890,167 +1054,42 @@ class ApplyCoefficientsFromEnsembleCalibration():
                 where the points of the coordinate are integer values and a
                 coefficient_name auxiliary coordinate where the points of
                 the coordinate are e.g. gamma, delta, alpha, beta.
-            predictor_of_mean_flag (str):
-                String to specify the input to calculate the calibrated mean.
-                Currently the ensemble mean ("mean") and the ensemble
-                realizations ("realizations") are supported as the predictors.
 
-        Raises:
-            ValueError: If the names of the current_forecast and
-                coefficients_cube do not match.
-            ValueError: If the domain information of the current_forecast and
-                coefficients_cube do not match.
+        Returns:
+            (tuple) : tuple containing:
+                **calibrated_forecast_predictor** (iris.cube.Cube):
+                    Cube containing the calibrated version of the
+                    ensemble predictor, either the ensemble mean or
+                    the ensemble realizations.
+                **calibrated_forecast_variance** (iris.cube.Cube):
+                    Cube containing the calibrated version of the
+                    ensemble variance, either the ensemble mean or
+                    the ensemble realizations.
         """
         self.current_forecast = current_forecast
         self.coefficients_cube = coefficients_cube
-        for coord_name in ["forecast_period", "time",
-                           "forecast_reference_time"]:
-            try:
-                if (self.current_forecast.coord(coord_name) !=
-                        self.coefficients_cube.coord(coord_name)):
-                    msg = ("The {} coordinate of the current forecast cube "
-                           "and coefficients cube differs. "
-                           "current forecast: {}, "
-                           "coefficients cube: {}").format(
-                               coord_name,
-                               self.current_forecast.coord(coord_name),
-                               self.coefficients_cube.coord(coord_name))
-                    raise ValueError(msg)
-            except CoordinateNotFoundError:
-                pass
 
-        # Check that the domain of the current forecast and coefficients cube
-        # matches.
-        for axis in ["x", "y"]:
-            current_forecast_points = [
-                current_forecast.coord(axis=axis).points[0],
-                current_forecast.coord(axis=axis).points[-1]]
-            if not np.allclose(current_forecast_points,
-                               coefficients_cube.coord(axis=axis).bounds):
-                msg = ("The domain along the {} axis given by the "
-                       "current forecast {} does not match the domain given "
-                       "by the coefficients cube {}.".format(
-                           axis, current_forecast_points,
-                           coefficients_cube.coord(axis=axis).bounds))
-                raise ValueError(msg)
+        # Check coefficients_cube and forecast cube are compatible.
+        time_coords_match(self.current_forecast, self.coefficients_cube)
+        self._spatial_domain_match()
 
-        # Ensure predictor_of_mean_flag is valid.
-        check_predictor_of_mean_flag(predictor_of_mean_flag)
-        self.predictor_of_mean_flag = predictor_of_mean_flag
-
-    def __repr__(self):
-        """Represent the configured plugin instance as a string."""
-        result = ('<ApplyCoefficientsFromEnsembleCalibration: '
-                  'current_forecast: {}; '
-                  'coefficients_cube: {}; '
-                  'predictor_of_mean_flag: {}>')
-        return result.format(
-            self.current_forecast.name(), self.coefficients_cube.name(),
-            self.predictor_of_mean_flag)
-
-    def process(self):
-        """
-        Wrapping function to calculate the forecast predictor and forecast
-        variance prior to applying coefficients to the current forecast.
-
-        Returns:
-            (tuple) : tuple containing:
-                **calibrated_forecast_predictor** (iris.cube.Cube):
-                    Cube containing the calibrated version of the
-                    ensemble predictor, either the ensemble mean or
-                    the ensemble realizations.
-                **calibrated_forecast_variance** (iris.cube.Cube):
-                    Cube containing the calibrated version of the
-                    ensemble variance, either the ensemble mean or
-                    the ensemble realizations.
-
-        """
-        if self.predictor_of_mean_flag.lower() == "mean":
-            forecast_predictors = self.current_forecast.collapsed(
-                "realization", iris.analysis.MEAN)
-        elif self.predictor_of_mean_flag.lower() == "realizations":
-            forecast_predictors = self.current_forecast
-
-        forecast_vars = self.current_forecast.collapsed(
-            "realization", iris.analysis.VARIANCE)
-
-        calibrated_forecast_predictor, calibrated_forecast_var = (
-            self._apply_params(forecast_predictors, forecast_vars))
-        return calibrated_forecast_predictor, calibrated_forecast_var
-
-    def _apply_params(self, forecast_predictors, forecast_vars):
-        """
-        Function to apply EMOS coefficients to all required dates.
-
-        Args:
-            forecast_predictors (iris.cube.Cube):
-                Cube containing the forecast predictor e.g. ensemble mean
-                or ensemble realizations.
-            forecast_vars (iris.cube.Cube):
-                Cube containing the forecast variance e.g. ensemble variance.
-
-        Returns:
-            (tuple) : tuple containing:
-                **calibrated_forecast_predictor** (iris.cube.Cube):
-                    Cube containing the calibrated version of the
-                    ensemble predictor, either the ensemble mean or
-                    the ensemble realizations.
-                **calibrated_forecast_variance** (iris.cube.Cube):
-                    Cube containing the calibrated version of the
-                    ensemble variance, either the ensemble mean or
-                    the ensemble realizations.
-        """
         optimised_coeffs = (
             dict(zip(self.coefficients_cube.coord("coefficient_name").points,
                      self.coefficients_cube.data)))
+        forecast_vars = self.current_forecast.collapsed(
+            "realization", iris.analysis.VARIANCE)
 
-        # Calculate the predicted mean based on whether the coefficients
-        # were estimated using the mean as the predictor or using the
-        # ensemble realizations as the predictor.
         if self.predictor_of_mean_flag.lower() == "mean":
-            # Calculate predicted mean = a + b*X, where X is the
-            # raw ensemble mean. In this case, b = beta.
-            a_and_b = [optimised_coeffs["alpha"], optimised_coeffs["beta"]]
-            forecast_predictor_flat = forecast_predictors.data.flatten()
-            col_of_ones = (
-                np.ones(forecast_predictor_flat.shape, dtype=np.float32))
-            ones_and_mean = (
-                np.column_stack((col_of_ones, forecast_predictor_flat)))
-            predicted_mean = np.dot(ones_and_mean, a_and_b)
-            calibrated_forecast_predictor = forecast_predictors
+            predicted_mean, forecast_predictor = (
+                self._get_calibrated_forecast_predictors_mean(
+                    optimised_coeffs))
         elif self.predictor_of_mean_flag.lower() == "realizations":
-            # Calculate predicted mean = a + b*X, where X is the
-            # raw ensemble mean. In this case, b = beta^2.
-            beta_values = np.array([], dtype=np.float32)
-            for key in optimised_coeffs.keys():
-                if key.startswith("beta"):
-                    beta_values = np.append(beta_values, optimised_coeffs[key])
-            a_and_b = np.append(optimised_coeffs["alpha"], beta_values**2)
-            forecast_predictor_flat = (
-                convert_cube_data_to_2d(forecast_predictors))
-            forecast_var_flat = forecast_vars.data.flatten()
-            col_of_ones = np.ones(forecast_var_flat.shape, dtype=np.float32)
-            ones_and_predictor = (
-                np.column_stack((col_of_ones, forecast_predictor_flat)))
-            predicted_mean = np.dot(ones_and_predictor, a_and_b)
-            # Calculate mean of ensemble realizations, as only the
-            # calibrated ensemble mean will be returned.
-            calibrated_forecast_predictor = (
-                forecast_predictors.collapsed(
-                    "realization", iris.analysis.MEAN))
+            predicted_mean, forecast_predictor = (
+                self._get_calibrated_forecast_predictors_realizations(
+                    optimised_coeffs, forecast_vars))
 
-        xlen = len(forecast_predictors.coord(axis="x").points)
-        ylen = len(forecast_predictors.coord(axis="y").points)
-
-        calibrated_forecast_predictor.data = (
-            np.reshape(predicted_mean, (ylen, xlen)))
-
-        calibrated_forecast_var = forecast_vars
-        # Calculating the predicted variance, based on the
-        # raw variance S^2, where predicted variance = c + dS^2,
-        # where c = (gamma)^2 and d = (delta)^2
-        calibrated_forecast_var.data = (
-            optimised_coeffs["gamma"]**2 +
-            optimised_coeffs["delta"]**2 * forecast_vars.data)
+        calibrated_forecast_predictor, calibrated_forecast_var = (
+            self.calibrate_forecast_data(optimised_coeffs, predicted_mean,
+                                         forecast_predictor, forecast_vars))
 
         return calibrated_forecast_predictor, calibrated_forecast_var

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -918,7 +918,7 @@ class ApplyCoefficientsFromEnsembleCalibration():
 
     def _get_calibrated_forecast_predictors_mean(self, optimised_coeffs):
         """
-        Function to get appropriately formated forecast_predictors when the
+        Function to get appropriately formatted forecast_predictors when the
         predictor of mean used is the ensemble mean.
 
         Args:
@@ -952,7 +952,7 @@ class ApplyCoefficientsFromEnsembleCalibration():
     def _get_calibrated_forecast_predictors_realizations(
             self, optimised_coeffs, forecast_vars):
         """
-        Function to get appropriately formated forecast_predictors when the
+        Function to get appropriately formatted forecast_predictors when the
         predictor of mean used each realization separately.
 
         Args:
@@ -995,7 +995,8 @@ class ApplyCoefficientsFromEnsembleCalibration():
 
         return predicted_mean, calibrated_forecast_predictor
 
-    def calibrate_forecast_data(self, optimised_coeffs, predicted_mean,
+    @staticmethod
+    def calibrate_forecast_data(optimised_coeffs, predicted_mean,
                                 calibrated_forecast_predictor,
                                 calibrated_forecast_var):
         """
@@ -1010,7 +1011,7 @@ class ApplyCoefficientsFromEnsembleCalibration():
             calibrated_forecast_predictor (iris.cube.Cube):
                 The forecast predictors, mean values taken by collapsing
                 the realization coordinate.
-            forecast_vars (iris.cube.Cube):
+            calibrated_forecast_var (iris.cube.Cube):
                 A cube of forecast predictor variance calculated across
                 realizations.
 

--- a/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
@@ -140,7 +140,7 @@ def check_predictor_of_mean_flag(predictor_of_mean_flag):
         ValueError: If the predictor_of_mean_flag is not valid.
     """
     if predictor_of_mean_flag.lower() not in ["mean", "realizations"]:
-        msg = ("The requested value for the predictor_of_mean_flag {}"
+        msg = ("The requested value for the predictor_of_mean_flag {} "
                "is not an accepted value."
                "Accepted values are 'mean' or 'realizations'").format(
                    predictor_of_mean_flag.lower())

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -38,6 +38,7 @@ import unittest
 
 import iris
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 from iris.tests import IrisTest
 
 from improver.ensemble_calibration.ensemble_calibration import (
@@ -48,8 +49,7 @@ from improver.tests.ensemble_calibration.ensemble_calibration. \
     helper_functions import SetupCubes, EnsembleCalibrationAssertions
 from improver.tests.ensemble_calibration.ensemble_calibration.\
     test_EstimateCoefficientsForEnsembleCalibration import (
-        create_coefficients_cube, SetupExpectedCoefficients)
-from improver.tests.set_up_test_cubes import set_up_variable_cube
+        SetupExpectedCoefficients)
 from improver.utilities.warnings_handler import ManageWarnings
 
 
@@ -113,150 +113,211 @@ class Test__init__(IrisTest):
 
     """Test the __init__ method."""
 
-    def setUp(self):
-        """Set up test cubes."""
-        data = np.ones([2, 2], dtype=np.float32)
-        self.current_forecast = set_up_variable_cube(data)
-        coeff_names = ["gamma", "delta", "alpha", "beta"]
-        coeff_values = np.array([0, 1, 2, 3], np.int32)
-        self.coefficients_cube, _, _ = create_coefficients_cube(
-            self.current_forecast, coeff_names, coeff_values)
-
     def test_basic(self):
-        """Test without specifying any keyword arguments."""
-        plugin = Plugin(self.current_forecast, self.coefficients_cube)
-        self.assertEqual(plugin.current_forecast, self.current_forecast)
-        self.assertEqual(plugin.coefficients_cube, self.coefficients_cube)
+        """Test without specifying a predictor_of_mean_flag."""
+        plugin = Plugin()
+        self.assertEqual(plugin.predictor_of_mean_flag, "mean")
 
-    def test_with_kwargs(self):
-        """Test without specifying any keyword arguments."""
-        plugin = Plugin(self.current_forecast, self.coefficients_cube,
-                        predictor_of_mean_flag="realizations")
-        self.assertEqual(plugin.current_forecast, self.current_forecast)
-        self.assertEqual(plugin.coefficients_cube, self.coefficients_cube)
+    def test_with_predictor_of_mean_flag(self):
+        """Test specifying the predictor_of_mean_flag."""
+        plugin = Plugin(predictor_of_mean_flag="realizations")
+        self.assertEqual(plugin.predictor_of_mean_flag, "realizations")
 
-    def test_mismatching_coordinates(self):
-        """Test if there is a mismatch in the forecast_period coordinate."""
-        self.current_forecast.coord("forecast_period").convert_units("hours")
-        msg = "The forecast_period coordinate of the current forecast cube"
+    def test_with_invalid_predictor_of_mean_flag(self):
+        """Test specifying the predictor_of_mean_flag as something invalid."""
+        msg = "The requested value for the predictor_of_mean_flag"
         with self.assertRaisesRegex(ValueError, msg):
-            Plugin(self.current_forecast, self.coefficients_cube)
-
-    def test_matching_domain(self):
-        """Test whether the domain of the forecast and the domain of the
-        coefficients cube matches."""
-        current_forecast = self.current_forecast[0, :]
-        msg = "The domain along the"
-        with self.assertRaisesRegex(ValueError, msg):
-            Plugin(current_forecast, self.coefficients_cube)
+            Plugin(predictor_of_mean_flag="kittens")
 
 
 class Test__repr__(IrisTest):
 
     """Test the __repr__ method."""
 
-    def setUp(self):
-        """Set up test cubes."""
-        data = np.ones([2, 2], dtype=np.float32)
-        self.current_forecast = set_up_variable_cube(data)
-        coeff_names = ["gamma", "delta", "alpha", "beta"]
-        coeff_values = np.array([0, 1, 2, 3], np.int32)
-        self.coefficients_cube, _, _ = create_coefficients_cube(
-            self.current_forecast, coeff_names, coeff_values)
-
     def test_basic(self):
-        """Test without specifying keyword arguments"""
-        result = str(Plugin(self.current_forecast, self.coefficients_cube))
+        """Test without the predictor_of_mean_flag."""
+        result = str(Plugin())
         msg = ("<ApplyCoefficientsFromEnsembleCalibration: "
-               "current_forecast: air_temperature; "
-               "coefficients_cube: emos_coefficients; "
                "predictor_of_mean_flag: mean>")
         self.assertEqual(result, msg)
 
-    def test_with_kwargs(self):
-        """Test when keyword arguments are specified."""
-        result = str(Plugin(
-            self.current_forecast, self.coefficients_cube,
-            predictor_of_mean_flag="realizations"))
+    def test_with_predictor_of_mean_flag(self):
+        """Test specifying the predictor_of_mean_flag."""
+        result = str(Plugin(predictor_of_mean_flag="realizations"))
         msg = ("<ApplyCoefficientsFromEnsembleCalibration: "
-               "current_forecast: air_temperature; "
-               "coefficients_cube: emos_coefficients; "
                "predictor_of_mean_flag: realizations>")
         self.assertEqual(result, msg)
 
 
-class Test_process(SetupCoefficientsCubes):
+class Test__spatial_domain_match(SetupCoefficientsCubes):
 
-    """Test the process plugin."""
+    """ Test the _spatial_domain_match method."""
+
+    def setUp(self):
+        super().setUp()
+        self.plugin = Plugin()
+
+    def test_matching(self):
+        """Test case in which spatial domains match."""
+        self.plugin.current_forecast = self.current_temperature_forecast_cube
+        self.plugin.coefficients_cube = self.coeffs_from_mean
+        self.plugin._spatial_domain_match()
+
+    def test_unmatching_x_axis(self):
+        """Test case in which spatial domains do not match."""
+        self.current_temperature_forecast_cube.coord(axis='x').points = (
+            self.current_temperature_forecast_cube.coord(axis='x').points * 2.)
+        self.plugin.current_forecast = self.current_temperature_forecast_cube
+        self.plugin.coefficients_cube = self.coeffs_from_mean
+        msg = "The domain along the x axis given by the current forecast"
+        with self.assertRaisesRegex(ValueError, msg):
+            self.plugin._spatial_domain_match()
+
+    def test_unmatching_y_axis(self):
+        """Test case in which spatial domains do not match."""
+        self.current_temperature_forecast_cube.coord(axis='y').points = (
+            self.current_temperature_forecast_cube.coord(axis='y').points * 2.)
+        self.plugin.current_forecast = self.current_temperature_forecast_cube
+        self.plugin.coefficients_cube = self.coeffs_from_mean
+        msg = "The domain along the y axis given by the current forecast"
+        with self.assertRaisesRegex(ValueError, msg):
+            self.plugin._spatial_domain_match()
+
+
+class Test__get_calibrated_forecast_predictors_mean(SetupCoefficientsCubes):
+
+    """Test the _get_calibrated_forecast_predictors_mean method."""
+
+    def setUp(self):
+        """Setup cubes and sundries for testing calibration of mean."""
+        super().setUp()
+        self.optimised_coeffs = (
+            dict(zip(self.coeffs_from_mean.coord("coefficient_name").points,
+                     self.coeffs_from_mean.data)))
+        self.plugin = Plugin()
+        self.plugin.current_forecast = self.current_temperature_forecast_cube
+
+        self.expected_calibrated_predictor_mean = (
+            np.array([273.7371, 274.6500, 275.4107,
+                      276.8409, 277.6321, 278.3928,
+                      279.4884, 280.1578, 280.9794]))
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_basic(self):
-        """Test that the plugin returns a tuple."""
-        cube = self.current_temperature_forecast_cube
-        plugin = Plugin(cube, self.coeffs_from_mean)
-        result = plugin.process()
-        self.assertIsInstance(result, tuple)
-        self.assertEqual(len(result), 2)
+        """
+        Test that the expected values are returned by this function.
+        """
+        expected_forecast_predictors = (
+            self.current_temperature_forecast_cube.collapsed(
+                "realization", iris.analysis.MEAN))
+        predicted_mean, forecast_predictors = (
+            self.plugin._get_calibrated_forecast_predictors_mean(
+                self.optimised_coeffs))
+        assert_array_almost_equal(
+            predicted_mean, self.expected_calibrated_predictor_mean, decimal=4)
+        assert_array_almost_equal(
+            forecast_predictors.data, expected_forecast_predictors.data)
+
+
+class Test__get_calibrated_forecast_predictors_realizations(
+        SetupCoefficientsCubes):
+
+    """Test the _get_calibrated_forecast_predictors_realizations method."""
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_basic_realizations(self):
-        """
-        Test that the plugin returns a tuple when using the ensemble
-        realizations as the predictor of the mean.
-        """
-        cube = self.current_temperature_forecast_cube
-        plugin = Plugin(cube, self.coeffs_from_statsmodels_realizations,
-                        predictor_of_mean_flag="realizations")
-        result = plugin.process()
-        self.assertIsInstance(result, tuple)
-        self.assertEqual(len(result), 2)
+    def setUp(self):
+        """Setup cubes and sundries for testing calibration of mean."""
+        super().setUp()
+
+        self.forecast_vars = self.current_temperature_forecast_cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+
+        self.plugin = Plugin()
+        self.plugin.current_forecast = self.current_temperature_forecast_cube
+
+        self.expected_calibrated_predictor_statsmodels_realizations = (
+            np.array([274.2120, 275.1703, 275.3308,
+                      277.0504, 277.4221, 278.3881,
+                      280.0826, 280.3248, 281.2376]))
+        self.expected_calibrated_predictor_no_statsmodels_realizations = (
+            np.array([274.1428, 275.0543, 275.2956,
+                      277.0344, 277.4110, 278.3598,
+                      280.0760, 280.3517, 281.2437]))
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_output_is_mean(self):
+    def test_with_statsmodels(self):
         """
-        Test that the plugin returns a tuple containing cubes with a
-        mean cell method.
+        Test that the expected values are returned by this function when using
+        statsmodel.
         """
-        cube = self.current_temperature_forecast_cube
-        plugin = Plugin(cube, self.coeffs_from_mean)
-        forecast_predictor, _ = plugin.process()
-        for cell_method in forecast_predictor[0].cell_methods:
-            self.assertEqual(cell_method.method, "mean")
+        optimised_coeffs = dict(
+            zip(self.coeffs_from_statsmodels_realizations.coord(
+                    "coefficient_name").points,
+                self.coeffs_from_statsmodels_realizations.data))
+        expected_forecast_predictors = (
+            self.current_temperature_forecast_cube.collapsed(
+                "realization", iris.analysis.MEAN))
+        predicted_mean, forecast_predictors = (
+            self.plugin._get_calibrated_forecast_predictors_realizations(
+                optimised_coeffs, self.forecast_vars))
+        assert_array_almost_equal(
+            predicted_mean,
+            self.expected_calibrated_predictor_statsmodels_realizations,
+            decimal=4)
+        assert_array_almost_equal(
+            forecast_predictors.data, expected_forecast_predictors.data)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
-    def test_output_is_variance(self):
+    def test_without_statsmodels(self):
         """
-        Test that the plugin returns a tuple containing cubes with a
-        variance cell method.
+        Test that the expected values are returned by this function when not
+        using statsmodel.
         """
-        cube = self.current_temperature_forecast_cube
-        plugin = Plugin(cube, self.coeffs_from_mean)
-        _, forecast_variance = plugin.process()
-        for cell_method in forecast_variance[0].cell_methods:
-            self.assertEqual(cell_method.method, "variance")
+        optimised_coeffs = dict(
+            zip(self.coeffs_from_no_statsmodels_realizations.coord(
+                    "coefficient_name").points,
+                self.coeffs_from_no_statsmodels_realizations.data))
+        expected_forecast_predictors = (
+            self.current_temperature_forecast_cube.collapsed(
+                "realization", iris.analysis.MEAN))
+        predicted_mean, forecast_predictors = (
+            self.plugin._get_calibrated_forecast_predictors_realizations(
+                optimised_coeffs, self.forecast_vars))
+        assert_array_almost_equal(
+            predicted_mean,
+            self.expected_calibrated_predictor_no_statsmodels_realizations,
+            decimal=4)
+        assert_array_almost_equal(
+            forecast_predictors.data, expected_forecast_predictors.data)
 
 
-class Test__apply_params(
+class Test_calibrate_forecast_data(
         SetupCoefficientsCubes, EnsembleCalibrationAssertions):
 
-    """Test the _apply_params plugin."""
+    """Test the calibrate_forecast_data method.
+
+    Note that there are several cross comparisons of results between the tests.
+    These overlap to ensure that if any one test is removed, the others still
+    check that the behaviour is as expected."""
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence",
-                          "can't resolve package from",
-                          "The statsmodels can not be imported"],
-        warning_types=[UserWarning, DeprecationWarning, ImportWarning,
-                       ImportWarning])
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
     def setUp(self):
-        """Set up expected arrays for the calibrated ensemble mean and variance
-        depending upon whether the ensemble mean or ensemble realizations have
-        been used."""
+        """Setup cubes and sundries for testing calibration."""
         super().setUp()
+
+        self.forecast_vars = self.current_temperature_forecast_cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        self.forecast_predictor = (
+            self.current_temperature_forecast_cube.collapsed(
+                "realization", iris.analysis.MEAN))
+
+        self.plugin = Plugin()
+
         self.expected_calibrated_predictor_mean = (
             np.array([[273.7371, 274.6500, 275.4107],
                       [276.8409, 277.6321, 278.3928],
@@ -282,194 +343,157 @@ class Test__apply_params(
                       [0.11588794, 0.10100815, 0.06006173],
                       [0.27221495, 0.01540077, 0.00423326]]))
 
-    @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_basic(self):
-        """Test that the plugin returns a tuple."""
-        cube = self.current_temperature_forecast_cube
+    def test_mean_as_predictor(self):
+        """Test that the calibrated forecast using ensemble mean as the
+        predictor returns the correct values. Check that the calibrated mean
+        is similar to when the ensemble realizations are used as the predictor
+        with and without statsmodel."""
 
-        predictor_cube = cube.collapsed("realization", iris.analysis.MEAN)
-        variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
+        optimised_coeffs = dict(
+            zip(self.coeffs_from_mean.coord("coefficient_name").points,
+                self.coeffs_from_mean.data))
+        predicted_mean = self.expected_calibrated_predictor_mean.flatten()
 
-        plugin = Plugin(cube, self.coeffs_from_mean)
-        result = plugin._apply_params(predictor_cube, variance_cube)
-        self.assertIsInstance(result, tuple)
-        self.assertEqual(len(result), 2)
+        calibrated_forecast_predictor, calibrated_forecast_var = (
+            self.plugin.calibrate_forecast_data(
+                optimised_coeffs, predicted_mean, self.forecast_predictor,
+                self.forecast_vars))
 
-    @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_predictor(self):
-        """
-        Test that the plugin returns the expected values for the calibrated
-        ensemble mean when the ensemble mean is used as the predictor. Check
-        that the calibrated mean is similar to when the ensemble realizations
-        are used as the predictor.
-        """
-        cube = self.current_temperature_forecast_cube
-        predictor_cube = cube.collapsed("realization", iris.analysis.MEAN)
-        variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
-
-        plugin = Plugin(cube, self.coeffs_from_mean)
-        forecast_predictor, _ = (
-            plugin._apply_params(predictor_cube, variance_cube))
         self.assertCalibratedVariablesAlmostEqual(
-            forecast_predictor.data, self.expected_calibrated_predictor_mean)
-        self.assertArrayAlmostEqual(
-            forecast_predictor.data,
+            calibrated_forecast_predictor.data,
+            self.expected_calibrated_predictor_mean)
+        self.assertCalibratedVariablesAlmostEqual(
+            calibrated_forecast_var.data,
+            self.expected_calibrated_variance_mean)
+        assert_array_almost_equal(
+            calibrated_forecast_predictor.data,
             self.expected_calibrated_predictor_statsmodels_realizations,
             decimal=0)
-        self.assertArrayAlmostEqual(
-            forecast_predictor.data,
+        assert_array_almost_equal(
+            calibrated_forecast_predictor.data,
             self.expected_calibrated_predictor_no_statsmodels_realizations,
             decimal=0)
+        self.assertIsInstance(calibrated_forecast_predictor, iris.cube.Cube)
+        self.assertIsInstance(calibrated_forecast_var, iris.cube.Cube)
 
-    @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_variance(self):
-        """
-        Test that the plugin returns the expected values for the calibrated
-        ensemble variance when the ensemble mean is used as the predictor.
-        Check that the calibrated variance is similar to when the ensemble
-        realizations are used as the predictor.
-        """
-        cube = self.current_temperature_forecast_cube
+    def test_realization_as_predictor_with_statsmodel(self):
+        """Test that the calibrated forecast using realization as the
+        predictor returns the correct values when using statsmodel. Check that
+        the calibrated mean is similar to when not using statsmodel and to when
+        the ensemble mean is used as the predictor."""
 
-        predictor_cube = cube.collapsed("realization", iris.analysis.MEAN)
-        variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
+        optimised_coeffs = dict(
+            zip(self.coeffs_from_statsmodels_realizations.coord(
+                    "coefficient_name").points,
+                self.coeffs_from_statsmodels_realizations.data))
+        predicted_mean = (
+            self.expected_calibrated_predictor_statsmodels_realizations.
+            flatten())
 
-        plugin = Plugin(cube, self.coeffs_from_mean)
-        _, forecast_variance = (
-            plugin._apply_params(predictor_cube, variance_cube))
+        calibrated_forecast_predictor, calibrated_forecast_var = (
+            self.plugin.calibrate_forecast_data(
+                optimised_coeffs, predicted_mean, self.forecast_predictor,
+                self.forecast_vars))
+
         self.assertCalibratedVariablesAlmostEqual(
-            forecast_variance.data, self.expected_calibrated_variance_mean)
-        self.assertArrayAlmostEqual(
-            forecast_variance.data,
-            self.expected_calibrated_variance_statsmodels_realizations,
-            decimal=0)
-        self.assertArrayAlmostEqual(
-            forecast_variance.data,
-            self.expected_calibrated_variance_no_statsmodels_realizations,
-            decimal=0)
-
-    @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_predictor_statsmodels_realizations(self):
-        """
-        Test that the plugin returns the expected values for the calibrated
-        ensemble mean when the ensemble realizations are used as the predictor.
-        The input coefficients have been generated using statsmodels. Check
-        that the calibrated mean is similar to when the ensemble mean is used
-        as the predictor.
-        """
-        cube = self.current_temperature_forecast_cube
-
-        predictor_cube = cube.copy()
-        variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
-
-        plugin = Plugin(cube, self.coeffs_from_statsmodels_realizations,
-                        predictor_of_mean_flag="realizations")
-        forecast_predictor, _ = plugin._apply_params(
-            predictor_cube, variance_cube)
-        self.assertCalibratedVariablesAlmostEqual(
-            forecast_predictor.data,
+            calibrated_forecast_predictor.data,
             self.expected_calibrated_predictor_statsmodels_realizations)
-        self.assertArrayAlmostEqual(
-            forecast_predictor.data,
-            self.expected_calibrated_predictor_mean, decimal=0)
-
-    @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_variance_statsmodels_realizations(self):
-        """
-        Test that the plugin returns the expected values for the calibrated
-        ensemble variance when the ensemble realizations are used as the
-        predictor. The input coefficients have been generated using
-        statsmodels. Check that the calibrated variance is similar to when the
-        ensemble mean is used as the predictor.
-        """
-        cube = self.current_temperature_forecast_cube
-
-        predictor_cube = cube.copy()
-        variance_cube = cube.collapsed("realization", iris.analysis.VARIANCE)
-
-        plugin = Plugin(cube, self.coeffs_from_statsmodels_realizations,
-                        predictor_of_mean_flag="realizations")
-        _, forecast_variance = plugin._apply_params(
-            predictor_cube, variance_cube)
         self.assertCalibratedVariablesAlmostEqual(
-            forecast_variance.data,
+            calibrated_forecast_var.data,
             self.expected_calibrated_variance_statsmodels_realizations)
-        self.assertArrayAlmostEqual(
-            forecast_variance.data,
-            self.expected_calibrated_variance_mean, decimal=0)
+        assert_array_almost_equal(
+            calibrated_forecast_predictor.data,
+            self.expected_calibrated_predictor_mean,
+            decimal=0)
+        assert_array_almost_equal(
+            calibrated_forecast_predictor.data,
+            self.expected_calibrated_predictor_no_statsmodels_realizations,
+            decimal=0)
+        self.assertIsInstance(calibrated_forecast_predictor, iris.cube.Cube)
+        self.assertIsInstance(calibrated_forecast_var, iris.cube.Cube)
 
-    @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_predictor_no_statsmodels_realizations(self):
-        """
-        Test that the plugin returns the expected values for the calibrated
-        ensemble mean when the ensemble realizations are used as the predictor.
-        The input coefficients have been generated without statsmodels. Check
-        that the calibrated mean is similar to when the ensemble mean is used
-        as the predictor.
-        """
-        cube = self.current_temperature_forecast_cube
+    def test_realization_as_predictor_without_statsmodel(self):
+        """Test that the calibrated forecast using realization as the
+        predictor returns the correct values when not using statsmodel. Check
+        that the calibrated mean is similar to when using statsmodel and to
+        when the ensemble mean is used as the predictor."""
 
-        predictor_cube = cube.copy()
-        variance_cube = cube.collapsed("realization",
-                                       iris.analysis.VARIANCE)
+        optimised_coeffs = dict(
+            zip(self.coeffs_from_no_statsmodels_realizations.coord(
+                    "coefficient_name").points,
+                self.coeffs_from_no_statsmodels_realizations.data))
+        predicted_mean = (
+            self.expected_calibrated_predictor_no_statsmodels_realizations.
+            flatten())
 
-        plugin = Plugin(cube, self.coeffs_from_no_statsmodels_realizations,
-                        predictor_of_mean_flag="realizations")
-        forecast_predictor, _ = plugin._apply_params(
-            predictor_cube, variance_cube)
+        calibrated_forecast_predictor, calibrated_forecast_var = (
+            self.plugin.calibrate_forecast_data(
+                optimised_coeffs, predicted_mean, self.forecast_predictor,
+                self.forecast_vars))
         self.assertCalibratedVariablesAlmostEqual(
-            forecast_predictor.data,
+            calibrated_forecast_predictor.data,
             self.expected_calibrated_predictor_no_statsmodels_realizations)
-        self.assertArrayAlmostEqual(
-            forecast_predictor.data,
-            self.expected_calibrated_predictor_mean, decimal=0)
+        self.assertCalibratedVariablesAlmostEqual(
+            calibrated_forecast_var.data,
+            self.expected_calibrated_variance_no_statsmodels_realizations)
+        assert_array_almost_equal(
+            calibrated_forecast_predictor.data,
+            self.expected_calibrated_predictor_mean,
+            decimal=0)
+        assert_array_almost_equal(
+            calibrated_forecast_predictor.data,
+            self.expected_calibrated_predictor_statsmodels_realizations,
+            decimal=0)
+        self.assertIsInstance(calibrated_forecast_predictor, iris.cube.Cube)
+        self.assertIsInstance(calibrated_forecast_var, iris.cube.Cube)
+
+
+class Test_process(SetupCoefficientsCubes, EnsembleCalibrationAssertions):
+
+    """Test the process plugin."""
+
+    def setUp(self):
+        """Setup cubes and sundries for testing calibration."""
+        super().setUp()
+        self.plugin = Plugin()
+
+        self.expected_calibrated_predictor_mean = (
+            np.array([[273.7371, 274.6500, 275.4107],
+                      [276.8409, 277.6321, 278.3928],
+                      [279.4884, 280.1578, 280.9794]]))
+        self.expected_calibrated_variance_mean = (
+            np.array([[0.2134, 0.2158, 0.0127],
+                      [0.0247, 0.0215, 0.0127],
+                      [0.0581, 0.0032, 0.0008]]))
 
     @ManageWarnings(
-        ignored_messages=["Collapsing a non-contiguous coordinate.",
-                          "invalid escape sequence"],
-        warning_types=[UserWarning, DeprecationWarning])
-    def test_calibrated_variance_no_statsmodels_realizations(self):
-        """
-        Test that the plugin returns the expected values for the calibrated
-        ensemble variance when the ensemble realizations are used as the
-        predictor. The input coefficients have been generated without
-        statsmodels. Check that the calibrated variance is similar to when the
-        ensemble mean is used as the predictor.
-        """
-        cube = self.current_temperature_forecast_cube
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_variable_setting(self):
+        """Test that the cubes passed into the plugin are allocated to
+        plugin variables appropriately."""
 
-        predictor_cube = cube.copy()
-        variance_cube = cube.collapsed("realization",
-                                       iris.analysis.VARIANCE)
+        _, _ = self.plugin.process(self.current_temperature_forecast_cube,
+                                   self.coeffs_from_mean)
+        self.assertEqual(self.current_temperature_forecast_cube,
+                         self.plugin.current_forecast)
+        self.assertEqual(self.coeffs_from_mean,
+                         self.plugin.coefficients_cube)
 
-        plugin = Plugin(cube, self.coeffs_from_no_statsmodels_realizations,
-                        predictor_of_mean_flag="realizations")
-        _, forecast_variance = plugin._apply_params(
-            predictor_cube, variance_cube)
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_end_to_end(self):
+        """An example end-to-end calculation. This repeats the test elements
+        above but all grouped together."""
+        calibrated_forecast_predictor, calibrated_forecast_var = (
+            self.plugin.process(self.current_temperature_forecast_cube,
+                                self.coeffs_from_mean))
+
         self.assertCalibratedVariablesAlmostEqual(
-            forecast_variance.data,
-            self.expected_calibrated_variance_no_statsmodels_realizations)
-        self.assertArrayAlmostEqual(
-            forecast_variance.data,
-            self.expected_calibrated_variance_mean, decimal=0)
+            calibrated_forecast_predictor.data,
+            self.expected_calibrated_predictor_mean)
+        self.assertCalibratedVariablesAlmostEqual(
+            calibrated_forecast_var.data,
+            self.expected_calibrated_variance_mean)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -123,12 +123,6 @@ class Test__init__(IrisTest):
         plugin = Plugin(predictor_of_mean_flag="realizations")
         self.assertEqual(plugin.predictor_of_mean_flag, "realizations")
 
-    def test_with_invalid_predictor_of_mean_flag(self):
-        """Test specifying the predictor_of_mean_flag as something invalid."""
-        msg = "The requested value for the predictor_of_mean_flag"
-        with self.assertRaisesRegex(ValueError, msg):
-            Plugin(predictor_of_mean_flag="kittens")
-
 
 class Test__repr__(IrisTest):
 
@@ -164,7 +158,7 @@ class Test__spatial_domain_match(SetupCoefficientsCubes):
         self.plugin._spatial_domain_match()
 
     def test_unmatching_x_axis(self):
-        """Test case in which spatial domains do not match."""
+        """Test case in which the x-dimensions of the domains do not match."""
         self.current_temperature_forecast_cube.coord(axis='x').points = (
             self.current_temperature_forecast_cube.coord(axis='x').points * 2.)
         self.plugin.current_forecast = self.current_temperature_forecast_cube
@@ -174,7 +168,7 @@ class Test__spatial_domain_match(SetupCoefficientsCubes):
             self.plugin._spatial_domain_match()
 
     def test_unmatching_y_axis(self):
-        """Test case in which spatial domains do not match."""
+        """Test case in which the y-dimensions of the domains do not match."""
         self.current_temperature_forecast_cube.coord(axis='y').points = (
             self.current_temperature_forecast_cube.coord(axis='y').points * 2.)
         self.plugin.current_forecast = self.current_temperature_forecast_cube
@@ -184,7 +178,8 @@ class Test__spatial_domain_match(SetupCoefficientsCubes):
             self.plugin._spatial_domain_match()
 
 
-class Test__get_calibrated_forecast_predictors_mean(SetupCoefficientsCubes):
+class Test__get_calibrated_forecast_predictors_mean(
+        SetupCoefficientsCubes, EnsembleCalibrationAssertions):
 
     """Test the _get_calibrated_forecast_predictors_mean method."""
 
@@ -214,14 +209,14 @@ class Test__get_calibrated_forecast_predictors_mean(SetupCoefficientsCubes):
         predicted_mean, forecast_predictors = (
             self.plugin._get_calibrated_forecast_predictors_mean(
                 self.optimised_coeffs))
-        assert_array_almost_equal(
-            predicted_mean, self.expected_calibrated_predictor_mean, decimal=4)
-        assert_array_almost_equal(
+        self.assertCalibratedVariablesAlmostEqual(
+            predicted_mean, self.expected_calibrated_predictor_mean)
+        self.assertCalibratedVariablesAlmostEqual(
             forecast_predictors.data, expected_forecast_predictors.data)
 
 
 class Test__get_calibrated_forecast_predictors_realizations(
-        SetupCoefficientsCubes):
+        SetupCoefficientsCubes, EnsembleCalibrationAssertions):
 
     """Test the _get_calibrated_forecast_predictors_realizations method."""
 
@@ -263,11 +258,10 @@ class Test__get_calibrated_forecast_predictors_realizations(
         predicted_mean, forecast_predictors = (
             self.plugin._get_calibrated_forecast_predictors_realizations(
                 optimised_coeffs, self.forecast_vars))
-        assert_array_almost_equal(
+        self.assertCalibratedVariablesAlmostEqual(
             predicted_mean,
-            self.expected_calibrated_predictor_statsmodels_realizations,
-            decimal=4)
-        assert_array_almost_equal(
+            self.expected_calibrated_predictor_statsmodels_realizations)
+        self.assertCalibratedVariablesAlmostEqual(
             forecast_predictors.data, expected_forecast_predictors.data)
 
     @ManageWarnings(
@@ -287,11 +281,10 @@ class Test__get_calibrated_forecast_predictors_realizations(
         predicted_mean, forecast_predictors = (
             self.plugin._get_calibrated_forecast_predictors_realizations(
                 optimised_coeffs, self.forecast_vars))
-        assert_array_almost_equal(
+        self.assertCalibratedVariablesAlmostEqual(
             predicted_mean,
-            self.expected_calibrated_predictor_no_statsmodels_realizations,
-            decimal=4)
-        assert_array_almost_equal(
+            self.expected_calibrated_predictor_no_statsmodels_realizations)
+        self.assertCalibratedVariablesAlmostEqual(
             forecast_predictors.data, expected_forecast_predictors.data)
 
 
@@ -379,8 +372,8 @@ class Test_calibrate_forecast_data(
     def test_realization_as_predictor_with_statsmodel(self):
         """Test that the calibrated forecast using realization as the
         predictor returns the correct values when using statsmodel. Check that
-        the calibrated mean is similar to when not using statsmodel and to when
-        the ensemble mean is used as the predictor."""
+        the calibrated mean is similar to when not using statsmodels and to
+        when the ensemble mean is used as the predictor."""
 
         optimised_coeffs = dict(
             zip(self.coeffs_from_statsmodels_realizations.coord(
@@ -415,7 +408,7 @@ class Test_calibrate_forecast_data(
     def test_realization_as_predictor_without_statsmodel(self):
         """Test that the calibrated forecast using realization as the
         predictor returns the correct values when not using statsmodel. Check
-        that the calibrated mean is similar to when using statsmodel and to
+        that the calibrated mean is similar to when using statsmodels and to
         when the ensemble mean is used as the predictor."""
 
         optimised_coeffs = dict(

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -246,7 +246,7 @@ class Test__get_calibrated_forecast_predictors_realizations(
     def test_with_statsmodels(self):
         """
         Test that the expected values are returned by this function when using
-        statsmodel.
+        statsmodels.
         """
         optimised_coeffs = dict(
             zip(self.coeffs_from_statsmodels_realizations.coord(
@@ -269,7 +269,7 @@ class Test__get_calibrated_forecast_predictors_realizations(
     def test_without_statsmodels(self):
         """
         Test that the expected values are returned by this function when not
-        using statsmodel.
+        using statsmodels.
         """
         optimised_coeffs = dict(
             zip(self.coeffs_from_no_statsmodels_realizations.coord(
@@ -340,7 +340,7 @@ class Test_calibrate_forecast_data(
         """Test that the calibrated forecast using ensemble mean as the
         predictor returns the correct values. Check that the calibrated mean
         is similar to when the ensemble realizations are used as the predictor
-        with and without statsmodel."""
+        with and without statsmodels."""
 
         optimised_coeffs = dict(
             zip(self.coeffs_from_mean.coord("coefficient_name").points,
@@ -369,9 +369,9 @@ class Test_calibrate_forecast_data(
         self.assertIsInstance(calibrated_forecast_predictor, iris.cube.Cube)
         self.assertIsInstance(calibrated_forecast_var, iris.cube.Cube)
 
-    def test_realization_as_predictor_with_statsmodel(self):
+    def test_realization_as_predictor_with_statsmodels(self):
         """Test that the calibrated forecast using realization as the
-        predictor returns the correct values when using statsmodel. Check that
+        predictor returns the correct values when using statsmodels. Check that
         the calibrated mean is similar to when not using statsmodels and to
         when the ensemble mean is used as the predictor."""
 
@@ -405,9 +405,9 @@ class Test_calibrate_forecast_data(
         self.assertIsInstance(calibrated_forecast_predictor, iris.cube.Cube)
         self.assertIsInstance(calibrated_forecast_var, iris.cube.Cube)
 
-    def test_realization_as_predictor_without_statsmodel(self):
+    def test_realization_as_predictor_without_statsmodels(self):
         """Test that the calibrated forecast using realization as the
-        predictor returns the correct values when not using statsmodel. Check
+        predictor returns the correct values when not using statsmodels. Check
         that the calibrated mean is similar to when using statsmodels and to
         when the ensemble mean is used as the predictor."""
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ApplyCoefficientsForEnsembleCalibration.py
@@ -108,6 +108,32 @@ class SetupCoefficientsCubes(SetupCubes, SetupExpectedCoefficients):
                 self.expected_realizations_gaussian_no_statsmodels,
                 self.current_temperature_forecast_cube))
 
+        # Some expected data that are used in various tests.
+        self.expected_calibrated_predictor_mean = (
+            np.array([[273.7371, 274.6500, 275.4107],
+                      [276.8409, 277.6321, 278.3928],
+                      [279.4884, 280.1578, 280.9794]]))
+        self.expected_calibrated_variance_mean = (
+            np.array([[0.2134, 0.2158, 0.0127],
+                      [0.0247, 0.0215, 0.0127],
+                      [0.0581, 0.0032, 0.0008]]))
+        self.expected_calibrated_predictor_statsmodels_realizations = (
+            np.array([[274.2120, 275.1703, 275.3308],
+                      [277.0504, 277.4221, 278.3881],
+                      [280.0826, 280.3248, 281.2376]]))
+        self.expected_calibrated_variance_statsmodels_realizations = (
+            np.array([[0.8975, 0.9075, 0.0536],
+                      [0.1038, 0.0904, 0.0536],
+                      [0.2444, 0.0134, 0.0033]]))
+        self.expected_calibrated_predictor_no_statsmodels_realizations = (
+            np.array([[274.1428, 275.0543, 275.2956],
+                      [277.0344, 277.4110, 278.3598],
+                      [280.0760, 280.3517, 281.2437]]))
+        self.expected_calibrated_variance_no_statsmodels_realizations = (
+            np.array([[0.99803287, 1.0091798, 0.06006174],
+                      [0.11588794, 0.10100815, 0.06006173],
+                      [0.27221495, 0.01540077, 0.00423326]]))
+
 
 class Test__init__(IrisTest):
 
@@ -193,9 +219,7 @@ class Test__get_calibrated_forecast_predictors_mean(
         self.plugin.current_forecast = self.current_temperature_forecast_cube
 
         self.expected_calibrated_predictor_mean = (
-            np.array([273.7371, 274.6500, 275.4107,
-                      276.8409, 277.6321, 278.3928,
-                      279.4884, 280.1578, 280.9794]))
+            self.expected_calibrated_predictor_mean.flatten())
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -231,15 +255,12 @@ class Test__get_calibrated_forecast_predictors_realizations(
 
         self.plugin = Plugin()
         self.plugin.current_forecast = self.current_temperature_forecast_cube
-
         self.expected_calibrated_predictor_statsmodels_realizations = (
-            np.array([274.2120, 275.1703, 275.3308,
-                      277.0504, 277.4221, 278.3881,
-                      280.0826, 280.3248, 281.2376]))
+            self.expected_calibrated_predictor_statsmodels_realizations.
+            flatten())
         self.expected_calibrated_predictor_no_statsmodels_realizations = (
-            np.array([274.1428, 275.0543, 275.2956,
-                      277.0344, 277.4110, 278.3598,
-                      280.0760, 280.3517, 281.2437]))
+            self.expected_calibrated_predictor_no_statsmodels_realizations.
+            flatten())
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -310,31 +331,6 @@ class Test_calibrate_forecast_data(
                 "realization", iris.analysis.MEAN))
 
         self.plugin = Plugin()
-
-        self.expected_calibrated_predictor_mean = (
-            np.array([[273.7371, 274.6500, 275.4107],
-                      [276.8409, 277.6321, 278.3928],
-                      [279.4884, 280.1578, 280.9794]]))
-        self.expected_calibrated_variance_mean = (
-            np.array([[0.2134, 0.2158, 0.0127],
-                      [0.0247, 0.0215, 0.0127],
-                      [0.0581, 0.0032, 0.0008]]))
-        self.expected_calibrated_predictor_statsmodels_realizations = (
-            np.array([[274.2120, 275.1703, 275.3308],
-                      [277.0504, 277.4221, 278.3881],
-                      [280.0826, 280.3248, 281.2376]]))
-        self.expected_calibrated_variance_statsmodels_realizations = (
-            np.array([[0.8975, 0.9075, 0.0536],
-                      [0.1038, 0.0904, 0.0536],
-                      [0.2444, 0.0134, 0.0033]]))
-        self.expected_calibrated_predictor_no_statsmodels_realizations = (
-            np.array([[274.1428, 275.0543, 275.2956],
-                      [277.0344, 277.4110, 278.3598],
-                      [280.0760, 280.3517, 281.2437]]))
-        self.expected_calibrated_variance_no_statsmodels_realizations = (
-            np.array([[0.99803287, 1.0091798, 0.06006174],
-                      [0.11588794, 0.10100815, 0.06006173],
-                      [0.27221495, 0.01540077, 0.00423326]]))
 
     def test_mean_as_predictor(self):
         """Test that the calibrated forecast using ensemble mean as the
@@ -450,15 +446,6 @@ class Test_process(SetupCoefficientsCubes, EnsembleCalibrationAssertions):
         super().setUp()
         self.plugin = Plugin()
 
-        self.expected_calibrated_predictor_mean = (
-            np.array([[273.7371, 274.6500, 275.4107],
-                      [276.8409, 277.6321, 278.3928],
-                      [279.4884, 280.1578, 280.9794]]))
-        self.expected_calibrated_variance_mean = (
-            np.array([[0.2134, 0.2158, 0.0127],
-                      [0.0247, 0.0215, 0.0127],
-                      [0.0581, 0.0032, 0.0008]]))
-
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_variable_setting(self):
@@ -487,6 +474,7 @@ class Test_process(SetupCoefficientsCubes, EnsembleCalibrationAssertions):
         self.assertCalibratedVariablesAlmostEqual(
             calibrated_forecast_var.data,
             self.expected_calibrated_variance_mean)
+        self.assertEqual(calibrated_forecast_predictor.dtype, np.float32)
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -156,19 +156,23 @@ class SetupExpectedCoefficients(IrisTest):
         super().setUp()
         # The expected coefficients for temperature in Kelvin.
         self.expected_mean_predictor_gaussian = (
-            [-0., 0.4888, 23.4351, 0.9129])
+            np.array([-0., 0.4888, 23.4351, 0.9129], dtype=np.float32))
         # The expected coefficients for wind speed in m s^-1.
         self.expected_mean_predictor_truncated_gaussian = (
-            [-0., 1.5434, -0.514, 0.94])
+            np.array([-0., 1.5434, -0.514, 0.94], dtype=np.float32))
 
         self.expected_realizations_gaussian_statsmodels = (
-            [-0.0003, 1.0023, -0.2831, -0.0774, 0.3893, 0.9168])
+            np.array([-0.0003, 1.0023, -0.2831, -0.0774, 0.3893, 0.9168],
+                     dtype=np.float32))
         self.expected_realizations_gaussian_no_statsmodels = (
-            [0.0226, 1.0567, -0.0039, 0.3432, 0.2542, 0.9026])
+            np.array([0.0226, 1.0567, -0.0039, 0.3432, 0.2542, 0.9026],
+                     dtype=np.float32))
         self.expected_realizations_truncated_gaussian_statsmodels = (
-            [-0.0070, 1.3360, -0.5012, -0.5295, 0.0003, 0.8128])
+            np.array([-0.0070, 1.3360, -0.5012, -0.5295, 0.0003, 0.8128],
+                     dtype=np.float32))
         self.expected_realizations_truncated_gaussian_no_statsmodels = (
-            [0.0810, 1.3406, -0.0310, 0.7003, -0.0036, 0.6083])
+            np.array([0.0810, 1.3406, -0.0310, 0.7003, -0.0036, 0.6083],
+                     dtype=np.float32))
 
 
 class Test__init__(SetupCubes):

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_ensemble_calibration_utilities.py
@@ -282,45 +282,27 @@ class Test_check_predictor_of_mean_flag(IrisTest):
 
     def test_mean(self):
         """
-        Test that the utility does not fail when the predictor_of_mean_flag
-        is "mean".
+        Test that the utility does not raise an exception when
+        predictor_of_mean_flag = "mean".
         """
-        predictor_of_mean_flag = "mean"
-
-        try:
-            check_predictor_of_mean_flag(predictor_of_mean_flag)
-        except ValueError as err:
-            msg = ("_check_predictor_of_mean_flag raised "
-                   "ValueError unexpectedly."
-                   "Message is {}").format(err)
-            self.fail(msg)
+        check_predictor_of_mean_flag("mean")
 
     def test_realizations(self):
         """
-        Test that the utility does not fail when the predictor_of_mean_flag
-        is "realizations".
+        Test that the utility does not raise an exception when
+        predictor_of_mean_flag = "realizations".
         """
-        predictor_of_mean_flag = "realizations"
+        check_predictor_of_mean_flag("realizations")
 
-        try:
-            check_predictor_of_mean_flag(predictor_of_mean_flag)
-        except ValueError as err:
-            msg = ("_check_predictor_of_mean_flag raised "
-                   "ValueError unexpectedly."
-                   "Message is {}").format(err)
-            self.fail(msg)
-
-    def test_foo(self):
+    def test_invalid_predictor_of_mean_flag(self):
         """
-        Test that the utility fails when the predictor_of_mean_flag
-        is "foo" i.e. a name not present in the list of accepted values
-        for the predictor_of_mean_flag.
+        Test that the utility raises an exception when
+        predictor_of_mean_flag = "foo", a name not present in the list of
+        accepted values for the predictor_of_mean_flag.
         """
-        predictor_of_mean_flag = "foo"
-
         msg = "The requested value for the predictor_of_mean_flag"
         with self.assertRaisesRegex(ValueError, msg):
-            check_predictor_of_mean_flag(predictor_of_mean_flag)
+            check_predictor_of_mean_flag("foo")
 
 
 if __name__ == '__main__':

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -409,13 +409,20 @@ class Test_time_coords_match(IrisTest):
     """Test for function that tests if cube temporal coordinates match."""
 
     def setUp(self):
-        """Create two unmatching cubes for temporal comparison."""
+        """Create a cube for temporal coordinate comparisons."""
         self.data = np.ones((3, 3), dtype=np.float32)
         self.ref_cube = set_up_variable_cube(self.data)
 
     def test_match(self):
         """Test returns True when cubes time coordinates match."""
         result = time_coords_match(self.ref_cube, self.ref_cube.copy())
+        self.assertTrue(result)
+
+    def test_match_with_raise_exception_option(self):
+        """Test returns True when cubes time coordinates match. In this case
+        the raise_exception option is True but we do not expect a exception."""
+        result = time_coords_match(
+            self.ref_cube, self.ref_cube.copy(), raise_exception=True)
         self.assertTrue(result)
 
     def test_validity_time_mismatch(self):
@@ -466,6 +473,14 @@ class Test_time_coords_match(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             time_coords_match(self.ref_cube, cube_different_both,
                               raise_exception=True)
+
+    def test_coordinate_not_found_exception(self):
+        """Test an exception is raised if any of the temporal coordinates are
+        missing."""
+        self.ref_cube.remove_coord('time')
+        msg = "Expected to find exactly 1 time coordinate, but found none."
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
+            time_coords_match(self.ref_cube, self.ref_cube.copy())
 
 
 class Test_find_percentile_coordinate(IrisTest):

--- a/lib/improver/tests/utilities/test_cube_checker.py
+++ b/lib/improver/tests/utilities/test_cube_checker.py
@@ -34,6 +34,7 @@ import unittest
 
 import iris
 import numpy as np
+from datetime import datetime
 from iris.cube import Cube
 from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
@@ -50,6 +51,7 @@ from improver.utilities.cube_checker import (
     check_cube_coordinates,
     find_dimension_coordinate_mismatch,
     spatial_coords_match,
+    time_coords_match,
     find_percentile_coordinate,
     find_threshold_coordinate)
 
@@ -400,6 +402,70 @@ class Test_spatial_coords_match(IrisTest):
         y_coord.points = [y*1.01 for y in y_coord.points]
         result = spatial_coords_match(self.cube_a, cube_c)
         self.assertFalse(result)
+
+
+class Test_time_coords_match(IrisTest):
+
+    """Test for function that tests if cube temporal coordinates match."""
+
+    def setUp(self):
+        """Create two unmatching cubes for temporal comparison."""
+        self.data = np.ones((3, 3), dtype=np.float32)
+        self.ref_cube = set_up_variable_cube(self.data)
+
+    def test_match(self):
+        """Test returns True when cubes time coordinates match."""
+        result = time_coords_match(self.ref_cube, self.ref_cube.copy())
+        self.assertTrue(result)
+
+    def test_validity_time_mismatch(self):
+        """Test returns False when cubes validity times do not match."""
+        cube_different_vt = set_up_variable_cube(
+            self.data, time=datetime(2017, 11, 10, 5, 0))
+        result = time_coords_match(self.ref_cube, cube_different_vt)
+        self.assertFalse(result)
+
+    def test_forecast_reference_time_mismatch(self):
+        """Test returns False when cubes forecast reference times do not
+        match."""
+        cube_different_frt = set_up_variable_cube(
+            self.data, frt=datetime(2017, 11, 10, 1, 0))
+        result = time_coords_match(self.ref_cube, cube_different_frt)
+        self.assertFalse(result)
+
+    def test_validity_time_mismatch_with_exception(self):
+        """Test raises exception when cubes validity times do not match and
+        raise_exception=True."""
+        cube_different_vt = set_up_variable_cube(
+            self.data, time=datetime(2017, 11, 10, 5, 0))
+        msg = ("The following coordinates of the two cubes do not match:"
+               " forecast_period, time")
+        with self.assertRaisesRegex(ValueError, msg):
+            time_coords_match(self.ref_cube, cube_different_vt,
+                              raise_exception=True)
+
+    def test_forecast_reference_time_mismatch_with_exception(self):
+        """Test raises exception when cubes forecast reference times do not
+        match and raise_exception=True."""
+        cube_different_frt = set_up_variable_cube(
+            self.data, frt=datetime(2017, 11, 10, 1, 0))
+        msg = ("The following coordinates of the two cubes do not match:"
+               " forecast_period, forecast_reference_time")
+        with self.assertRaisesRegex(ValueError, msg):
+            time_coords_match(self.ref_cube, cube_different_frt,
+                              raise_exception=True)
+
+    def test_all_times_mismatch_with_exception(self):
+        """Test raises exception when all cube time coordinates differ and
+        raise_exception=True."""
+        cube_different_both = set_up_variable_cube(
+            self.data, time=datetime(2017, 11, 10, 6, 0),
+            frt=datetime(2017, 11, 10, 1, 0))
+        msg = ("The following coordinates of the two cubes do not match:"
+               " forecast_period, time, forecast_reference_time")
+        with self.assertRaisesRegex(ValueError, msg):
+            time_coords_match(self.ref_cube, cube_different_both,
+                              raise_exception=True)
 
 
 class Test_find_percentile_coordinate(IrisTest):

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -257,7 +257,7 @@ def time_coords_match(first_cube, second_cube, raise_exception=False):
     Raised:
         ValueError: The two cubes are not equivalent.
         CoordinateNotFoundError: One of the expected temporal coordinates is
-                                 not present on one or more cubes.
+        not present on one or more cubes.
     """
     cubes_equivalent = True
     mismatches = []

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -234,6 +234,47 @@ def spatial_coords_match(first_cube, second_cube):
             first_cube.coord(axis='y') == second_cube.coord(axis='y'))
 
 
+def time_coords_match(first_cube, second_cube, raise_exception=False):
+    """
+    Determine if two cubes have equivalent time, forecast_period, and
+    forecast_reference_time points.
+
+    Args:
+        first_cube (iris.cube.Cube):
+            First cube to compare.
+        second_cube (iris.cube.Cube):
+            Second cube to compare.
+        raise_exception (bool):
+            By default this function returns True or False, but if this
+            argument is set to True it will raise an exception.
+
+    Returns:
+        result (bool):
+            True if the cube time coordinates are equivalent, False if they are
+            not.
+
+    Raised:
+        ValueError: The two cubes are not equivalent.
+        CoordinateNotFoundError: One of the expected temporal coordinates is
+                                 not present on one or more cubes.
+    """
+    cubes_equivalent = True
+    mismatches = []
+    for coord_name in ["forecast_period", "time", "forecast_reference_time"]:
+        try:
+            if (first_cube.coord(coord_name) != second_cube.coord(coord_name)):
+                mismatches.append(coord_name)
+                cubes_equivalent = False
+        except CoordinateNotFoundError:
+            raise
+
+    if mismatches and raise_exception:
+        msg = "The following coordinates of the two cubes do not match: {}"
+        raise ValueError(msg.format(', '.join(mismatches)))
+
+    return cubes_equivalent
+
+
 def find_percentile_coordinate(cube):
     """Find percentile coord in cube.
 

--- a/lib/improver/utilities/cube_checker.py
+++ b/lib/improver/utilities/cube_checker.py
@@ -245,11 +245,12 @@ def time_coords_match(first_cube, second_cube, raise_exception=False):
         second_cube (iris.cube.Cube):
             Second cube to compare.
         raise_exception (bool):
-            By default this function returns True or False, but if this
-            argument is set to True it will raise an exception.
+            By default this function returns a boolean, but if this argument is
+            set to True it will raise an exception if there is a mismatch in
+            the coordinates.
 
     Returns:
-        result (bool):
+        cubes_equivalent (bool):
             True if the cube time coordinates are equivalent, False if they are
             not.
 


### PR DESCRIPTION
Refactoring of the apply ensemble calibration plugin to make it adhere to our more typical style. This shrinks the init, passes cubes to the process method (rather than the init), and splits the processing into smaller functions.

The unit tests have necessarily been changed quite substantially, but the results data are all unchanged. The CLI tests pass as before.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)