### PR TITLE
Temporal utilities

### DIFF
--- a/lib/improver/blending/weighted_blend.py
+++ b/lib/improver/blending/weighted_blend.py
@@ -42,12 +42,12 @@ from iris.exceptions import CoordinateNotFoundError
 from improver import BasePlugin
 from improver.metadata.amend import amend_attributes
 from improver.metadata.probabilistic import find_percentile_coordinate
+from improver.metadata.forecast_times import (
+    forecast_period_coord, rebadge_forecasts_as_latest_cycle)
 from improver.utilities.cube_manipulation import (
     enforce_coordinate_ordering, sort_coord_in_cube, build_coordinate,
     MergeCubes)
-from improver.utilities.temporal import (
-    cycletime_to_number, forecast_period_coord,
-    rebadge_forecasts_as_latest_cycle)
+from improver.utilities.temporal import cycletime_to_number
 
 
 class MergeCubesForWeightedBlending(BasePlugin):

--- a/lib/improver/metadata/forecast_times.py
+++ b/lib/improver/metadata/forecast_times.py
@@ -169,10 +169,10 @@ def rebadge_forecasts_as_latest_cycle(cubes, cycletime):
         return cubes
     cycle_datetime = (find_latest_cycletime(cubes) if cycletime is None
                       else cycletime_to_datetime(cycletime))
-    return unify_forecast_reference_time(cubes, cycle_datetime)
+    return unify_cycletime(cubes, cycle_datetime)
 
 
-def unify_forecast_reference_time(cubes, cycletime):
+def unify_cycletime(cubes, cycletime):
     """
     Function to unify the forecast_reference_time and update forecast_period.
     The cycletime specified is used as the forecast_reference_time, and the

--- a/lib/improver/metadata/forecast_times.py
+++ b/lib/improver/metadata/forecast_times.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Utilities to manipulate forecast time coordinates"""
+
+import warnings
+import numpy as np
+from cf_units import Unit
+
+import iris
+from iris.exceptions import CoordinateNotFoundError
+
+from improver.utilities.cube_manipulation import build_coordinate
+from improver.utilities.temporal import cycletime_to_datetime
+
+
+def forecast_period_coord(
+        cube, force_lead_time_calculation=False, result_units="seconds"):
+    """
+    Return or calculate the lead time coordinate (forecast_period)
+    within a cube, either by reading the forecast_period coordinate,
+    or by calculating the difference between the time (points and bounds) and
+    the forecast_reference_time. The units of the forecast_period, time and
+    forecast_reference_time coordinates are converted, if required. The final
+    coordinate will have units of seconds.
+
+    Args:
+        cube (iris.cube.Cube):
+            Cube from which the lead times will be determined.
+        force_lead_time_calculation (bool):
+            Force the lead time to be calculated from the
+            forecast_reference_time and the time coordinate, even if
+            the forecast_period coordinate exists.
+            Default is False.
+        result_units (str or cf_units.Unit):
+            Desired units for the resulting forecast period coordinate.
+
+    Returns:
+        iris.coords.Coord:
+            Describing the points and their units for
+            'forecast_period'. A DimCoord is returned if the
+            forecast_period coord is already present in the cube as a
+            DimCoord and this coord does not need changing, otherwise
+            it will be an AuxCoord. Units are result_units.
+    """
+    if cube.coords("forecast_period"):
+        fp_type = cube.coord("forecast_period").dtype
+    else:
+        fp_type = np.int32
+
+    if cube.coords("forecast_period") and not force_lead_time_calculation:
+        result_coord = cube.coord("forecast_period").copy()
+        try:
+            result_coord.convert_units(result_units)
+        except ValueError as err:
+            msg = "For forecast_period: {}".format(err)
+            raise ValueError(msg)
+
+    # Try to return forecast_reference_time - time coordinate.
+    elif cube.coords("time") and cube.coords("forecast_reference_time"):
+        time_units = cube.coord("time").units
+        t_coord = cube.coord("time")
+        fr_coord = cube.coord("forecast_reference_time")
+        fr_type = fr_coord.dtype
+        try:
+            fr_coord.convert_units(time_units)
+        except ValueError as err:
+            msg = "For forecast_reference_time: {}".format(err)
+            raise ValueError(msg)
+        time_points = np.array(
+            [c.point for c in t_coord.cells()])
+        forecast_reference_time_points = np.array(
+            [c.point for c in fr_coord.cells()])
+        required_lead_times = (
+            time_points - forecast_reference_time_points)
+        required_lead_times = np.array(
+            [x.total_seconds() for x in required_lead_times]).astype(fr_type)
+        if t_coord.bounds is not None:
+            time_bounds = np.array(
+                [c.bound for c in t_coord.cells()])
+            required_lead_bounds = (
+                time_bounds - forecast_reference_time_points)
+            required_lead_bounds = np.array(
+                [[b.total_seconds() for b in x]
+                 for x in required_lead_bounds]).astype(fr_type)
+        else:
+            required_lead_bounds = None
+        coord_type = iris.coords.AuxCoord
+        if cube.coords("forecast_period"):
+            if isinstance(
+                    cube.coord("forecast_period"), iris.coords.DimCoord):
+                coord_type = iris.coords.DimCoord
+        result_coord = coord_type(
+            required_lead_times,
+            standard_name='forecast_period',
+            bounds=required_lead_bounds,
+            units="seconds")
+        result_coord.convert_units(result_units)
+        if np.any(result_coord.points < 0):
+            msg = ("The values for the time {} and "
+                   "forecast_reference_time {} coordinates from the "
+                   "input cube have produced negative values for the "
+                   "forecast_period. A forecast does not generate "
+                   "values in the past.").format(
+                       cube.coord("time").points,
+                       cube.coord("forecast_reference_time").points)
+            warnings.warn(msg)
+    else:
+        msg = ("The forecast period coordinate is not available within {}."
+               "The time coordinate and forecast_reference_time "
+               "coordinate were also not available for calculating "
+               "the forecast_period.".format(cube))
+        raise CoordinateNotFoundError(msg)
+
+    result_coord.points = result_coord.points.astype(fp_type)
+    if result_coord.bounds is not None:
+        result_coord.bounds = result_coord.bounds.astype(fp_type)
+
+    return result_coord
+
+
+def rebadge_forecasts_as_latest_cycle(cubes, cycletime):
+    """
+    Function to update the forecast_reference_time and forecast_period
+    on a list of input forecasts to match either a given cycletime, or
+    the most recent forecast in the list (proxy for the current cycle).
+
+    Args:
+        cubes (iris.cube.CubeList):
+            Cubes that will have their forecast_reference_time and
+            forecast_period updated.
+        cycletime (str or None):
+            Required forecast reference time in a YYYYMMDDTHHMMZ format
+            e.g. 20171122T0100Z. If None, the latest forecast reference
+            time is used.
+
+    Returns:
+        iris.cube.CubeList:
+            Updated cubes
+    """
+    if cycletime is None and len(cubes) == 1:
+        return cubes
+    cycle_datetime = (find_latest_cycletime(cubes) if cycletime is None
+                      else cycletime_to_datetime(cycletime))
+    return unify_forecast_reference_time(cubes, cycle_datetime)
+
+
+def unify_forecast_reference_time(cubes, cycletime):
+    """
+    Function to unify the forecast_reference_time and update forecast_period.
+    The cycletime specified is used as the forecast_reference_time, and the
+    forecast_period is recalculated using the time coordinate and updated
+    forecast_reference_time.
+
+    Args:
+        cubes (iris.cube.CubeList):
+            Cubes that will have their forecast_reference_time and
+            forecast_period updated. Any bounds on the forecast_reference_time
+            coordinate will be discarded.
+        cycletime (datetime.datetime):
+            Datetime for the cycletime that will be used to replace the
+            forecast_reference_time on the individual cubes.
+
+    Returns:
+        iris.cube.CubeList:
+            Updated cubes
+
+    Raises:
+        ValueError: if forecast_reference_time is a dimension coordinate
+    """
+    result_cubes = iris.cube.CubeList([])
+    for cube in cubes:
+        cube = cube.copy()
+        frt_units = cube.coord('forecast_reference_time').units
+        frt_type = cube.coord('forecast_reference_time').dtype
+        new_frt_units = Unit('seconds since 1970-01-01 00:00:00')
+        frt_points = np.round(
+            [new_frt_units.date2num(cycletime)]).astype(frt_type)
+        frt_coord = build_coordinate(
+            frt_points, standard_name="forecast_reference_time", bounds=None,
+            template_coord=cube.coord('forecast_reference_time'),
+            units=new_frt_units)
+        frt_coord.convert_units(frt_units)
+        frt_coord.points = frt_coord.points.astype(frt_type)
+        cube.remove_coord("forecast_reference_time")
+        cube.add_aux_coord(frt_coord, data_dims=None)
+
+        # Update the forecast period for consistency within each cube
+        fp_units = "seconds"
+        if cube.coords("forecast_period"):
+            fp_units = cube.coord("forecast_period").units
+            cube.remove_coord("forecast_period")
+        fp_coord = forecast_period_coord(
+            cube, force_lead_time_calculation=True, result_units=fp_units)
+        cube.add_aux_coord(fp_coord, data_dims=cube.coord_dims("time"))
+        result_cubes.append(cube)
+    return result_cubes
+
+
+def find_latest_cycletime(cubelist):
+    """
+    Find the latest cycletime from the cubes in a cubelist and convert it into
+    a datetime object.
+
+    Args:
+        cubelist (iris.cube.CubeList):
+            A list of cubes each containing single time step from different
+            forecast cycles.
+
+    Returns:
+        datetime.datetime:
+            A datetime object corresponding to the latest forecast reference
+            time in the input cubelist.
+    """
+    # Get cycle time as latest forecast reference time
+    if any([cube.coord_dims("forecast_reference_time")
+            for cube in cubelist]):
+        raise ValueError(
+            "Expecting scalar forecast_reference_time for each input "
+            "cube - cannot replace a dimension coordinate")
+
+    frt_coord = cubelist[0].coord("forecast_reference_time").copy()
+    for cube in cubelist:
+        next_coord = cube.coord("forecast_reference_time").copy()
+        next_coord.convert_units(frt_coord.units)
+        if next_coord.points[0] > frt_coord.points[0]:
+            frt_coord = next_coord
+    cycletime, = frt_coord.units.num2date(
+        frt_coord.points)
+    return cycletime

