### PR TITLE
Fixed bug caused by unnecessary processing of percentile values

### DIFF
--- a/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/lib/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -495,8 +495,8 @@ class GeneratePercentilesFromProbabilities(BasePlugin):
             warnings.warn(msg)
 
         # Convert percentiles into fractions.
-        percentiles = np.array([x/100.0 for x in percentiles],
-                               dtype=np.float32)
+        percentiles_as_fractions = np.array(
+            [x/100.0 for x in percentiles], dtype=np.float32)
 
         forecast_at_percentiles = (
             np.empty((len(percentiles), probabilities_for_cdf.shape[0]),
@@ -504,12 +504,8 @@ class GeneratePercentilesFromProbabilities(BasePlugin):
         )
         for index in range(probabilities_for_cdf.shape[0]):
             forecast_at_percentiles[:, index] = np.interp(
-                percentiles, probabilities_for_cdf[index, :],
+                percentiles_as_fractions, probabilities_for_cdf[index, :],
                 threshold_points)
-
-        # Convert percentiles back into percentages.
-        percentiles = np.array([x*100.0 for x in percentiles],
-                               dtype=np.float32)
 
         # Reshape forecast_at_percentiles, so the percentiles dimension is
         # first, and any other dimension coordinates follow.
@@ -617,7 +613,6 @@ class GeneratePercentilesFromProbabilities(BasePlugin):
         for cube_realization in slices_over_realization:
             cubelist.append(self._probabilities_to_percentiles(
                 cube_realization, percentiles, bounds_pairing))
-
         forecast_at_percentiles = cubelist.merge_cube()
         return forecast_at_percentiles
 


### PR DESCRIPTION
Problem with improver-percentile outputting messy percentile values of the form:
```
>> print(cube.coord('percentile'))
DimCoord(array([  0.      ,   5.      ,  10.      ,  15.000001,  20.      ,
        30.000002,  40.      ,  50.      ,  60.000004,  70.      ,
        80.      ,  85.      ,  90.      ,  95.      , 100.      ],
      dtype=float32), standard_name=None, units=Unit('%'), long_name='percentile', var_name='percentile')
```
when given a list of int / float inputs.  This was traced to unnecessary processing of the input percentile values, which has been fixed in this PR.

Testing:
 - [x] Ran tests and they passed OK
