### PR TITLE
Improve forecast times

### DIFF
--- a/lib/improver/metadata/forecast_times.py
+++ b/lib/improver/metadata/forecast_times.py
@@ -86,10 +86,6 @@ def forecast_period_coord(cube, force_lead_time_calculation=False):
                "the forecast_period.".format(cube))
         raise CoordinateNotFoundError(msg)
 
-    result_coord.points = result_coord.points.astype(TIME_INTERVAL_DTYPE)
-    if result_coord.bounds is not None:
-        result_coord.bounds = result_coord.bounds.astype(TIME_INTERVAL_DTYPE)
-
     return result_coord
 
 
@@ -141,6 +137,10 @@ def _calculate_forecast_period(time_coord, frt_coord, dim_coord=False):
         bounds=required_lead_time_bounds,
         units="seconds")
     result_coord.convert_units(TIME_INTERVAL_UNIT)
+
+    result_coord.points = result_coord.points.astype(TIME_INTERVAL_DTYPE)
+    if result_coord.bounds is not None:
+        result_coord.bounds = result_coord.bounds.astype(TIME_INTERVAL_DTYPE)
 
     if np.any(result_coord.points < 0):
         msg = ("The values for the time {} and "

--- a/lib/improver/metadata/forecast_times.py
+++ b/lib/improver/metadata/forecast_times.py
@@ -43,15 +43,11 @@ from improver.utilities.cube_manipulation import build_coordinate
 from improver.utilities.temporal import cycletime_to_datetime
 
 
-def forecast_period_coord(cube, force_lead_time_calculation=False,
-                          result_units=TIME_INTERVAL_UNIT):
+def forecast_period_coord(cube, force_lead_time_calculation=False):
     """
-    Return or calculate the lead time coordinate (forecast_period)
-    within a cube, either by reading the forecast_period coordinate,
-    or by calculating the difference between the time (points and bounds) and
-    the forecast_reference_time. The units of the forecast_period, time and
-    forecast_reference_time coordinates are converted, if required. The final
-    coordinate will have units of seconds.
+    Return the lead time coordinate (forecast_period) from a cube, either by
+    reading an existing forecast_period coordinate, or by calculating the
+    difference between time and forecast_reference_time.
 
     Args:
         cube (iris.cube.Cube):
@@ -59,41 +55,29 @@ def forecast_period_coord(cube, force_lead_time_calculation=False,
         force_lead_time_calculation (bool):
             Force the lead time to be calculated from the
             forecast_reference_time and the time coordinate, even if
-            the forecast_period coordinate exists.
-            Default is False.
-        result_units (str or cf_units.Unit):
-            Desired units for the resulting forecast period coordinate.
+            the forecast_period coordinate exists. Default is False.
 
     Returns:
         iris.coords.Coord:
-            Describing the points and their units for
-            'forecast_period'. A DimCoord is returned if the
+            New forecast_period coord. A DimCoord is returned if the
             forecast_period coord is already present in the cube as a
             DimCoord and this coord does not need changing, otherwise
-            it will be an AuxCoord. Units are result_units.
+            it will be an AuxCoord.
     """
     create_dim_coord = False
     if cube.coords("forecast_period"):
-        fp_type = cube.coord("forecast_period").dtype
         if isinstance(cube.coord("forecast_period"), iris.coords.DimCoord):
             create_dim_coord = True
-    else:
-        fp_type = TIME_INTERVAL_DTYPE
 
     if cube.coords("forecast_period") and not force_lead_time_calculation:
         result_coord = cube.coord("forecast_period").copy()
-        try:
-            result_coord.convert_units(result_units)
-        except ValueError as err:
-            msg = "For forecast_period: {}".format(err)
-            raise ValueError(msg)
 
     elif cube.coords("time") and cube.coords("forecast_reference_time"):
         # Try to calculate forecast period from forecast reference time and
         # time coordinates
         result_coord = _calculate_forecast_period(
             cube.coord("time"), cube.coord("forecast_reference_time"),
-            result_units, dim_coord=create_dim_coord)
+            dim_coord=create_dim_coord)
 
     else:
         msg = ("The forecast period coordinate is not available within {}."
@@ -102,26 +86,23 @@ def forecast_period_coord(cube, force_lead_time_calculation=False,
                "the forecast_period.".format(cube))
         raise CoordinateNotFoundError(msg)
 
-    result_coord.points = result_coord.points.astype(fp_type)
+    result_coord.points = result_coord.points.astype(TIME_INTERVAL_DTYPE)
     if result_coord.bounds is not None:
-        result_coord.bounds = result_coord.bounds.astype(fp_type)
+        result_coord.bounds = result_coord.bounds.astype(TIME_INTERVAL_DTYPE)
 
     return result_coord
 
 
-def _calculate_forecast_period(time_coord, frt_coord, fp_units,
-                               dim_coord=False):
+def _calculate_forecast_period(time_coord, frt_coord, dim_coord=False):
     """
     Calculate a forecast period from existing time and forecast reference
-    time coordinates, and return in the required units.
+    time coordinates.
 
     Args:
         time_coord (iris.coords.Coord):
             Time coordinate
         frt_coord (iris.coords.Coord):
             Forecast reference coordinate
-        fp_units (cf_units.Unit or str):
-            Required units of forecast period coordinate
         dim_coord (bool):
             If true, create an iris.coords.DimCoord instance.  Default is to
             create an iris.coords.AuxCoord.
@@ -159,7 +140,7 @@ def _calculate_forecast_period(time_coord, frt_coord, fp_units,
         standard_name='forecast_period',
         bounds=required_lead_time_bounds,
         units="seconds")
-    result_coord.convert_units(fp_units)
+    result_coord.convert_units(TIME_INTERVAL_UNIT)
 
     if np.any(result_coord.points < 0):
         msg = ("The values for the time {} and "
@@ -240,12 +221,10 @@ def unify_cycletime(cubes, cycletime):
         cube.add_aux_coord(frt_coord, data_dims=None)
 
         # Update the forecast period for consistency within each cube
-        fp_units = TIME_INTERVAL_UNIT
         if cube.coords("forecast_period"):
-            fp_units = cube.coord("forecast_period").units
             cube.remove_coord("forecast_period")
         fp_coord = forecast_period_coord(
-            cube, force_lead_time_calculation=True, result_units=fp_units)
+            cube, force_lead_time_calculation=True)
         cube.add_aux_coord(fp_coord, data_dims=cube.coord_dims("time"))
         result_cubes.append(cube)
     return result_cubes

--- a/lib/improver/tests/metadata/test_forecast_times.py
+++ b/lib/improver/tests/metadata/test_forecast_times.py
@@ -39,122 +39,140 @@ from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
 
 from improver.metadata.forecast_times import (
-    forecast_period_coord, rebadge_forecasts_as_latest_cycle,
-    unify_cycletime, find_latest_cycletime)
+    forecast_period_coord, _calculate_forecast_period,
+    rebadge_forecasts_as_latest_cycle, unify_cycletime, find_latest_cycletime)
 from improver.tests.set_up_test_cubes import (
     set_up_variable_cube, add_coordinate)
 from improver.utilities.warnings_handler import ManageWarnings
 
 
 class Test_forecast_period_coord(IrisTest):
-
-    """Test determining of the lead times present within the input cube."""
+    """Test the forecast_period_coord function"""
 
     def setUp(self):
         """Set up a test cube with a forecast period scalar coordinate"""
         self.cube = set_up_variable_cube(np.ones((1, 3, 3), dtype=np.float32))
 
     def test_basic(self):
-        """Test that an iris.coords.DimCoord is returned."""
+        """Test that an iris.coords.DimCoord is returned from a cube with an
+        existing forecast period"""
         result = forecast_period_coord(self.cube)
         self.assertIsInstance(result, iris.coords.DimCoord)
 
-    def test_basic_AuxCoord(self):
-        """Test that an iris.coords.AuxCoord is returned."""
+    def test_no_forecast_period(self):
+        """Test that an iris.coords.AuxCoord is returned from a cube with no
+        forecast period"""
         self.cube.remove_coord('forecast_period')
         result = forecast_period_coord(
             self.cube, force_lead_time_calculation=True)
         self.assertIsInstance(result, iris.coords.AuxCoord)
 
-    def test_check_coordinate(self):
+    def test_values(self):
         """Test that the data within the coord is as expected with the
         expected units, when the input cube has a forecast_period coordinate.
         """
         fp_coord = self.cube.coord("forecast_period").copy()
-        expected_points = fp_coord.points
-        expected_units = str(fp_coord.units)
         result = forecast_period_coord(self.cube)
-        self.assertArrayEqual(result.points, expected_points)
-        self.assertEqual(str(result.units), expected_units)
+        self.assertArrayEqual(result.points, fp_coord.points)
+        self.assertEqual(result.units, fp_coord.units)
+        self.assertEqual(result.dtype, fp_coord.dtype)
 
-    def test_check_coordinate_force_lead_time_calculation(self):
+    def test_values_force_lead_time_calculation(self):
         """Test that the data within the coord is as expected with the
         expected units, when the input cube has a forecast_period coordinate.
         """
         fp_coord = self.cube.coord("forecast_period").copy()
-        expected_points = fp_coord.points
-        expected_units = str(fp_coord.units)
+        # put incorrect data into the existing coordinate so we can test it is
+        # correctly recalculated
+        self.cube.coord("forecast_period").points = [-3600]
         result = forecast_period_coord(
             self.cube, force_lead_time_calculation=True)
-        self.assertArrayEqual(result.points, expected_points)
-        self.assertEqual(result.units, expected_units)
+        self.assertArrayEqual(result.points, fp_coord.points)
+        self.assertEqual(result.units, fp_coord.units)
+        self.assertEqual(result.dtype, fp_coord.dtype)
 
-    def test_check_coordinate_without_forecast_period(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a time coordinate and a
-        forecast_reference_time coordinate.
-        """
-        fp_coord = self.cube.coord("forecast_period").copy()
-        expected_result = fp_coord
-        self.cube.remove_coord("forecast_period")
-        result = forecast_period_coord(self.cube)
-        self.assertEqual(result, expected_result)
-
-    def test_check_time_unit_conversion(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube time and forecast reference time
-        coordinates are in different units.
-        """
-        expected_result = self.cube.coord("forecast_period")
-        self.cube.coord("time").convert_units(
-            "seconds since 1970-01-01 00:00:00")
-        self.cube.coord("forecast_reference_time").convert_units(
-            "hours since 1970-01-01 00:00:00")
-        result = forecast_period_coord(
-            self.cube, force_lead_time_calculation=True)
-        self.assertEqual(result, expected_result)
-
-    def test_check_time_unit_has_bounds(self):
-        """Test that the forecast_period coord has bounds if time has bounds.
-        """
-        cube = set_up_variable_cube(
-            np.ones((3, 3), dtype=np.float32),
-            time=datetime(2018, 3, 12, 20), frt=datetime(2018, 3, 12, 15),
-            time_bounds=[datetime(2018, 3, 12, 19), datetime(2018, 3, 12, 20)])
-        expected_result = cube.coord("forecast_period").copy()
-        expected_result.bounds = [[14400, 18000]]
-        result = forecast_period_coord(cube, force_lead_time_calculation=True)
-        self.assertEqual(result, expected_result)
-
-    @ManageWarnings(record=True)
-    def test_negative_forecast_periods_warning(self, warning_list=None):
-        """Test that a warning is raised if the point within the
-        time coordinate is prior to the point within the
-        forecast_reference_time, and therefore the forecast_period values that
-        have been generated are negative.
-        """
-        cube = set_up_variable_cube(np.ones((3, 3), dtype=np.float32))
-        cube.remove_coord("forecast_period")
-        # default cube has a 4 hour forecast period, so add 5 hours to frt
-        cube.coord("forecast_reference_time").points = (
-            cube.coord("forecast_reference_time").points + 5*3600)
-        warning_msg = "The values for the time"
-        forecast_period_coord(cube)
-        self.assertTrue(any(item.category == UserWarning
-                            for item in warning_list))
-        self.assertTrue(any(warning_msg in str(item)
-                            for item in warning_list))
-
-    def test_exception_raised(self):
-        """Test that a CoordinateNotFoundError exception is raised if the
-        forecast_period, or the time and forecast_reference_time,
-        are not present.
+    def test_exception_insufficient_data(self):
+        """Test that a CoordinateNotFoundError exception is raised if forecast
+        period cannot be calculated from the available coordinates
         """
         self.cube.remove_coord("forecast_reference_time")
         self.cube.remove_coord("forecast_period")
         msg = "The forecast period coordinate is not available"
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             forecast_period_coord(self.cube)
+
+
+class Test__calculate_forecast_period(IrisTest):
+    """Test the _calculate_forecast_period function"""
+
+    def setUp(self):
+        """Set up test inputs (4 hour forecast period)"""
+        cube = set_up_variable_cube(np.ones((1, 3, 3), dtype=np.float32))
+        self.time_coord = cube.coord("time")
+        self.frt_coord = cube.coord("forecast_reference_time")
+        self.fp_coord = cube.coord("forecast_period")
+
+    def test_basic(self):
+        """Test correct coordinate type is returned"""
+        result = _calculate_forecast_period(self.time_coord, self.frt_coord)
+        self.assertIsInstance(result, iris.coords.AuxCoord)
+
+    def test_dim_coord(self):
+        """Test it is possible to create a dimension coordinate"""
+        result = _calculate_forecast_period(
+            self.time_coord, self.frt_coord, dim_coord=True)
+        self.assertIsInstance(result, iris.coords.DimCoord)
+
+    def test_values(self):
+        """Test correct values are returned"""
+        result = _calculate_forecast_period(self.time_coord, self.frt_coord)
+        self.assertArrayAlmostEqual(result.points, self.fp_coord.points)
+        self.assertEqual(result.units, self.fp_coord.units)
+        self.assertEqual(result.dtype, self.fp_coord.dtype)
+
+    def test_bounds(self):
+        """Test that the forecast_period coord has bounds where appropriate"""
+        time_point = self.time_coord.points[0]
+        self.time_coord.bounds = [[time_point - 3600, time_point]]
+        fp_point = self.fp_coord.points[0]
+        expected_fp_bounds = [[fp_point - 3600, fp_point]]
+        result = _calculate_forecast_period(self.time_coord, self.frt_coord)
+        self.assertArrayAlmostEqual(result.points, [fp_point])
+        self.assertArrayAlmostEqual(result.bounds, expected_fp_bounds)
+
+    def test_multiple_time_points(self):
+        """Test a multi-valued forecast period coordinate can be created"""
+        time_point = self.time_coord.points[0]
+        new_time_points = [time_point, time_point + 3600, time_point + 7200]
+        new_time_coord = self.time_coord.copy(new_time_points)
+        fp_point = self.fp_coord.points[0]
+        expected_fp_points = [fp_point, fp_point + 3600, fp_point + 7200]
+        result = _calculate_forecast_period(new_time_coord, self.frt_coord)     
+        self.assertArrayAlmostEqual(result.points, expected_fp_points)
+
+    def test_check_time_unit_conversion(self):
+        """Test correct values and units are returned when the input time and
+        forecast reference time coordinates are in different units
+        """
+        self.time_coord.convert_units("seconds since 1970-01-01 00:00:00")
+        self.frt_coord.convert_units("hours since 1970-01-01 00:00:00")
+        result = _calculate_forecast_period(self.time_coord, self.frt_coord)
+        self.assertEqual(result, self.fp_coord)
+
+    @ManageWarnings(record=True)
+    def test_negative_forecast_period(self, warning_list=None):
+        """Test a warning is raised if the calculated forecast period is
+        negative"""
+        # default cube has a 4 hour forecast period, so add 5 hours to frt
+        self.frt_coord.points = self.frt_coord.points + 5*3600
+        result = _calculate_forecast_period(self.time_coord, self.frt_coord)
+        warning_msg = "The values for the time"
+        result = _calculate_forecast_period(self.time_coord, self.frt_coord)
+        self.assertTrue(any(item.category == UserWarning
+                            for item in warning_list))
+        self.assertTrue(any(warning_msg in str(item)
+                            for item in warning_list))
+        self.assertEqual(result.points, [-3600])
 
 
 class Test_rebadge_forecasts_as_latest_cycle(IrisTest):

--- a/lib/improver/tests/metadata/test_forecast_times.py
+++ b/lib/improver/tests/metadata/test_forecast_times.py
@@ -89,20 +89,6 @@ class Test_forecast_period_coord(IrisTest):
         self.assertArrayEqual(result.points, expected_points)
         self.assertEqual(result.units, expected_units)
 
-    def test_check_coordinate_in_hours_force_lead_time_calculation(self):
-        """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
-        """
-        fp_coord = self.cube.coord("forecast_period").copy()
-        fp_coord.convert_units("hours")
-        expected_points = fp_coord.points
-        expected_units = str(fp_coord.units)
-        result = forecast_period_coord(
-            self.cube, force_lead_time_calculation=True,
-            result_units=fp_coord.units)
-        self.assertArrayEqual(result.points, expected_points)
-        self.assertEqual(result.units, expected_units)
-
     def test_check_coordinate_without_forecast_period(self):
         """Test that the data within the coord is as expected with the
         expected units, when the input cube has a time coordinate and a

--- a/lib/improver/tests/metadata/test_forecast_times.py
+++ b/lib/improver/tests/metadata/test_forecast_times.py
@@ -147,7 +147,7 @@ class Test__calculate_forecast_period(IrisTest):
         new_time_coord = self.time_coord.copy(new_time_points)
         fp_point = self.fp_coord.points[0]
         expected_fp_points = [fp_point, fp_point + 3600, fp_point + 7200]
-        result = _calculate_forecast_period(new_time_coord, self.frt_coord)     
+        result = _calculate_forecast_period(new_time_coord, self.frt_coord)
         self.assertArrayAlmostEqual(result.points, expected_fp_points)
 
     def test_check_time_unit_conversion(self):


### PR DESCRIPTION
Following from #1019 , this PR tidies up the unit tests for `improver.metadata.forecast_times.forecast_period_coord` and restricts this function to generate a coordinate with the IMPROVER-expected units and datatype.  Some tidy-up of existing unit tests was required.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
