### PR TITLE
IMPRO-1523: Convert optical flow to clize

### DIFF
--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -49,7 +49,7 @@ def process(orographic_enhancement_cube: cli.inputcube,
             Cube containing the orographic enhancement fields.
         radar (iris.cube.CubeList):
             Cubes from which to calculate optical flow velocities.
-            These three cubes can be any order.
+            These three cubes will be sorted by their time coords.
         attributes_dict (dict):
             Dictionary containing required changes to the attributes.
             Every output file will have the attributes_dict applied.

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -48,7 +48,7 @@ def process(orographic_enhancement_cube: cli.inputcube,
         orographic_enhancement_cube (iris.cube.Cube):
             Cube containing the orographic enhancement fields.
         radar (iris.cube.CubeList):
-            Cube from which to calculate optical flow velocities.
+            Cubes from which to calculate optical flow velocities.
             These three cubes can be any order.
         attributes_dict (dict):
             Dictionary containing required changes to the attributes.

--- a/lib/improver/cli/nowcast_optical_flow.py
+++ b/lib/improver/cli/nowcast_optical_flow.py
@@ -64,10 +64,6 @@ def process(orographic_enhancement_cube: cli.inputcube,
         iris.cube.CubeList:
             List of the umean and vmean cubes.
 
-    Raises:
-        ValueError:
-            If there is no oe_cube but a cube is called 'precipitation_rate'.
-
     """
     from iris.cube import CubeList
 

--- a/lib/improver/tests/acceptance/test_nowcast_optical_flow.py
+++ b/lib/improver/tests/acceptance/test_nowcast_optical_flow.py
@@ -55,7 +55,7 @@ def test_basic(tmp_path):
                    for hhmm in ("1530", "1545", "1600")]
     oe_path = kgo_dir / OE
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, oe_path,
+    args = [oe_path, *input_paths,
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
@@ -72,34 +72,7 @@ def test_metadata(tmp_path):
     # TODO: the BATS test does not call improver with the metadata file
     # metadata_path = kgo_dir / "../metadata/precip.json"
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, oe_path,
-            "--output", output_path]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
-def test_no_orographic_error(tmp_path):
-    """Test missing orographic enhancement error"""
-    kgo_dir = acc.kgo_root() / "nowcast-optical-flow/basic"
-    input_paths = [kgo_dir / f"20181103{hhmm}_{RADAR_REGRID}.nc"
-                   for hhmm in ("1530", "1545", "1600")]
-    output_path = tmp_path / "output.nc"
-    args = [*input_paths,
-            "--output", output_path]
-    with pytest.raises(ValueError, match=".*orographic enhancement.*"):
-        run_cli(args)
-
-
-@pytest.mark.slow
-def test_basic_no_orographic(tmp_path):
-    """Test basic optical flow without orographic enhancement"""
-    kgo_dir = (acc.kgo_root() / "nowcast-optical-flow" /
-               "basic_no_orographic_enhancement")
-    kgo_path = kgo_dir / "kgo.nc"
-    input_paths = [kgo_dir / f"20181103{hhmm}_{RADAR_REGRID}.nc"
-                   for hhmm in ("1530", "1545", "1600")]
-    output_path = tmp_path / "output.nc"
-    args = [*input_paths,
+    args = [oe_path, *input_paths,
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
@@ -112,8 +85,9 @@ def test_remasked(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_paths = [kgo_dir / f"20181127{hhmm}_{RADAR_REMASK}.nc"
                    for hhmm in ("1330", "1345", "1400")]
+    oe_path = kgo_dir / "../basic" / OE
     output_path = tmp_path / "output.nc"
-    args = [*input_paths,
+    args = [oe_path, *input_paths,
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/lib/improver/tests/acceptance/test_nowcast_optical_flow.py
+++ b/lib/improver/tests/acceptance/test_nowcast_optical_flow.py
@@ -85,7 +85,8 @@ def test_remasked(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_paths = [kgo_dir / f"20181127{hhmm}_{RADAR_REMASK}.nc"
                    for hhmm in ("1330", "1345", "1400")]
-    oe_path = kgo_dir / "../basic" / OE
+    oe_path = kgo_dir / "20181127T1400Z-PT0004H00M-orographic_enhancement_" \
+                        "standard_resolution.nc"
     output_path = tmp_path / "output.nc"
     args = [oe_path, *input_paths,
             "--output", output_path]

--- a/lib/improver/tests/acceptance/test_nowcast_optical_flow.py
+++ b/lib/improver/tests/acceptance/test_nowcast_optical_flow.py
@@ -55,8 +55,8 @@ def test_basic(tmp_path):
                    for hhmm in ("1530", "1545", "1600")]
     oe_path = kgo_dir / OE
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, output_path,
-            "--orographic_enhancement_filepaths", oe_path]
+    args = [*input_paths, oe_path,
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -72,8 +72,8 @@ def test_metadata(tmp_path):
     # TODO: the BATS test does not call improver with the metadata file
     # metadata_path = kgo_dir / "../metadata/precip.json"
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, output_path,
-            "--orographic_enhancement_filepaths", oe_path]
+    args = [*input_paths, oe_path,
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -84,7 +84,8 @@ def test_no_orographic_error(tmp_path):
     input_paths = [kgo_dir / f"20181103{hhmm}_{RADAR_REGRID}.nc"
                    for hhmm in ("1530", "1545", "1600")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, output_path]
+    args = [*input_paths,
+            "--output", output_path]
     with pytest.raises(ValueError, match=".*orographic enhancement.*"):
         run_cli(args)
 
@@ -98,7 +99,8 @@ def test_basic_no_orographic(tmp_path):
     input_paths = [kgo_dir / f"20181103{hhmm}_{RADAR_REGRID}.nc"
                    for hhmm in ("1530", "1545", "1600")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, output_path]
+    args = [*input_paths,
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -111,6 +113,7 @@ def test_remasked(tmp_path):
     input_paths = [kgo_dir / f"20181127{hhmm}_{RADAR_REMASK}.nc"
                    for hhmm in ("1330", "1345", "1400")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, output_path]
+    args = [*input_paths,
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)


### PR DESCRIPTION
As this is part of nowcasting it will not be going into the clize feature branch.

## Major change.
- the three radar files now get input as separate cubes and merged into a cubelist.
This is becase clize saw them as variable length and it clased with the orographic enhancement cube which could be `None`.

Testing:
 - [x] Ran tests and they passed OK
