### PR TITLE
Specify the distribution when creating percentiles/probabilities from the mean and variance

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -403,6 +403,7 @@ intersphinx_mapping = {
     'https://scitools.org.uk/cartopy/docs/latest/': None,
     'https://scitools.org.uk/cf-units/docs/latest/': None,
     'https://docs.scipy.org/doc/numpy/': None,
+    'https://docs.scipy.org/doc/scipy/reference/': None,
 }
 
 # Get napoleon to document constructor methods.

--- a/lib/improver/ensemble_calibration/ensemble_calibration.py
+++ b/lib/improver/ensemble_calibration/ensemble_calibration.py
@@ -319,7 +319,8 @@ class ContinuousRankedProbabilityScoreMinimisers:
             self, initial_guess, forecast_predictor, truth, forecast_var,
             sqrt_pi, predictor_of_mean_flag):
         """
-        Calculate the CRPS for a truncated normal distribution.
+        Calculate the CRPS for a truncated normal distribution with zero
+        as the lower bound.
 
         Scientific Reference:
         Thorarinsdottir, T.L. & Gneiting, T., 2010.

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -642,9 +642,8 @@ class FromMeanAndVariance():
                 Please note that for use with
                 :meth:`~improver.ensemble_calibration.ensemble_calibration.\
 ContinuousRankedProbabilityScoreMinimisers.calculate_truncated_normal_crps`,
-                the shape parameters for a
-                truncated normal distribution with a lower bound of zero
-                should be [0, np.inf].
+                the shape parameters for a truncated normal distribution with
+                a lower bound of zero should be [0, np.inf].
 
         """
         try:

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -977,8 +977,8 @@ class GenerateProbabilitiesFromMeanAndVariance(
             probability_cube_template).attributes['spp__relative_to_threshold']
 
         self._rescale_shape_parameters(
-            mean_values.data.flatten(),
-            np.sqrt(variance_values.data).flatten())
+            mean_values.data,
+            np.sqrt(variance_values.data))
 
         # Loop over thresholds, and use the specified distribution with the
         # mean and variance to calculate the probabilities relative to each
@@ -987,16 +987,15 @@ class GenerateProbabilitiesFromMeanAndVariance(
 
         distribution = self.distribution(
             *self.shape_parameters,
-            loc=mean_values.data.flatten(),
-            scale=np.sqrt(variance_values.data.flatten()))
+            loc=mean_values.data,
+            scale=np.sqrt(variance_values.data))
 
         probability_method = distribution.cdf
         if relative_to_threshold == 'above':
             probability_method = distribution.sf
 
         for index, threshold in enumerate(thresholds):
-            probabilities[index, ...] = np.reshape(
-                probability_method(threshold), probabilities.shape[1:])
+            probabilities[index, ...] = probability_method(threshold)
 
         probability_cube = probability_cube_template.copy(data=probabilities)
         return probability_cube

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -640,8 +640,8 @@ class FromMeanAndVariance():
                 require the specification of shape parameters to be able to
                 define the shape of the distribution. For the truncated normal
                 distribution, the shape parameters should be appropriate for
-                the mean and standard deviation used to describe the
-                distribution.
+                distribution constructed from the mean and standard deviation
+                provided.
                 Please note that for use with
                 :meth:`~improver.ensemble_calibration.ensemble_calibration.\
 ContinuousRankedProbabilityScoreMinimisers.calculate_truncated_normal_crps`,
