### PR TITLE
IMPRO-1495 test 90 minute extrapolation

### DIFF
--- a/tests/improver-nowcast-extrapolate/02-basic.bats
+++ b/tests/improver-nowcast-extrapolate/02-basic.bats
@@ -38,15 +38,17 @@
   UVCOMP="$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/kgo.nc"
   INFILE="201811031600_radar_rainrate_composite_UK_regridded.nc"
   OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
+  OE2="20181103T1700Z-PT0004H00M-orographic_enhancement_standard_resolution.nc"
 
   # Run processing and check it passes
   run improver nowcast-extrapolate \
     "$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/$INFILE" \
     "$TEST_DIR/output.nc" \
-    --max_lead_time 30 \
+    --max_lead_time 90 \
     --u_and_v_filepath "$UVCOMP" \
     --orographic_enhancement_filepaths \
-    "$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/$OE1"
+    "$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/$OE1" \
+    "$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/$OE2"
   [[ "$status" -eq 0 ]]
 
   improver_check_recreate_kgo "output.nc" $KGO

--- a/tests/improver-nowcast-extrapolate/02-basic.bats
+++ b/tests/improver-nowcast-extrapolate/02-basic.bats
@@ -37,7 +37,7 @@
 
   UVCOMP="$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/kgo.nc"
   INFILE="201811031600_radar_rainrate_composite_UK_regridded.nc"
-  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
 
   # Run processing and check it passes
   run improver nowcast-extrapolate \

--- a/tests/improver-nowcast-extrapolate/03-metadata.bats
+++ b/tests/improver-nowcast-extrapolate/03-metadata.bats
@@ -38,7 +38,7 @@
   UVCOMP="$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/basic/kgo.nc"
   INFILE="201811031600_radar_rainrate_composite_UK_regridded.nc"
   JSONFILE="$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/metadata/precip.json"
-  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
 
   # Run processing and check it passes
   run improver nowcast-extrapolate \

--- a/tests/improver-nowcast-extrapolate/05-model_winds.bats
+++ b/tests/improver-nowcast-extrapolate/05-model_winds.bats
@@ -38,7 +38,7 @@
   WSPEED="$IMPROVER_ACC_TEST_DIR/nowcast-extrapolate/model_winds/20181103T1600Z-PT0001H00M-wind_speed_on_pressure_levels.nc"
   WDIR="$IMPROVER_ACC_TEST_DIR/nowcast-extrapolate/model_winds/20181103T1600Z-PT0001H00M-wind_direction_on_pressure_levels.nc"
   INFILE="201811031600_radar_rainrate_composite_UK_regridded.nc"
-  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
 
   # Run processing and check it passes
   run improver nowcast-extrapolate \

--- a/tests/improver-nowcast-extrapolate/07-unavailable_pressure_level.bats
+++ b/tests/improver-nowcast-extrapolate/07-unavailable_pressure_level.bats
@@ -37,7 +37,7 @@
   WSPEED="$IMPROVER_ACC_TEST_DIR/nowcast-extrapolate/model_winds/20181103T1600Z-PT0001H00M-wind_speed_on_pressure_levels.nc"
   WDIR="$IMPROVER_ACC_TEST_DIR/nowcast-extrapolate/model_winds/20181103T1600Z-PT0001H00M-wind_direction_on_pressure_levels.nc"
   INFILE="201811031600_radar_rainrate_composite_UK_regridded.nc"
-  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
 
   # Run processing and check it passes
   run improver nowcast-extrapolate \

--- a/tests/improver-nowcast-optical-flow/02-basic.bats
+++ b/tests/improver-nowcast-optical-flow/02-basic.bats
@@ -39,7 +39,7 @@
   COMP2="201811031545_radar_rainrate_composite_UK_regridded.nc"
   COMP3="201811031600_radar_rainrate_composite_UK_regridded.nc"
 
-  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
 
   # Run processing and check it passes
   run improver nowcast-optical-flow \

--- a/tests/improver-nowcast-optical-flow/03-metadata.bats
+++ b/tests/improver-nowcast-optical-flow/03-metadata.bats
@@ -39,7 +39,7 @@
   COMP2="201811031545_radar_rainrate_composite_UK_regridded.nc"
   COMP3="201811031600_radar_rainrate_composite_UK_regridded.nc"
 
-  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+  OE1="20181103T1600Z-PT0003H00M-orographic_enhancement_standard_resolution.nc"
 
   JSONFILE="$IMPROVER_ACC_TEST_DIR/nowcast-optical-flow/metadata/precip.json"
 


### PR DESCRIPTION
Replaces the orographic-enhancement data that are input to the nowcast-optical-flow and nowcast-extrapolate CLI tests as the generating code behaviour changed in #943. 
Extends the nowcast-extrapolate 02-basic test from a 30-minute forecast to a 90-minute forecast to ensure that multiple orographic-enhancement fields are being used and to be more in line with how the code is used.

Testing:
 - [x] Ran tests and they passed OK

