### PR TITLE
Enable Travis build config validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ version: ~> 1.0
 language: python
 python:
   - 3.6.6
-sudo: false
-
+os: linux
 git:
   depth: 10000
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-
 # Iris setup credit to github.com/SciTools/iris 07bbaf4.
 #
 
+version: ~> 1.0
 language: python
 python:
   - 3.6.6


### PR DESCRIPTION
Switches on https://docs.travis-ci.com/user/build-config-validation and responds to that feedback - removes deprecated `sudo` and adds explicit OS `linux`.