### PR TITLE
Support filtering for EMOS for bounded variables

### DIFF
--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -751,6 +751,25 @@ class Test__filter_non_matching_cubes(SetupCubes):
         self.assertEqual(hf_result, self.historic_temperature_forecast_cube)
         self.assertEqual(truth_result, self.temperature_truth_cube)
 
+    def test_bounded_variables(self):
+        """Test for when the historic forecast and truth cubes all match
+        inclusive of both the points and bounds on the time coordinate."""
+        # Define bounds so that the lower bound is one hour preceding the point
+        # whilst the upper bound is equal to the point.
+        points = self.historic_temperature_forecast_cube.coord("time").points
+        bounds = []
+        for point in points:
+            bounds.append([point - 1*60*60, point])
+
+        self.historic_temperature_forecast_cube.coord("time").bounds = bounds
+        self.temperature_truth_cube.coord("time").bounds = bounds
+
+        hf_result, truth_result = Plugin._filter_non_matching_cubes(
+            self.historic_temperature_forecast_cube,
+            self.temperature_truth_cube)
+        self.assertEqual(hf_result, self.historic_temperature_forecast_cube)
+        self.assertEqual(truth_result, self.temperature_truth_cube)
+
     def test_fewer_historic_forecasts(self):
         """Test for when there are fewer historic forecasts than truths,
         for example, if there is a missing forecast cycle."""

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -288,6 +288,24 @@ class Test_iris_time_to_datetime(IrisTest):
             self.assertIsInstance(item, datetime.datetime)
         self.assertEqual(result[0], datetime.datetime(2017, 2, 17, 6, 0))
 
+    def test_bounds(self):
+        """Test iris_time_to_datetime returns list of datetimes calculated
+        from the coordinate bounds."""
+        # Assign time bounds equivalent to [
+        # datetime.datetime(2017, 2, 17, 5, 0),
+        # datetime.datetime(2017, 2, 17, 6, 0)]
+        self.cube.coord('time').bounds = [1487307600, 1487311200]
+
+        result = iris_time_to_datetime(
+            self.cube.coord('time'), point_or_bound="bound")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 2)
+        for item in result[0]:
+            self.assertIsInstance(item, datetime.datetime)
+        self.assertEqual(result[0][0], datetime.datetime(2017, 2, 17, 5, 0))
+        self.assertEqual(result[0][1], datetime.datetime(2017, 2, 17, 6, 0))
+
     def test_input_cube_unmodified(self):
         """Test that an input cube with unexpected coordinate units is not
         modified"""

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -217,7 +217,7 @@ def forecast_period_coord(
     return result_coord
 
 
-def iris_time_to_datetime(time_coord):
+def iris_time_to_datetime(time_coord, point_or_bound="point"):
     """
     Convert iris time to python datetime object. Working in UTC.
 
@@ -231,7 +231,11 @@ def iris_time_to_datetime(time_coord):
     """
     coord = time_coord.copy()
     coord.convert_units('seconds since 1970-01-01 00:00:00')
-    return [value.point for value in coord.cells()]
+    if point_or_bound == "point":
+        datetime_list = [value.point for value in coord.cells()]
+    elif point_or_bound == "bound":
+        datetime_list = [value.bound for value in coord.cells()]
+    return datetime_list
 
 
 def datetime_to_iris_time(dt_in):


### PR DESCRIPTION
Description
Add support to filtering within ensemble calibration for diagnostics that have bounds e.g. 1 hour max temperature.

This PR adds:
- Updates to the _filter_non_matching_cubes method within the EstimateCoefficientsForEnsembleCalibration class. This method ensures that the historic forecasts and truth dataset match in terms of validity time with this functionality being extended to support matching for diagnostics that have bounds e.g. 1 hour max temperature.
- Update the iris_time_to_datetime function to support the desire to process the bounds information.
- Add unit tests.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