@@ -678,8 +678,15 @@ ContinuousRankedProbabilityScoreMinimisers.calculate_truncated_normal_crps`,
         parameters are appropriate for a standard normal distribution. As the
         aim is to construct a distribution using specific values for the mean
         and standard deviation, the assumption of a standard normal
-        distribution is not appropriate. Please see
-        :data:`scipy.stats.truncnorm` for some further information.
+        distribution is not appropriate. Therefore the shape parameters are
+        rescaled using the equations:
+
+        .. math::
+          a\\_rescaled = (a - mean)/standard\\_deviation
+
+          b\\_rescaled = (b - mean)/standard\\_deviation
+
+        Please see :data:`scipy.stats.truncnorm` for some further information.
 
         Args:
             mean (numpy.ndarray):

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -638,7 +638,10 @@ class FromMeanAndVariance():
             shape_parameters (list or None):
                 For use with distributions in scipy.stats (e.g. truncnorm) that
                 require the specification of shape parameters to be able to
-                define the shape of the distribution.
+                define the shape of the distribution. For the truncated normal
+                distribution, the shape parameters should be appropriate for
+                the mean and standard deviation used to describe the
+                distribution.
                 Please note that for use with
                 :meth:`~improver.ensemble_calibration.ensemble_calibration.\
 ContinuousRankedProbabilityScoreMinimisers.calculate_truncated_normal_crps`,
@@ -667,7 +670,16 @@ ContinuousRankedProbabilityScoreMinimisers.calculate_truncated_normal_crps`,
     def _rescale_shape_parameters(self, mean, std):
         """
         Rescale the shape parameters for the desired mean and standard
-        deviation for the truncated normal distribution.
+        deviation for the truncated normal distribution. The shape parameters
+        for any other distribution will remain unchanged.
+
+        For the truncated normal distribution, if the shape parameters are not
+        rescaled, then :data:`scipy.stats.truncnorm` will assume that the shape
+        parameters are appropriate for a standard normal distribution. As the
+        aim is to construct a distribution using specific values for the mean
+        and standard deviation, the assumption of a standard normal
+        distribution is not appropriate. Please see
+        :data:`scipy.stats.truncnorm` for some further information.
 
         Args:
             mean (numpy.ndarray):
@@ -694,19 +706,6 @@ class GeneratePercentilesFromMeanAndVariance(BasePlugin, FromMeanAndVariance):
     In combination with the EnsembleReordering plugin, this is Ensemble
     Copula Coupling.
     """
