### PR TITLE
Tidy-up of datatypes checking

### DIFF
--- a/lib/improver/metadata/check_datatypes.py
+++ b/lib/improver/metadata/check_datatypes.py
@@ -149,14 +149,14 @@ def check_datatypes(cube, coords=None):
             continue
 
         # check numerical datatypes
-        reqd_dtype = _get_required_datatype(item)
-        if item.dtype.type != reqd_dtype:
-            error_string += msg.format(item.name(), item.dtype, reqd_dtype)
+        required_dtype = _get_required_datatype(item)
+        if item.dtype.type != required_dtype:
+            error_string += msg.format(item.name(), item.dtype, required_dtype)
 
         if (hasattr(item, "bounds") and item.bounds is not None
-                and item.bounds.dtype.type != reqd_dtype):
+                and item.bounds.dtype.type != required_dtype):
             error_string += msg.format(
-                item.name()+' bounds', item.bounds.dtype, reqd_dtype)
+                item.name()+' bounds', item.bounds.dtype, required_dtype)
 
     # if any data was non-compliant, raise details here
     if error_string:
@@ -212,17 +212,17 @@ def check_time_coordinate_metadata(cube):
             continue
 
         if coord.units.is_time_reference():
-            reqd_unit = "seconds since 1970-01-01 00:00:00"
-            reqd_dtype = TIME_REFERENCE_DTYPE
+            required_unit = "seconds since 1970-01-01 00:00:00"
+            required_dtype = TIME_REFERENCE_DTYPE
         else:
-            reqd_unit = "seconds"
-            reqd_dtype = np.int32
+            required_unit = "seconds"
+            required_dtype = np.int32
 
-        if not _check_units_and_dtype(coord, reqd_unit, reqd_dtype):
+        if not _check_units_and_dtype(coord, required_unit, required_dtype):
             msg = ('Coordinate {} does not match required '
                    'standard (units {}, datatype {})\n')
             error_string += msg.format(
-                coord.name(), reqd_unit, reqd_dtype)
+                coord.name(), required_unit, required_dtype)
 
     # if non-compliance was encountered, raise all messages here
     if error_string:

--- a/lib/improver/metadata/check_datatypes.py
+++ b/lib/improver/metadata/check_datatypes.py
@@ -197,7 +197,7 @@ def check_time_coordinate_metadata(cube):
     are non-conformant an error is raised.
 
     Args:
-        cubes (iris.cube.Cube):
+        cube (iris.cube.Cube):
             Cube to be checked
 
     Raises:

--- a/lib/improver/tests/metadata/test_check_datatypes.py
+++ b/lib/improver/tests/metadata/test_check_datatypes.py
@@ -46,12 +46,30 @@ class Test_check_cube_not_float64(IrisTest):
     """Test whether a cube contains any float64 values."""
 
     def setUp(self):
-        """Set up a cube to test."""
-        self.cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32),
+        """Set up a test cube with the following data and coordinates, which
+        comply with the IMPROVER datatypes standard:
+
+        +-------------------------+-------------+
+        | Name                    | Datatype    |
+        +=========================+=============+
+        | data (air_temperature)  | np.float32  |
+        +-------------------------+-------------+
+        | projection_x_coordinate | np.float32  |
+        +-------------------------+-------------+
+        | projection_y_coordinate | np.float32  |
+        +-------------------------+-------------+
+        | time                    | np.int64    |
+        +-------------------------+-------------+
+        | forecast_reference_time | np.int64    |
+        +-------------------------+-------------+
+        | forecast_period         | np.int32    |
+        +-------------------------+-------------+
+        """
+        self.cube = set_up_variable_cube(280*np.ones((5, 5), dtype=np.float32),
                                          spatial_grid='equalarea')
 
-    def test_float32_ok(self):
-        """Test a cube that should pass."""
+    def test_success(self):
+        """Test a cube that should pass does not throw an error."""
         enforce.check_cube_not_float64(self.cube)
 
     def test_float64_cube_data(self):
@@ -64,10 +82,8 @@ class Test_check_cube_not_float64(IrisTest):
     def test_float64_cube_data_with_fix(self):
         """Test a cube with 64 bit data is converted to 32 bit data."""
         self.cube.data = self.cube.data.astype(np.float64)
-        expected_cube = self.cube.copy()
-        expected_cube.data = expected_cube.data.astype(np.float64)
         enforce.check_cube_not_float64(self.cube, fix=True)
-        self.assertEqual(self.cube, expected_cube)
+        self.assertEqual(self.cube.data.dtype, np.float32)
 
     def test_float64_cube_coord_points(self):
         """Test a failure of a cube with 64 bit coord points."""
@@ -84,15 +100,9 @@ class Test_check_cube_not_float64(IrisTest):
         self.cube.coord("projection_x_coordinate").points = (
             self.cube.coord("projection_x_coordinate").points.astype(
                 np.float64))
-        expected_cube = self.cube.copy()
-        expected_cube.coord("projection_x_coordinate").points = (
-            expected_cube.coord("projection_x_coordinate").points.astype(
-                np.float64))
-        expected_coord = expected_cube.coord("projection_x_coordinate")
         enforce.check_cube_not_float64(self.cube, fix=True)
-        self.assertEqual(self.cube, expected_cube)
-        self.assertEqual(
-            self.cube.coord("projection_x_coordinate"), expected_coord)
+        coord = self.cube.coord("projection_x_coordinate")
+        self.assertEqual(coord.points.dtype, np.float32)
 
     def test_float64_cube_coord_bounds(self):
         """Test a failure of a cube with 64 bit coord bounds."""
@@ -112,12 +122,10 @@ class Test_check_cube_not_float64(IrisTest):
         x_coord.bounds = (
             np.array([(point - 10., point + 10.) for point in x_coord.points])
         )
-        expected_cube = self.cube.copy()
-        expected_coord = expected_cube.coord("projection_x_coordinate")
         enforce.check_cube_not_float64(self.cube, fix=True)
-        self.assertEqual(self.cube, expected_cube)
-        self.assertEqual(
-            self.cube.coord("projection_x_coordinate"), expected_coord)
+        coord = self.cube.coord("projection_x_coordinate")
+        self.assertEqual(coord.points.dtype, np.float32)
+        self.assertEqual(coord.bounds.dtype, np.float32)
 
 
 class Test_check_time_coordinate_metadata(IrisTest):

--- a/lib/improver/tests/metadata/test_check_datatypes.py
+++ b/lib/improver/tests/metadata/test_check_datatypes.py
@@ -230,6 +230,17 @@ class Test_check_datatypes(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             enforce.check_datatypes(self.percentile_cube)
 
+    def test_coord_bounds_datatype_fail(self):
+        """Test error is raised for a coordinate whose bounds datatype is
+        incorrect, but points are correct"""
+        time_bounds = np.array(
+            [self.data_cube.coord("time").points[0] - 3600,
+             self.data_cube.coord("time").points[0] + 3600], dtype=np.int32)
+        self.data_cube.coord("time").bounds = [time_bounds]
+        msg = "does not conform"
+        with self.assertRaisesRegex(ValueError, msg):
+            enforce.check_datatypes(self.data_cube)
+
     def test_subset_of_coordinates(self):
         """Test function can check a selected subset of coordinates and
         ignore others"""


### PR DESCRIPTION
Follow-up from #978 

Added bounds checking to `check_datatypes` and made functional unit tests for `check_cube_not_float64`.  Last commit is code rearrangements with no functional changes - suggest reviewers look at all but the last commit for a clear picture of what has changed.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)