### PR TITLE
Update EMOS to calculate CRPS mean

### DIFF
--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -277,7 +277,8 @@ class ContinuousRankedProbabilityScoreMinimisers():
 
         Returns:
             float:
-                CRPS for the current set of coefficients.
+                CRPS for the current set of coefficients. This CRPS is a mean
+                value across all points.
 
         """
         if predictor_of_mean_flag.lower() == "mean":
@@ -337,7 +338,8 @@ class ContinuousRankedProbabilityScoreMinimisers():
 
         Returns:
             float:
-                CRPS for the current set of coefficients.
+                CRPS for the current set of coefficients. This CRPS is a mean
+                value across all points.
 
         """
         if predictor_of_mean_flag.lower() == "mean":

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -296,11 +296,12 @@ class ContinuousRankedProbabilityScoreMinimisers():
         xz = (truth - mu) / sigma
         normal_cdf = norm.cdf(xz)
         normal_pdf = norm.pdf(xz)
-        result = np.nansum(
-            sigma * (xz * (2 * normal_cdf - 1) + 2 * normal_pdf - 1 / sqrt_pi))
-        if not np.isfinite(np.min(mu/sigma)):
+        if np.isfinite(np.min(mu/sigma)):
+            result = np.nanmean(
+                sigma * (
+                    xz * (2 * normal_cdf - 1) + 2 * normal_pdf - 1 / sqrt_pi))
+        else:
             result = self.BAD_VALUE
-
         return result
 
     def calculate_truncated_normal_crps(
@@ -358,12 +359,13 @@ class ContinuousRankedProbabilityScoreMinimisers():
         x0 = mu / sigma
         normal_cdf_0 = norm.cdf(x0)
         normal_cdf_root_two = norm.cdf(np.sqrt(2) * x0)
-        result = np.nansum(
-            (sigma / normal_cdf_0**2) *
-            (xz * normal_cdf_0 * (2 * normal_cdf + normal_cdf_0 - 2) +
-             2 * normal_pdf * normal_cdf_0 -
-             normal_cdf_root_two / sqrt_pi))
-        if not np.isfinite(np.min(mu/sigma)) or (np.min(mu/sigma) < -3):
+        if np.isfinite(np.min(mu / sigma)) or (np.min(mu / sigma) >= -3):
+            result = np.nanmean(
+                (sigma / normal_cdf_0**2) *
+                (xz * normal_cdf_0 * (2 * normal_cdf + normal_cdf_0 - 2) +
+                 2 * normal_pdf * normal_cdf_0 -
+                 normal_cdf_root_two / sqrt_pi))
+        else:
             result = self.BAD_VALUE
         return result
 

--- a/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/lib/improver/tests/ensemble_calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -148,7 +148,7 @@ class Test_calculate_normal_crps(SetupGaussianInputs):
             predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertAlmostEqual(result, 11.7407838)
+        self.assertAlmostEqual(result, 0.2609063)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -168,7 +168,7 @@ class Test_calculate_normal_crps(SetupGaussianInputs):
             predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertAlmostEqual(result, 11.7407763)
+        self.assertAlmostEqual(result, 0.2609061)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",
@@ -442,7 +442,7 @@ class Test_calculate_truncated_normal_crps(SetupTruncatedGaussianInputs):
             predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertAlmostEqual(result, 7.5157541)
+        self.assertAlmostEqual(result, 0.1670168)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])
@@ -461,7 +461,7 @@ class Test_calculate_truncated_normal_crps(SetupTruncatedGaussianInputs):
             self.forecast_variance_data, self.sqrt_pi, predictor_of_mean_flag)
 
         self.assertIsInstance(result, np.float64)
-        self.assertAlmostEqual(result, 7.5157531)
+        self.assertAlmostEqual(result, 0.1670167)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate.",


### PR DESCRIPTION
Description
Edits to ensure that the mean CRPS is calculated, rather than the CRPS sum

This PR:
- Ensures that the mean of the CRPS values is computed, rather than the sum. This is more correct and allows for easier interpretability of the CRPS values being computed. None of the values for the coefficients computed have changed for either the unit tests or the CLI tests.
- calculate_normal_crps and calculate_truncated_normal_crps have been updated to calculate the mean.
- Update value of CRPS computed in the unit tests.

The equations updated in this PR follow equations 5 and 6 from [Gneiting et al., 2005](https://journals.ametsoc.org/doi/full/10.1175/MWR2904.1) for the Gaussian distribution and the equations from section 2.3 of [Thorarinsdottir & Gneiting, 2010](https://rss.onlinelibrary.wiley.com/doi/10.1111/j.1467-985X.2009.00616.x) for the truncated Gaussian distribution.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