-
-    def __init__(self, *args, **kwargs):
-        """
-        Initialise the class.
-
-        Args:
-            *args:
-                Variable length argument list.
-            **kwargs:
-                Arbitrary keyword arguments.
-
-        """
-        super().__init__(*args, **kwargs)
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -864,19 +863,6 @@ class GenerateProbabilitiesFromMeanAndVariance(
     Plugin to generate probabilities relative to given thresholds from the mean
     and variance of a distribution.
     """
-
-    def __init__(self, *args, **kwargs):
-        """
-        Initialise the class.
-
-        Args:
-            *args:
-                Variable length argument list.
-            **kwargs:
-                Arbitrary keyword arguments.
-
-        """
-        super().__init__(*args, **kwargs)
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -977,8 +977,8 @@ class GenerateProbabilitiesFromMeanAndVariance(
             probability_cube_template).attributes['spp__relative_to_threshold']
 
         self._rescale_shape_parameters(
-            mean_values.data,
-            np.sqrt(variance_values.data))
+            mean_values.data.flatten(),
+            np.sqrt(variance_values.data).flatten())
 
         # Loop over thresholds, and use the specified distribution with the
         # mean and variance to calculate the probabilities relative to each
@@ -987,15 +987,16 @@ class GenerateProbabilitiesFromMeanAndVariance(
 
         distribution = self.distribution(
             *self.shape_parameters,
-            loc=mean_values.data,
-            scale=np.sqrt(variance_values.data))
+            loc=mean_values.data.flatten(),
+            scale=np.sqrt(variance_values.data.flatten()))
 
         probability_method = distribution.cdf
         if relative_to_threshold == 'above':
             probability_method = distribution.sf
 
         for index, threshold in enumerate(thresholds):
-            probabilities[index, ...] = probability_method(threshold)
+            probabilities[index, ...] = np.reshape(
+                probability_method(threshold), probabilities.shape[1:])
 
         probability_cube = probability_cube_template.copy(data=probabilities)
         return probability_cube

--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -37,7 +37,7 @@ import warnings
 import iris
 import numpy as np
 from iris.exceptions import CoordinateNotFoundError, InvalidCubeError
-from scipy.stats import norm
+from scipy import stats
 
 from improver import BasePlugin
 from improver.ensemble_calibration.ensemble_calibration_utilities import (
@@ -622,22 +622,101 @@ class GeneratePercentilesFromProbabilities(BasePlugin):
         return forecast_at_percentiles
 
 
-class GeneratePercentilesFromMeanAndVariance(BasePlugin):
+class FromMeanAndVariance():
+    """
+    Base Class to support the plugins that compute percentiles and
+    probabilities from the mean and variance.
+    """
+
+    def __init__(self, distribution="norm", shape_parameters=None):
+        """
+        Initialise the class.
+
+        Args:
+            distribution (str):
+                Name of a distribution supported by scipy.stats.
+            shape_parameters (list or None):
+                For use with distributions in scipy.stats (e.g. truncnorm) that
+                require the specification of shape parameters to be able to
+                define the shape of the distribution.
+                Please note that for use with
+                :meth:`~improver.ensemble_calibration.ensemble_calibration.\
+ContinuousRankedProbabilityScoreMinimisers.calculate_truncated_normal_crps`,
+                the shape parameters for a
+                truncated normal distribution with a lower bound of zero
+                should be [0, np.inf].
+
+        """
+        try:
+            self.distribution = getattr(stats, distribution)
+        except AttributeError as err:
+            msg = ("The distribution requested {} is not a valid distribution "
+                   "in scipy.stats. {}".format(distribution, err))
+            raise AttributeError(msg)
+
+        if shape_parameters is None:
+            shape_parameters = []
+        self.shape_parameters = shape_parameters
+
+    def __repr__(self):
+        """Represent the configured plugin instance as a string."""
+        result = ('<FromMeanAndVariance: distribution: {}; '
+                  'shape_parameters: {}>')
+        return result.format(
+            self.distribution.name, self.shape_parameters)
+
+    def _rescale_shape_parameters(self, mean, std):
+        """
+        Rescale the shape parameters for the desired mean and standard
+        deviation for the truncated normal distribution.
+
+        Args:
+            mean (numpy.ndarray):
+                Mean to be used to scale the shape parameters.
+            std (numpy.ndarray):
+                Standard deviation to be used to scale the shape parameters.
+
+        """
+        if self.distribution.name == "truncnorm":
+            if self.shape_parameters:
+                rescaled_values = []
+                for value in self.shape_parameters:
+                    rescaled_values.append((value - mean) / std)
+                self.shape_parameters = rescaled_values
+            else:
+                msg = ("For the truncated normal distribution, "
+                       "shape parameters must be specified.")
+                raise ValueError(msg)
+
+
+class GeneratePercentilesFromMeanAndVariance(BasePlugin, FromMeanAndVariance):
     """
     Plugin focussing on generating percentiles from mean and variance.
     In combination with the EnsembleReordering plugin, this is Ensemble
     Copula Coupling.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """
         Initialise the class.
-        """
-        pass
 
-    @staticmethod
+        Args:
+            *args:
+                Variable length argument list.
+            **kwargs:
+                Arbitrary keyword arguments.
+
+        """
+        super().__init__(*args, **kwargs)
+
+    def __repr__(self):
+        """Represent the configured plugin instance as a string."""
+        result = ('<GeneratePercentilesFromMeanAndVariance: '
+                  'distribution: {}; shape_parameters: {}>')
+        return result.format(self.distribution.name, self.shape_parameters)
+
     def _mean_and_variance_to_percentiles(
-            calibrated_forecast_predictor, calibrated_forecast_variance,
+            self, calibrated_forecast_predictor, calibrated_forecast_variance,
             percentiles):
         """
         Function returning percentiles based on the supplied
@@ -683,14 +762,21 @@ class GeneratePercentilesFromMeanAndVariance(BasePlugin):
                            calibrated_forecast_predictor_data.shape[0]),
                           dtype=np.float32)
 
-        # Loop over percentiles, and use a normal distribution with the mean
-        # and variance to calculate the values at each percentile.
+        self._rescale_shape_parameters(
+            calibrated_forecast_predictor_data,
+            np.sqrt(calibrated_forecast_variance_data))
+
+        percentile_method = self.distribution(
+            *self.shape_parameters,
+            loc=calibrated_forecast_predictor_data,
+            scale=np.sqrt(calibrated_forecast_variance_data))
+
+        # Loop over percentiles, and use the specified distribution with the
+        # mean and variance to calculate the values at each percentile.
         for index, percentile in enumerate(percentiles):
             percentile_list = np.repeat(
                 percentile, len(calibrated_forecast_predictor_data))