--- a/lib/improver/nbhood/nbhood.py
+++ b/lib/improver/nbhood/nbhood.py
@@ -38,10 +38,10 @@ from improver.constants import DEFAULT_PERCENTILES
 from improver.nbhood.circular_kernel import (
     CircularNeighbourhood, GeneratePercentilesFromACircularNeighbourhood)
 from improver.nbhood.square_kernel import SquareNeighbourhood
+from improver.metadata.forecast_times import forecast_period_coord
 from improver.utilities.cube_checker import (
     check_cube_coordinates, find_dimension_coordinate_mismatch)
 from improver.utilities.cube_manipulation import concatenate_cubes
-from improver.utilities.temporal import forecast_period_coord
 
 
 class BaseNeighbourhoodProcessing(BasePlugin):

--- a/lib/improver/tests/blending/weights/test_ChooseWeightsLinear.py
+++ b/lib/improver/tests/blending/weights/test_ChooseWeightsLinear.py
@@ -40,9 +40,9 @@ from iris.coords import AuxCoord
 from iris.tests import IrisTest
 
 from improver.blending.weights import ChooseWeightsLinear
+from improver.metadata.forecast_times import forecast_period_coord
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, set_up_probability_cube, add_coordinate)
-from improver.utilities.temporal import forecast_period_coord
 
 CONFIG_DICT_UKV = {"uk_det": {"forecast_period": [7, 12, 48, 54],
                               "weights": [0, 1, 1, 0],

--- a/lib/improver/tests/metadata/test_forecast_times.py
+++ b/lib/improver/tests/metadata/test_forecast_times.py
@@ -40,7 +40,7 @@ from iris.tests import IrisTest
 
 from improver.metadata.forecast_times import (
     forecast_period_coord, rebadge_forecasts_as_latest_cycle,
-    unify_forecast_reference_time, find_latest_cycletime)
+    unify_cycletime, find_latest_cycletime)
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.utilities.warnings_handler import ManageWarnings
@@ -231,9 +231,9 @@ class Test_rebadge_forecasts_as_latest_cycle(IrisTest):
                          expected_fp_point)
 
 
-class Test_unify_forecast_reference_time(IrisTest):
+class Test_unify_cycletime(IrisTest):
 
-    """Test the unify_forecast_reference_time function."""
+    """Test the unify_cycletime function."""
 
     def setUp(self):
         """Set up a UK deterministic cube for testing."""
@@ -287,7 +287,7 @@ class Test_unify_forecast_reference_time(IrisTest):
         expected = iris.cube.CubeList([expected_uk_det, expected_uk_ens])
 
         cubes = iris.cube.CubeList([self.cube_uk_det, cube_uk_ens])
-        result = unify_forecast_reference_time(cubes, self.cycletime)
+        result = unify_cycletime(cubes, self.cycletime)
 
         self.assertIsInstance(result, iris.cube.CubeList)
         self.assertEqual(result, expected)
@@ -303,8 +303,7 @@ class Test_unify_forecast_reference_time(IrisTest):
         expected_uk_det.coord("forecast_reference_time").points = frt_points
         expected_uk_det.coord("forecast_period").points = (
             np.array([3, 5, 7]) * 3600)
-        result = unify_forecast_reference_time(
-            [self.cube_uk_det], self.cycletime)
+        result = unify_cycletime([self.cube_uk_det], self.cycletime)
         self.assertIsInstance(result, iris.cube.CubeList)
         self.assertEqual(result[0], expected_uk_det)
 
@@ -322,7 +321,7 @@ class Test_unify_forecast_reference_time(IrisTest):
             np.array([3, 5, 7]) * 3600)
         cube_uk_det = self.cube_uk_det.copy()
         cube_uk_det.remove_coord("forecast_period")
-        result = unify_forecast_reference_time([cube_uk_det], self.cycletime)
+        result = unify_cycletime([cube_uk_det], self.cycletime)
         self.assertIsInstance(result, iris.cube.CubeList)
         self.assertEqual(result[0], expected_uk_det)
 

