### PR TITLE
Bug: Spot site lat/lons as lat/lons regardless of input coordinate system

### DIFF
--- a/lib/improver/spotdata/neighbour_finding.py
+++ b/lib/improver/spotdata/neighbour_finding.py
@@ -130,7 +130,8 @@ class NeighbourSelection:
                                       '_minimum_dz' if self.minimum_dz else '')
         return method_name
 
-    def _transform_sites_coordinate_system(self, x_points, y_points, cube):
+    def _transform_sites_coordinate_system(self, x_points, y_points,
+                                           target_crs):
         """
         Function to convert coordinate pairs that specify spot sites into the
         coordinate system of the model from which data will be extracted. Note
@@ -144,19 +145,17 @@ class NeighbourSelection:
             y_points (numpy.ndarray):
                 An array of y coordinates to be transformed in conjunction
                 with the corresponding x coordinates.
-            cube (iris.cube.Cube):
-                A cube from the model from which data will be extracted. This
-                provides the coordinate system onto which the spot site's
-                coordinates should be remapped.
+            target_crs (cartopy.crs):
+                Coordinate system to which the site coordinates should be
+                transformed. This should be the coordinate system of the model
+                from which data will be spot extracted.
         Returns:
             numpy.ndarray:
                 An array containing the x and y coordinates of the spot sites
                 in the target coordinate system, shaped as (n_sites, 2). The
                 z coordinate column is excluded from the return.
         """
-        target_coordinate_system = cube.coord_system().as_cartopy_crs()
-
-        return target_coordinate_system.transform_points(
+        return target_crs.transform_points(
             self.site_coordinate_system, x_points, y_points)[:, 0:2]
 
     def check_sites_are_within_domain(self, sites, site_coords, site_x_coords,
@@ -448,7 +447,8 @@ class NeighbourSelection:
         site_y_coords = np.array([site[self.site_y_coordinate]
                                   for site in sites])
         site_coords = self._transform_sites_coordinate_system(
-            site_x_coords, site_y_coords, orography)
+            site_x_coords, site_y_coords,
+            orography.coord_system().as_cartopy_crs())
 
         # Exclude any sites falling outside the domain given by the cube and
         # notify the user.
@@ -526,10 +526,21 @@ class NeighbourSelection:
                          vertical_displacements), axis=1)
         data = np.expand_dims(data, 1).astype(np.float32)
 
+        # Regardless of input sitelist coordinate system, the site coordinates
+        # are stored as latitudes and longitudes in the neighbour cube.
+        if self.site_coordinate_system != ccrs.PlateCarree():
+            lon_lats = self._transform_sites_coordinate_system(
+                site_x_coords, site_y_coords, ccrs.PlateCarree())
+            longitudes = lon_lats[:, 0]
+            latitudes = lon_lats[:, 1]
+        else:
+            longitudes = site_x_coords
+            latitudes = site_y_coords
+
         # Create a cube of neighbours
         neighbour_cube = build_spotdata_cube(
             data, 'grid_neighbours', 1, site_altitudes.astype(np.float32),
-            site_y_coords.astype(np.float32), site_x_coords.astype(np.float32),
+            latitudes.astype(np.float32), longitudes.astype(np.float32),
             wmo_ids, neighbour_methods=[method_name],
             grid_attributes=['x_index', 'y_index', 'vertical_displacement'])
 

--- a/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
@@ -195,7 +195,8 @@ class Test__transform_sites_coordinate_system(Test_NeighbourSelection):
         expected = [[0., 0.], [1111782.53516264, 0.],
                     [2189747.33076441, 1121357.32401753]]
         result = plugin._transform_sites_coordinate_system(
-            x_points, y_points, self.region_orography)
+            x_points, y_points,
+            self.region_orography.coord_system().as_cartopy_crs())
         self.assertArrayAlmostEqual(result, expected)
 
     def test_region_to_global(self):
@@ -209,7 +210,8 @@ class Test__transform_sites_coordinate_system(Test_NeighbourSelection):
         expected = [[0., 0.], [8.98315284e-06, 0.],
                     [1.79663057e-05, 9.04369476e-06]]
         result = plugin._transform_sites_coordinate_system(
-            x_points, y_points, self.global_orography)
+            x_points, y_points,
+            self.global_orography.coord_system().as_cartopy_crs())
         self.assertArrayAlmostEqual(result, expected)
 
     def test_global_to_global(self):
@@ -220,7 +222,8 @@ class Test__transform_sites_coordinate_system(Test_NeighbourSelection):
         y_points = np.array([0, 0, 10])
         expected = np.stack((x_points, y_points), axis=1)
         result = plugin._transform_sites_coordinate_system(
-            x_points, y_points, self.global_orography)
+            x_points, y_points,
+            self.global_orography.coord_system().as_cartopy_crs())
 
         self.assertArrayAlmostEqual(result, expected)
 
@@ -233,7 +236,8 @@ class Test__transform_sites_coordinate_system(Test_NeighbourSelection):
         y_points = np.array([0, 0, 1])
         expected = np.stack((x_points, y_points), axis=1)
         result = plugin._transform_sites_coordinate_system(
-            x_points, y_points, self.region_orography)
+            x_points, y_points,
+            self.region_orography.coord_system().as_cartopy_crs())
 
         self.assertArrayAlmostEqual(result, expected)
 

