### PR TITLE
Fix tests modifying DEFAULT_UNITS constant

### DIFF
--- a/lib/improver/tests/metadata/test_enforce_datatypes_units.py
+++ b/lib/improver/tests/metadata/test_enforce_datatypes_units.py
@@ -339,6 +339,7 @@ class Test__find_dict_key(LimitedDictTest):
         enforce.DEFAULT_UNITS = self.units_dict
 
     def tearDown(self):
+        """Reset DEFAULT_UNITS back to original"""
         enforce.DEFAULT_UNITS = self.orig_default_units
 
     def test_match(self):
@@ -377,6 +378,7 @@ class Test__get_required_units_and_dtype(LimitedDictTest):
         enforce.DEFAULT_UNITS = self.units_dict
 
     def tearDown(self):
+        """Reset DEFAULT_UNITS back to original"""
         enforce.DEFAULT_UNITS = self.orig_default_units
 
     def test_match(self):

--- a/lib/improver/tests/metadata/test_enforce_datatypes_units.py
+++ b/lib/improver/tests/metadata/test_enforce_datatypes_units.py
@@ -335,7 +335,11 @@ class Test__find_dict_key(LimitedDictTest):
     def setUp(self):
         """Redirect to dummy dictionary"""
         super().setUp()
+        self.orig_default_units = enforce.DEFAULT_UNITS.copy()
         enforce.DEFAULT_UNITS = self.units_dict
+
+    def tearDown(self):
+        enforce.DEFAULT_UNITS = self.orig_default_units
 
     def test_match(self):
         """Test correct identification of single substring match"""
@@ -369,7 +373,11 @@ class Test__get_required_units_and_dtype(LimitedDictTest):
     def setUp(self):
         """Redirect to dummy dictionary"""
         super().setUp()
+        self.orig_default_units = enforce.DEFAULT_UNITS.copy()
         enforce.DEFAULT_UNITS = self.units_dict
+
+    def tearDown(self):
+        enforce.DEFAULT_UNITS = self.orig_default_units
 
     def test_match(self):
         """Test correct requirements identified"""


### PR DESCRIPTION
Addresses #981

Take a copy of DEFAULT_UNITS and put it back in place during the test teardown step so that side-effects are contained to within the test class.

This is a quick workaround to fix #981. Ideally, tests should not be modifying constants. For example, by modifying the called code to be able to pass it a different units dictionary other than the default, or by using unittest.mock.

Testing:
- [x] Ran tests and they passed OK
- [x] Ran tests in randomised order multiple times and they passed OK