--- a/lib/improver/tests/metadata/test_forecast_times.py
+++ b/lib/improver/tests/metadata/test_forecast_times.py
@@ -1,0 +1,401 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for forecast time coordinate utilities"""
+
+import unittest
+import numpy as np
+from datetime import datetime, timedelta
+
+import iris
+from iris.exceptions import CoordinateNotFoundError
+from iris.tests import IrisTest
+
+from improver.metadata.forecast_times import (
+    forecast_period_coord, rebadge_forecasts_as_latest_cycle,
+    unify_forecast_reference_time, find_latest_cycletime)
+from improver.tests.set_up_test_cubes import (
+    set_up_variable_cube, add_coordinate)
+from improver.utilities.warnings_handler import ManageWarnings
+
+
+class Test_forecast_period_coord(IrisTest):
+
+    """Test determining of the lead times present within the input cube."""
+
+    def setUp(self):
+        """Set up a test cube with a forecast period scalar coordinate"""
+        self.cube = set_up_variable_cube(np.ones((1, 3, 3), dtype=np.float32))
+
+    def test_basic(self):
+        """Test that an iris.coords.DimCoord is returned."""
+        result = forecast_period_coord(self.cube)
+        self.assertIsInstance(result, iris.coords.DimCoord)
+
+    def test_basic_AuxCoord(self):
+        """Test that an iris.coords.AuxCoord is returned."""
+        self.cube.remove_coord('forecast_period')
+        result = forecast_period_coord(
+            self.cube, force_lead_time_calculation=True)
+        self.assertIsInstance(result, iris.coords.AuxCoord)
+
+    def test_check_coordinate(self):
+        """Test that the data within the coord is as expected with the
+        expected units, when the input cube has a forecast_period coordinate.
+        """
+        fp_coord = self.cube.coord("forecast_period").copy()
+        expected_points = fp_coord.points
+        expected_units = str(fp_coord.units)
+        result = forecast_period_coord(self.cube)
+        self.assertArrayEqual(result.points, expected_points)
+        self.assertEqual(str(result.units), expected_units)
+
+    def test_check_coordinate_force_lead_time_calculation(self):
+        """Test that the data within the coord is as expected with the
+        expected units, when the input cube has a forecast_period coordinate.
+        """
+        fp_coord = self.cube.coord("forecast_period").copy()
+        expected_points = fp_coord.points
+        expected_units = str(fp_coord.units)
+        result = forecast_period_coord(
+            self.cube, force_lead_time_calculation=True)
+        self.assertArrayEqual(result.points, expected_points)
+        self.assertEqual(result.units, expected_units)
+
+    def test_check_coordinate_in_hours_force_lead_time_calculation(self):
+        """Test that the data within the coord is as expected with the
+        expected units, when the input cube has a forecast_period coordinate.
+        """
+        fp_coord = self.cube.coord("forecast_period").copy()
+        fp_coord.convert_units("hours")
+        expected_points = fp_coord.points
+        expected_units = str(fp_coord.units)
+        result = forecast_period_coord(
+            self.cube, force_lead_time_calculation=True,
+            result_units=fp_coord.units)
+        self.assertArrayEqual(result.points, expected_points)
+        self.assertEqual(result.units, expected_units)
+
+    def test_check_coordinate_without_forecast_period(self):
+        """Test that the data within the coord is as expected with the
+        expected units, when the input cube has a time coordinate and a
+        forecast_reference_time coordinate.
+        """
+        fp_coord = self.cube.coord("forecast_period").copy()
+        expected_result = fp_coord
+        self.cube.remove_coord("forecast_period")
+        result = forecast_period_coord(self.cube)
+        self.assertEqual(result, expected_result)
+
+    def test_check_time_unit_conversion(self):
+        """Test that the data within the coord is as expected with the
+        expected units, when the input cube has a time coordinate with units
+        other than the usual units of seconds since 1970-01-01 00:00:00.
+        """
+        expected_result = self.cube.coord("forecast_period")
+        self.cube.coord("time").convert_units(
+            "hours since 1970-01-01 00:00:00")
+        result = forecast_period_coord(
+            self.cube, force_lead_time_calculation=True)
+        self.assertEqual(result, expected_result)
+
+    def test_check_time_unit_has_bounds(self):
+        """Test that the forecast_period coord has bounds if time has bounds.
+        """
+        cube = set_up_variable_cube(
+            np.ones((3, 3), dtype=np.float32),
+            time=datetime(2018, 3, 12, 20), frt=datetime(2018, 3, 12, 15),
+            time_bounds=[datetime(2018, 3, 12, 19), datetime(2018, 3, 12, 20)])
+        expected_result = cube.coord("forecast_period").copy()
+        expected_result.bounds = [[14400, 18000]]
+        result = forecast_period_coord(cube, force_lead_time_calculation=True)
+        self.assertEqual(result, expected_result)
+
+    @ManageWarnings(record=True)
+    def test_negative_forecast_periods_warning(self, warning_list=None):
+        """Test that a warning is raised if the point within the
+        time coordinate is prior to the point within the
+        forecast_reference_time, and therefore the forecast_period values that
+        have been generated are negative.
+        """
+        cube = set_up_variable_cube(np.ones((3, 3), dtype=np.float32))
+        cube.remove_coord("forecast_period")
+        # default cube has a 4 hour forecast period, so add 5 hours to frt
+        cube.coord("forecast_reference_time").points = (
+            cube.coord("forecast_reference_time").points + 5*3600)
+        warning_msg = "The values for the time"
+        forecast_period_coord(cube)
+        self.assertTrue(any(item.category == UserWarning
+                            for item in warning_list))
+        self.assertTrue(any(warning_msg in str(item)
+                            for item in warning_list))
+
+    def test_exception_raised(self):
+        """Test that a CoordinateNotFoundError exception is raised if the
+        forecast_period, or the time and forecast_reference_time,
+        are not present.
+        """
+        self.cube.remove_coord("forecast_reference_time")
+        self.cube.remove_coord("forecast_period")
+        msg = "The forecast period coordinate is not available"
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
+            forecast_period_coord(self.cube)
+
+
+class Test_rebadge_forecasts_as_latest_cycle(IrisTest):
+    """Test the rebadge_forecasts_as_latest_cycle function"""
+
+    def setUp(self):
+        """Set up some cubes with different cycle times"""
+        self.cycletime = '20190711T1200Z'
+        validity_time = datetime(2019, 7, 11, 14)
+        self.cube_early = set_up_variable_cube(
+            np.full((4, 4), 273.15, dtype=np.float32),
+            time=validity_time, frt=datetime(2019, 7, 11, 9))
+        self.cube_late = set_up_variable_cube(
+            np.full((4, 4), 273.15, dtype=np.float32),
+            time=validity_time, frt=datetime(2019, 7, 11, 10))
+
+    def test_cubelist(self):
+        """Test a list of cubes is returned with the latest frt"""
+        expected = self.cube_late.copy()
+        result = rebadge_forecasts_as_latest_cycle(
+            [self.cube_early, self.cube_late], None)
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertEqual(len(result), 2)
+        for cube in result:
+            for coord in ["forecast_reference_time", "forecast_period"]:
+                self.assertEqual(cube.coord(coord), expected.coord(coord))
+
+    def test_cycletime(self):
+        """Test a list of cubes using the cycletime argument"""
+        expected_frt_point = (
+            self.cube_late.coord("forecast_reference_time").points[0] + 2*3600)
+        expected_fp_point = (
+            self.cube_late.coord("forecast_period").points[0] - 2*3600)
+        result = rebadge_forecasts_as_latest_cycle(
+            [self.cube_early, self.cube_late], self.cycletime)
+        for cube in result:
+            self.assertEqual(cube.coord("forecast_reference_time").points[0],
+                             expected_frt_point)
+            self.assertEqual(cube.coord("forecast_period").points[0],
+                             expected_fp_point)
+
+    def test_single_cube(self):
+        """Test a single cube is returned unchanged if the cycletime argument
+        is not set"""
+        expected = self.cube_early.copy()
+        result, = rebadge_forecasts_as_latest_cycle([self.cube_early], None)
+        for coord in ["forecast_reference_time", "forecast_period"]:
+            self.assertEqual(result.coord(coord), expected.coord(coord))
+
+    def test_single_cube_with_cycletime(self):
+        """Test a single cube has its forecast reference time and period
+        updated if cycletime is specified"""
+        expected_frt_point = (
+            self.cube_late.coord("forecast_reference_time").points[0] + 2*3600)
+        expected_fp_point = (
+            self.cube_late.coord("forecast_period").points[0] - 2*3600)
+        result, = rebadge_forecasts_as_latest_cycle(
+            [self.cube_late], self.cycletime)
+        self.assertEqual(result.coord("forecast_reference_time").points[0],
+                         expected_frt_point)
+        self.assertEqual(result.coord("forecast_period").points[0],
+                         expected_fp_point)
+
+
+class Test_unify_forecast_reference_time(IrisTest):
+
+    """Test the unify_forecast_reference_time function."""
+
+    def setUp(self):
+        """Set up a UK deterministic cube for testing."""
+        self.cycletime = datetime(2017, 1, 10, 6)
+        cube_uk_det = set_up_variable_cube(
+            np.full((4, 4), 273.15, dtype=np.float32),
+            time=self.cycletime, frt=datetime(2017, 1, 10, 3))
+
+        cube_uk_det.remove_coord("forecast_period")
+        # set up forecast periods of 6, 8 and 10 hours
+        time_points = [1484038800, 1484046000, 1484053200]
+        cube_uk_det = add_coordinate(
+            cube_uk_det, time_points, "time", dtype=np.int64,
+            coord_units="seconds since 1970-01-01 00:00:00")
+        fp_coord = forecast_period_coord(cube_uk_det)
+        cube_uk_det.add_aux_coord(fp_coord, data_dims=0)
+
+        self.cube_uk_det = add_coordinate(cube_uk_det, [1000], "model_id")
+        self.cube_uk_det.add_aux_coord(
+            iris.coords.AuxCoord(["uk_det"], long_name="model_configuration"))
+
+    def test_cubelist_input(self):
+        """Test when supplying a cubelist as input containing cubes
+        representing UK deterministic and UK ensemble model configuration
+        and unifying the forecast_reference_time, so that both model
+        configurations have a common forecast_reference_time."""
+        cube_uk_ens = set_up_variable_cube(
+            np.full((3, 4, 4), 273.15, dtype=np.float32),
+            time=self.cycletime, frt=datetime(2017, 1, 10, 4))
+
+        cube_uk_ens.remove_coord("forecast_period")
+        # set up forecast periods of 5, 7 and 9 hours
+        time_points = [1484031600, 1484038800, 1484046000]
+        cube_uk_ens = add_coordinate(
+            cube_uk_ens, time_points, "time", dtype=np.int64,
+            coord_units="seconds since 1970-01-01 00:00:00")
+        fp_coord = forecast_period_coord(cube_uk_ens)
+        cube_uk_ens.add_aux_coord(fp_coord, data_dims=0)
+
+        expected_uk_det = self.cube_uk_det.copy()
+        frt_units = expected_uk_det.coord('forecast_reference_time').units
+        frt_points = [
+            np.round(frt_units.date2num(self.cycletime)).astype(np.int64)]
+        expected_uk_det.coord("forecast_reference_time").points = frt_points
+        expected_uk_det.coord("forecast_period").points = (
+            np.array([3, 5, 7]) * 3600)
+        expected_uk_ens = cube_uk_ens.copy()
+        expected_uk_ens.coord("forecast_reference_time").points = frt_points
+        expected_uk_ens.coord("forecast_period").points = (
+            np.array([1, 3, 5]) * 3600)
+        expected = iris.cube.CubeList([expected_uk_det, expected_uk_ens])
+
+        cubes = iris.cube.CubeList([self.cube_uk_det, cube_uk_ens])
+        result = unify_forecast_reference_time(cubes, self.cycletime)
+
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertEqual(result, expected)
+
+    def test_single_item_cubelist_input(self):
+        """Test when supplying a cube representing a UK deterministic model
+        configuration only. This effectively updates the
+        forecast_reference_time on the cube to the specified cycletime."""
+        expected_uk_det = self.cube_uk_det.copy()
+        frt_units = expected_uk_det.coord('forecast_reference_time').units
+        frt_points = [
+            np.round(frt_units.date2num(self.cycletime)).astype(np.int64)]
+        expected_uk_det.coord("forecast_reference_time").points = frt_points
+        expected_uk_det.coord("forecast_period").points = (
+            np.array([3, 5, 7]) * 3600)
+        result = unify_forecast_reference_time(
+            [self.cube_uk_det], self.cycletime)
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertEqual(result[0], expected_uk_det)
+
+    def test_input_no_forecast_period_coordinate(self):
+        """Test when supplying a cube representing a UK deterministic model
+        configuration only. This forces a forecast_period coordinate to be
+        created from a forecast_reference_time coordinate and a time
+        coordinate."""
+        expected_uk_det = self.cube_uk_det.copy()
+        frt_units = expected_uk_det.coord('forecast_reference_time').units
+        frt_points = [
+            np.round(frt_units.date2num(self.cycletime)).astype(np.int64)]
+        expected_uk_det.coord("forecast_reference_time").points = frt_points
+        expected_uk_det.coord("forecast_period").points = (
+            np.array([3, 5, 7]) * 3600)
+        cube_uk_det = self.cube_uk_det.copy()
+        cube_uk_det.remove_coord("forecast_period")
+        result = unify_forecast_reference_time([cube_uk_det], self.cycletime)
+        self.assertIsInstance(result, iris.cube.CubeList)
+        self.assertEqual(result[0], expected_uk_det)
+
+
+class Test_find_latest_cycletime(IrisTest):
+
+    """Test the find_latest_cycletime function."""
+
+    def setUp(self):
+        """Set up a template cubes with scalar time, forecast_reference_time
+           and forecast_period coordinates"""
+        self.input_cube = set_up_variable_cube(
+            np.full((7, 7), 273.15, dtype=np.float32),
+            time=datetime(2015, 11, 23, 6), frt=datetime(2015, 11, 23, 3))
+        self.input_cube2 = self.input_cube.copy()
+        self.input_cube2.coord("forecast_reference_time").points = np.array(
+            self.input_cube2.coord("forecast_reference_time").points[0] + 3600)
+        self.input_cubelist = iris.cube.CubeList(
+            [self.input_cube, self.input_cube2])
+
+    def test_basic(self):
+        """Test the type of the output and that the input is unchanged."""
+        original_cubelist = iris.cube.CubeList(
+            [self.input_cube.copy(), self.input_cube2.copy()])
+        cycletime = find_latest_cycletime(self.input_cubelist)
+        self.assertEqual(self.input_cubelist[0], original_cubelist[0])
+        self.assertEqual(self.input_cubelist[1], original_cubelist[1])
+        self.assertIsInstance(cycletime, datetime)
+
+    def test_returns_latest(self):
+        """Test the returned cycle time is the latest in the input cubelist."""
+        cycletime = find_latest_cycletime(self.input_cubelist)
+        expected_datetime = datetime(2015, 11, 23, 4)
+        self.assertEqual(timedelta(hours=0, seconds=0),
+                         cycletime - expected_datetime)
+
+    def test_two_cubes_same_reference_time(self):
+        """Test the a cycletime is still found when two cubes have the same
+           cycletime."""
+        input_cubelist = iris.cube.CubeList(
+            [self.input_cube, self.input_cube.copy()])
+        cycletime = find_latest_cycletime(input_cubelist)
+        expected_datetime = datetime(2015, 11, 23, 3)
+        self.assertEqual(timedelta(hours=0, seconds=0),
+                         cycletime - expected_datetime)
+
+    def test_one_input_cube(self):
+        """Test the a cycletime is still found when only one input cube."""
+        input_cubelist = iris.cube.CubeList([self.input_cube])
+        cycletime = find_latest_cycletime(input_cubelist)
+        expected_datetime = datetime(2015, 11, 23, 3)
+        self.assertEqual(timedelta(hours=0, seconds=0),
+                         cycletime - expected_datetime)
+
+    def test_different_units(self):
+        """Test the right cycletime is still returned if the coords have
+        different units."""
+        self.input_cube2.coord("forecast_reference_time").convert_units(
+            'minutes since 1970-01-01 00:00:00')
+        cycletime = find_latest_cycletime(self.input_cubelist)
+        expected_datetime = datetime(2015, 11, 23, 4)
+        self.assertEqual(timedelta(hours=0, seconds=0),
+                         cycletime - expected_datetime)
+
+    def test_raises_error(self):
+        """Test the error is raised if time is dimensional"""
+        input_cube2 = iris.util.new_axis(
+            self.input_cube2, "forecast_reference_time")
+        input_cubelist = iris.cube.CubeList([self.input_cube, input_cube2])
+        msg = "Expecting scalar forecast_reference_time for each input cube"
+        with self.assertRaisesRegex(ValueError, msg):
+            find_latest_cycletime(input_cubelist)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/improver/tests/metadata/test_forecast_times.py
+++ b/lib/improver/tests/metadata/test_forecast_times.py
@@ -31,10 +31,10 @@
 """Unit tests for forecast time coordinate utilities"""
 
 import unittest
-import numpy as np
 from datetime import datetime, timedelta
 
 import iris
+import numpy as np
 from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
 

--- a/lib/improver/tests/set_up_test_cubes.py
+++ b/lib/improver/tests/set_up_test_cubes.py
@@ -45,7 +45,7 @@ from iris.exceptions import CoordinateNotFoundError
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
 from improver.metadata.constants.mo_attributes import MOSG_GRID_DEFINITION
 from improver.metadata.check_datatypes import check_cube_not_float64
-from improver.utilities.temporal import forecast_period_coord
+from improver.metadata.forecast_times import forecast_period_coord
 
 TIME_UNIT = "seconds since 1970-01-01 00:00:00"
 CALENDAR = "gregorian"

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -44,8 +44,8 @@ from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.utilities.temporal import (
     cycletime_to_datetime, cycletime_to_number, datetime_to_cycletime,
-    iris_time_to_datetime, datetime_to_iris_time, set_utc_offset,
-    datetime_constraint, extract_cube_at_time, extract_nearest_time_point)
+    iris_time_to_datetime, datetime_to_iris_time, datetime_constraint,
+    extract_cube_at_time, extract_nearest_time_point)
 from improver.utilities.warnings_handler import ManageWarnings
 
 
@@ -207,22 +207,6 @@ class Test_datetime_to_iris_time(IrisTest):
         expected = 1487311200.0
         self.assertIsInstance(result, np.int64)
         self.assertEqual(result, expected)
-
-
-class Test_set_utc_offset(IrisTest):
-    """
-    Test setting of UTC_offsets with longitudes using crude 15 degree bins.
-    """
-
-    def test_output(self):
-        """
-        Test full span of crude timezones from UTC-12 to UTC+12. Note the
-        degeneracy at +-180.
-        """
-        longitudes = np.arange(-180, 185, 15)
-        expected = np.arange(-12, 13, 1)
-        result = set_utc_offset(longitudes)
-        self.assertArrayEqual(expected, result)
 
 
 class Test_datetime_constraint(IrisTest):

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -211,8 +211,7 @@ class Test_datetime_to_iris_time(IrisTest):
 
 class Test_datetime_constraint(IrisTest):
     """