-            result[index, :] = norm.ppf(
-                percentile_list, loc=calibrated_forecast_predictor_data,
-                scale=np.sqrt(calibrated_forecast_variance_data))
+            result[index, :] = percentile_method.ppf(percentile_list)
             # If percent point function (PPF) returns NaNs, fill in
             # mean instead of NaN values. NaN will only be generated if the
             # variance is zero. Therefore, if the variance is zero, the mean
@@ -773,22 +859,31 @@ class GeneratePercentilesFromMeanAndVariance(BasePlugin):
         return calibrated_forecast_percentiles
 
 
-class GenerateProbabilitiesFromMeanAndVariance(BasePlugin):
+class GenerateProbabilitiesFromMeanAndVariance(
+        BasePlugin, FromMeanAndVariance):
     """
     Plugin to generate probabilities relative to given thresholds from the mean
     and variance of a distribution.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """
         Initialise the class.
+
+        Args:
+            *args:
+                Variable length argument list.
+            **kwargs:
+                Arbitrary keyword arguments.
+
         """
-        pass
+        super().__init__(*args, **kwargs)
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
-        desc = '<GenerateProbabilitiesFromMeanAndVariance>'
-        return desc
+        result = ('<GenerateProbabilitiesFromMeanAndVariance: '
+                  'distribution: {}; shape_parameters: {}>')
+        return result.format(self.distribution.name, self.shape_parameters)
 
     @staticmethod
     def _check_template_cube(cube):
@@ -854,8 +949,7 @@ class GenerateProbabilitiesFromMeanAndVariance(BasePlugin):
                    'not equivalent/compatible.'.format(err))
             raise ValueError(msg)
 
-    @staticmethod
-    def _mean_and_variance_to_probabilities(mean_values, variance_values,
+    def _mean_and_variance_to_probabilities(self, mean_values, variance_values,
                                             probability_cube_template):
         """
         Function returning probabilities relative to provided thresholds based
@@ -883,18 +977,27 @@ class GenerateProbabilitiesFromMeanAndVariance(BasePlugin):
         relative_to_threshold = find_threshold_coordinate(
             probability_cube_template).attributes['spp__relative_to_threshold']
 
-        # Loop over thresholds, and use a normal distribution with the mean
-        # and variance to calculate the probabilities relative to each
+        self._rescale_shape_parameters(
+            mean_values.data.flatten(),
+            np.sqrt(variance_values.data).flatten())
+
+        # Loop over thresholds, and use the specified distribution with the
+        # mean and variance to calculate the probabilities relative to each
         # threshold.
         probabilities = np.empty_like(probability_cube_template.data)
-        distribution = norm(loc=mean_values.data,
-                            scale=np.sqrt(variance_values.data))
+
+        distribution = self.distribution(
+            *self.shape_parameters,
+            loc=mean_values.data.flatten(),
+            scale=np.sqrt(variance_values.data.flatten()))
+
         probability_method = distribution.cdf
         if relative_to_threshold == 'above':
             probability_method = distribution.sf
 
         for index, threshold in enumerate(thresholds):
