### PR TITLE
Impro 1445: Remove standard output from orographic enhancement

### DIFF
--- a/lib/improver/cli/orographic_enhancement.py
+++ b/lib/improver/cli/orographic_enhancement.py
@@ -133,15 +133,12 @@ def main(argv=None):
         temperature, humidity, pressure, wind_speed, wind_dir, orography)
 
     # generate file names
-    fname_standard = os.path.join(
-        args.output_dir, generate_file_name(orogenh_standard))
     fname_high_res = os.path.join(
         args.output_dir, generate_file_name(
             orogenh_high_res,
             parameter="orographic_enhancement_high_resolution"))
 
     # save output files
-    save_netcdf(orogenh_standard, fname_standard)
     save_netcdf(orogenh_high_res, fname_high_res)
 
 
@@ -149,8 +146,7 @@ def process(temperature, humidity, pressure, wind_speed, wind_dir, orography):
     """Calculate orograhpic enhancement
 
     Uses the ResolveWindComponents() and OrographicEnhancement() plugins.
-    Outputs data on the high resolution orography grid and regrided to the
-    coarser resolution of the input diagnostic variables.
+    Outputs data on the high resolution orography grid.
 
     Args:
         temperature (iris.cube.Cube):
@@ -168,21 +164,16 @@ def process(temperature, humidity, pressure, wind_speed, wind_dir, orography):
             resolution (1 km) UKPP domain grid.
 
     Returns:
-        (tuple): tuple containing:
-                **orogenh_high_res** (iris.cube.Cube):
-                    Precipitation enhancement due to orography in mm/h on the
-                    UK standard grid, padded with masked up np.nans where
-                    outside the UKPP domain.
-                **orogenh_standard** (iris.cube.Cube):
-                    Precipitation enhancement due to orography in mm/h on
-                    the 1km Transverse Mercator UKPP grid domain.
+        iris.cube.Cube:
+            Precipitation enhancement due to orography in mm/h on the
+            UK standard grid, padded with masked up np.nans where
+            outside the UKPP domain.
     """
     # resolve u and v wind components
     u_wind, v_wind = ResolveWindComponents().process(wind_speed, wind_dir)
     # calculate orographic enhancement
-    orogenh_high_res, orogenh_standard = OrographicEnhancement().process(
-        temperature, humidity, pressure, u_wind, v_wind, orography)
-    return orogenh_high_res, orogenh_standard
+    return OrographicEnhancement().process(temperature, humidity, pressure,
+                                           u_wind, v_wind, orography)
 
 
 if __name__ == "__main__":

--- a/lib/improver/cli/orographic_enhancement.py
+++ b/lib/improver/cli/orographic_enhancement.py
@@ -164,9 +164,8 @@ def process(temperature, humidity, pressure, wind_speed, wind_dir, orography):
 
     Returns:
         iris.cube.Cube:
-            Precipitation enhancement due to orography in mm/h on the
-            UK standard grid, padded with masked up np.nans where
-            outside the UKPP domain.
+            Precipitation enhancement due to orography on the high resolution
+            input orography grid.
     """
     # resolve u and v wind components
     u_wind, v_wind = ResolveWindComponents().process(wind_speed, wind_dir)

--- a/lib/improver/cli/orographic_enhancement.py
+++ b/lib/improver/cli/orographic_enhancement.py
@@ -82,8 +82,7 @@ def main(argv=None):
     parser = ArgParser(description='Calculate orographic enhancement using the'
                        ' ResolveWindComponents() and OrographicEnhancement() '
                        'plugins. Outputs data on the high resolution orography'
-                       ' grid and regridded to the coarser resolution of the '
-                       'input diagnostic variables.')
+                       ' grid.')
 
     parser.add_argument('temperature_filepath', metavar='TEMPERATURE_FILEPATH',
                         help='Full path to input NetCDF file of temperature on'
@@ -129,7 +128,7 @@ def main(argv=None):
     # load high resolution orography
     orography = load_cube(args.orography_filepath)
 
-    orogenh_high_res, orogenh_standard = process(
+    orogenh_high_res = process(
         temperature, humidity, pressure, wind_speed, wind_dir, orography)
 
     # generate file names

--- a/lib/improver/orographic_enhancement.py
+++ b/lib/improver/orographic_enhancement.py
@@ -482,7 +482,7 @@ class OrographicEnhancement:
 
         Returns:
             iris.cube.Cube:
-                Orographic enhancement cube on 1 km UKPP grid (m s-1)
+                Orographic enhancement cube (m s-1)
         """
         # create cube containing high resolution data in mm/h
         x_coord = self.topography.coord(axis='x')