-    Test construction of an iris.Constraint from a python.datetime
-    object.
+    Test construction of an iris.Constraint from a python datetime object.
     """
     def setUp(self):
         """Set up test cubes"""

--- a/lib/improver/tests/utilities/test_temporal.py
+++ b/lib/improver/tests/utilities/test_temporal.py
@@ -30,9 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for temporal utilities."""
 
-import datetime
 import unittest
-from datetime import timedelta
+from datetime import datetime
 
 import iris
 import numpy as np
@@ -45,10 +44,8 @@ from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.utilities.temporal import (
     cycletime_to_datetime, cycletime_to_number, datetime_to_cycletime,
-    forecast_period_coord, iris_time_to_datetime, datetime_constraint,
-    extract_cube_at_time, set_utc_offset,
-    rebadge_forecasts_as_latest_cycle, unify_forecast_reference_time,
-    find_latest_cycletime, extract_nearest_time_point, datetime_to_iris_time)
+    iris_time_to_datetime, datetime_to_iris_time, set_utc_offset,
+    datetime_constraint, extract_cube_at_time, extract_nearest_time_point)
 from improver.utilities.warnings_handler import ManageWarnings
 
 
@@ -60,15 +57,15 @@ class Test_cycletime_to_datetime(IrisTest):
     def test_basic(self):
         """Test that a datetime object is returned of the expected value."""
         cycletime = "20171122T0100Z"
-        dt = datetime.datetime(2017, 11, 22, 1, 0)
+        dt = datetime(2017, 11, 22, 1, 0)
         result = cycletime_to_datetime(cycletime)
-        self.assertIsInstance(result, datetime.datetime)
+        self.assertIsInstance(result, datetime)
         self.assertEqual(result, dt)
 
     def test_define_cycletime_format(self):
         """Test when a cycletime is defined."""
         cycletime = "201711220100"
-        dt = datetime.datetime(2017, 11, 22, 1, 0)
+        dt = datetime(2017, 11, 22, 1, 0)
         result = cycletime_to_datetime(
             cycletime, cycletime_format="%Y%m%d%H%M")
         self.assertEqual(result, dt)
@@ -81,7 +78,7 @@ class Test_datetime_to_cycletime(IrisTest):
 
     def test_basic(self):
         """Test that a datetime object is returned of the expected value."""
-        dt = datetime.datetime(2017, 11, 22, 1, 0)
+        dt = datetime(2017, 11, 22, 1, 0)
         cycletime = "20171122T0100Z"
         result = datetime_to_cycletime(dt)
         self.assertIsInstance(result, str)
@@ -89,14 +86,14 @@ class Test_datetime_to_cycletime(IrisTest):
 
     def test_define_cycletime_format(self):
         """Test when a cycletime is defined."""
-        dt = datetime.datetime(2017, 11, 22, 1, 0)
+        dt = datetime(2017, 11, 22, 1, 0)
         cycletime = "201711220100"
         result = datetime_to_cycletime(dt, cycletime_format="%Y%m%d%H%M")
         self.assertEqual(result, cycletime)
 
     def test_define_cycletime_format_with_seconds(self):
         """Test when a cycletime is defined with seconds."""
-        dt = datetime.datetime(2017, 11, 22, 1, 0)
+        dt = datetime(2017, 11, 22, 1, 0)
         cycletime = "20171122010000"
         result = datetime_to_cycletime(dt, cycletime_format="%Y%m%d%H%M%S")
         self.assertEqual(result, cycletime)
@@ -143,131 +140,6 @@ class Test_cycletime_to_number(IrisTest):
         self.assertAlmostEqual(result, dt)
 
 
