### PR TITLE
Added utility to create "new diagnostic" cubes, to replace "cube.copy…

### DIFF
--- a/lib/improver/metadata/amend.py
+++ b/lib/improver/metadata/amend.py
@@ -134,17 +134,10 @@ def add_coord(cube, coord_name, changes, warnings_on=False):
     else:
         new_coord_method = iris.coords.DimCoord
 
-    try:
-        new_coord = new_coord_method(
-            standard_name=coord_name, var_name=var_name, points=points,
-            bounds=bounds, units=units, attributes=attributes)
-    except ValueError as cause:
-        if 'is not a valid standard_name' in str(cause):
-            new_coord = new_coord_method(
-                long_name=coord_name, var_name=var_name, points=points,
-                bounds=bounds, units=units, attributes=attributes)
-        else:
-            raise ValueError(cause)
+    new_coord = new_coord_method(
+        points=points, bounds=bounds, units=units, attributes=attributes)
+    new_coord.rename(coord_name)
+    new_coord.var_name = var_name
 
     result.add_aux_coord(new_coord)
     if metatype == 'DimCoord':

--- a/lib/improver/metadata/utilities.py
+++ b/lib/improver/metadata/utilities.py
@@ -41,7 +41,8 @@ import numpy as np
 
 
 def create_new_diagnostic_cube(
-        name, units, coordinate_template, attributes=None, data=None):
+        name, units, coordinate_template, attributes=None, data=None,
+        datatype=np.float32):
     """
     Creates a template for a new diagnostic cube with suitable metadata.
 
@@ -54,18 +55,19 @@ def create_new_diagnostic_cube(
             Cube from which to copy dimensional and auxiliary coordinates
         attributes (dict or None):
             Dictionary of attribute names and values
-        data (np.ndarray or None):
+        data (numpy.ndarray or None):
             Data array.  If not set, cube is filled with zeros using a lazy
             data object, as this will be overwritten later by the caller
             routine.
+        datatype (numpy.dtype):
+            Datatype for dummy cube data if "data" argument is None.
 
     Returns:
         iris.cube.Cube:
             Cube with correct metadata to accommodate new diagnostic field
     """
     if data is None:
-        data = da.zeros_like(
-            coordinate_template, dtype=np.float32, chunks=-1)
+        data = da.zeros_like(coordinate_template, dtype=datatype)
 
     aux_coords_and_dims, dim_coords_and_dims = [
         [(coord, coordinate_template.coord_dims(coord))

--- a/lib/improver/metadata/utilities.py
+++ b/lib/improver/metadata/utilities.py
@@ -42,7 +42,7 @@ import numpy as np
 
 def create_new_diagnostic_cube(
         name, units, coordinate_template, attributes=None, data=None,
-        datatype=np.float32):
+        dtype=np.float32):
     """
     Creates a template for a new diagnostic cube with suitable metadata.
 
@@ -59,7 +59,7 @@ def create_new_diagnostic_cube(
             Data array.  If not set, cube is filled with zeros using a lazy
             data object, as this will be overwritten later by the caller
             routine.
-        datatype (numpy.dtype):
+        dtype (numpy.dtype):
             Datatype for dummy cube data if "data" argument is None.
 
     Returns:
@@ -67,7 +67,7 @@ def create_new_diagnostic_cube(
             Cube with correct metadata to accommodate new diagnostic field
     """
     if data is None:
-        data = da.zeros_like(coordinate_template, dtype=datatype)
+        data = da.zeros_like(coordinate_template.core_data(), dtype=dtype)
 
     aux_coords_and_dims, dim_coords_and_dims = [
         [(coord, coordinate_template.coord_dims(coord))

--- a/lib/improver/metadata/utilities.py
+++ b/lib/improver/metadata/utilities.py
@@ -31,11 +31,11 @@
 """General IMPROVER metadata utilities"""
 
 import hashlib
-import iris
 # Usage of pickle in this module is only for creation of pickles and hashing
 # the contents. There is no loading pickles which would create security risks.
 import pickle  # nosec
 
+import iris
 import dask.array as da
 import numpy as np
 

--- a/lib/improver/metadata/utilities.py
+++ b/lib/improver/metadata/utilities.py
@@ -63,8 +63,8 @@ def create_new_diagnostic_cube(
             Cube with correct metadata to accommodate new diagnostic field
     """
     if data is None:
-        data = dask.array.zeros(
-            coordinate_template.shape, dtype=np.float32, chunks=-1)
+        data = dask.array.zeros_like(
+            coordinate_template, dtype=np.float32, chunks=-1)
 
     aux_coords_and_dims, dim_coords_and_dims = [
         [(coord, coordinate_template.coord_dims(coord))

--- a/lib/improver/tests/metadata/test_utilities.py
+++ b/lib/improver/tests/metadata/test_utilities.py
@@ -82,7 +82,7 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
             self.name, self.units, self.template_cube, data=data)
         self.assertTrue(np.allclose(result.data, data))
 
-    def test_datatype(self):
+    def test_dtype(self):
         """Test dummy data of a different type can be set"""
         result = create_new_diagnostic_cube(
             self.name, self.units, self.template_cube, dtype=np.int32)

--- a/lib/improver/tests/metadata/test_utilities.py
+++ b/lib/improver/tests/metadata/test_utilities.py
@@ -66,6 +66,7 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
         self.assertFalse(np.allclose(result.data, self.template_cube.data))
         self.assertFalse(result.attributes)
         self.assertFalse(result.cell_methods)
+        self.assertEqual(result.data.dtype, np.float32)
 
     def test_attributes(self):
         """Test attributes can be set on the output cube"""
@@ -80,6 +81,12 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
         result = create_new_diagnostic_cube(
             self.name, self.units, self.template_cube, data=data)
         self.assertTrue(np.allclose(result.data, data))
+
+    def test_datatype(self):
+        """Test dummy data of a different type can be set"""
+        result = create_new_diagnostic_cube(
+            self.name, self.units, self.template_cube, datatype=np.int32)
+        self.assertEqual(result.data.dtype, np.int32)
 
     def test_non_standard_name(self):
         """Test cube can be created with a non-CF-standard name"""

--- a/lib/improver/tests/metadata/test_utilities.py
+++ b/lib/improver/tests/metadata/test_utilities.py
@@ -59,9 +59,10 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.standard_name, "lwe_precipitation_rate")
         self.assertEqual(result.units, "mm h-1")
-        self.assertSequenceEqual(result.coords(), self.template_cube.coords())
         self.assertSequenceEqual(result.coords(dim_coords=True),
                                  self.template_cube.coords(dim_coords=True))
+        self.assertSequenceEqual(result.coords(dim_coords=False),
+                                 self.template_cube.coords(dim_coords=False))
         self.assertFalse(np.allclose(result.data, self.template_cube.data))
         self.assertFalse(result.attributes)
         self.assertFalse(result.cell_methods)

--- a/lib/improver/tests/metadata/test_utilities.py
+++ b/lib/improver/tests/metadata/test_utilities.py
@@ -31,10 +31,61 @@
 """Tests for the improver.metadata.utilities module"""
 
 import unittest
+import iris
 import numpy as np
 
-from improver.metadata.utilities import generate_hash, create_coordinate_hash
+from improver.metadata.utilities import (
+    create_new_diagnostic_cube, generate_hash, create_coordinate_hash)
 from improver.tests.set_up_test_cubes import set_up_variable_cube
+
+
+class Test_create_new_diagnostic_cube(unittest.TestCase):
+    """Test utility to create new diagnostic cubes"""
+
+    def setUp(self):
+        """Set up template with data, coordinates, attributes and cell
+        methods"""
+        self.template_cube = set_up_variable_cube(
+            280*np.ones((3, 5, 5), dtype=np.float32),
+            standard_grid_metadata='uk_det')
+        self.template_cube.add_cell_method('time (max): 1 hour')
+        self.name = "lwe_precipitation_rate"
+        self.units = "mm h-1"
+
+    def test_basic(self):
+        """Test result is a cube that inherits coordinates only"""
+        result = create_new_diagnostic_cube(
+            self.name, self.units, self.template_cube)
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertEqual(result.standard_name, "lwe_precipitation_rate")
+        self.assertEqual(result.units, "mm h-1")
+        self.assertSequenceEqual(result.coords(), self.template_cube.coords())
+        self.assertSequenceEqual(result.coords(dim_coords=True),
+                                 self.template_cube.coords(dim_coords=True))
+        self.assertFalse(np.allclose(result.data, self.template_cube.data))
+        self.assertFalse(result.attributes)
+        self.assertFalse(result.cell_methods)
+
+    def test_attributes(self):
+        """Test attributes can be set on the output cube"""
+        attributes = {"source": "IMPROVER"}
+        result = create_new_diagnostic_cube(
+            self.name, self.units, self.template_cube, attributes=attributes)
+        self.assertDictEqual(result.attributes, attributes)
+
+    def test_data(self):
+        """Test data can be set on the output cube"""
+        data = np.arange(3*5*5).reshape((3, 5, 5)).astype(np.float32)
+        result = create_new_diagnostic_cube(
+            self.name, self.units, self.template_cube, data=data)
+        self.assertTrue(np.allclose(result.data, data))
+
+    def test_non_standard_name(self):
+        """Test cube can be created with a non-CF-standard name"""
+        result = create_new_diagnostic_cube(
+            "RainRate Composite", self.units, self.template_cube)
+        self.assertEqual(result.long_name, "RainRate Composite")
+        self.assertIsNone(result.standard_name)
 
 
 class Test_generate_hash(unittest.TestCase):

--- a/lib/improver/tests/metadata/test_utilities.py
+++ b/lib/improver/tests/metadata/test_utilities.py
@@ -85,7 +85,7 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
     def test_datatype(self):
         """Test dummy data of a different type can be set"""
         result = create_new_diagnostic_cube(
-            self.name, self.units, self.template_cube, datatype=np.int32)
+            self.name, self.units, self.template_cube, dtype=np.int32)
         self.assertEqual(result.data.dtype, np.int32)
 
     def test_non_standard_name(self):

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -242,17 +242,10 @@ def set_up_variable_cube(data, name='air_temperature', units='K',
         cube_attrs.update(attributes)
 
     # create data cube
-    try:
-        cube = iris.cube.Cube(data, name, units=units,
-                              dim_coords_and_dims=dim_coords,
-                              aux_coords_and_dims=scalar_coords,
-                              attributes=cube_attrs)
-    except ValueError:
-        # if "name" is not a standard name, set long name instead
-        cube = iris.cube.Cube(data, long_name=name, units=units,
-                              dim_coords_and_dims=dim_coords,
-                              aux_coords_and_dims=scalar_coords,
-                              attributes=cube_attrs)
+    cube = iris.cube.Cube(data, units=units, attributes=cube_attrs,
+                          dim_coords_and_dims=dim_coords,
+                          aux_coords_and_dims=scalar_coords)
+    cube.rename(name)
 
     # don't allow unit tests to set up invalid cubes
     check_cube_not_float64(cube)

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -220,19 +220,10 @@ class BasicThreshold(object):
             iris.cube.Cube:
                 With new "threshold" axis
         """
-        try:
-            coord = iris.coords.DimCoord(
-                np.array([threshold], dtype=np.float32),
-                standard_name=self.threshold_coord_name,
-                var_name="threshold", units=cube.units)
-        except ValueError as cause:
-            if 'is not a valid standard_name' in str(cause):
-                coord = iris.coords.DimCoord(
-                    np.array([threshold], dtype=np.float32),
-                    long_name=self.threshold_coord_name,
-                    var_name="threshold", units=cube.units)
-            else:
-                raise ValueError(cause)
+        coord = iris.coords.DimCoord(np.array([threshold], dtype=np.float32),
+                                     units=cube.units)
+        coord.rename(self.threshold_coord_name)
+        coord.var_name = "threshold"
 
         # Use an spp__relative_to_threshold attribute, as an extension to the
         # CF-conventions.


### PR DESCRIPTION
…()" statements in plugins that change the diagnostic type (eg lapse rate).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

