### PR TITLE
save atomically by writing to a temporary file and then renaming

### DIFF
--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -175,7 +175,7 @@ def save_netcdf(cubelist, filename):
 
     cubelist = _append_metadata_cube(cubelist, global_keys)
     # save atomically by writing to a temporary file and then renaming
-    ftmp = filename + '.tmp'
+    ftmp = str(filename) + '.tmp'
     iris.fileformats.netcdf.save(cubelist, ftmp, local_keys=local_keys,
                                  complevel=1, shuffle=True, zlib=True,
                                  chunksizes=chunksizes)

--- a/lib/improver/utilities/save.py
+++ b/lib/improver/utilities/save.py
@@ -30,6 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for saving netcdf cubes with desired attribute types."""
 
+import os
 import warnings
 
 import cf_units
@@ -173,6 +174,9 @@ def save_netcdf(cubelist, filename):
                   if key not in global_keys}
 
     cubelist = _append_metadata_cube(cubelist, global_keys)
-    iris.fileformats.netcdf.save(cubelist, filename, local_keys=local_keys,
+    # save atomically by writing to a temporary file and then renaming
+    ftmp = filename + '.tmp'
+    iris.fileformats.netcdf.save(cubelist, ftmp, local_keys=local_keys,
                                  complevel=1, shuffle=True, zlib=True,
                                  chunksizes=chunksizes)
+    os.rename(ftmp, filename)


### PR DESCRIPTION
This allows to poll for netcdf files directly without need for `.done` files.