@@ -503,18 +503,18 @@ class OrographicEnhancement:
             except KeyError:
                 continue
 
-        orog_cube = iris.cube.Cube(
+        orog_enhance_cube = iris.cube.Cube(
             orogenh_data, long_name="orographic_enhancement",
             units="mm h-1", attributes=attributes,
             dim_coords_and_dims=[(y_coord, 0), (x_coord, 1)],
             aux_coords_and_dims=aux_coords)
-        orog_cube.convert_units("m s-1")
+        orog_enhance_cube.convert_units("m s-1")
 
         for key, value in self.topography.attributes.items():
             if 'mosg__grid' in key:
-                orog_cube.attributes[key] = value
+                orog_enhance_cube.attributes[key] = value
 
-        return orog_cube
+        return orog_enhance_cube
 
     def process(self, temperature, humidity, pressure, uwind, vwind,
                 topography):

--- a/lib/improver/orographic_enhancement.py
+++ b/lib/improver/orographic_enhancement.py
@@ -471,9 +471,7 @@ class OrographicEnhancement:
         return orogenh
 
     def _create_output_cube(self, orogenh_data, reference_cube):
-        """
-        Creates a cube of orographic enhancement on a grid.
-        Casts coordinate points and bounds explicitly to np.float32.
+        """Creates a cube containing orographic enhancement values in SI units.
 
         Args:
             orogenh_data (numpy.ndarray):
@@ -521,9 +519,9 @@ class OrographicEnhancement:
     def process(self, temperature, humidity, pressure, uwind, vwind,
                 topography):
         """
-        Calculate precipitation enhancement over orography on high
-        resolution grids.  Input variables are expected to be on the same
-        grid (either standard or high resolution).
+        Calculate precipitation enhancement over orography on high resolution
+        grid. Input diagnostics are all expected to be on the same grid, and
+        are regridded to match the orography.
 
         Args:
             temperature (iris.cube.Cube):
@@ -544,8 +542,7 @@ class OrographicEnhancement:
 
         Returns:
             iris.cube.Cube:
-                Precipitation enhancement due to orography in mm/h on the
-                1 km Transverse Mercator UKPP grid domain
+                Precipitation enhancement due to orography in m/s.
         """
         # check input variable cube coordinates match
         unmatched_coords = compare_coords(

--- a/lib/improver/tests/orographic_enhancement/test_OrographicEnhancement.py
+++ b/lib/improver/tests/orographic_enhancement/test_OrographicEnhancement.py
@@ -608,7 +608,7 @@ class Test__add_upstream_component(IrisTest):
 
 
 class Test__create_output_cubes(IrisTest):
-    """Test the _create_output_cubes method"""
+    """Test the _create_output_cube method"""
 
     def setUp(self):
         """Set up a plugin instance, data array and cubes"""
@@ -631,88 +631,68 @@ class Test__create_output_cubes(IrisTest):
                                  [0.8, 0.9, 1.2, 0.9]])
 
     def test_basic(self):
