### PR TITLE
Fix duplicate clize output and errors

### DIFF
--- a/lib/improver/cli/__init__.py
+++ b/lib/improver/cli/__init__.py
@@ -75,6 +75,10 @@ def docutilize(obj):
         doc = getdoc(obj)
     doc = str(NumpyDocstring(doc))
     doc = str(GoogleDocstring(doc))
+    doc = doc.replace(':exc:', '')
+    doc = doc.replace(':keyword', ':param')
+    doc = doc.replace(':kwtype', ':type')
+
     if isinstance(obj, str):
         return doc
     obj.__doc__ = doc

--- a/lib/improver/cli/__init__.py
+++ b/lib/improver/cli/__init__.py
@@ -408,11 +408,7 @@ def execute_command(dispatcher, prog_name, *args,
     if dry_run:
         return args
 
-    try:
-        result = dispatcher(prog_name, *args)
-    except Exception as exc:
-        print(exc)
-        raise exc
+    result = dispatcher(prog_name, *args)
 
     if verbose:
         print(ObjectAsStr.obj_to_name(result))


### PR DESCRIPTION
Fixes two bugs with Clize CLIs:
- `(ERROR/3) Unknown interpreted text role "exc".` - Fixed by adding a filter to cli.__init__.docutilitze.
- Error messages printed twice. - Fixed by removing a print statement (and surrounding try block)

You can reproduce these things on `master` with the command `bin/improver apply_lapse_rate` which returns:

```
process:33: (ERROR/3) Unknown interpreted text role "exc".
process:40: (ERROR/3) Unknown interpreted text role "exc".
process:44: (ERROR/3) Unknown interpreted text role "exc".
process:45: (ERROR/3) Unknown interpreted text role "exc".
process:46: (ERROR/3) Unknown interpreted text role "exc".
process:33: (ERROR/3) Unknown interpreted text role "exc".
process:40: (ERROR/3) Unknown interpreted text role "exc".
process:44: (ERROR/3) Unknown interpreted text role "exc".
process:45: (ERROR/3) Unknown interpreted text role "exc".
process:46: (ERROR/3) Unknown interpreted text role "exc".
improver: Unknown command "apply_lapse_rate". Did you mean "apply-lapse-rate"?
Usage: improver command [args...]
process:33: (ERROR/3) Unknown interpreted text role "exc".
process:40: (ERROR/3) Unknown interpreted text role "exc".
process:44: (ERROR/3) Unknown interpreted text role "exc".
process:45: (ERROR/3) Unknown interpreted text role "exc".
process:46: (ERROR/3) Unknown interpreted text role "exc".
process:33: (ERROR/3) Unknown interpreted text role "exc".
process:40: (ERROR/3) Unknown interpreted text role "exc".
process:44: (ERROR/3) Unknown interpreted text role "exc".
process:45: (ERROR/3) Unknown interpreted text role "exc".
process:46: (ERROR/3) Unknown interpreted text role "exc".
improver: Unknown command "apply_lapse_rate". Did you mean "apply-lapse-rate"?
Usage: improver command [args...]
```

Testing:
 - [x] Ran tests and they passed OK
