### PR TITLE
Pylint with Github Actions 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,3 +23,6 @@ jobs:
       
     - name: Pytest (Unit tests)
       run:  $CONDA/bin/pytest -m "not acc"
+
+    - name: Pylint (More linting goodness)
+      run: $CONDA/bin/pylint -j 0 -E --rcfile=etc/pylintrc lib

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - sphinx
   - pytest
   - pylint=2.1.1
+  - astroid=2.1.0
   - pycodestyle
   - filelock
   - mock

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - python-stratify=0.1
   - sphinx
   - pytest
+  - pylint=2.1.1
   - pycodestyle
   - filelock
   - mock


### PR DESCRIPTION
Adds `pylint -E` to the actions tests.
It is faster in parallel (GH action runners have 2cores available), but making it a separate job (to run in parallel with the other steps) would mean duplicating the install step as they run on different VMs. 
Caching dependencies is possible, but not straightforward if you are using the the Conda base environment. Activating named environments currently doesn't work with actions. 

