### PR TITLE
Remove unconditional cube transpose - only do so if dims change order

### DIFF
--- a/lib/improver/utilities/cube_manipulation.py
+++ b/lib/improver/utilities/cube_manipulation.py
@@ -853,9 +853,12 @@ def enforce_coordinate_ordering(
     # Transpose by inserting the requested coordinates at either the start
     # or the end.
     if anchor == "start":
-        cube.transpose(coord_dims + remaining_coords)
+        dim_order = coord_dims + remaining_coords
     elif anchor == "end":
-        cube.transpose(remaining_coords + coord_dims)
+        dim_order = remaining_coords + coord_dims
+    # Don't reorder if dim_order is already correct:
+    if dim_order != sorted(dim_order):
+        cube.transpose(dim_order)
     return cube
 
 


### PR DESCRIPTION
Made this change a long time ago - from memory this shaves a small (but non-trivial) amount of time from all improver calls.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s) - could add a regression test, but seemed unnecessary...