### PR TITLE
Support cube extraction without reconverting units

### DIFF
--- a/lib/improver/tests/utilities/test_cube_extraction.py
+++ b/lib/improver/tests/utilities/test_cube_extraction.py
@@ -327,7 +327,8 @@ class Test_apply_extraction(IrisTest):
                 lambda cell: any(np.isclose(cell.point, [0.1]))}
         constr = iris.Constraint(**constraint_dict)
         cube = apply_extraction(
-            self.precip_cube, constr, self.units_dict, convert_units=False)
+            self.precip_cube, constr, self.units_dict,
+            use_original_units=False)
         self.assertIsInstance(cube, iris.cube.Cube)
         self.assertEqual(cube.coord(self.threshold_coord).units, "mm h-1")
         reference_data = self.precip_cube.data[1, :, :]
@@ -462,7 +463,7 @@ class Test_extract_subcube(IrisTest):
                                  units=precip_units)
         self.assertArrayAlmostEqual(result.data, expected.data)
 
-    def test_single_threshold_do_not_convert_units(self):
+    def test_single_threshold_use_original_units(self):
         """Test that a single threshold is extracted correctly when using the
         key=value syntax without converting the coordinate units back to the
         original units."""
@@ -471,7 +472,7 @@ class Test_extract_subcube(IrisTest):
         expected = self.precip_cube[0]
         expected.coord("precipitation_rate").convert_units("mm h-1")
         result = extract_subcube(self.precip_cube, constraints,
-                                 units=precip_units, convert_units=False)
+                                 units=precip_units, use_original_units=False)
         self.assertArrayAlmostEqual(result.data, expected.data)
         self.assertEqual(expected.coord("precipitation_rate"),
                          result.coord("precipitation_rate"))

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -178,7 +178,7 @@ def parse_constraint_list(constraints, units=None):
     return constraints, units_dict
 
 
-def apply_extraction(cube, constraint, units=None):
+def apply_extraction(cube, constraint, units=None, convert_units=True):
     """
     Using a set of constraints, extract a subcube from the provided cube if it
     is available.
@@ -193,6 +193,11 @@ def apply_extraction(cube, constraint, units=None):
             A dictionary of units for the constraints. Supplied if any
             coordinate constraints are provided in different units from those
             of the input cube (eg precip in mm/h for cube threshold in m/s).
+        convert_units (bool):
+            Boolean to state whether the coordinates used in the extraction
+            should be converted back to their original units. The default is
+            True, indicating that the units should be converted back to the
+            original units.
 
     Returns:
         output_cube (iris.cube.Cube):
@@ -207,18 +212,20 @@ def apply_extraction(cube, constraint, units=None):
             original_units[coord] = cube.coord(coord).units
             cube.coord(coord).convert_units(units[coord])
         output_cube = cube.extract(constraint)
-        for coord in original_units.keys():
-            cube.coord(coord).convert_units(original_units[coord])
-            try:
-                output_cube.coord(coord).convert_units(original_units[coord])
-            except AttributeError:
-                # an empty output cube (None) is handled by the CLI
-                pass
+        if convert_units:
+            for coord in original_units.keys():
+                cube.coord(coord).convert_units(original_units[coord])
+                try:
+                    output_cube.coord(coord).convert_units(
+                        original_units[coord])
+                except AttributeError:
+                    # an empty output cube (None) is handled by the CLI
+                    pass
 
     return output_cube
 
 
-def extract_subcube(cube, constraints, units=None):
+def extract_subcube(cube, constraints, units=None, convert_units=True):
     """
     Using a set of constraints, extract a subcube from the provided cube if it
     is available.
@@ -233,6 +240,11 @@ def extract_subcube(cube, constraints, units=None):
             List of units (as strings) corresponding to each coordinate in the
             list of constraints.  One or more "units" may be None, and units
             may only be associated with coordinate constraints.
+        convert_units (bool):
+            Boolean to state whether the coordinates used in the extraction
+            should be converted back to their original units. The default is
+            True, indicating that the units should be converted back to the
+            original units.
 
     Returns:
         output_cube (iris.cube.Cube or None):
@@ -240,5 +252,6 @@ def extract_subcube(cube, constraints, units=None):
             is found within cube that matches the constraints.
     """
     constraints, units = parse_constraint_list(constraints, units=units)
-    output_cube = apply_extraction(cube, constraints, units=units)
+    output_cube = apply_extraction(
+        cube, constraints, units=units, convert_units=convert_units)
     return output_cube

--- a/lib/improver/utilities/cube_extraction.py
+++ b/lib/improver/utilities/cube_extraction.py
@@ -178,7 +178,7 @@ def parse_constraint_list(constraints, units=None):
     return constraints, units_dict
 
 
-def apply_extraction(cube, constraint, units=None, convert_units=True):
+def apply_extraction(cube, constraint, units=None, use_original_units=True):
     """
     Using a set of constraints, extract a subcube from the provided cube if it
     is available.
@@ -193,7 +193,7 @@ def apply_extraction(cube, constraint, units=None, convert_units=True):
             A dictionary of units for the constraints. Supplied if any
             coordinate constraints are provided in different units from those
             of the input cube (eg precip in mm/h for cube threshold in m/s).
-        convert_units (bool):
+        use_original_units (bool):
             Boolean to state whether the coordinates used in the extraction
             should be converted back to their original units. The default is
             True, indicating that the units should be converted back to the
@@ -212,7 +212,7 @@ def apply_extraction(cube, constraint, units=None, convert_units=True):
             original_units[coord] = cube.coord(coord).units
             cube.coord(coord).convert_units(units[coord])
         output_cube = cube.extract(constraint)
-        if convert_units:
+        if use_original_units:
             for coord in original_units.keys():
                 cube.coord(coord).convert_units(original_units[coord])
                 try:
@@ -225,7 +225,7 @@ def apply_extraction(cube, constraint, units=None, convert_units=True):
     return output_cube
 
 
-def extract_subcube(cube, constraints, units=None, convert_units=True):
+def extract_subcube(cube, constraints, units=None, use_original_units=True):
     """
     Using a set of constraints, extract a subcube from the provided cube if it
     is available.
@@ -240,7 +240,7 @@ def extract_subcube(cube, constraints, units=None, convert_units=True):
             List of units (as strings) corresponding to each coordinate in the
             list of constraints.  One or more "units" may be None, and units
             may only be associated with coordinate constraints.
-        convert_units (bool):
+        use_original_units (bool):
             Boolean to state whether the coordinates used in the extraction
             should be converted back to their original units. The default is
             True, indicating that the units should be converted back to the
@@ -253,5 +253,5 @@ def extract_subcube(cube, constraints, units=None, convert_units=True):
     """
     constraints, units = parse_constraint_list(constraints, units=units)
     output_cube = apply_extraction(
-        cube, constraints, units=units, convert_units=convert_units)
+        cube, constraints, units=units, use_original_units=use_original_units)
     return output_cube


### PR DESCRIPTION
Description
Add option to support not reconverting the units of the coordinates of the cube back into the original units.

This PR aims to:
- Add an option to the `apply_extraction` function, so that the coordinates within the cube to not have to be re-converted into the original coordinate units. This allows the extracted cube to be returned with its units converted.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