-            probabilities[index, ...] = probability_method(threshold)
+            probabilities[index, ...] = np.reshape(
+                probability_method(threshold), probabilities.shape[1:])
 
         probability_cube = probability_cube_template.copy(data=probabilities)
         return probability_cube

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_FromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_FromMeanAndVariance.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Unit tests for FromMeanAndVariance
+
+"""
+import unittest
+
+import numpy as np
+from scipy import stats
+from iris.tests import IrisTest
+
+from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
+    FromMeanAndVariance as Plugin)
+
+
+class Test__init__(IrisTest):
+
+    """Test the __init__ method."""
+
+    def test_valid_distribution(self):
+        """Test for a valid distribution."""
+        plugin = Plugin(distribution="norm")
+        self.assertEqual(plugin.distribution, stats.norm)
+        self.assertEqual(plugin.shape_parameters, [])
+
+    def test_valid_distribution_with_shape_parameters(self):
+        """Test for a valid distribution with ."""
+        plugin = Plugin(distribution="truncnorm", shape_parameters=[0, np.inf])
+        self.assertEqual(plugin.distribution, stats.truncnorm)
+        self.assertEqual(plugin.shape_parameters, [0, np.inf])
+
+    def test_invalid_distribution(self):
+        """Test for an invalid distribution."""
+        msg = "The distribution requested"
+        with self.assertRaisesRegex(AttributeError, msg):
+            Plugin(distribution="elephant")
+
+
+class Test__repr__(IrisTest):
+
+    """Test string representation of plugin."""
+
+    def test_basic(self):
+        """Test string representation"""
+        expected_string = ("<FromMeanAndVariance: "
+                           "distribution: norm; shape_parameters: []>")
+        result = str(Plugin())
+        self.assertEqual(result, expected_string)
+
+
+class Test__rescale_shape_parameters(IrisTest):
+
+    """Test the _rescale_shape_parameters"""
+
+    def setUp(self):
+        """Set up values for testing."""
+        self.mean = np.array([-1, 0, 1])
+        self.std = np.array([1, 1.5, 2])
+
+    def test_truncated_at_zero(self):
+        """Test scaling shape parameters implying a truncation at zero."""
+        expected = [np.array([1., 0, -0.5]),
+                    np.array([np.inf, np.inf, np.inf])]
+        shape_parameters = [0, np.inf]
+        plugin = Plugin(distribution="truncnorm",
+                        shape_parameters=shape_parameters)
+        plugin._rescale_shape_parameters(self.mean, self.std)
+        self.assertArrayAlmostEqual(plugin.shape_parameters, expected)
+
+    def test_discrete_shape_parameters(self):
+        """Test scaling discrete shape parameters."""
+        expected = [np.array([-3, -2.666667, -2.5]), np.array([7, 4, 2.5])]
+        shape_parameters = [-4, 6]
+        plugin = Plugin(distribution="truncnorm",
+                        shape_parameters=shape_parameters)
+        plugin._rescale_shape_parameters(self.mean, self.std)
+        self.assertArrayAlmostEqual(plugin.shape_parameters, expected)
+
+    def test_alternative_distribution(self):
+        """Test specifying a distribution other than truncated normal. In
+        this instance, no rescaling is applied."""
+        shape_parameters = [0, np.inf]
+        plugin = Plugin(distribution="norm",
+                        shape_parameters=shape_parameters)
+        plugin._rescale_shape_parameters(self.mean, self.std)
+        self.assertArrayEqual(plugin.shape_parameters, shape_parameters)
+
+    def test_no_shape_parameters_exception(self):
+        """Test raising an exception when shape parameters are not specified
+        for the truncated normal."""
+        plugin = Plugin(distribution="truncnorm")
+        msg = "For the truncated normal distribution"
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin._rescale_shape_parameters(self.mean, self.std)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_FromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_FromMeanAndVariance.py
@@ -53,7 +53,7 @@ class Test__init__(IrisTest):
         self.assertEqual(plugin.shape_parameters, [])
 
     def test_valid_distribution_with_shape_parameters(self):
-        """Test for a valid distribution with ."""
+        """Test for a valid distribution with shape parameters."""
         plugin = Plugin(distribution="truncnorm", shape_parameters=[0, np.inf])
         self.assertEqual(plugin.distribution, stats.truncnorm)
         self.assertEqual(plugin.shape_parameters, [0, np.inf])
@@ -116,7 +116,7 @@ class Test__rescale_shape_parameters(IrisTest):
 
     def test_no_shape_parameters_exception(self):
         """Test raising an exception when shape parameters are not specified
