### PR TITLE
Strip verbosity out of nowcasting CLIs

### DIFF
--- a/lib/improver/cli/nowcast_extrapolate.py
+++ b/lib/improver/cli/nowcast_extrapolate.py
@@ -253,7 +253,6 @@ def process(input_cube, u_cube, v_cube, speed_cube, direction_cube,
             If accumulation_fidelity is greater than 0 and max_lead_time is not
             cleanly divisible by accumulation_fidelity.
     """
-
     if (speed_cube and direction_cube) and not (u_cube or v_cube):
         u_cube, v_cube = ResolveWindComponents().process(
             speed_cube, direction_cube)

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -209,19 +209,14 @@ def process(original_cube_list, orographic_enhancement_cube=None,
     u_mean, v_mean = generate_optical_flow_components(
         cube_list, ofc_box_size, smart_smoothing_iterations, attributes_dict)
 
-    forecast_cubes = []
+    forecast_cubes = None
     if extrapolate:
-        # generate list of lead times in minutes
-        lead_times = np.arange(0, max_lead_time + 1,
-                               lead_time_interval)
         forecast_plugin = CreateExtrapolationForecast(
             original_cube_list[-1], u_mean, v_mean,
             orographic_enhancement_cube=orographic_enhancement_cube,
             attributes_dict=attributes_dict)
-        # extrapolate input data to required lead times
-        for lead_time in lead_times:
-            forecast_cubes.append(forecast_plugin.extrapolate(
-                leadtime_minutes=lead_time))
+        forecast_cubes = forecast_plugin.process(
+            lead_time_interval, max_lead_time)
 
     return forecast_cubes, [u_mean, v_mean]
 

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -204,8 +204,8 @@ def process(original_cube_list, orographic_enhancement_cube=None,
                    "supplied were: {}".format(cube_names))
             raise ValueError(msg)
 
-    # calculate optical flow velocities from T-1 to T and T-2 to T-1,
-    # and return averages
+    # calculate optical flow velocities from T-1 to T and T-2 to T-1, and
+    # average to produce the velocities for use in advection
     u_mean, v_mean = generate_optical_flow_components(
         cube_list, ofc_box_size, smart_smoothing_iterations, attributes_dict)
 

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -39,7 +39,7 @@ import numpy as np
 
 from improver.argparser import ArgParser
 from improver.nowcasting.forecasting import CreateExtrapolationForecast
-from improver.nowcasting.optical_flow import generate_optical_flow_components  # OpticalFlow
+from improver.nowcasting.optical_flow import generate_optical_flow_components
 from improver.nowcasting.utilities import ApplyOrographicEnhancement
 from improver.utilities.cli_utilities import load_json_or_none
 from improver.utilities.filename import generate_file_name

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -39,7 +39,7 @@ import numpy as np
 
 from improver.argparser import ArgParser
 from improver.nowcasting.forecasting import CreateExtrapolationForecast
-from improver.nowcasting.optical_flow import OpticalFlow
+from improver.nowcasting.optical_flow import generate_optical_flow_components  # OpticalFlow
 from improver.nowcasting.utilities import ApplyOrographicEnhancement
 from improver.utilities.cli_utilities import load_json_or_none
 from improver.utilities.filename import generate_file_name
@@ -188,6 +188,10 @@ def process(original_cube_list, orographic_enhancement_cube=None,
             If there is no oe_cube but a cube is called 'precipitation_rate'.
 
     """
+    # order input files by validity time
+    original_cube_list.sort(key=lambda x: x.coord("time").points[0])
+
+    # subtract orographic enhancement
     if orographic_enhancement_cube:
         cube_list = ApplyOrographicEnhancement("subtract").process(
             original_cube_list, orographic_enhancement_cube)
@@ -200,32 +204,11 @@ def process(original_cube_list, orographic_enhancement_cube=None,
                    "supplied were: {}".format(cube_names))
             raise ValueError(msg)
 
-    # order input files by validity time
-    cube_list.sort(key=lambda x: x.coord("time").points[0])
-    time_coord = cube_list[-1].coord("time")
-    # calculate optical flow velocities from T-1 to T and T-2 to T-1
-    ofc_plugin = OpticalFlow(iterations=smart_smoothing_iterations,
-                             attributes_dict=attributes_dict)
-    u_cubes = iris.cube.CubeList([])
-    v_cubes = iris.cube.CubeList([])
-    for older_cube, newer_cube in zip(cube_list[:-1], cube_list[1:]):
-        ucube, vcube = ofc_plugin.process(older_cube, newer_cube,
-                                          boxsize=ofc_box_size)
-        u_cubes.append(ucube)
-        v_cubes.append(vcube)
+    # calculate optical flow velocities from T-1 to T and T-2 to T-1,
+    # and return averages
+    u_mean, v_mean = generate_optical_flow_components(
+        cube_list, ofc_box_size, smart_smoothing_iterations, attributes_dict)
 
-    # average optical flow velocity components
-    u_cube = u_cubes.merge_cube()
-    u_mean = u_cube.collapsed("time", iris.analysis.MEAN)
-    u_mean.coord("time").points = time_coord.points
-    u_mean.coord("time").units = time_coord.units
-
-    v_cube = v_cubes.merge_cube()
-    v_mean = v_cube.collapsed("time", iris.analysis.MEAN)
-    v_mean.coord("time").points = time_coord.points
-    v_mean.coord("time").units = time_coord.units
-
-    u_and_v_mean = [u_mean, v_mean]
     forecast_cubes = []
     if extrapolate:
         # generate list of lead times in minutes
@@ -240,7 +223,7 @@ def process(original_cube_list, orographic_enhancement_cube=None,
             forecast_cubes.append(forecast_plugin.extrapolate(
                 leadtime_minutes=lead_time))
 
-    return forecast_cubes, u_and_v_mean
+    return forecast_cubes, [u_mean, v_mean]
 
 
 if __name__ == "__main__":

--- a/lib/improver/nowcasting/forecasting.py
+++ b/lib/improver/nowcasting/forecasting.py
@@ -34,6 +34,7 @@ This module defines plugins used to create nowcast extrapolation forecasts.
 import datetime
 import warnings
 
+import iris
 import numpy as np
 from iris.coords import AuxCoord
 from iris.exceptions import CoordinateNotFoundError, InvalidCubeError
@@ -413,3 +414,20 @@ class CreateExtrapolationForecast():
                 forecast_cube, self.orographic_enhancement_cube)
 
         return forecast_cube
+
+    def process(self, interval, max_lead_time):
+        """
+        Generate nowcasts at required intervals up to the maximum lead time
+
+        Args:
+            interval (int):
+                Lead time interval, in minutes
+            max_lead_time (int):
+                Maximum lead time required, in minutes
+        """
+        lead_times = np.arange(0, max_lead_time + 1, interval)
+        forecast_cubes = iris.cube.CubeList()
+        for lead_time in lead_times:
+            forecast_cubes.append(
+                self.extrapolate(leadtime_minutes=lead_time))
+        return forecast_cubes

--- a/lib/improver/nowcasting/forecasting.py
+++ b/lib/improver/nowcasting/forecasting.py
@@ -379,7 +379,7 @@ class CreateExtrapolationForecast():
                       repr(self.advection_plugin)))
         return result
 
