### PR TITLE
Update merging of historic forecasts and truth for EMOS

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration_utilities.py
@@ -36,6 +36,8 @@ specific for ensemble calibration.
 import iris
 import numpy as np
 
+from improver.utilities.cube_manipulation import merge_cubes
+
 
 def convert_cube_data_to_2d(
         forecast, coord="realization", transpose=True):
@@ -254,4 +256,5 @@ class SplitHistoricForecastAndTruth():
             cubes, self.historic_forecast_dict)
         truths = self._find_required_cubes_using_metadata(
             cubes, self.truth_dict)
-        return historic_forecasts.merge_cube(), truths.merge_cube()
+        # Use improver merge_cubes to equalise attributes
+        return merge_cubes(historic_forecasts), merge_cubes(truths)

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_SplitHistoricForecastAndTruth.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_SplitHistoricForecastAndTruth.py
@@ -32,6 +32,7 @@
 Unit tests for the `SplitHistoricForecastAndTruth` plugin.
 
 """
+import datetime
 import unittest
 
 from iris.tests import IrisTest
@@ -136,6 +137,16 @@ class Test_process(SetupCubes, SetupDicts):
         can be split using the metadata dictionaries provided."""
         hf_result, truth_result = self.plugin.process(self.combined)
         self.assertEqual(hf_result, self.historic_temperature_forecast_cube)
+        self.assertEqual(truth_result, self.temperature_truth_cube)
+
+    def test_mismatching_history_attribute(self):
+        """Test that the input cubelist combining historic forecasts and truth
+        can be split using the metadata dictionaries provided, for where there
+        are mismatches in the history attribute."""
+        self.combined[0].attributes["history"] = "history"
+        hf_result, truth_result = self.plugin.process(self.combined)
+        self.assertEqual(hf_result,
+                         self.historic_temperature_forecast_cube)
         self.assertEqual(truth_result, self.temperature_truth_cube)
 
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_SplitHistoricForecastAndTruth.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_SplitHistoricForecastAndTruth.py
@@ -32,7 +32,6 @@
 Unit tests for the `SplitHistoricForecastAndTruth` plugin.
 
 """
-import datetime
 import unittest
 
 from iris.tests import IrisTest

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_SplitHistoricForecastAndTruth.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration_utilities/test_SplitHistoricForecastAndTruth.py
@@ -140,8 +140,8 @@ class Test_process(SetupCubes, SetupDicts):
 
     def test_mismatching_history_attribute(self):
         """Test that the input cubelist combining historic forecasts and truth
-        can be split using the metadata dictionaries provided, for where there
-        are mismatches in the history attribute."""
+        can be split using the metadata dictionaries provided, when there are
+        mismatches in the history attribute."""
         self.combined[0].attributes["history"] = "history"
         hf_result, truth_result = self.plugin.process(self.combined)
         self.assertEqual(hf_result,


### PR DESCRIPTION
Description
The SplitHistoricForecastsAndTruth plugin currently uses the Iris cube.merge_cube functionality. This has been switched for the IMPROVER merge_cubes functionality functionality, so that files with mismatching history attributes are handled correctly.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