-        for the truncated normal."""
+        for the truncated normal distribution."""
         plugin = Plugin(distribution="truncnorm")
         msg = "For the truncated normal distribution"
         with self.assertRaisesRegex(ValueError, msg):

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
@@ -111,7 +111,7 @@ class Test__mean_and_variance_to_percentiles(IrisTest):
         ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_simple_data_truncnorm_distribution(self):
         """
-        Test that the plugin returns an Iris.cube.Cube matching the expected
+        Test that the plugin returns an iris.cube.Cube matching the expected
         data values when a cube containing mean and variance is passed in.
         The resulting data values are the percentiles, which have been
         generated using a truncated normal distribution.

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
@@ -40,6 +40,7 @@ import numpy as np
 from iris.cube import Cube
 from iris.tests import IrisTest
 
+
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GeneratePercentilesFromMeanAndVariance as Plugin)
 from improver.tests.ensemble_calibration.ensemble_calibration. \
@@ -47,6 +48,18 @@ from improver.tests.ensemble_calibration.ensemble_calibration. \
                              set_up_temperature_cube,
                              add_forecast_reference_time_and_forecast_period)
 from improver.utilities.warnings_handler import ManageWarnings
+
+
+class Test__repr__(IrisTest):
+
+    """Test string representation of plugin."""
+
+    def test_basic(self):
+        """Test string representation"""
+        expected_string = ("<GeneratePercentilesFromMeanAndVariance: "
+                           "distribution: norm; shape_parameters: []>")
+        result = str(Plugin())
+        self.assertEqual(result, expected_string)
 
 
 class Test__mean_and_variance_to_percentiles(IrisTest):
@@ -94,6 +107,49 @@ class Test__mean_and_variance_to_percentiles(IrisTest):
             percentiles)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.data, data)
+
+    @ManageWarnings(
+        ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_simple_data_truncnorm_distribution(self):
+        """
+        Test that the plugin returns an Iris.cube.Cube matching the expected
+        data values when a cube containing mean and variance is passed in.
+        The resulting data values are the percentiles, which have been
+        generated using a truncated normal distribution.
+        """
+        data = np.array([[[[1, 1, 1],
+                           [1, 1, 1],
+                           [1, 1, 1]]],
+                         [[[2, 2, 2],
+                           [2, 2, 2],
+                           [2, 2, 2]]],
+                         [[[3, 3, 3],
+                           [3, 3, 3],
+                           [3, 3, 3]]]])
+
+        result_data = np.array([[[[0.827385, 0.827385, 0.827385],
+                                  [0.827385, 0.827385, 0.827385],
+                                  [0.827385, 0.827385, 0.827385]]],
+                                [[[2.028517, 2.028517, 2.028517],
+                                  [2.028517, 2.028517, 2.028517],
+                                  [2.028517, 2.028517, 2.028517]]],
+                                [[[3.2946239, 3.2946239, 3.2946239],
+                                  [3.2946239, 3.2946239, 3.2946239],
+                                  [3.2946239, 3.2946239, 3.2946239]]]])
+
+        cube = self.current_temperature_forecast_cube
+        cube.data = data
+        current_forecast_predictor = cube.collapsed(
+            "realization", iris.analysis.MEAN)
+        current_forecast_variance = cube.collapsed(
+            "realization", iris.analysis.VARIANCE)
+        percentiles = [10, 50, 90]
+        plugin = Plugin(distribution="truncnorm", shape_parameters=[0, np.inf])
+        result = plugin._mean_and_variance_to_percentiles(
+            current_forecast_predictor, current_forecast_variance,
+            percentiles)
+        self.assertIsInstance(result, Cube)
+        self.assertArrayAlmostEqual(result.data, result_data)
 
     @ManageWarnings(
         ignored_messages=["Collapsing a non-contiguous coordinate."])

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GeneratePercentilesFromMeanAndVariance.py
@@ -40,7 +40,6 @@ import numpy as np
 from iris.cube import Cube
 from iris.tests import IrisTest
 
-
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     GeneratePercentilesFromMeanAndVariance as Plugin)
 from improver.tests.ensemble_calibration.ensemble_calibration. \

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -165,8 +165,8 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         self.variances.units = 'Celsius2'
 
     def test_threshold_above_cube(self):
-        """Test that the expected probabilites are returned for a cube in which
-        they are calculated above the thresholds."""
+        """Test that the expected probabilities are returned for a cube in
+        which they are calculated above the thresholds."""
 
         expected = (np.ones((3, 3, 3)) * [0.75, 0.5, 0.25]).T
         result = Plugin()._mean_and_variance_to_probabilities(
@@ -174,8 +174,8 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         np.testing.assert_allclose(result.data, expected, rtol=1.e-4)
 
     def test_threshold_above_cube_truncnorm(self):
-        """Test that the expected probabilites are returned for a cube in which
-        they are calculated above the thresholds using a truncated normal
+        """Test that the expected probabilities are returned for a cube in
+        which they are calculated above the thresholds using a truncated normal
         distribution."""
 
         expected = (np.ones((3, 3, 3)) * [0.8914245, 0.5942867, 0.2971489]).T

