### PR TITLE
Convert wind-gust-diagnostic CLI to use Clize

### DIFF
--- a/lib/improver/cli/wind_gust_diagnostic.py
+++ b/lib/improver/cli/wind_gust_diagnostic.py
@@ -31,72 +31,19 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to create wind-gust data."""
 
-from improver.argparser import ArgParser
-from improver.utilities.load import load_cube
-from improver.utilities.save import save_netcdf
-from improver.wind_calculations.wind_gust_diagnostic import WindGustDiagnostic
+from improver import cli
 
 
-def main(argv=None):
-    """Load in arguments for wind-gust diagnostic.
-    Wind-gust and Wind-speed data should be supplied along with the required
-    percentile value. The wind-gust diagnostic will be the Max of the specified
-    percentile data.
-    Currently:
-
-        * Typical gusts is
-          MAX(wind-gust(50th percentile),wind-speed(95th percentile))
-        * Extreme gust is
-          MAX(wind-gust(95th percentile),wind-speed(100th percentile))
-
-    If no percentile values are supplied the code defaults
-    to values for Typical gusts.
-    """
-    parser = ArgParser(
-        description="Calculate revised wind-gust data using a specified "
-        "percentile of wind-gust data and a specified percentile "
-        "of wind-speed data through the WindGustDiagnostic plugin. "
-        "The wind-gust diagnostic will be the Max of the specified "
-        "percentile data."
-        "Currently Typical gusts is "
-        "MAX(wind-gust(50th percentile),wind-speed(95th percentile))"
-        "and Extreme gust is "
-        "MAX(wind-gust(95th percentile),wind-speed(100th percentile)). "
-        "If no percentile values are supplied the code defaults "
-        "to values for Typical gusts.")
-    parser.add_argument("input_filegust", metavar="INPUT_FILE_GUST",
-                        help="A path to an input Wind Gust Percentile"
-                        " NetCDF file")
-    parser.add_argument("input_filews", metavar="INPUT_FILE_WINDSPEED",
-                        help="A path to an input Wind Speed Percentile"
-                        " NetCDF file")
-    parser.add_argument("output_filepath", metavar="OUTPUT_FILE",
-                        help="The output path for the processed NetCDF")
-    parser.add_argument("--percentile_gust", metavar="PERCENTILE_GUST",
-                        default="50.0",
-                        help="Percentile of wind-gust required."
-                        " Default=50.0", type=float)
-    parser.add_argument("--percentile_ws",
-                        metavar="PERCENTILE_WIND_SPEED",
-                        default="95.0",
-                        help="Percentile of wind-speed required."
-                        " Default=95.0", type=float)
-
-    args = parser.parse_args(args=argv)
-    # Load Cube
-    gust_cube = load_cube(args.input_filegust)
-    speed_cube = load_cube(args.input_filews)
-    # Process Cube
-    result = process(gust_cube, speed_cube, args.percentile_gust,
-                     args.percentile_ws)
-    # Save Cube
-    save_netcdf(result, args.output_filepath)
-
-
-def process(gust_cube, speed_cube, percentile_gust, percentile_speed):
+@cli.clizefy
+@cli.with_output
+def process(gust_cube: cli.inputcube,
+            ws_cube: cli.inputcube,
+            *,
+            percentile_gust: float = 50,
+            percentile_ws: float = 95):
     """Create a cube containing the wind_gust diagnostic.
 
-    Calculate revised wind-gust data using a specified percentiles of
+    Calculate revised wind-gust data using a specified percentile of
     wind-gust data and a specified percentile of wind-speed data through the
     WindGustDiagnostic plugin. The wind-gust diagnostic will be the max of the
     specified percentile data.
@@ -104,22 +51,21 @@ def process(gust_cube, speed_cube, percentile_gust, percentile_speed):
     Args:
         gust_cube (iris.cube.Cube):
             Cube containing one or more percentiles of wind_gust data.
-        speed_cube (iris.cube.Cube):
+        ws_cube (iris.cube.Cube):
             Cube containing one or more percentiles of wind_speed data.
         percentile_gust (float):
             Percentile value required from wind-gust cube.
-        percentile_speed (float):
+        percentile_ws (float):
             Percentile value required from wind-speed cube.
 
     Returns:
         iris.cube.Cube:
             Cube containing the wind-gust diagnostic data.
     """
+    from improver.wind_calculations.wind_gust_diagnostic import (
+        WindGustDiagnostic)
+
     result = (
         WindGustDiagnostic(percentile_gust,
-                           percentile_speed).process(gust_cube, speed_cube))
+                           percentile_ws).process(gust_cube, ws_cube))
     return result
-
-
-if __name__ == "__main__":
-    main()

--- a/lib/improver/cli/wind_gust_diagnostic.py
+++ b/lib/improver/cli/wind_gust_diagnostic.py
@@ -39,8 +39,8 @@ from improver import cli
 def process(gust_cube: cli.inputcube,
             ws_cube: cli.inputcube,
             *,
-            percentile_gust: float = 50,
-            percentile_ws: float = 95):
+            percentile_gust: float = 50.0,
+            percentile_ws: float = 95.0):
     """Create a cube containing the wind_gust diagnostic.
 
     Calculate revised wind-gust data using a specified percentile of

--- a/lib/improver/tests/acceptance/test_wind_gust_diagnostic.py
+++ b/lib/improver/tests/acceptance/test_wind_gust_diagnostic.py
@@ -46,7 +46,7 @@ def test_average_wind_gust(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [kgo_dir / "wind_gust_perc.nc",
             kgo_dir / "wind_speed_perc.nc",
-            output_path]
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -56,9 +56,9 @@ def test_extreme_wind_gust(tmp_path):
     kgo_dir = acc.kgo_root() / "wind-gust-diagnostic/basic"
     kgo_path = kgo_dir / "kgo_extreme_wind_gust.nc"
     output_path = tmp_path / "output.nc"
-    args = ["--percentile_gust=95.0", "--percentile_ws=100.0",
-            kgo_dir / "wind_gust_perc.nc",
+    args = [kgo_dir / "wind_gust_perc.nc",
             kgo_dir / "wind_speed_perc.nc",
-            output_path]
+            "--percentile-gust", "95.0", "--percentile-ws", "100.0",
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)


### PR DESCRIPTION
Description
This PR converts the `wind_gust_diagnostic` CLI to use Clize.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
