### PR TITLE
IMPRO-1456: Remove unused code in spatial/utilities

### DIFF
--- a/lib/improver/tests/utilities/test_spatial.py
+++ b/lib/improver/tests/utilities/test_spatial.py
@@ -131,7 +131,8 @@ class Test_common_functions(IrisTest):
         # So there is higher pressure in the west.
         orography.data[0:10] = 0
         orography.data[10:] = 10
-        ancillary_data = {'orography': orography}
+        ancillary_data = {}
+        ancillary_data['orography'] = orography
 
         additional_data = {}
         adlist = CubeList()
@@ -179,7 +180,7 @@ class Test_calculate_grid_spacing(IrisTest):
 
     def test_axis_keyword(self):
         """Test using the other axis"""
-        self.cube.coord(axis='y').points *= 2
+        self.cube.coord(axis='y').points = 2*(self.cube.coord(axis='y').points)
         result = calculate_grid_spacing(self.cube, self.unit, axis='y')
         self.assertAlmostEqual(result, 2*self.spacing)
 
@@ -214,7 +215,7 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
     def test_distance_to_grid_cells_other_axis(self):
         """Test the distance in metres to grid cell conversion along the
         y-axis."""
-        self.cube.coord(axis='y').points *= 0.5
+        self.cube.coord(axis='y').points = 0.5*self.cube.coord(axis='y').points
         result = convert_distance_into_number_of_grid_cells(
             self.cube, self.DISTANCE, axis='y')
         self.assertEqual(result, 6)
@@ -363,7 +364,7 @@ class Test_check_if_grid_is_equal_area(IrisTest):
 
     def test_non_equal_xy_spacing(self):
         """Test that the cubes have an equal areas grid"""
-        self.cube.coord(axis='x').points *= 2
+        self.cube.coord(axis='x').points = 2*self.cube.coord(axis='x').points
         msg = "Grid does not have equal spacing in x and y"
         with self.assertRaisesRegex(ValueError, msg):
             check_if_grid_is_equal_area(self.cube)
@@ -371,7 +372,7 @@ class Test_check_if_grid_is_equal_area(IrisTest):
     def test_non_equal_xy_spacing_override(self):
         """Test that the requirement for equal x and y spacing can be
         overridden"""
-        self.cube.coord(axis='x').points *= 2
+        self.cube.coord(axis='x').points = 2*self.cube.coord(axis='x').points
         self.assertIsNone(
             check_if_grid_is_equal_area(
                 self.cube, require_equal_xy_spacing=False))

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -510,33 +510,6 @@ def transform_grid_to_lat_lon(cube):
     return lats, lons
 
 
-def get_nearest_coords(cube, latitude, longitude, iname, jname):
-    """
-    Uses the iris cube method nearest_neighbour_index to find the nearest grid
-    points to a given latitude-longitude position.
-
-    Args:
-        cube (iris.cube.Cube):
-            Cube containing a representative grid.
-        latitude (float):
-            Latitude coordinates of spot data site of interest.
-        longitude (float):
-            Longitude coordinates of spot data site of interest.
-        iname (str):
-            String giving the name of the y coordinates to be searched.
-        jname (str):
-            String giving the names of the x coordinates to be searched.
-
-    Returns:
-        Tuple[int, int]: Grid coordinates of the nearest grid point to the
-        spot data site.
-
-    """
-    i_latitude = cube.coord(iname).nearest_neighbour_index(latitude)
-    j_longitude = cube.coord(jname).nearest_neighbour_index(longitude)
-    return i_latitude, j_longitude
-
-
 class RegridLandSea():
     """
     Replace data values at points where the nearest-regridding technique

--- a/lib/improver/utilities/spatial.py
+++ b/lib/improver/utilities/spatial.py
@@ -473,34 +473,6 @@ def lat_lon_determine(cube):
     return trg_crs
 
 
-def lat_lon_transform(trg_crs, latitude, longitude):
-    """
-    Transforms latitude/longitude coordinate pairs from a latitude/longitude
-    grid into an alternative projection defined by trg_crs.
-
-    Args:
-        trg_crs (cartopy.crs.CRS or None):
-            Target coordinate system in cartopy format or None.
-
-        latitude (float):
-            Latitude coordinate.
-
-        longitude (float):
-            Longitude coordinate.
-
-    Returns:
-        x, y (float):
-            Longitude and latitude transformed into the target coordinate
-            system.
-
-    """
-    if trg_crs is None:
-        return longitude, latitude
-    else:
-        return trg_crs.transform_point(longitude, latitude,
-                                       ccrs.PlateCarree())
-
-
 def transform_grid_to_lat_lon(cube):
     """
     Calculate the latitudes and longitudes of each points in the cube.


### PR DESCRIPTION
Removing unused functions and their tests.
- lat_lon_transform
- get_nearest_coords

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