--- a/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
+++ b/lib/improver/tests/ensemble_copula_coupling/ensemble_copula_coupling/test_GenerateProbabilitiesFromMeanAndVariance.py
@@ -52,7 +52,8 @@ class Test__repr__(IrisTest):
 
     def test_basic(self):
         """Test string representation"""
-        expected_string = "<GenerateProbabilitiesFromMeanAndVariance>"
+        expected_string = ("<GenerateProbabilitiesFromMeanAndVariance: "
+                           "distribution: norm; shape_parameters: []>")
         result = str(Plugin())
         self.assertEqual(result, expected_string)
 
@@ -155,8 +156,8 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
         # Thresholds such that we obtain probabilities of 75%, 50%, and 25% for
         # the mean and variance values set here.
         threshold_coord = find_threshold_coordinate(self.template_cube)
-        threshold_coord.points = [8.65105, 10., 11.34895]
-        mean_values = np.ones((3, 3)) * 10
+        threshold_coord.points = [0.65105, 2., 3.34895]
+        mean_values = np.ones((3, 3)) * 2
         variance_values = np.ones((3, 3)) * 4
         self.means = self.template_cube[0, :, :].copy(data=mean_values)
         self.means.units = 'Celsius'
@@ -169,6 +170,17 @@ class Test__mean_and_variance_to_probabilities(IrisTest):
 
         expected = (np.ones((3, 3, 3)) * [0.75, 0.5, 0.25]).T
         result = Plugin()._mean_and_variance_to_probabilities(
+            self.means, self.variances, self.template_cube)
+        np.testing.assert_allclose(result.data, expected, rtol=1.e-4)
+
+    def test_threshold_above_cube_truncnorm(self):
+        """Test that the expected probabilites are returned for a cube in which
+        they are calculated above the thresholds using a truncated normal
+        distribution."""
+
+        expected = (np.ones((3, 3, 3)) * [0.8914245, 0.5942867, 0.2971489]).T
+        plugin = Plugin(distribution="truncnorm", shape_parameters=[0, np.inf])
+        result = plugin._mean_and_variance_to_probabilities(
             self.means, self.variances, self.template_cube)
         np.testing.assert_allclose(result.data, expected, rtol=1.e-4)
 


### PR DESCRIPTION
Description
Edits to be able to specify the distribution used when creating either percentiles or probabilities from the mean and variance. This is primarily for the purposes of converting from mean and variance for EMOS where currently either a normal or truncated normal distribution are support when minimising the CRPS.

The contents of this PR is:
- Minor docstring amendment to ensemble_calibration.py
- Modification to the `GeneratePercentilesFromMeanAndVariance` and `GenerateProbabilitiesFromMeanAndVariance` to accept the specification of a distribution when computing percentiles or probabilities from the mean and variance.
The details are:
  - Addition of a `FromMeanAndVariance` class, so that the `GeneratePercentilesFromMeanAndVariance` and `GenerateProbabilitiesFromMeanAndVariance` can share the same interface. 
  - Modification to handle a `distribution` argument and `shape_parameters` argument. Shape parameters are required when using the [`truncnorm`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html) scipy distribution. 
  - Flattening has been added to the `GenerateProbabilitiesFromMeanAndVariance`, in order for the `truncnorm` distribution to work as intended otherwise a broadcast-related exception is raised. I think this has actually been solved by https://github.com/scipy/scipy/pull/9900, however, as we're using scipy version 1.2.1, rather than the latest scipy version (1.3.2), at the moment, the flattening is required. I've tested the removal of the flattening on Travis using scipy version (1.3.2) and, in this case, the unit tests pass successfully: [Travis output](https://travis-ci.org/gavinevans/improver/builds/614938933?utm_source=github_status&utm_medium=notification).
- Add unit tests as required for `FromMeanAndVariance`, `GeneratePercentilesFromMeanAndVariance` and `GenerateProbabilitiesFromMeanAndVariance` plugin.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