-        """Test that two cubes are returned with float32 coords"""
-        output, regridded_output = self.plugin._create_output_cubes(
+        """Test that the cube is returned with float32 coords"""
+        output = self.plugin._create_output_cube(
             self.orogenh, self.temperature)
-        for cube in [output, regridded_output]:
-            self.assertIsInstance(cube, iris.cube.Cube)
-            for coord in cube.coords(dim_coords=True):
-                self.assertEqual(coord.points.dtype, 'float32')
+
+        self.assertIsInstance(output, iris.cube.Cube)
+        for coord in output.coords(dim_coords=True):
+            self.assertEqual(coord.points.dtype, 'float32')
 
     def test_values(self):
-        """Test first cube is changed only in units (to m s-1) and regridded
-        output cube is masked as expected"""
-        expected_data = np.array(
-            [[np.nan, 2.777778e-07, 3.8888888e-07, np.nan],
-             [np.nan, np.nan, np.nan, np.nan]], dtype=np.float32)
+        """Test the cube is changed only in units (to m s-1)"""
         original_converted = 2.7777778e-07 * self.orogenh
-        expected_mask = np.where(np.isfinite(expected_data), False, True)
-        output, regridded_output = self.plugin._create_output_cubes(
+
+        output = self.plugin._create_output_cube(
             self.orogenh, self.temperature)
         self.assertArrayAlmostEqual(output.data, original_converted)
-        self.assertTrue(np.allclose(regridded_output.data.data,
-                                    expected_data, equal_nan=True))
-        self.assertArrayEqual(regridded_output.data.mask, expected_mask)
 
     def test_metadata(self):
-        """Check output metadata on both cubes is as expected"""
+        """Check output metadata on cube is as expected"""
         hi_res_attributes = self.temperature.attributes
         for key, val in self.plugin.topography.attributes.items():
             hi_res_attributes[key] = val
 
-        tref = sort_coord_in_cube(
-            self.temperature, self.temperature.coord(axis='y'))
-        output, regridded_output = self.plugin._create_output_cubes(
-            self.orogenh, self.temperature)
+        output = self.plugin._create_output_cube(self.orogenh,
+                                                 self.temperature)
 
         for axis in ['x', 'y']:
             self.assertEqual(output.coord(axis=axis),
                              self.plugin.topography.coord(axis=axis))
-            self.assertEqual(regridded_output.coord(axis=axis),
-                             tref.coord(axis=axis))
 
-        for cube in [output, regridded_output]:
-            self.assertEqual(cube.name(), 'orographic_enhancement')
-            self.assertEqual(cube.units, 'm s-1')
-            for t_coord in ['time', 'forecast_period',
-                            'forecast_reference_time']:
-                self.assertEqual(
-                    cube.coord(t_coord), self.temperature.coord(t_coord))
-        self.assertDictEqual(
-            regridded_output.attributes, self.temperature.attributes)
+        self.assertEqual(output.name(), 'orographic_enhancement')
+        self.assertEqual(output.units, 'm s-1')
+        for t_coord in ['time', 'forecast_period', 'forecast_reference_time']:
+            self.assertEqual(
+                output.coord(t_coord), self.temperature.coord(t_coord))
         self.assertDictEqual(output.attributes, hi_res_attributes)
 
     def test_grid_metadata(self):
         """Test specific grid and model metadata inheritance"""
-        output, regridded_output = self.plugin._create_output_cubes(
-            self.orogenh, self.temperature)
+        output = self.plugin._create_output_cube(self.orogenh,
+                                                 self.temperature)
 
         for attr in ['mosg__grid_type', 'mosg__grid_version',
                      'mosg__grid_domain']:
-            self.assertEqual(regridded_output.attributes[attr],
-                             self.temperature.attributes[attr])
             self.assertEqual(output.attributes[attr],
                              self.plugin.topography.attributes[attr])
 
-        for cube in [output, regridded_output]:
-            self.assertEqual(
-                cube.attributes['mosg__model_configuration'],
-                self.temperature.attributes['mosg__model_configuration'])
+        self.assertEqual(output.attributes['mosg__model_configuration'],
+                    self.temperature.attributes['mosg__model_configuration'])
 
 
 class Test_process(DataCubeTest):
     """Test the process method"""
 
     def test_basic(self):
-        """Test outputs are float32 cubes with float32 coordinates"""
-        orogenh, orogenh_standard_grid = self.plugin.process(
+        """Test output is float32 cube with float32 coordinates"""
+        orogenh = self.plugin.process(
             self.temperature, self.humidity, self.pressure,
             self.uwind, self.vwind, self.orography_cube)
-        for cube in [orogenh, orogenh_standard_grid]:
-            self.assertIsInstance(cube, iris.cube.Cube)
-            self.assertEqual(cube.data.dtype, 'float32')
-            for coord in cube.coords(dim_coords=True):
-                self.assertEqual(coord.points.dtype, 'float32')
+        self.assertIsInstance(orogenh, iris.cube.Cube)
+        self.assertEqual(orogenh.data.dtype, 'float32')
+        for coord in orogenh.coords(dim_coords=True):
+            self.assertEqual(coord.points.dtype, 'float32')
 
     def test_unmatched_coords(self):
         """Test error thrown if input variable cubes do not match"""
@@ -734,6 +714,7 @@ class Test_process(DataCubeTest):
         uwind = set_up_invalid_variable_cube(self.uwind)
         vwind = set_up_invalid_variable_cube(self.vwind)
         msg = 'Require 2D fields as input; found 3 dimensions'
+        
         with self.assertRaisesRegex(ValueError, msg):
             _ = self.plugin.process(
                 temperature, humidity, pressure, uwind, vwind,
@@ -756,7 +737,7 @@ class Test_process(DataCubeTest):
             self.assertEqual(cube.metadata, copy.metadata)
 
     def test_values(self):
-        """Test values of outputs"""
+        """Test values of output"""
         expected_data = np.array(
             [[2.6524199e-07, 3.4075157e-07, 2.5099993e-07, 9.1911055e-08,
               1.7481890e-08, 1.5676112e-09],
@@ -766,16 +747,12 @@ class Test_process(DataCubeTest):
               5.3441389e-09, 1.5676112e-09],
              [8.5711110e-10, 8.5711110e-10, 8.5711110e-10, 8.5711110e-10,
               2.1291666e-09, 2.4547223e-10]], dtype=np.float32)
-        expected_data_regridded = np.array(
-            [[1.679777e-07, 1.763937e-07, 1.748190e-08],
-             [8.571141e-10, 8.571141e-10, 2.129176e-09]], dtype=np.float32)
 
-        orogenh, orogenh_standard_grid = self.plugin.process(
+        orogenh = self.plugin.process(
             self.temperature, self.humidity, self.pressure,
             self.uwind, self.vwind, self.orography_cube)
+
         self.assertArrayAlmostEqual(orogenh.data, expected_data)
-        self.assertArrayAlmostEqual(
-            orogenh_standard_grid.data, expected_data_regridded)
         self.assertAlmostEqual(self.plugin.grid_spacing_km, 1.)
 
 

--- a/lib/improver/tests/orographic_enhancement/test_OrographicEnhancement.py
+++ b/lib/improver/tests/orographic_enhancement/test_OrographicEnhancement.py
@@ -669,8 +669,8 @@ class Test__create_output_cubes(IrisTest):
 
     def test_grid_metadata(self):
         """Test specific grid and model metadata inheritance"""
-        output = self.plugin._create_output_cube(self.orogenh,
-                                                 self.temperature)
+        output = self.plugin._create_output_cube(
+            self.orogenh, self.temperature)
 
         for attr in ['mosg__grid_type', 'mosg__grid_version',
                      'mosg__grid_domain']:

--- a/lib/improver/tests/orographic_enhancement/test_OrographicEnhancement.py
+++ b/lib/improver/tests/orographic_enhancement/test_OrographicEnhancement.py
@@ -677,8 +677,9 @@ class Test__create_output_cubes(IrisTest):
             self.assertEqual(output.attributes[attr],
                              self.plugin.topography.attributes[attr])
 
-        self.assertEqual(output.attributes['mosg__model_configuration'],
-                    self.temperature.attributes['mosg__model_configuration'])
+        self.assertEqual(
+            output.attributes['mosg__model_configuration'],
+            self.temperature.attributes['mosg__model_configuration'])
 
 
 class Test_process(DataCubeTest):
@@ -714,7 +715,7 @@ class Test_process(DataCubeTest):
         uwind = set_up_invalid_variable_cube(self.uwind)
         vwind = set_up_invalid_variable_cube(self.vwind)
         msg = 'Require 2D fields as input; found 3 dimensions'
-        
+
         with self.assertRaisesRegex(ValueError, msg):
             _ = self.plugin.process(
                 temperature, humidity, pressure, uwind, vwind,

--- a/tests/improver-orographic-enhancement/01-help.bats
+++ b/tests/improver-orographic-enhancement/01-help.bats
@@ -44,8 +44,7 @@ usage: improver orographic-enhancement [-h] [--profile]
 
 Calculate orographic enhancement using the ResolveWindComponents() and
 OrographicEnhancement() plugins. Outputs data on the high resolution orography
-grid and regridded to the coarser resolution of the input diagnostic
-variables.
+grid.
 
 positional arguments:
   TEMPERATURE_FILEPATH  Full path to input NetCDF file of temperature on

--- a/tests/improver-orographic-enhancement/02-basic.bats
+++ b/tests/improver-orographic-enhancement/02-basic.bats
@@ -34,7 +34,6 @@
 @test "orographic-enhancement" {
   improver_check_skip_acceptance
   KGO_HI_RES="orographic_enhancement/basic/kgo_hi_res.nc"
-  KGO_STANDARD="orographic_enhancement/basic/kgo_standard.nc"
 
   # Run orographic enhancement and check it passes
   run improver orographic-enhancement \
@@ -47,15 +46,11 @@
       "$TEST_DIR"
   [[ "$status" -eq 0 ]]
 
-  OUTPUT_STANDARD="20180810T1200Z-PT0006H00M-orographic_enhancement.nc"
   OUTPUT_HI_RES="20180810T1200Z-PT0006H00M-orographic_enhancement_high_resolution.nc"
 
   improver_check_recreate_kgo $OUTPUT_HI_RES $KGO_HI_RES
-  improver_check_recreate_kgo $OUTPUT_STANDARD $KGO_STANDARD
 
   # Run nccmp to compare the output and kgo.
   improver_compare_output "$TEST_DIR/$OUTPUT_HI_RES" \
       "$IMPROVER_ACC_TEST_DIR/$KGO_HI_RES"
-  improver_compare_output "$TEST_DIR/$OUTPUT_STANDARD" \
-      "$IMPROVER_ACC_TEST_DIR/$KGO_STANDARD"
 }

--- a/tests/improver-orographic-enhancement/03-boundary_height.bats
+++ b/tests/improver-orographic-enhancement/03-boundary_height.bats
@@ -34,7 +34,6 @@
 @test "orographic-enhancement boundary height" {
   improver_check_skip_acceptance
   KGO_HI_RES="orographic_enhancement/boundary_height/kgo_hi_res.nc"
-  KGO_STANDARD="orographic_enhancement/boundary_height/kgo_standard.nc"
 
   # Run orographic enhancement and check it passes
   run improver orographic-enhancement \
@@ -51,11 +50,8 @@
   OUTPUT_HI_RES="20180810T1200Z-PT0006H00M-orographic_enhancement_high_resolution.nc"
 
   improver_check_recreate_kgo $OUTPUT_HI_RES $KGO_HI_RES
-  improver_check_recreate_kgo $OUTPUT_STANDARD $KGO_STANDARD
 
   # Run nccmp to compare the output and kgo.
   improver_compare_output "$TEST_DIR/$OUTPUT_HI_RES" \
       "$IMPROVER_ACC_TEST_DIR/$KGO_HI_RES"
-  improver_compare_output "$TEST_DIR/$OUTPUT_STANDARD" \
-      "$IMPROVER_ACC_TEST_DIR/$KGO_STANDARD"
 }

--- a/tests/improver-orographic-enhancement/03-boundary_height.bats
+++ b/tests/improver-orographic-enhancement/03-boundary_height.bats
@@ -46,7 +46,6 @@
       "$TEST_DIR" --boundary_height=500. --boundary_height_units=m
   [[ "$status" -eq 0 ]]
 
-  OUTPUT_STANDARD="20180810T1200Z-PT0006H00M-orographic_enhancement.nc"
   OUTPUT_HI_RES="20180810T1200Z-PT0006H00M-orographic_enhancement_high_resolution.nc"
 
   improver_check_recreate_kgo $OUTPUT_HI_RES $KGO_HI_RES

--- a/tests/improver-orographic-enhancement/04-unit_convert_boundary_height.bats
+++ b/tests/improver-orographic-enhancement/04-unit_convert_boundary_height.bats
@@ -34,7 +34,6 @@
 @test "orographic-enhancement boundary height convert units" {
   improver_check_skip_acceptance
   KGO_HI_RES="orographic_enhancement/boundary_height/kgo_hi_res.nc"
-  KGO_STANDARD="orographic_enhancement/boundary_height/kgo_standard.nc"
 
   # Run orographic enhancement and check it passes
   run improver orographic-enhancement \
@@ -47,15 +46,11 @@
       "$TEST_DIR" --boundary_height=1640.41994751 --boundary_height_units=ft
   [[ "$status" -eq 0 ]]
 
-  OUTPUT_STANDARD="20180810T1200Z-PT0006H00M-orographic_enhancement.nc"
   OUTPUT_HI_RES="20180810T1200Z-PT0006H00M-orographic_enhancement_high_resolution.nc"
 
   improver_check_recreate_kgo $OUTPUT_HI_RES $KGO_HI_RES
-  improver_check_recreate_kgo $OUTPUT_STANDARD $KGO_STANDARD
 
   # Run nccmp to compare the output and kgo.
   improver_compare_output "$TEST_DIR/$OUTPUT_HI_RES" \
       "$IMPROVER_ACC_TEST_DIR/$KGO_HI_RES"
-  improver_compare_output "$TEST_DIR/$OUTPUT_STANDARD" \
-      "$IMPROVER_ACC_TEST_DIR/$KGO_STANDARD"
 }


### PR DESCRIPTION
# Removed  the standard cube from oropgraphic enhancement.

To conform to the "one output object per CLI" rule, the oropgraphic enhacement cli and plug in now only returns one cube.

Are any other changes required in the cli?


## Functions changed
- orographic_enhancement
    - _create_output_cube
    - process
- cli/orographic_enhancement
    - main
    - process

## Tests changed
- removing standard from bats
    - 02-basic
    - 03-boundary_height
    - 04-unit_convert_boundary_height
- unit tests
    - Test__create_output_cubes
    - Test_process


Testing:
 - [x] Ran tests and they passed OK
 - [N/A] Added new tests for the new feature(s)