-class Test_forecast_period_coord(IrisTest):
-
-    """Test determining of the lead times present within the input cube."""
-
-    def setUp(self):
-        """Set up a test cube with a forecast period scalar coordinate"""
-        self.cube = set_up_variable_cube(np.ones((1, 3, 3), dtype=np.float32))
-
-    def test_basic(self):
-        """Test that an iris.coords.DimCoord is returned."""
-        result = forecast_period_coord(self.cube)
-        self.assertIsInstance(result, iris.coords.DimCoord)
-
-    def test_basic_AuxCoord(self):
-        """Test that an iris.coords.AuxCoord is returned."""
-        self.cube.remove_coord('forecast_period')
-        result = forecast_period_coord(
-            self.cube, force_lead_time_calculation=True)
-        self.assertIsInstance(result, iris.coords.AuxCoord)
-
-    def test_check_coordinate(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
-        """
-        fp_coord = self.cube.coord("forecast_period").copy()
-        expected_points = fp_coord.points
-        expected_units = str(fp_coord.units)
-        result = forecast_period_coord(self.cube)
-        self.assertArrayEqual(result.points, expected_points)
-        self.assertEqual(str(result.units), expected_units)
-
-    def test_check_coordinate_force_lead_time_calculation(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
-        """
-        fp_coord = self.cube.coord("forecast_period").copy()
-        expected_points = fp_coord.points
-        expected_units = str(fp_coord.units)
-        result = forecast_period_coord(
-            self.cube, force_lead_time_calculation=True)
-        self.assertArrayEqual(result.points, expected_points)
-        self.assertEqual(result.units, expected_units)
-
-    def test_check_coordinate_in_hours_force_lead_time_calculation(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
-        """
-        fp_coord = self.cube.coord("forecast_period").copy()
-        fp_coord.convert_units("hours")
-        expected_points = fp_coord.points
-        expected_units = str(fp_coord.units)
-        result = forecast_period_coord(
-            self.cube, force_lead_time_calculation=True,
-            result_units=fp_coord.units)
-        self.assertArrayEqual(result.points, expected_points)
-        self.assertEqual(result.units, expected_units)
-
-    def test_check_coordinate_without_forecast_period(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a time coordinate and a
-        forecast_reference_time coordinate.
-        """
-        fp_coord = self.cube.coord("forecast_period").copy()
-        expected_result = fp_coord
-        self.cube.remove_coord("forecast_period")
-        result = forecast_period_coord(self.cube)
-        self.assertEqual(result, expected_result)
-
-    def test_check_time_unit_conversion(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a time coordinate with units
-        other than the usual units of seconds since 1970-01-01 00:00:00.
-        """
-        expected_result = self.cube.coord("forecast_period")
-        self.cube.coord("time").convert_units(
-            "hours since 1970-01-01 00:00:00")
-        result = forecast_period_coord(
-            self.cube, force_lead_time_calculation=True)
-        self.assertEqual(result, expected_result)
-
-    def test_check_time_unit_has_bounds(self):
-        """Test that the forecast_period coord has bounds if time has bounds.
-        """
-        cube = set_up_variable_cube(
-            np.ones((3, 3), dtype=np.float32),
-            time=datetime.datetime(2018, 3, 12, 20, 0),
-            frt=datetime.datetime(2018, 3, 12, 15, 0),
-            time_bounds=[datetime.datetime(2018, 3, 12, 19, 0),
-                         datetime.datetime(2018, 3, 12, 20, 0)])
-        expected_result = cube.coord("forecast_period").copy()
-        expected_result.bounds = [[14400, 18000]]
-        result = forecast_period_coord(cube, force_lead_time_calculation=True)
-        self.assertEqual(result, expected_result)
-
-    @ManageWarnings(record=True)
-    def test_negative_forecast_periods_warning(self, warning_list=None):
-        """Test that a warning is raised if the point within the
-        time coordinate is prior to the point within the
-        forecast_reference_time, and therefore the forecast_period values that
-        have been generated are negative.
-        """
-        cube = set_up_variable_cube(np.ones((3, 3), dtype=np.float32))
-        cube.remove_coord("forecast_period")
-        # default cube has a 4 hour forecast period, so add 5 hours to frt
-        cube.coord("forecast_reference_time").points = (
-            cube.coord("forecast_reference_time").points + 5*3600)
-        warning_msg = "The values for the time"
-        forecast_period_coord(cube)
-        self.assertTrue(any(item.category == UserWarning
-                            for item in warning_list))
-        self.assertTrue(any(warning_msg in str(item)
-                            for item in warning_list))
-
-    def test_exception_raised(self):
-        """Test that a CoordinateNotFoundError exception is raised if the
-        forecast_period, or the time and forecast_reference_time,
-        are not present.
-        """
-        self.cube.remove_coord("forecast_reference_time")
-        self.cube.remove_coord("forecast_period")
-        msg = "The forecast period coordinate is not available"
-        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
-            forecast_period_coord(self.cube)
-
-
 class Test_iris_time_to_datetime(IrisTest):
     """ Test iris_time_to_datetime """
 
@@ -275,23 +147,23 @@ class Test_iris_time_to_datetime(IrisTest):
         """Set up an input cube"""
         self.cube = set_up_variable_cube(
             np.ones((3, 3), dtype=np.float32),
-            time=datetime.datetime(2017, 2, 17, 6, 0),
-            frt=datetime.datetime(2017, 2, 17, 3, 0))
+            time=datetime(2017, 2, 17, 6, 0),
+            frt=datetime(2017, 2, 17, 3, 0))
 
     def test_basic(self):
         """Test iris_time_to_datetime returns list of datetime """
         result = iris_time_to_datetime(self.cube.coord('time'))
         self.assertIsInstance(result, list)
         for item in result:
-            self.assertIsInstance(item, datetime.datetime)
-        self.assertEqual(result[0], datetime.datetime(2017, 2, 17, 6, 0))
+            self.assertIsInstance(item, datetime)
+        self.assertEqual(result[0], datetime(2017, 2, 17, 6, 0))
 
     def test_bounds(self):
         """Test iris_time_to_datetime returns list of datetimes calculated
         from the coordinate bounds."""
         # Assign time bounds equivalent to [
-        # datetime.datetime(2017, 2, 17, 5, 0),
-        # datetime.datetime(2017, 2, 17, 6, 0)]
+        # datetime(2017, 2, 17, 5, 0),
+        # datetime(2017, 2, 17, 6, 0)]
         self.cube.coord('time').bounds = [1487307600, 1487311200]
 
         result = iris_time_to_datetime(
@@ -300,9 +172,9 @@ class Test_iris_time_to_datetime(IrisTest):
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0]), 2)
         for item in result[0]:
-            self.assertIsInstance(item, datetime.datetime)
-        self.assertEqual(result[0][0], datetime.datetime(2017, 2, 17, 5, 0))
-        self.assertEqual(result[0][1], datetime.datetime(2017, 2, 17, 6, 0))
+            self.assertIsInstance(item, datetime)
+        self.assertEqual(result[0][0], datetime(2017, 2, 17, 5, 0))
+        self.assertEqual(result[0][1], datetime(2017, 2, 17, 6, 0))
 
     def test_input_cube_unmodified(self):
         """Test that an input cube with unexpected coordinate units is not
@@ -326,7 +198,7 @@ class Test_datetime_to_iris_time(IrisTest):
 
     def setUp(self):
         """Define datetime for use in tests."""
-        self.dt_in = datetime.datetime(2017, 2, 17, 6, 0)
+        self.dt_in = datetime(2017, 2, 17, 6, 0)
 
     def test_seconds(self):
         """Test datetime_to_iris_time returns float with expected value
@@ -337,17 +209,33 @@ class Test_datetime_to_iris_time(IrisTest):
         self.assertEqual(result, expected)
 
 
+class Test_set_utc_offset(IrisTest):
+    """
+    Test setting of UTC_offsets with longitudes using crude 15 degree bins.
+    """
+
+    def test_output(self):
+        """
+        Test full span of crude timezones from UTC-12 to UTC+12. Note the
+        degeneracy at +-180.
+        """
+        longitudes = np.arange(-180, 185, 15)
+        expected = np.arange(-12, 13, 1)
+        result = set_utc_offset(longitudes)
+        self.assertArrayEqual(expected, result)
+
+
 class Test_datetime_constraint(IrisTest):
     """
-    Test construction of an iris.Constraint from a python.datetime.datetime
+    Test construction of an iris.Constraint from a python.datetime
     object.
     """
     def setUp(self):
         """Set up test cubes"""
         cube = set_up_variable_cube(
             np.ones((12, 12), dtype=np.float32),
-            time=datetime.datetime(2017, 2, 17, 6, 0),
-            frt=datetime.datetime(2017, 2, 17, 6, 0))
+            time=datetime(2017, 2, 17, 6, 0),
+            frt=datetime(2017, 2, 17, 6, 0))
         cube.remove_coord("forecast_period")
         self.time_points = np.arange(
             1487311200, 1487354400, 3600).astype(np.int64)
@@ -358,8 +246,8 @@ class Test_datetime_constraint(IrisTest):
     def test_constraint_list_equality(self):
         """Check a list of constraints is as expected."""
         plugin = datetime_constraint
-        time_start = datetime.datetime(2017, 2, 17, 6, 0)
-        time_limit = datetime.datetime(2017, 2, 17, 18, 0)
+        time_start = datetime(2017, 2, 17, 6, 0)
+        time_limit = datetime(2017, 2, 17, 18, 0)
         dt_constraint = plugin(time_start, time_max=time_limit)
         result = self.cube.extract(dt_constraint)
         self.assertEqual(result.shape, (12, 12, 12))
@@ -368,20 +256,20 @@ class Test_datetime_constraint(IrisTest):
     def test_constraint_type(self):
         """Check type is iris.Constraint."""
         plugin = datetime_constraint
-        dt_constraint = plugin(datetime.datetime(2017, 2, 17, 6, 0))
+        dt_constraint = plugin(datetime(2017, 2, 17, 6, 0))
         self.assertIsInstance(dt_constraint, iris.Constraint)
 
     def test_valid_constraint(self):
         """Test use of constraint at a time valid within the cube."""
         plugin = datetime_constraint
-        dt_constraint = plugin(datetime.datetime(2017, 2, 17, 6, 0))
+        dt_constraint = plugin(datetime(2017, 2, 17, 6, 0))
         result = self.cube.extract(dt_constraint)
         self.assertIsInstance(result, Cube)
 
     def test_invalid_constraint(self):
         """Test use of constraint at a time invalid within the cube."""
         plugin = datetime_constraint
-        dt_constraint = plugin(datetime.datetime(2017, 2, 17, 18, 0))
+        dt_constraint = plugin(datetime(2017, 2, 17, 18, 0))
         result = self.cube.extract(dt_constraint)
         self.assertNotIsInstance(result, Cube)
 
@@ -394,15 +282,15 @@ class Test_extract_cube_at_time(IrisTest):
         """Set up a test cube with several time points"""
         cube = set_up_variable_cube(
             np.ones((12, 12), dtype=np.float32),
-            time=datetime.datetime(2017, 2, 17, 6, 0),
-            frt=datetime.datetime(2017, 2, 17, 6, 0))
+            time=datetime(2017, 2, 17, 6, 0),
+            frt=datetime(2017, 2, 17, 6, 0))
         cube.remove_coord("forecast_period")
         self.time_points = np.arange(
             1487311200, 1487354400, 3600).astype(np.int64)
         self.cube = add_coordinate(
             cube, self.time_points, "time", dtype=np.int64,
             coord_units="seconds since 1970-01-01 00:00:00")
-        self.time_dt = datetime.datetime(2017, 2, 17, 6, 0)
+        self.time_dt = datetime(2017, 2, 17, 6, 0)
         self.time_constraint = iris.Constraint(
             time=lambda cell: cell.point == PartialDateTime(
                 self.time_dt.year, self.time_dt.month,
@@ -428,7 +316,7 @@ class Test_extract_cube_at_time(IrisTest):
     def test_invalid_time(self, warning_list=None):
         """Case for a time that is unavailable within the diagnostic cube."""
         plugin = extract_cube_at_time
-        time_dt = datetime.datetime(2017, 2, 18, 6, 0)
+        time_dt = datetime(2017, 2, 18, 6, 0)
         time_constraint = iris.Constraint(time=PartialDateTime(
             time_dt.year, time_dt.month, time_dt.day, time_dt.hour))
         cubes = CubeList([self.cube])
@@ -440,22 +328,6 @@ class Test_extract_cube_at_time(IrisTest):
                             for item in warning_list))
 
 
-class Test_set_utc_offset(IrisTest):
-    """
-    Test setting of UTC_offsets with longitudes using crude 15 degree bins.
-    """
-
-    def test_output(self):
-        """
-        Test full span of crude timezones from UTC-12 to UTC+12. Note the
-        degeneracy at +-180.
-        """
-        longitudes = np.arange(-180, 185, 15)
-        expected = np.arange(-12, 13, 1)
-        result = set_utc_offset(longitudes)
-        self.assertArrayEqual(expected, result)
-
-
 class Test_extract_nearest_time_point(IrisTest):
 
     """Test the extract_nearest_time_point function."""
@@ -464,8 +336,8 @@ class Test_extract_nearest_time_point(IrisTest):
         """Set up a cube for the tests."""
         cube = set_up_variable_cube(
             np.ones((1, 7, 7), dtype=np.float32),
-            time=datetime.datetime(2015, 11, 23, 7, 0),
-            frt=datetime.datetime(2015, 11, 23, 3, 0))
+            time=datetime(2015, 11, 23, 7, 0),
+            frt=datetime(2015, 11, 23, 3, 0))
         cube.remove_coord("forecast_period")
         time_points = [1448262000, 1448265600]
         self.cube = add_coordinate(
@@ -477,7 +349,7 @@ class Test_extract_nearest_time_point(IrisTest):
         """Test that the nearest time point within the time coordinate is
         extracted."""
         expected = self.cube[:, 0, :, :]
-        time_point = datetime.datetime(2015, 11, 23, 6, 31)
+        time_point = datetime(2015, 11, 23, 6, 31)
         result = extract_nearest_time_point(self.cube, time_point,
                                             allowed_dt_difference=1800)
         self.assertEqual(result, expected)
@@ -486,7 +358,7 @@ class Test_extract_nearest_time_point(IrisTest):
         """Test that the nearest time point within the time coordinate is
         extracted, when a time of 07:30 is requested."""
         expected = self.cube[:, 0, :, :]
-        time_point = datetime.datetime(2015, 11, 23, 7, 30)
+        time_point = datetime(2015, 11, 23, 7, 30)
         result = extract_nearest_time_point(self.cube, time_point,
                                             allowed_dt_difference=1800)
         self.assertEqual(result, expected)
@@ -495,7 +367,7 @@ class Test_extract_nearest_time_point(IrisTest):
         """Test that the nearest time point within the time coordinate is
         extracted, when a time of 07:31 is requested."""
         expected = self.cube[:, 1, :, :]
-        time_point = datetime.datetime(2015, 11, 23, 7, 31)
+        time_point = datetime(2015, 11, 23, 7, 31)
         result = extract_nearest_time_point(self.cube, time_point,
                                             allowed_dt_difference=1800)
         self.assertEqual(result, expected)
@@ -509,7 +381,7 @@ class Test_extract_nearest_time_point(IrisTest):
         cubes = iris.cube.CubeList([self.cube, later_frt])
         cube = cubes.merge_cube()
         expected = self.cube
-        time_point = datetime.datetime(2015, 11, 23, 3, 29)
+        time_point = datetime(2015, 11, 23, 3, 29)
         result = extract_nearest_time_point(
             cube, time_point, time_name="forecast_reference_time",
             allowed_dt_difference=1800)
@@ -518,7 +390,7 @@ class Test_extract_nearest_time_point(IrisTest):
     def test_exception_using_allowed_dt_difference(self):
         """Test that an exception is raised, if the time point is outside of
         the allowed difference specified in seconds."""
-        time_point = datetime.datetime(2017, 11, 23, 6, 0)
+        time_point = datetime(2017, 11, 23, 6, 0)
         msg = "is not available within the input cube"
         with self.assertRaisesRegex(ValueError, msg):
             extract_nearest_time_point(self.cube, time_point,
@@ -527,241 +399,12 @@ class Test_extract_nearest_time_point(IrisTest):
     def test_time_name_exception(self):
         """Test that an exception is raised, if an invalid time name
         is specified."""
-        time_point = datetime.datetime(2017, 11, 23, 6, 0)
+        time_point = datetime(2017, 11, 23, 6, 0)
         msg = ("The time_name must be either "
                "'time' or 'forecast_reference_time'")
         with self.assertRaisesRegex(ValueError, msg):
             extract_nearest_time_point(self.cube, time_point,
                                        time_name="forecast_period")
-
-
-class Test_rebadge_forecasts_as_latest_cycle(IrisTest):
-    """Test the rebadge_forecasts_as_latest_cycle function"""
-
-    def setUp(self):
-        """Set up some cubes with different cycle times"""
-        self.cycletime = '20190711T1200Z'
-        validity_time = datetime.datetime(2019, 7, 11, 14)
-        self.cube_early = set_up_variable_cube(
-            np.full((4, 4), 273.15, dtype=np.float32),
-            time=validity_time, frt=datetime.datetime(2019, 7, 11, 9))
-        self.cube_late = set_up_variable_cube(
-            np.full((4, 4), 273.15, dtype=np.float32),
-            time=validity_time, frt=datetime.datetime(2019, 7, 11, 10))
-
-    def test_cubelist(self):
-        """Test a list of cubes is returned with the latest frt"""
-        expected = self.cube_late.copy()
-        result = rebadge_forecasts_as_latest_cycle(
-            [self.cube_early, self.cube_late], None)
-        self.assertIsInstance(result, iris.cube.CubeList)
-        self.assertEqual(len(result), 2)
-        for cube in result:
-            for coord in ["forecast_reference_time", "forecast_period"]:
-                self.assertEqual(cube.coord(coord), expected.coord(coord))
-
-    def test_cycletime(self):
-        """Test a list of cubes using the cycletime argument"""
-        expected_frt_point = (
-            self.cube_late.coord("forecast_reference_time").points[0] + 2*3600)
-        expected_fp_point = (
-            self.cube_late.coord("forecast_period").points[0] - 2*3600)
-        result = rebadge_forecasts_as_latest_cycle(
-            [self.cube_early, self.cube_late], self.cycletime)
-        for cube in result:
-            self.assertEqual(cube.coord("forecast_reference_time").points[0],
-                             expected_frt_point)
-            self.assertEqual(cube.coord("forecast_period").points[0],
-                             expected_fp_point)
-
-    def test_single_cube(self):
-        """Test a single cube is returned unchanged if the cycletime argument
-        is not set"""
-        expected = self.cube_early.copy()
-        result, = rebadge_forecasts_as_latest_cycle([self.cube_early], None)
-        for coord in ["forecast_reference_time", "forecast_period"]:
-            self.assertEqual(result.coord(coord), expected.coord(coord))
-
-    def test_single_cube_with_cycletime(self):
-        """Test a single cube has its forecast reference time and period
-        updated if cycletime is specified"""
-        expected_frt_point = (
-            self.cube_late.coord("forecast_reference_time").points[0] + 2*3600)
-        expected_fp_point = (
-            self.cube_late.coord("forecast_period").points[0] - 2*3600)
-        result, = rebadge_forecasts_as_latest_cycle(
-            [self.cube_late], self.cycletime)
-        self.assertEqual(result.coord("forecast_reference_time").points[0],
-                         expected_frt_point)
-        self.assertEqual(result.coord("forecast_period").points[0],
-                         expected_fp_point)
-
-
-class Test_unify_forecast_reference_time(IrisTest):
-
-    """Test the unify_forecast_reference_time function."""
-
-    def setUp(self):
-        """Set up a UK deterministic cube for testing."""
-        self.cycletime = datetime.datetime(2017, 1, 10, 6, 0)
-        cube_uk_det = set_up_variable_cube(
-            np.full((4, 4), 273.15, dtype=np.float32),
-            time=self.cycletime, frt=datetime.datetime(2017, 1, 10, 3, 0))
-
-        cube_uk_det.remove_coord("forecast_period")
-        # set up forecast periods of 6, 8 and 10 hours
-        time_points = [1484038800, 1484046000, 1484053200]
-        cube_uk_det = add_coordinate(
-            cube_uk_det, time_points, "time", dtype=np.int64,
-            coord_units="seconds since 1970-01-01 00:00:00")
-        fp_coord = forecast_period_coord(cube_uk_det)
-        cube_uk_det.add_aux_coord(fp_coord, data_dims=0)
-
-        self.cube_uk_det = add_coordinate(cube_uk_det, [1000], "model_id")
-        self.cube_uk_det.add_aux_coord(
-            iris.coords.AuxCoord(["uk_det"], long_name="model_configuration"))
-
-    def test_cubelist_input(self):
-        """Test when supplying a cubelist as input containing cubes
-        representing UK deterministic and UK ensemble model configuration
-        and unifying the forecast_reference_time, so that both model
-        configurations have a common forecast_reference_time."""
-        cube_uk_ens = set_up_variable_cube(
-            np.full((3, 4, 4), 273.15, dtype=np.float32),
-            time=self.cycletime, frt=datetime.datetime(2017, 1, 10, 4, 0))
-
-        cube_uk_ens.remove_coord("forecast_period")
-        # set up forecast periods of 5, 7 and 9 hours
-        time_points = [1484031600, 1484038800, 1484046000]
-        cube_uk_ens = add_coordinate(
-            cube_uk_ens, time_points, "time", dtype=np.int64,
-            coord_units="seconds since 1970-01-01 00:00:00")
-        fp_coord = forecast_period_coord(cube_uk_ens)
-        cube_uk_ens.add_aux_coord(fp_coord, data_dims=0)
-
-        expected_uk_det = self.cube_uk_det.copy()
-        frt_units = expected_uk_det.coord('forecast_reference_time').units
-        frt_points = [
-            np.round(frt_units.date2num(self.cycletime)).astype(np.int64)]
-        expected_uk_det.coord("forecast_reference_time").points = frt_points
-        expected_uk_det.coord("forecast_period").points = (
-            np.array([3, 5, 7]) * 3600)
-        expected_uk_ens = cube_uk_ens.copy()
-        expected_uk_ens.coord("forecast_reference_time").points = frt_points
-        expected_uk_ens.coord("forecast_period").points = (
-            np.array([1, 3, 5]) * 3600)
-        expected = iris.cube.CubeList([expected_uk_det, expected_uk_ens])
-
-        cubes = iris.cube.CubeList([self.cube_uk_det, cube_uk_ens])
-        result = unify_forecast_reference_time(cubes, self.cycletime)
-
-        self.assertIsInstance(result, iris.cube.CubeList)
-        self.assertEqual(result, expected)
-
-    def test_single_item_cubelist_input(self):
-        """Test when supplying a cube representing a UK deterministic model
-        configuration only. This effectively updates the
-        forecast_reference_time on the cube to the specified cycletime."""
-        expected_uk_det = self.cube_uk_det.copy()
-        frt_units = expected_uk_det.coord('forecast_reference_time').units
-        frt_points = [
-            np.round(frt_units.date2num(self.cycletime)).astype(np.int64)]
-        expected_uk_det.coord("forecast_reference_time").points = frt_points
-        expected_uk_det.coord("forecast_period").points = (
-            np.array([3, 5, 7]) * 3600)
-        result = unify_forecast_reference_time(
-            [self.cube_uk_det], self.cycletime)
-        self.assertIsInstance(result, iris.cube.CubeList)
-        self.assertEqual(result[0], expected_uk_det)
-
-    def test_input_no_forecast_period_coordinate(self):
-        """Test when supplying a cube representing a UK deterministic model
-        configuration only. This forces a forecast_period coordinate to be
-        created from a forecast_reference_time coordinate and a time
-        coordinate."""
-        expected_uk_det = self.cube_uk_det.copy()
-        frt_units = expected_uk_det.coord('forecast_reference_time').units
-        frt_points = [
-            np.round(frt_units.date2num(self.cycletime)).astype(np.int64)]
-        expected_uk_det.coord("forecast_reference_time").points = frt_points
-        expected_uk_det.coord("forecast_period").points = (
-            np.array([3, 5, 7]) * 3600)
-        cube_uk_det = self.cube_uk_det.copy()
-        cube_uk_det.remove_coord("forecast_period")
-        result = unify_forecast_reference_time([cube_uk_det], self.cycletime)
-        self.assertIsInstance(result, iris.cube.CubeList)
-        self.assertEqual(result[0], expected_uk_det)
-
-
-class Test_find_latest_cycletime(IrisTest):
-
-    """Test the find_latest_cycletime function."""
-
-    def setUp(self):
-        """Set up a template cubes with scalar time, forecast_reference_time
-           and forecast_period coordinates"""
-        self.input_cube = set_up_variable_cube(
-            np.full((7, 7), 273.15, dtype=np.float32),
-            time=datetime.datetime(2015, 11, 23, 6, 0),
-            frt=datetime.datetime(2015, 11, 23, 3, 0))
-        self.input_cube2 = self.input_cube.copy()
-        self.input_cube2.coord("forecast_reference_time").points = np.array(
-            self.input_cube2.coord("forecast_reference_time").points[0] + 3600)
-        self.input_cubelist = iris.cube.CubeList(
-            [self.input_cube, self.input_cube2])
-
-    def test_basic(self):
-        """Test the type of the output and that the input is unchanged."""
-        original_cubelist = iris.cube.CubeList(
-            [self.input_cube.copy(), self.input_cube2.copy()])
-        cycletime = find_latest_cycletime(self.input_cubelist)
-        self.assertEqual(self.input_cubelist[0], original_cubelist[0])
-        self.assertEqual(self.input_cubelist[1], original_cubelist[1])
-        self.assertIsInstance(cycletime, datetime.datetime)
-
-    def test_returns_latest(self):
-        """Test the returned cycle time is the latest in the input cubelist."""
-        cycletime = find_latest_cycletime(self.input_cubelist)
-        expected_datetime = datetime.datetime(2015, 11, 23, 4, 0, 0)
-        self.assertEqual(timedelta(hours=0, seconds=0),
-                         cycletime - expected_datetime)
-
-    def test_two_cubes_same_reference_time(self):
-        """Test the a cycletime is still found when two cubes have the same
-           cycletime."""
-        input_cubelist = iris.cube.CubeList(
-            [self.input_cube, self.input_cube.copy()])
-        cycletime = find_latest_cycletime(input_cubelist)
-        expected_datetime = datetime.datetime(2015, 11, 23, 3, 0, 0)
-        self.assertEqual(timedelta(hours=0, seconds=0),
-                         cycletime - expected_datetime)
-
-    def test_one_input_cube(self):
-        """Test the a cycletime is still found when only one input cube."""
-        input_cubelist = iris.cube.CubeList([self.input_cube])
-        cycletime = find_latest_cycletime(input_cubelist)
-        expected_datetime = datetime.datetime(2015, 11, 23, 3, 0, 0)
-        self.assertEqual(timedelta(hours=0, seconds=0),
-                         cycletime - expected_datetime)
-
-    def test_different_units(self):
-        """Test the right cycletime is still the coords have different
-           units."""
-        self.input_cube2.coord("forecast_reference_time").convert_units(
-            'minutes since 1970-01-01 00:00:00')
-        cycletime = find_latest_cycletime(self.input_cubelist)
-        expected_datetime = datetime.datetime(2015, 11, 23, 4, 0, 0)
-        self.assertEqual(timedelta(hours=0, seconds=0),
-                         cycletime - expected_datetime)
-
-    def test_raises_error(self):
-        """Test the error is raised if time is dimensional"""
-        input_cube2 = iris.util.new_axis(
-            self.input_cube2, "forecast_reference_time")
-        input_cubelist = iris.cube.CubeList([self.input_cube, input_cube2])
-        msg = "Expecting scalar forecast_reference_time for each input cube"
-        with self.assertRaisesRegex(ValueError, msg):
-            find_latest_cycletime(input_cubelist)
 
 
 if __name__ == '__main__':

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -28,20 +28,16 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Provide support utilities for making temporal calculations."""
+"""General utilities for parsing and extracting cubes at times"""
 
 import warnings
 from datetime import datetime, timezone
 
-import cf_units as unit
+import cf_units
 import iris
 import numpy as np
-from cf_units import Unit
 from iris import Constraint
-from iris.exceptions import CoordinateNotFoundError
 from iris.time import PartialDateTime
-
-from improver.utilities.cube_manipulation import build_coordinate
 
 
 def cycletime_to_datetime(cycletime, cycletime_format="%Y%m%dT%H%MZ"):
@@ -105,112 +101,7 @@ def cycletime_to_number(
     """
     dtval = cycletime_to_datetime(cycletime,
                                   cycletime_format=cycletime_format)
-    return unit.date2num(dtval, time_unit, calendar)
-
-
-def forecast_period_coord(
-        cube, force_lead_time_calculation=False, result_units="seconds"):
-    """
-    Return or calculate the lead time coordinate (forecast_period)
-    within a cube, either by reading the forecast_period coordinate,
-    or by calculating the difference between the time (points and bounds) and
-    the forecast_reference_time. The units of the forecast_period, time and
-    forecast_reference_time coordinates are converted, if required. The final
-    coordinate will have units of seconds.
-
-    Args:
-        cube (iris.cube.Cube):
-            Cube from which the lead times will be determined.
-        force_lead_time_calculation (bool):
-            Force the lead time to be calculated from the
-            forecast_reference_time and the time coordinate, even if
-            the forecast_period coordinate exists.
-            Default is False.
-        result_units (str or cf_units.Unit):
-            Desired units for the resulting forecast period coordinate.
-
-    Returns:
-        iris.coords.Coord:
-            Describing the points and their units for
-            'forecast_period'. A DimCoord is returned if the
-            forecast_period coord is already present in the cube as a
-            DimCoord and this coord does not need changing, otherwise
-            it will be an AuxCoord. Units are result_units.
-    """
-    if cube.coords("forecast_period"):
-        fp_type = cube.coord("forecast_period").dtype
-    else:
-        fp_type = np.int32
-
-    if cube.coords("forecast_period") and not force_lead_time_calculation:
-        result_coord = cube.coord("forecast_period").copy()
-        try:
-            result_coord.convert_units(result_units)
-        except ValueError as err:
-            msg = "For forecast_period: {}".format(err)
-            raise ValueError(msg)
-
-    # Try to return forecast_reference_time - time coordinate.
-    elif cube.coords("time") and cube.coords("forecast_reference_time"):
-        time_units = cube.coord("time").units
-        t_coord = cube.coord("time")
-        fr_coord = cube.coord("forecast_reference_time")
-        fr_type = fr_coord.dtype
-        try:
-            fr_coord.convert_units(time_units)
-        except ValueError as err:
-            msg = "For forecast_reference_time: {}".format(err)
-            raise ValueError(msg)
-        time_points = np.array(
-            [c.point for c in t_coord.cells()])
-        forecast_reference_time_points = np.array(
-            [c.point for c in fr_coord.cells()])
-        required_lead_times = (
-            time_points - forecast_reference_time_points)
-        required_lead_times = np.array(
-            [x.total_seconds() for x in required_lead_times]).astype(fr_type)
-        if t_coord.bounds is not None:
-            time_bounds = np.array(
-                [c.bound for c in t_coord.cells()])
-            required_lead_bounds = (
-                time_bounds - forecast_reference_time_points)
-            required_lead_bounds = np.array(
-                [[b.total_seconds() for b in x]
-                 for x in required_lead_bounds]).astype(fr_type)
-        else:
-            required_lead_bounds = None
-        coord_type = iris.coords.AuxCoord
-        if cube.coords("forecast_period"):
-            if isinstance(
-                    cube.coord("forecast_period"), iris.coords.DimCoord):
-                coord_type = iris.coords.DimCoord
-        result_coord = coord_type(
-            required_lead_times,
-            standard_name='forecast_period',
-            bounds=required_lead_bounds,
-            units="seconds")
-        result_coord.convert_units(result_units)
-        if np.any(result_coord.points < 0):
-            msg = ("The values for the time {} and "
-                   "forecast_reference_time {} coordinates from the "
-                   "input cube have produced negative values for the "
-                   "forecast_period. A forecast does not generate "
-                   "values in the past.").format(
-                       cube.coord("time").points,
-                       cube.coord("forecast_reference_time").points)
-            warnings.warn(msg)
-    else:
-        msg = ("The forecast period coordinate is not available within {}."
-               "The time coordinate and forecast_reference_time "
-               "coordinate were also not available for calculating "
-               "the forecast_period.".format(cube))
-        raise CoordinateNotFoundError(msg)
-
-    result_coord.points = result_coord.points.astype(fp_type)
-    if result_coord.bounds is not None:
-        result_coord.bounds = result_coord.bounds.astype(fp_type)
-
-    return result_coord
+    return cf_units.date2num(dtval, time_unit, calendar)
 
 
 def iris_time_to_datetime(time_coord, point_or_bound="point"):
@@ -248,6 +139,23 @@ def datetime_to_iris_time(dt_in):
     """
     result = dt_in.replace(tzinfo=timezone.utc).timestamp()
     return np.int64(result)
+
+
+def set_utc_offset(longitudes):
+    """
+    Simplistic timezone setting for unset sites that uses 15 degree bins
+    centred on 0 degrees longitude. Used for on the fly site generation
+    when no more rigorous source of timeszone information is provided.
+
+    Args:
+        longitudes (list or np.ndarray):
+            List of longitudes in degrees
+
+    Returns:
+        numpy.ndarray:
+            List of utc_offsets in hours
+    """
+    return np.floor((np.array(longitudes) + 7.5)/15.)
 
 
 def datetime_constraint(time_in, time_max=None):
@@ -306,134 +214,6 @@ def extract_cube_at_time(cubes, time, time_extract):
             time.strftime("%Y-%m-%d:%H:%M")))
         warnings.warn(msg)
         return None
-
-
-def set_utc_offset(longitudes):
-    """
-    Simplistic timezone setting for unset sites that uses 15 degree bins
-    centred on 0 degrees longitude. Used for on the fly site generation
-    when no more rigorous source of timeszone information is provided.
-
-    Args:
-        longitudes (list or np.ndarray):
-            List of longitudes in degrees
-
-    Returns:
-        numpy.ndarray:
-            List of utc_offsets in hours
-    """
-    return np.floor((np.array(longitudes) + 7.5)/15.)
-
-
-def rebadge_forecasts_as_latest_cycle(cubes, cycletime):
-    """
-    Function to update the forecast_reference_time and forecast_period
-    on a list of input forecasts to match either a given cycletime, or
-    the most recent forecast in the list (proxy for the current cycle).
-
-    Args:
-        cubes (iris.cube.CubeList):
-            Cubes that will have their forecast_reference_time and
-            forecast_period updated.
-        cycletime (str or None):
-            Required forecast reference time in a YYYYMMDDTHHMMZ format
-            e.g. 20171122T0100Z. If None, the latest forecast reference
-            time is used.
-
-    Returns:
-        iris.cube.CubeList:
-            Updated cubes
-    """
-    if cycletime is None and len(cubes) == 1:
-        return cubes
-    cycle_datetime = (find_latest_cycletime(cubes) if cycletime is None
-                      else cycletime_to_datetime(cycletime))
-    return unify_forecast_reference_time(cubes, cycle_datetime)
-
-
-def unify_forecast_reference_time(cubes, cycletime):
-    """
-    Function to unify the forecast_reference_time and update forecast_period.
-    The cycletime specified is used as the forecast_reference_time, and the
-    forecast_period is recalculated using the time coordinate and updated
-    forecast_reference_time.
-
-    Args:
-        cubes (iris.cube.CubeList):
-            Cubes that will have their forecast_reference_time and
-            forecast_period updated. Any bounds on the forecast_reference_time
-            coordinate will be discarded.
-        cycletime (datetime.datetime):
-            Datetime for the cycletime that will be used to replace the
-            forecast_reference_time on the individual cubes.
-
-    Returns:
-        iris.cube.CubeList:
-            Updated cubes
-
-    Raises:
-        ValueError: if forecast_reference_time is a dimension coordinate
-    """
-    result_cubes = iris.cube.CubeList([])
-    for cube in cubes:
-        cube = cube.copy()
-        frt_units = cube.coord('forecast_reference_time').units
-        frt_type = cube.coord('forecast_reference_time').dtype
-        new_frt_units = Unit('seconds since 1970-01-01 00:00:00')
-        frt_points = np.round(
-            [new_frt_units.date2num(cycletime)]).astype(frt_type)
-        frt_coord = build_coordinate(
-            frt_points, standard_name="forecast_reference_time", bounds=None,
-            template_coord=cube.coord('forecast_reference_time'),
-            units=new_frt_units)
-        frt_coord.convert_units(frt_units)
-        frt_coord.points = frt_coord.points.astype(frt_type)
-        cube.remove_coord("forecast_reference_time")
-        cube.add_aux_coord(frt_coord, data_dims=None)
-
-        # Update the forecast period for consistency within each cube
-        fp_units = "seconds"
-        if cube.coords("forecast_period"):
-            fp_units = cube.coord("forecast_period").units
-            cube.remove_coord("forecast_period")
-        fp_coord = forecast_period_coord(
-            cube, force_lead_time_calculation=True, result_units=fp_units)
-        cube.add_aux_coord(fp_coord, data_dims=cube.coord_dims("time"))
-        result_cubes.append(cube)
-    return result_cubes
-
-
-def find_latest_cycletime(cubelist):
-    """
-    Find the latest cycletime from the cubes in a cubelist and convert it into
-    a datetime object.
-
-    Args:
-        cubelist (iris.cube.CubeList):
-            A list of cubes each containing single time step from different
-            forecast cycles.
-
-    Returns:
-        datetime.datetime:
-            A datetime object corresponding to the latest forecast reference
-            time in the input cubelist.
-    """
-    # Get cycle time as latest forecast reference time
-    if any([cube.coord_dims("forecast_reference_time")
-            for cube in cubelist]):
-        raise ValueError(
-            "Expecting scalar forecast_reference_time for each input "
-            "cube - cannot replace a dimension coordinate")
-
-    frt_coord = cubelist[0].coord("forecast_reference_time").copy()
-    for cube in cubelist:
-        next_coord = cube.coord("forecast_reference_time").copy()
-        next_coord.convert_units(frt_coord.units)
-        if next_coord.points[0] > frt_coord.points[0]:
-            frt_coord = next_coord
-    cycletime, = frt_coord.units.num2date(
-        frt_coord.points)
-    return cycletime
 
 
 def extract_nearest_time_point(

--- a/lib/improver/utilities/temporal.py
+++ b/lib/improver/utilities/temporal.py
@@ -141,23 +141,6 @@ def datetime_to_iris_time(dt_in):
     return np.int64(result)
 
 
-def set_utc_offset(longitudes):
-    """
-    Simplistic timezone setting for unset sites that uses 15 degree bins
-    centred on 0 degrees longitude. Used for on the fly site generation
-    when no more rigorous source of timeszone information is provided.
-
-    Args:
-        longitudes (list or np.ndarray):
-            List of longitudes in degrees
-
-    Returns:
-        numpy.ndarray:
-            List of utc_offsets in hours
-    """
-    return np.floor((np.array(longitudes) + 7.5)/15.)
-
-
 def datetime_constraint(time_in, time_max=None):
     """
     Constructs an iris equivalence constraint from a python datetime object.

--- a/lib/improver/utilities/time_lagging.py
+++ b/lib/improver/utilities/time_lagging.py
@@ -33,8 +33,8 @@
 import numpy as np
 
 from improver import BasePlugin
+from improver.metadata.forecast_times import rebadge_forecasts_as_latest_cycle
 from improver.utilities.cube_manipulation import concatenate_cubes
-from improver.utilities.temporal import rebadge_forecasts_as_latest_cycle
 
 
 class GenerateTimeLaggedEnsemble(BasePlugin):


### PR DESCRIPTION
- Moved temporal utilities which assume a specific cube structure (forecast period and cycletime coordinates) into a separate metadata module, away from the more general time parsing utilities.
- Renamed a function so that "cycletime" is used consistently within both modules
- Removed unused `set_utc_offset` function

Testing:
 - [x] Ran tests and they passed OK