-    def extrapolate(self, leadtime_minutes=None):
+    def extrapolate(self, leadtime_minutes):
         """
         Produce a new forecast cube for the supplied lead time. Creates a new
         advected forecast and then reapplies the orographic enhancement if it
@@ -400,10 +400,6 @@ class CreateExtrapolationForecast():
         Raises:
             ValueError: If no leadtime_minutes are provided.
         """
-        if leadtime_minutes is None:
-            message = ("leadtime_minutes must be provided in order to produce"
-                       " an extrapolated forecast")
-            raise ValueError(message)
         # cast to float as datetime.timedelta cannot accept np.int
         timestep = datetime.timedelta(minutes=float(leadtime_minutes))
         forecast_cube = self.advection_plugin.process(
@@ -432,6 +428,5 @@ class CreateExtrapolationForecast():
         lead_times = np.arange(0, max_lead_time + 1, interval)
         forecast_cubes = iris.cube.CubeList()
         for lead_time in lead_times:
-            forecast_cubes.append(
-                self.extrapolate(leadtime_minutes=lead_time))
+            forecast_cubes.append(self.extrapolate(lead_time))
         return forecast_cubes

--- a/lib/improver/nowcasting/forecasting.py
+++ b/lib/improver/nowcasting/forecasting.py
@@ -426,7 +426,7 @@ class CreateExtrapolationForecast():
                 Maximum lead time required, in minutes
 
         Returns:
-            list of iris.cube.Cube:
+            iris.cube.CubeList:
                 List of forecast cubes at the required lead times
         """
         lead_times = np.arange(0, max_lead_time + 1, interval)

--- a/lib/improver/nowcasting/forecasting.py
+++ b/lib/improver/nowcasting/forecasting.py
@@ -424,6 +424,10 @@ class CreateExtrapolationForecast():
                 Lead time interval, in minutes
             max_lead_time (int):
                 Maximum lead time required, in minutes
+
+        Returns:
+            list of iris.cube.Cube:
+                List of forecast cubes at the required lead times
         """
         lead_times = np.arange(0, max_lead_time + 1, interval)
         forecast_cubes = iris.cube.CubeList()

--- a/lib/improver/nowcasting/optical_flow.py
+++ b/lib/improver/nowcasting/optical_flow.py
@@ -45,7 +45,7 @@ from improver.utilities.spatial import check_if_grid_is_equal_area
 
 
 def generate_optical_flow_components(
-    cube_list, ofc_box_size, smart_smoothing_iterations, attributes_dict):
+        cube_list, ofc_box_size, smart_smoothing_iterations, attributes_dict):
     """
     Calculate the mean optical flow components between the cubes in cube_list
 

--- a/lib/improver/tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
+++ b/lib/improver/tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
@@ -177,7 +177,7 @@ class Test_extrapolate(SetUpCubes):
         input_cube.units = "K"
         plugin = CreateExtrapolationForecast(
                 input_cube, self.vel_x, self.vel_y)
-        result = plugin.extrapolate(leadtime_minutes=10)
+        result = plugin.extrapolate(10)
         expected_result = np.array([[np.nan, np.nan, np.nan],
                                     [np.nan, 1, 2],
                                     [np.nan, 1, 1],
@@ -207,7 +207,7 @@ class Test_extrapolate(SetUpCubes):
         plugin = CreateExtrapolationForecast(
                 self.precip_cube, self.vel_x, self.vel_y,
                 orographic_enhancement_cube=self.oe_cube)
-        result = plugin.extrapolate(leadtime_minutes=10)
+        result = plugin.extrapolate(10)
         expected_result = np.array([[np.nan, np.nan, np.nan],
                                     [np.nan, 1.03125, 1.0],
                                     [np.nan, 1.0, 0.03125],
@@ -231,9 +231,8 @@ class Test_extrapolate(SetUpCubes):
         plugin = CreateExtrapolationForecast(
                 self.precip_cube, self.vel_x, self.vel_y,
                 orographic_enhancement_cube=self.oe_cube)
-        message = ("leadtime_minutes must be provided in order to "
-                   "produce an extrapolated forecast")
-        with self.assertRaisesRegex(ValueError, message):
+        message = ("missing 1 required positional argument")
+        with self.assertRaisesRegex(TypeError, message):
             plugin.extrapolate()
 
 

--- a/lib/improver/tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
+++ b/lib/improver/tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
@@ -226,15 +226,6 @@ class Test_extrapolate(SetUpCubes):
         self.assertEqual(result.coord("time").points,
                          self.precip_cube.coord("time").points+600)
 
-    def test_raises_error(self):
-        """Test an error is raised if no leadtime is provided"""
-        plugin = CreateExtrapolationForecast(
-                self.precip_cube, self.vel_x, self.vel_y,
-                orographic_enhancement_cube=self.oe_cube)
-        message = ("missing 1 required positional argument")
-        with self.assertRaisesRegex(TypeError, message):
-            plugin.extrapolate()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/nowcasting/optical_flow/test_generate_optical_flow_components.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_generate_optical_flow_components.py
@@ -98,6 +98,18 @@ class Test_generate_optical_flow_components(IrisTest):
             self.assertAlmostEqual(
                 cube.coord("time").points[0], self.expected_time)
 
+    @ManageWarnings(ignored_messages=[
+        "No non-zero data in input fields",
+        "Collapsing a non-contiguous coordinate"])
+    def test_fewer_inputs(self):
+        """Test routine can produce output from a shorter list of inputs"""
+        result = generate_optical_flow_components(
+            [self.second_cube, self.third_cube], self.ofc_box_size,
+            self.iterations, None)
+        for cube in result:
+            self.assertAlmostEqual(
+                cube.coord("time").points[0], self.expected_time)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/nowcasting/optical_flow/test_generate_optical_flow_components.py
+++ b/lib/improver/tests/nowcasting/optical_flow/test_generate_optical_flow_components.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for generation of optical flow components"""
+
+import unittest
+from datetime import datetime
+
+import iris
+import numpy as np
+from iris.tests import IrisTest
+
+from improver.nowcasting.optical_flow import generate_optical_flow_components
+from improver.tests.set_up_test_cubes import set_up_variable_cube
+from improver.utilities.warnings_handler import ManageWarnings
+
+
+class Test_generate_optical_flow_components(IrisTest):
+    """Tests for the generate_optical_flow_components method"""
+
+    def setUp(self):
+        """Set up test cubes.  Optical flow velocity values are tested within
+        the Test_optical_flow module; this class tests timestamps only."""
+        self.iterations = 20
+        self.ofc_box_size = 10
+
+        dummy_cube = set_up_variable_cube(
+            np.zeros((30, 30), dtype=np.float32),
+            name="lwe_precipitation_rate", units="mm h-1",
+            spatial_grid="equalarea", time=datetime(2018, 2, 20, 4, 0),
+            frt=datetime(2018, 2, 20, 4, 0))
+        coord_points = 2000*np.arange(30, dtype=np.float32)  # in metres
+        dummy_cube.coord(axis='x').points = coord_points
+        dummy_cube.coord(axis='y').points = coord_points
+
+        self.first_cube = dummy_cube.copy()
+        self.second_cube = dummy_cube.copy()
+        # 15 minutes later, in seconds
+        self.second_cube.coord("time").points = (
+            self.second_cube.coord("time").points + 15*60)
+
+        self.third_cube = dummy_cube.copy()
+        # 30 minutes later, in seconds
+        self.third_cube.coord("time").points = (
+            self.third_cube.coord("time").points + 30*60)
+
+        self.expected_time = self.third_cube.coord("time").points[0]
+
+    @ManageWarnings(ignored_messages=[
+        "No non-zero data in input fields",
+        "Collapsing a non-contiguous coordinate"])
+    def test_basic(self):
+        """Test output is a tuple of cubes"""
+        cubelist = [self.first_cube, self.second_cube, self.third_cube]
+        result = generate_optical_flow_components(
+            cubelist, self.ofc_box_size, self.iterations, None)
+        for cube in result:
+            self.assertIsInstance(cube, iris.cube.Cube)
+            self.assertAlmostEqual(
+                cube.coord("time").points[0], self.expected_time)
+
+    @ManageWarnings(ignored_messages=[
+        "No non-zero data in input fields",
+        "Collapsing a non-contiguous coordinate"])
+    def test_time_ordering(self):
+        """Test output timestamps are insensitive to input cube order"""
+        cubelist = [self.second_cube, self.third_cube, self.first_cube]
+        result = generate_optical_flow_components(
+            cubelist, self.ofc_box_size, self.iterations, None)
+        for cube in result:
+            self.assertAlmostEqual(
+                cube.coord("time").points[0], self.expected_time)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Stripped a ton of processing that shouldn't have been there out of the nowcasting CLIs and into plugins / utilities.  Cut-n-paste programming.  Added some basic unit tests, but coverage is already provided by CLI tests - there are no new features here.

Testing:
 - [x] Ran tests and they passed OK
