### PR TITLE
IMPRO-1330: Cap alpha values

### DIFF
--- a/lib/improver/cli/nbhood.py
+++ b/lib/improver/cli/nbhood.py
@@ -387,6 +387,14 @@ def process(cube, neighbourhood_output, neighbourhood_shape, radius=None,
             raise ValueError(
                 'Cannot process complex numbers with recursive filter')
 
+    if alphas_x_cube is not None and (alphas_x_cube.data > 0.5).any():
+        raise ValueError("alpha must be less than 0.5. A large alpha value "
+                         "leads to poor conservation of probabilities")
+
+    if alphas_y_cube is not None and (alphas_y_cube.data > 0.5).any():
+        raise ValueError("alpha must be less than 0.5. A large alpha value "
+                         "leads to poor conservation of probabilities")
+
     if degrees_as_complex:
         # convert cube data into complex numbers
         cube.data = WindDirection.deg_to_complex(cube.data)

--- a/lib/improver/cli/nbhood.py
+++ b/lib/improver/cli/nbhood.py
@@ -387,14 +387,6 @@ def process(cube, neighbourhood_output, neighbourhood_shape, radius=None,
             raise ValueError(
                 'Cannot process complex numbers with recursive filter')
 
-    if alphas_x_cube is not None and (alphas_x_cube.data > 0.5).any():
-        raise ValueError("alpha must be less than 0.5. A large alpha value "
-                         "leads to poor conservation of probabilities")
-
-    if alphas_y_cube is not None and (alphas_y_cube.data > 0.5).any():
-        raise ValueError("alpha must be less than 0.5. A large alpha value "
-                         "leads to poor conservation of probabilities")
-
     if degrees_as_complex:
         # convert cube data into complex numbers
         cube.data = WindDirection.deg_to_complex(cube.data)

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -137,7 +137,7 @@ def process(cube, mask_cube=None, alphas_x_cube=None, alphas_y_cube=None,
         iterations (int):
             Number of times to apply the filter. (Typically < 3)
             Number of iterations should be less than 3, higher values have been
-            show to lead to poorer conservation.
+            shown to lead to poorer conservation.
             Default is 1 (one).
         re_mask (bool):
             Re-apply mask to recursively filtered output.

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -147,13 +147,6 @@ def process(cube, mask_cube=None, alphas_x_cube=None, alphas_y_cube=None,
         result (iris.cube.Cube):
             The processed Cube.
     """
-    if alphas_x_cube is not None and (alphas_x_cube.data > 0.5).any():
-        raise ValueError("alpha must be less than 0.5. A large alpha value "
-                         "leads to poor conservation of probabilities")
-
-    if alphas_y_cube is not None and (alphas_y_cube.data > 0.5).any():
-        raise ValueError("alpha must be less than 0.5. A large alpha value "
-                         "leads to poor conservation of probabilities")
     result = RecursiveFilter(
         alpha_x=alpha_x, alpha_y=alpha_y,
         iterations=iterations, re_mask=re_mask).process(

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -136,7 +136,7 @@ def process(cube, mask_cube=None, alphas_x_cube=None, alphas_y_cube=None,
             Default is None.
         iterations (int):
             Number of times to apply the filter. (Typically < 3)
-            Number of iterations should be less than 3, higher values have been
+            Number of iterations should be 2 or less, higher values have been
             shown to lead to poorer conservation.
             Default is 1 (one).
         re_mask (bool):

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -136,8 +136,8 @@ def process(cube, mask_cube=None, alphas_x_cube=None, alphas_y_cube=None,
             Default is None.
         iterations (int):
             Number of times to apply the filter. (Typically < 3)
-            Number of iterations should be less than 3, any high and it may
-            lead to poorer conservation.
+            Number of iterations should be less than 3, higher values have been
+            show to lead to poorer conservation.
             Default is 1 (one).
         re_mask (bool):
             Re-apply mask to recursively filtered output.

--- a/lib/improver/cli/recursive_filter.py
+++ b/lib/improver/cli/recursive_filter.py
@@ -135,7 +135,9 @@ def process(cube, mask_cube=None, alphas_x_cube=None, alphas_y_cube=None,
             square in the y direction.
             Default is None.
         iterations (int):
-            Number of times to apply the filter. (Typically < 5)
+            Number of times to apply the filter. (Typically < 3)
+            Number of iterations should be less than 3, any high and it may
+            lead to poorer conservation.
             Default is 1 (one).
         re_mask (bool):
             Re-apply mask to recursively filtered output.
@@ -145,6 +147,13 @@ def process(cube, mask_cube=None, alphas_x_cube=None, alphas_y_cube=None,
         result (iris.cube.Cube):
             The processed Cube.
     """
+    if alphas_x_cube is not None and (alphas_x_cube.data > 0.5).any():
+        raise ValueError("alpha must be less than 0.5. A large alpha value "
+                         "leads to poor conservation of probabilities")
+
+    if alphas_y_cube is not None and (alphas_y_cube.data > 0.5).any():
+        raise ValueError("alpha must be less than 0.5. A large alpha value "
+                         "leads to poor conservation of probabilities")
     result = RecursiveFilter(
         alpha_x=alpha_x, alpha_y=alpha_y,
         iterations=iterations, re_mask=re_mask).process(

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -29,6 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Module to apply a recursive filter to neighbourhooded data."""
+import warnings
 
 import iris
 import numpy as np
@@ -49,6 +50,11 @@ class RecursiveFilter(object):
                  edge_width=1, re_mask=False):
         """
         Initialise the class.
+
+        The alpha values determine how much "value" of a cell undergoing
+        filtering os comprised of the current value at that cell and how much
+        comes from the adjacent cell preceding it in the direction in which
+        filtering is being applied.
 
         Args:
             alpha_x (float or None):
@@ -73,29 +79,33 @@ class RecursiveFilter(object):
                 originally masked.
 
         Raises:
-            ValueError: If alpha_x is not set such that 0 < alpha_x < 1
-            ValueError: If alpha_y is not set such that 0 < alpha_y < 1
+            ValueError: If alpha_x is not set such that 0 < alpha_x <= 0.5
+            ValueError: If alpha_y is not set such that 0 < alpha_y <= 0.5
             ValueError: If number of iterations is not None and is set such
                         that iterations is not >= 1
 
         """
-        if alpha_x is not None:
-            if not 0 < alpha_x < 1:
-                raise ValueError(
-                    "Invalid alpha_x: must be > 0 and < 1: {}".format(
-                        alpha_x))
+        alpha_error = (
+            "alpha must be less than 0.5. A large alpha value leads to poor "
+            "conservation of probabilities: ")
+        if alpha_x is not None and not 0 < alpha_x <= 0.5:
+            message = alpha_error if alpha_x > 0.5 else ''
+            message += "Invalid alpha_x: must be > 0 and <= 0.5: {}"
+            raise ValueError(message.format(alpha_x))
 
-        if alpha_y is not None:
-            if not 0 < alpha_y < 1:
-                raise ValueError(
-                    "Invalid alpha_y: must be > 0 and < 1: {}".format(
-                        alpha_y))
+        if alpha_y is not None and not 0 < alpha_y <= 0.5:
+            message = alpha_error if alpha_y > 0.5 else ''
+            message += "Invalid alpha_y: must be > 0 and <= 0.5: {}"
+            raise ValueError(message.format(alpha_y))
 
         if iterations is not None:
-            if not iterations >= 1:
+            if iterations < 1:
                 raise ValueError(
                     "Invalid number of iterations: must be >= 1: {}".format(
                         iterations))
+            if iterations > 2:
+                warnings.warn(
+                    "Iterations of two will lead to poorer conservation.")
 
         self.alpha_x = alpha_x
         self.alpha_y = alpha_y

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -82,22 +82,24 @@ class RecursiveFilter(object):
             ValueError: If alpha_x is not set such that 0 < alpha_x <= 0.5
             ValueError: If alpha_y is not set such that 0 < alpha_y <= 0.5
             ValueError: If number of iterations is not None and is set such
-                        that iterations is not >= 1
+                        that iterations is less than 1.
+
+        Warns:
+            UserWarning:
+                If iterations is higher than 2.
+
 
         """
-        alpha_error = (
-            "alpha must be less than 0.5. A large alpha value leads to poor "
-            "conservation of probabilities: ")
+        alpha_error = ("alpha must be less than 0.5. A large alpha value"
+                       "leads to poor conservation of probabilities: ")
         if alpha_x is not None and not 0 < alpha_x <= 0.5:
             message = alpha_error if alpha_x > 0.5 else ''
             message += "Invalid alpha_x: must be > 0 and <= 0.5: {}"
             raise ValueError(message.format(alpha_x))
-
         if alpha_y is not None and not 0 < alpha_y <= 0.5:
             message = alpha_error if alpha_y > 0.5 else ''
             message += "Invalid alpha_y: must be > 0 and <= 0.5: {}"
             raise ValueError(message.format(alpha_y))
-
         if iterations is not None:
             if iterations < 1:
                 raise ValueError(
@@ -329,7 +331,21 @@ class RecursiveFilter(object):
             new_cube (iris.cube.Cube):
                 Cube containing the smoothed field after the recursive filter
                 method has been applied.
+
+        Raises:
+            ValueError: If any alpha cube value is over 0.5
         """
+
+        if alphas_x is not None and (alphas_x.data > 0.5).any():
+            raise ValueError(
+                "alpha must be less than 0.5. A large alpha value "
+                "leads to poor conservation of probabilities")
+
+        if alphas_y is not None and (alphas_y.data > 0.5).any():
+            raise ValueError(
+                "alpha must be less than 0.5. A large alpha value "
+                "leads to poor conservation of probabilities")
+
         cube_format = next(cube.slices([cube.coord(axis='y'),
                                         cube.coord(axis='x')]))
         alphas_x = self._set_alphas(cube_format, self.alpha_x, alphas_x)

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -335,7 +335,7 @@ class RecursiveFilter(object):
         for alpha in (alphas_x, alphas_y):
             if alpha is not None and (alpha.data > 0.5).any():
                 raise ValueError(
-                    "alpha must be less than 0.5. A large alpha value "
+                    "All alpha values must be less than 0.5. A large alpha value "
                     "leads to poor conservation of probabilities")
 
         cube_format = next(cube.slices([cube.coord(axis='y'),

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -52,7 +52,7 @@ class RecursiveFilter(object):
         Initialise the class.
 
         The alpha values determine how much "value" of a cell undergoing
-        filtering os comprised of the current value at that cell and how much
+        filtering is comprised of the current value at that cell and how much
         comes from the adjacent cell preceding it in the direction in which
         filtering is being applied.
 
@@ -92,14 +92,11 @@ class RecursiveFilter(object):
         """
         alpha_error = ("alpha must be less than 0.5. A large alpha value"
                        "leads to poor conservation of probabilities: ")
-        if alpha_x is not None and not 0 < alpha_x <= 0.5:
-            message = alpha_error if alpha_x > 0.5 else ''
-            message += "Invalid alpha_x: must be > 0 and <= 0.5: {}"
-            raise ValueError(message.format(alpha_x))
-        if alpha_y is not None and not 0 < alpha_y <= 0.5:
-            message = alpha_error if alpha_y > 0.5 else ''
-            message += "Invalid alpha_y: must be > 0 and <= 0.5: {}"
-            raise ValueError(message.format(alpha_y))
+        for k, v in {'x':alpha_x, 'y':alpha_y}.items():
+            if v is not None and not 0 < v <= 0.5:
+                message = alpha_error if v > 0.5 else ''
+                message += "Invalid alpha_{}: must be > 0 and <= 0.5: {}"
+                raise ValueError(message.format(k, v))
         if iterations is not None:
             if iterations < 1:
                 raise ValueError(
@@ -107,8 +104,8 @@ class RecursiveFilter(object):
                         iterations))
             if iterations > 2:
                 warnings.warn(
-                    "Iterations of two will lead to poorer conservation.")
-
+                    "More than two iterations degrades the conservation"
+                    "of probability assumption.")
         self.alpha_x = alpha_x
         self.alpha_y = alpha_y
         self.iterations = iterations
@@ -335,16 +332,11 @@ class RecursiveFilter(object):
         Raises:
             ValueError: If any alpha cube value is over 0.5
         """
-
-        if alphas_x is not None and (alphas_x.data > 0.5).any():
-            raise ValueError(
-                "alpha must be less than 0.5. A large alpha value "
-                "leads to poor conservation of probabilities")
-
-        if alphas_y is not None and (alphas_y.data > 0.5).any():
-            raise ValueError(
-                "alpha must be less than 0.5. A large alpha value "
-                "leads to poor conservation of probabilities")
+        for alpha in (alphas_x, alphas_y):
+            if alpha is not None and (alpha.data > 0.5).any():
+                raise ValueError(
+                    "alpha must be less than 0.5. A large alpha value "
+                    "leads to poor conservation of probabilities")
 
         cube_format = next(cube.slices([cube.coord(axis='y'),
                                         cube.coord(axis='x')]))

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -92,7 +92,7 @@ class RecursiveFilter(object):
         """
         alpha_error = ("alpha must be less than 0.5. A large alpha value"
                        "leads to poor conservation of probabilities: ")
-        for k, v in {'x':alpha_x, 'y':alpha_y}.items():
+        for k, v in {'x': alpha_x, 'y': alpha_y}.items():
             if v is not None and not 0 < v <= 0.5:
                 message = alpha_error if v > 0.5 else ''
                 message += "Invalid alpha_{}: must be > 0 and <= 0.5: {}"

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -92,11 +92,11 @@ class RecursiveFilter(object):
         """
         alpha_error = ("alpha must be less than 0.5. A large alpha value"
                        "leads to poor conservation of probabilities: ")
-        for k, v in {'x': alpha_x, 'y': alpha_y}.items():
-            if v is not None and not 0 < v <= 0.5:
-                message = alpha_error if v > 0.5 else ''
+        for k, alpha in {'x': alpha_x, 'y': alpha_y}.items():
+            if alpha is not None and not 0 < alpha <= 0.5:
+                message = alpha_error if alpha > 0.5 else ''
                 message += "Invalid alpha_{}: must be > 0 and <= 0.5: {}"
-                raise ValueError(message.format(k, v))
+                raise ValueError(message.format(k, alpha))
         if iterations is not None:
             if iterations < 1:
                 raise ValueError(

--- a/lib/improver/nbhood/recursive_filter.py
+++ b/lib/improver/nbhood/recursive_filter.py
@@ -335,8 +335,8 @@ class RecursiveFilter(object):
         for alpha in (alphas_x, alphas_y):
             if alpha is not None and (alpha.data > 0.5).any():
                 raise ValueError(
-                    "All alpha values must be less than 0.5. A large alpha value "
-                    "leads to poor conservation of probabilities")
+                    "All alpha values must be less than 0.5. A large alpha"
+                    "value leads to poor conservation of probabilities")
 
         cube_format = next(cube.slices([cube.coord(axis='y'),
                                         cube.coord(axis='x')]))

--- a/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -131,7 +131,7 @@ class Test__init__(Test_RecursiveFilter):
                             iterations=iterations, edge_width=1)
 
     @ManageWarnings(record=True)
-    def test_interations_warn(self, warning_list=None):
+    def test_iterations_warn(self, warning_list=None):
         """Test when the iteration value is more than 3 it warns."""
         iterations = 5
         warning_msg = ("More than two iterations degrades the conservation"

--- a/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -95,7 +95,7 @@ class Test__init__(Test_RecursiveFilter):
     """Test plugin initialisation."""
 
     def test_alpha_x_gt_unity(self):
-        """Test when an alpha_x value > unity is given (invalid)."""
+        """Test when an alpha_x value > 0.5 is given (invalid)."""
         alpha_x = 0.6
         msg = r"alpha must be less than 0.5.*?(alpha_x).*?(: 0\.6)"
         with self.assertRaisesRegex(ValueError, msg):
@@ -109,7 +109,7 @@ class Test__init__(Test_RecursiveFilter):
             RecursiveFilter(alpha_x=alpha_x)
 
     def test_alpha_y_gt_unity(self):
-        """Test when an alpha_y value > unity is given (invalid)."""
+        """Test when an alpha_y value > 0.5 is given (invalid)."""
         alpha_y = 0.6
         msg = r"alpha must be less than 0.5.*?(alpha_y).*?(: 0\.6)"
         with self.assertRaisesRegex(ValueError, msg):
@@ -134,7 +134,9 @@ class Test__init__(Test_RecursiveFilter):
     def test_interations_warn(self, warning_list=None):
         """Test when the iteration value is more than 3 it warns."""
         iterations = 5
-        warning_msg = "Iterations of two will lead to poorer conservation."
+        warning_msg = ("More than two iterations degrades the conservation"
+                       "of probability assumption.")
+
         RecursiveFilter(iterations=iterations)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))

--- a/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/lib/improver/tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -41,6 +41,7 @@ from improver.nbhood.recursive_filter import RecursiveFilter
 from improver.tests.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 from improver.utilities.pad_spatial import pad_cube_with_halo
+from improver.utilities.warnings_handler import ManageWarnings
 
 
 class Test__repr__(IrisTest):
@@ -95,35 +96,31 @@ class Test__init__(Test_RecursiveFilter):
 
     def test_alpha_x_gt_unity(self):
         """Test when an alpha_x value > unity is given (invalid)."""
-        alpha_x = 1.1
-        msg = "Invalid alpha_x: must be > 0 and < 1: 1.1"
+        alpha_x = 0.6
+        msg = r"alpha must be less than 0.5.*?(alpha_x).*?(: 0\.6)"
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
-                            iterations=None, edge_width=1)
+            RecursiveFilter(alpha_x=alpha_x)
 
     def test_alpha_x_lt_zero(self):
         """Test when an alpha_x value <= zero is given (invalid)."""
         alpha_x = -0.5
-        msg = "Invalid alpha_x: must be > 0 and < 1: -0.5"
+        msg = "Invalid alpha_x: must be > 0 and <= 0.5: -0.5"
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter(alpha_x=alpha_x, alpha_y=None,
-                            iterations=None, edge_width=1)
+            RecursiveFilter(alpha_x=alpha_x)
 
     def test_alpha_y_gt_unity(self):
         """Test when an alpha_y value > unity is given (invalid)."""
-        alpha_y = 1.1
-        msg = "Invalid alpha_y: must be > 0 and < 1: 1.1"
+        alpha_y = 0.6
+        msg = r"alpha must be less than 0.5.*?(alpha_y).*?(: 0\.6)"
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
-                            iterations=None, edge_width=1)
+            RecursiveFilter(alpha_y=alpha_y)
 
     def test_alpha_y_lt_zero(self):
         """Test when an alpha_y value <= zero is given (invalid)."""
         alpha_y = -0.5
-        msg = "Invalid alpha_y: must be > 0 and < 1: -0.5"
+        msg = "Invalid alpha_y: must be > 0 and <= 0.5: -0.5"
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter(alpha_x=None, alpha_y=alpha_y,
-                            iterations=None, edge_width=1)
+            RecursiveFilter(alpha_y=alpha_y)
 
     def test_iterations(self):
         """Test when iterations value less than unity is given (invalid)."""
@@ -132,6 +129,17 @@ class Test__init__(Test_RecursiveFilter):
         with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(alpha_x=None, alpha_y=None,
                             iterations=iterations, edge_width=1)
+
+    @ManageWarnings(record=True)
+    def test_interations_warn(self, warning_list=None):
+        """Test when the iteration value is more than 3 it warns."""
+        iterations = 5
+        warning_msg = "Iterations of two will lead to poorer conservation."
+        RecursiveFilter(iterations=iterations)
+        self.assertTrue(any(item.category == UserWarning
+                            for item in warning_list))
+        self.assertTrue(any(warning_msg in str(item)
+                            for item in warning_list))
 
 
 class Test__set_alphas(Test_RecursiveFilter):

--- a/tests/improver-nbhood/09-recursive-filter-alpha-basic-square.bats
+++ b/tests/improver-nbhood/09-recursive-filter-alpha-basic-square.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.8 --alpha_y 0.8 --iterations 5" {
+@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.5 --alpha_y 0.5 --iterations 2" {
   improver_check_skip_acceptance
   KGO="nbhood/recursive/kgo_recursive_alpha.nc"
 
@@ -39,7 +39,7 @@
   run improver nbhood 'probabilities' 'square' --radius=20000 \
       "$IMPROVER_ACC_TEST_DIR/nbhood/basic/input_square.nc" \
       "$TEST_DIR/output.nc" --apply-recursive-filter \
-      --alpha_x=0.8 --alpha_y=0.8 --iterations=5
+      --alpha_x=0.5 --alpha_y=0.5 --iterations=2
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-nbhood/10-recursive-filter-alphas-basic-square.bats
+++ b/tests/improver-nbhood/10-recursive-filter-alphas-basic-square.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --input_filepath_alphas_x_cube --input_filepath_alphas_y_cube --iterations 5" {
+@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --input_filepath_alphas_x_cube --input_filepath_alphas_y_cube --iterations 2" {
   improver_check_skip_acceptance
   KGO="nbhood/recursive/kgo_recursive_alphas_gridded.nc"
 
@@ -40,7 +40,7 @@
       "$IMPROVER_ACC_TEST_DIR/nbhood/basic/input_square.nc" \
       "$TEST_DIR/output.nc" --apply-recursive-filter \
       --input_filepath_alphas_x_cube="$IMPROVER_ACC_TEST_DIR/nbhood/recursive/alphasx.nc" \
-      --input_filepath_alphas_y_cube="$IMPROVER_ACC_TEST_DIR/nbhood/recursive/alphasy.nc" --iterations=5
+      --input_filepath_alphas_y_cube="$IMPROVER_ACC_TEST_DIR/nbhood/recursive/alphasy.nc" --iterations=2
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-nbhood/11-recursive-filter-alpha-internal-mask-with-re-mask.bats
+++ b/tests/improver-nbhood/11-recursive-filter-alpha-internal-mask-with-re-mask.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.8 --alpha_y 0.8 --iterations 5 --re_mask" {
+@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.5 --alpha_y 0.5 --iterations 2 --re_mask" {
   improver_check_skip_acceptance
   KGO="nbhood/recursive/kgo_internal_mask_re_masked_recursive_alpha.nc"
 
@@ -39,7 +39,7 @@
   run improver nbhood 'probabilities' 'square' --radius=20000 \
       "$IMPROVER_ACC_TEST_DIR/nbhood/mask/input_masked.nc" \
       "$TEST_DIR/output.nc" --apply-recursive-filter --re_mask \
-      --alpha_x=0.8 --alpha_y=0.8 --iterations=5
+      --alpha_x=0.5 --alpha_y=0.5 --iterations=2
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-nbhood/12-recursive-filter-alpha-internal-mask-no-re-mask.bats
+++ b/tests/improver-nbhood/12-recursive-filter-alpha-internal-mask-no-re-mask.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.8 --alpha_y 0.8 --iterations 5" {
+@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.5 --alpha_y 0.5 --iterations 2" {
   improver_check_skip_acceptance
   KGO="nbhood/recursive/kgo_internal_mask_no_re_mask_recursive_alpha.nc"
 
@@ -39,7 +39,7 @@
   run improver nbhood 'probabilities' 'square' --radius=20000 \
       "$IMPROVER_ACC_TEST_DIR/nbhood/mask/input_masked.nc" \
       "$TEST_DIR/output.nc" --apply-recursive-filter \
-      --alpha_x=0.8 --alpha_y=0.8 --iterations=5
+      --alpha_x=0.5 --alpha_y=0.5 --iterations=2
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-nbhood/13-recursive-filter-alpha-external-mask-with-re-mask.bats
+++ b/tests/improver-nbhood/13-recursive-filter-alpha-external-mask-with-re-mask.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.8 --alpha_y 0.8 --iterations 5 --re_mask --input_mask_filepath" {
+@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.5 --alpha_y 0.5 --iterations 2 --re_mask --input_mask_filepath" {
   improver_check_skip_acceptance
   KGO="nbhood/recursive/kgo_external_mask_with_re_mask_recursive_alpha.nc"
 
@@ -39,7 +39,7 @@
   run improver nbhood 'probabilities' 'square' --radius=20000 \
       "$IMPROVER_ACC_TEST_DIR/nbhood/mask/input.nc" \
       "$TEST_DIR/output.nc" --apply-recursive-filter --re_mask \
-      --alpha_x=0.8 --alpha_y=0.8 --iterations=5 \
+      --alpha_x=0.5 --alpha_y=0.5 --iterations=2 \
       --input_mask_filepath="$IMPROVER_ACC_TEST_DIR/nbhood/mask/mask.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-nbhood/14-recursive-filter-alpha-external-mask-no-re-mask.bats
+++ b/tests/improver-nbhood/14-recursive-filter-alpha-external-mask-no-re-mask.bats
@@ -31,7 +31,7 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.8 --alpha_y 0.8 --iterations 5 --re_mask --input_mask_filepath" {
+@test "nbhood 'probabilities' 'square' --radius=20000 input output --apply-recursive-filter --alpha_x 0.5 --alpha_y 0.5 --iterations 2 --re_mask --input_mask_filepath" {
   improver_check_skip_acceptance
   KGO="nbhood/recursive/kgo_external_mask_no_re_mask_recursive_alpha.nc"
 
@@ -39,7 +39,7 @@
   run improver nbhood 'probabilities' 'square' --radius=20000 \
       "$IMPROVER_ACC_TEST_DIR/nbhood/mask/input.nc" \
       "$TEST_DIR/output.nc" --apply-recursive-filter \
-      --alpha_x=0.8 --alpha_y=0.8 --iterations=5 \
+      --alpha_x=0.5 --alpha_y=0.5 --iterations=2 \
       --input_mask_filepath="$IMPROVER_ACC_TEST_DIR/nbhood/mask/mask.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-recursive-filter/02-basic_alpha.bats
+++ b/tests/improver-recursive-filter/02-basic_alpha.bats
@@ -37,7 +37,7 @@
 
   # Run recursive-filter processing and check it passes.
   run improver recursive-filter "$IMPROVER_ACC_TEST_DIR/recursive-filter/basic_alpha/input.nc"\
-      "$TEST_DIR/output.nc" --alpha_x=0.8 --alpha_y=0.8 --iterations=5
+      "$TEST_DIR/output.nc" --alpha_x=0.5 --alpha_y=0.5 --iterations=2
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-recursive-filter/04-external_mask_with_re_mask.bats
+++ b/tests/improver-recursive-filter/04-external_mask_with_re_mask.bats
@@ -37,7 +37,7 @@
 
   # Run recursive-filter processing and check it passes.
   run improver recursive-filter "$IMPROVER_ACC_TEST_DIR/recursive-filter/masked_input/input.nc"\
-      "$TEST_DIR/output.nc" --alpha_x=0.8 --alpha_y=0.8 --iterations=5 \
+      "$TEST_DIR/output.nc" --alpha_x=0.5 --alpha_y=0.5 --iterations=2 \
       --input_mask_filepath="$IMPROVER_ACC_TEST_DIR/recursive-filter/masked_input/mask.nc" --re_mask
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-recursive-filter/05-external_mask_no_re_mask.bats
+++ b/tests/improver-recursive-filter/05-external_mask_no_re_mask.bats
@@ -37,7 +37,7 @@
 
   # Run recursive-filter processing and check it passes.
   run improver recursive-filter "$IMPROVER_ACC_TEST_DIR/recursive-filter/masked_input/input.nc"\
-      "$TEST_DIR/output.nc" --alpha_x=0.8 --alpha_y=0.8 --iterations=5 \
+      "$TEST_DIR/output.nc" --alpha_x=0.5 --alpha_y=0.5 --iterations=2 \
       --input_mask_filepath="$IMPROVER_ACC_TEST_DIR/recursive-filter/masked_input/mask.nc"
   [[ "$status" -eq 0 ]]
 

--- a/tests/improver-recursive-filter/06-internal_mask_with_re_mask.bats
+++ b/tests/improver-recursive-filter/06-internal_mask_with_re_mask.bats
@@ -37,7 +37,7 @@
 
   # Run recursive-filter processing and check it passes.
   run improver recursive-filter "$IMPROVER_ACC_TEST_DIR/recursive-filter/masked_input/input_masked.nc" \
-      "$TEST_DIR/output.nc" --alpha_x=0.8 --alpha_y=0.8 --iterations=5 --re_mask
+      "$TEST_DIR/output.nc" --alpha_x=0.5 --alpha_y=0.5 --iterations=2 --re_mask
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-recursive-filter/07-internal_mask_no_re_mask.bats
+++ b/tests/improver-recursive-filter/07-internal_mask_no_re_mask.bats
@@ -37,7 +37,7 @@
 
   # Run recursive-filter processing and check it passes.
   run improver recursive-filter "$IMPROVER_ACC_TEST_DIR/recursive-filter/masked_input/input_masked.nc"\
-      "$TEST_DIR/output.nc" --alpha_x=0.8 --alpha_y=0.8 --iterations=5
+      "$TEST_DIR/output.nc" --alpha_x=0.5 --alpha_y=0.5 --iterations=2
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO


### PR DESCRIPTION
Capped the alphas values at 0.5.
given warnings at any more iterations than 2.
changed the cubes and bats to be acceptable and therefore changed the KGO to allow for this.
Tested for the errors and warning.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
