### PR TITLE
Minor edits to reduce Read the Docs memory consumption

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 conda:
-    file: environment.yml
+    file: doc/rtd_environment.yml
 build:
     image: latest
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,9 @@
 conda:
     file: environment.yml
+build:
+    image: latest
 python:
-    version: 3
+    version: 3.6
+    system_packages: true
+formats:
+    - htmlzip

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -1,5 +1,6 @@
 # Use this file to create a conda environment using:
 # conda create -n <name> --file environment.yml
+# This is for use with Read the Docs.
 
 name: improver
 channels:

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,7 @@ name: improver
 channels:
   - conda-forge
 dependencies:
-  - python=3
+  - python=3.6
   - iris=2.1
-  - numpy
   - cf_units
-  - sphinx
   - python-stratify


### PR DESCRIPTION
Description
Minor edits to reduce Read the Docs memory consumption.

This PR contains:
* An update to `.readthedocs.yml` that:
  1. Only builds the documentation in the htmlzip format, as used on the webpages.
  2. Set `system_packages: true`, so that common packages e.g. numpy and sphinx from the Read the Docs environment are used, rather than re-downscaling them within the conda environment.
* Remove `numpy` and `sphinx` from `environment.yml`, as these packages are available within the default Read the Docs environment.

These updates follow the recommendations in  https://docs.readthedocs.io/en/latest/guides/build-using-too-many-resources.html. 

Failing Read the Docs build using master: https://readthedocs.org/projects/improver-gavinevans/builds/10057853/

Successful Read the Docs build: https://readthedocs.org/projects/improver-gavinevans/builds/10057810/

Testing:
 - [x] Ran tests and they passed OK