--- a/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
@@ -670,14 +670,13 @@ class Test_process(Test_NeighbourSelection):
         coordinates defined in latitudes and longitudes, so they should be
         unchanged."""
 
-        plugin = NeighbourSelection()
-        result = plugin.process(self.global_sites, self.global_orography,
-                                self.global_land_mask)
-
         latitude_expected = np.array([self.global_sites[0]['latitude']],
                                      dtype=np.float32)
         longitude_expected = np.array([self.global_sites[0]['longitude']],
                                       dtype=np.float32)
+        plugin = NeighbourSelection()
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
 
         self.assertIsNotNone(result.coord('latitude'))
         self.assertIsNotNone(result.coord('longitude'))

--- a/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
+++ b/lib/improver/tests/spotdata/spotdata/test_NeighbourSelection.py
@@ -664,6 +664,28 @@ class Test_process(Test_NeighbourSelection):
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayEqual(result.data, expected)
 
+    def test_global_returned_site_coordinates(self):
+        """Test that the site coordinates in the returned neighbour cube are
+        latitudes and longitudes. Here the input site list contains site
+        coordinates defined in latitudes and longitudes, so they should be
+        unchanged."""
+
+        plugin = NeighbourSelection()
+        result = plugin.process(self.global_sites, self.global_orography,
+                                self.global_land_mask)
+
+        latitude_expected = np.array([self.global_sites[0]['latitude']],
+                                     dtype=np.float32)
+        longitude_expected = np.array([self.global_sites[0]['longitude']],
+                                      dtype=np.float32)
+
+        self.assertIsNotNone(result.coord('latitude'))
+        self.assertIsNotNone(result.coord('longitude'))
+        self.assertArrayAlmostEqual(result.coord('latitude').points,
+                                    latitude_expected)
+        self.assertArrayAlmostEqual(result.coord('longitude').points,
+                                    longitude_expected)
+
     def test_global_land(self):
         """Test how the neighbour index changes when a land constraint is
         imposed. Here we expect to go 'west' to the first band of land
@@ -744,6 +766,27 @@ class Test_process(Test_NeighbourSelection):
 
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayEqual(result.data, expected)
+
+    def test_region_returned_site_coordinates(self):
+        """Test that the site coordinates in the returned neighbour cube are
+        latitudes and longitudes. Here the input site list contains site
+        coordinates defined in metres in an equal areas projection."""
+
+        plugin = NeighbourSelection(
+            site_coordinate_system=self.region_projection.as_cartopy_crs(),
+            site_x_coordinate='projection_x_coordinate',
+            site_y_coordinate='projection_y_coordinate')
+        result = plugin.process(self.region_sites, self.region_orography,
+                                self.region_land_mask)
+        latitude_expected = np.array([0], dtype=np.float32)
+        longitude_expected = np.array([-0.359327], dtype=np.float32)
+
+        self.assertIsNotNone(result.coord('latitude'))
+        self.assertIsNotNone(result.coord('longitude'))
+        self.assertArrayAlmostEqual(result.coord('latitude').points,
+                                    latitude_expected)
+        self.assertArrayAlmostEqual(result.coord('longitude').points,
+                                    longitude_expected)
 
     def test_region_land(self):
         """Test how the neighbour index changes when a land constraint is

--- a/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
+++ b/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
@@ -52,6 +52,6 @@
   # data (neighbour indices and vertical displacements) should be identical
   # to the 07 test in which sites were defined with latitudes and longitudes.
   # For this reason we invoke nccmp here directly to use different options.
-  run nccmp -dm "$TEST_DIR/output.nc" "$IMPROVER_ACC_TEST_DIR/$KGO"
-  [[ "$status" -eq 0 ]]
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
 }

--- a/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
+++ b/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
@@ -53,4 +53,5 @@
   # to the 07 test in which sites were defined with latitudes and longitudes.
   # For this reason we invoke nccmp here directly to use different options.
   run nccmp -dm "$TEST_DIR/output.nc" "$IMPROVER_ACC_TEST_DIR/$KGO"
+  [[ "$status" -eq 0 ]]
 }

--- a/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
+++ b/tests/improver-neighbour-finding/12-alternative-site-coordinate-system.bats
@@ -48,10 +48,6 @@
   [[ "$status" -eq 0 ]]
 
   # Run nccmp to compare the output and kgo.
-  # Note this is a special case. The site coordinates are different, but the
-  # data (neighbour indices and vertical displacements) should be identical
-  # to the 07 test in which sites were defined with latitudes and longitudes.
-  # For this reason we invoke nccmp here directly to use different options.
   improver_compare_output "$TEST_DIR/output.nc" \
       "$IMPROVER_ACC_TEST_DIR/$KGO"
 }


### PR DESCRIPTION
The motivation for this change was a CLI test that was not actually checking the result. The fix to this was simply to update the sitelist being used, which should match the global test site list input but using a Lambert Azimuthal Equal Areas coordinate system. Unfortunately the global list was changed without updating the LAEA site list.

Updating this list made the neighbour data match, in that the grid point neighbours identified by both lists were the same; CLI tests 7 and 12 share the same KGO, which has not been changed.

The output data do not share the same coordinates, because there has been a long standing unaddressed issue of non-lat/lon input sitelists (which we don't use) returning non-lat/lon site coordinates that are labelled as latitude and longitude in the neighbour cubes.

To simplify steps later on that may wish to use the site coordinates, it is helpful for these to be consistently expressed. As such this change ensures that all site coordinates, regardless of the coordinate system used to express the originally, are output as lat/lons on a simple PlateCarree coordinate system ('ellps': 'WGS84', 'a': 57.29577951308232, 'proj': 'eqc', 'lon_0': 0.0).

Testing:
 - [x] Ran tests and they passed OK