### PR TITLE
Fix codacy coverage and report combined unit/acceptance coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 os: linux
 git:
   depth: 10000
+env:
+  - CI_COVERAGE=yes
 
 install:
   # Install miniconda

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -149,7 +149,7 @@ function improver_test_unit {
         VERBOSE_OPT='-v'
     fi
     if [[ -n "${CODACY_PROJECT_TOKEN:-}" || -n "${CODECOV_TOKEN:-}" ]]; then
-        pytest -m 'not acc' --cov=lib/improver --cov-report xml:coverage.xml ${VERBOSE_OPT:-}
+        pytest -m 'not acc' --cov=improver --cov-report xml:coverage.xml ${VERBOSE_OPT:-}
         if [[ -n "${CODACY_PROJECT_TOKEN:-}" ]]; then
             # Report coverage to Codacy if possible.
             python-codacy-coverage -r coverage.xml

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -148,16 +148,9 @@ function improver_test_unit {
     if [[ -n $DEBUG_OPT ]]; then
         VERBOSE_OPT='-v'
     fi
-    if [[ -n "${CODACY_PROJECT_TOKEN:-}" || -n "${CODECOV_TOKEN:-}" ]]; then
-        pytest -m 'not acc' --cov=improver --cov-report xml:coverage.xml ${VERBOSE_OPT:-}
-        if [[ -n "${CODACY_PROJECT_TOKEN:-}" ]]; then
-            # Report coverage to Codacy if possible.
-            python-codacy-coverage -r coverage.xml
-        fi
-        if [[ -n "${CODECOV_TOKEN:-}" ]]; then
-            # Report coverage to CodeCov if possible.
-            codecov
-        fi
+    if [[ -n "${CI_COVERAGE:-}" ]]; then
+        pytest -m 'not acc' --cov=improver \
+        --cov-report xml:coverage.xml ${VERBOSE_OPT:-}
     else
         pytest -m 'not acc' ${VERBOSE_OPT:-}
     fi
@@ -176,8 +169,21 @@ function improver_test_cli {
     if [[ -n $DEBUG_OPT ]]; then
         VERBOSE_OPT='-v'
     fi
-
-    pytest -m acc ${VERBOSE_OPT:-}
+    if [[ -n "${CI_COVERAGE:-}" ]]; then
+        pytest -m acc --cov-append --cov=improver \
+        --cov-report xml:coverage.xml \
+        --cov-report term ${VERBOSE_OPT:-}
+        if [[ -n "${CODACY_PROJECT_TOKEN:-}" ]]; then
+            # Report coverage to Codacy if possible.
+            python-codacy-coverage -v -r coverage.xml
+        fi
+        if [[ -n "${CODECOV_TOKEN:-}" ]]; then
+            # Report coverage to CodeCov if possible.
+            codecov
+        fi
+    else
+        pytest -m acc ${VERBOSE_OPT:-}
+    fi
 
     echo_ok "CLI tests"
 }


### PR DESCRIPTION
The coverage reporting path for `pytest-cov` was previously set incorrectly, causing no coverage data file to be created.

This PR also applies coverage testing to the acceptance tests, so acceptance test coverage is appended to the unit test coverage and the combined coverage result gets reported to codacy and codecov. This will currently have no effect, as all the acceptance tests are skipped on Travis CI.
