### PR TITLE
Clize threshold

### DIFF
--- a/lib/improver/cli/threshold.py
+++ b/lib/improver/cli/threshold.py
@@ -125,20 +125,10 @@ def main(argv=None):
     # Load Cube
     cube = load_cube(args.input_filepath)
     threshold_dict = None
+
     if args.threshold_config:
-        try:
-            # Read in threshold configuration from JSON file.
-            with open(args.threshold_config, 'r') as input_file:
-                threshold_dict = json.load(input_file)
-        except ValueError as err:
-            # Extend error message with hint for common JSON error.
-            raise type(err)("{} in JSON file {}. \nHINT: Try "
-                            "adding a zero after the decimal point.".
-                            format(err, args.threshold_config))
-        except Exception as err:
-            # Extend any errors with message about WHERE this occurred.
-            raise type(err)("{} in JSON file {}".format(
-                err, args.threshold_config))
+        with open(args.threshold_config, 'r') as input_file:
+            threshold_dict = json.load(input_file)
 
     # Process Cube
     result = process(cube, args.threshold_values, threshold_dict,
@@ -227,28 +217,19 @@ def process(cube, threshold_values=None, threshold_dict=None,
         raise RuntimeError('threshold_dict cannot be used '
                            'with threshold_values')
     if threshold_dict:
-        try:
-            thresholds = []
-            fuzzy_bounds = []
-            is_fuzzy = True
-            for key in threshold_dict.keys():
-                thresholds.append(float(key))
-                if is_fuzzy:
-                    # If the first threshold has no bounds, fuzzy_bounds is
-                    # set to None and subsequent bounds checks are skipped
-                    if threshold_dict[key] == "None":
-                        is_fuzzy = False
-                        fuzzy_bounds = None
-                    else:
-                        fuzzy_bounds.append(tuple(threshold_dict[key]))
-        except ValueError as err:
-            # Extend error message with hint for common JSON error.
-            raise type(err)(
-                "{} in threshold dictionary file. \nHINT: Try adding a zero "
-                "after the decimal point.".format(err))
-        except Exception as err:
-            # Extend any errors with message about WHERE this occurred.
-            raise type(err)("{} in dictionary file.".format(err))
+        thresholds = []
+        fuzzy_bounds = []
+        is_fuzzy = True
+        for key in threshold_dict.keys():
+            thresholds.append(float(key))
+            if is_fuzzy:
+                # If the first threshold has no bounds, fuzzy_bounds is
+                # set to None and subsequent bounds checks are skipped
+                if threshold_dict[key] == "None":
+                    is_fuzzy = False
+                    fuzzy_bounds = None
+                else:
+                    fuzzy_bounds.append(tuple(threshold_dict[key]))
     else:
         thresholds = threshold_values
         fuzzy_bounds = None

--- a/lib/improver/tests/acceptance/test_threshold.py
+++ b/lib/improver/tests/acceptance/test_threshold.py
@@ -47,7 +47,9 @@ def test_basic(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path, "280"]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "280"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -58,18 +60,23 @@ def test_below_threshold(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path, "280", "--comparison_operator", "<="]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "280",
+            "--comparison-operator", "<="]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
 
-def test_multiple_threshold(tmp_path):
+def test_multiple_thresholds(tmp_path):
     """Test thresholding with multiple thresholds"""
     kgo_dir = acc.kgo_root() / "threshold/multiple_thresholds"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path, "270", "280", "290"]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "270,280,290"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -80,7 +87,10 @@ def test_threshold_units(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path, "6.85", "--threshold_units", "celsius"]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "6.85",
+            "--threshold-units", "celsius"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -91,7 +101,10 @@ def test_fuzzy_factor(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path, "280", "--fuzzy_factor", "0.99"]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "280",
+            "--fuzzy-factor", "0.99"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -103,8 +116,9 @@ def test_fuzzy_bounds(tmp_path):
     threshold_path = kgo_dir / "../fuzzy_bounds/threshold_config.json"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path,
-            "--threshold_config", threshold_path]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-config", threshold_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -115,10 +129,11 @@ def test_threshold_units_fuzzy(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, output_path,
-            "6.85",
-            "--threshold_units", "celsius",
-            "--fuzzy_factor", "0.2"]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "6.85",
+            "--threshold-units", "celsius",
+            "--fuzzy-factor", "0.2"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -129,10 +144,10 @@ def test_collapse_realization(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "../basic/input.nc"
     output_path = tmp_path / "output.nc"
-    args = ["--collapse-coord=realization",
-            input_path,
-            output_path,
-            "280"]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-values", "280",
+            "--collapse-coord", "realization"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -144,8 +159,9 @@ def test_vicinity(tmp_path):
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [input_path,
-            output_path,
-            "0.03", "0.1", "1.0", "--threshold_units=mm hr-1",
+            "--output", output_path,
+            "--threshold-values", "0.03,0.1,1.0",
+            "--threshold-units", "mm hr-1",
             "--vicinity", "10000"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
@@ -158,8 +174,9 @@ def test_vicinity_collapse(tmp_path):
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [input_path,
-            output_path,
-            "0.03", "0.1", "1.0", "--threshold_units=mm hr-1",
+            "--output", output_path,
+            "--threshold-values", "0.03,0.1,1.0",
+            "--threshold-units", "mm hr-1",
             "--vicinity", "10000",
             "--collapse-coord=realization"]
     run_cli(args)
@@ -173,8 +190,9 @@ def test_vicinity_masked(tmp_path):
     input_path = kgo_dir / "masked_precip.nc"
     output_path = tmp_path / "output.nc"
     args = [input_path,
-            output_path,
-            "0.03", "0.1", "1.0", "--threshold_units=mm hr-1",
+            "--output", output_path,
+            "--threshold-values", "0.03,0.1,1.0",
+            "--threshold-units", "mm hr-1",
             "--vicinity", "10000"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
@@ -187,6 +205,8 @@ def test_threshold_config(tmp_path):
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     config_path = kgo_dir / "../json/threshold_config.json"
-    args = [input_path, output_path, "--threshold_config", config_path]
+    args = [input_path,
+            "--output", output_path,
+            "--threshold-config", config_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/lib/improver/threshold.py
+++ b/lib/improver/threshold.py
@@ -74,7 +74,7 @@ class BasicThreshold(BasePlugin):
 
         ::
 
-            Data value | Probability
+            Data value  | Probability
             ------------|-------------
                 4.5     |   0
                 5.0     |   0.167


### PR DESCRIPTION
I have changed the interface a bit: where `threshold_values` used to be a list of space-separated values, now it is comma-separated values in line with the clize options.

Testing:
 - [x] Ran tests and they passed OK
