### PR TITLE
wind-downscaling CLI to clize

### DIFF
--- a/lib/improver/cli/wind_downscaling.py
+++ b/lib/improver/cli/wind_downscaling.py
@@ -43,7 +43,6 @@ def process(wind_speed: cli.inputcube,
             standard_orog: cli.inputcube,
             veg_roughness_cube: cli.inputcube = None,
             *,
-            height_levels: cli.inputcube = None,
             model_resolution: float,
             output_height_level: float = None,
             output_height_level_units='m'):
@@ -69,18 +68,14 @@ def process(wind_speed: cli.inputcube,
         standard_orog (iris.cube.Cube):
             Cube of orography on standard grid. (interpolated model orography).
             Units of field: m.
-        model_resolution (float):
-            Original resolution of model orography (before interpolation to
-            standard grid)
-            Units of field: m.
-        height_levels (iris.cube.Cube):
-            Cube of height levels coincident with wind direction.
-            Units of field: m.
-            Default is None.
         veg_roughness_cube (iris.cube.Cube):
             Cube of vegetative roughness length.
             Units of field: m.
             Default is None.
+        model_resolution (float):
+            Original resolution of model orography (before interpolation to
+            standard grid)
+            Units of field: m.
         output_height_level (float):
             If only a single height level is desired as output from
             wind-downscaling, this option can be used to select the height
@@ -127,9 +122,9 @@ def process(wind_speed: cli.inputcube,
                 silhouette_roughness, sigma, target_orog,
                 standard_orog, model_resolution,
                 z0_cube=veg_roughness_cube,
-                height_levels_cube=height_levels).process(wind_speed_slice))
+                height_levels_cube=None).process(wind_speed_slice))
         wind_speed_list.append(result)
-    # Temporary fix for chunking problems when merging cubes
+    # TODO: Remove temporary fix for chunking problems when merging cubes
     max_npoints = max([np.prod(cube.data.shape) for cube in wind_speed_list])
     while iris._lazy_data._MAX_CHUNK_SIZE < max_npoints:
         iris._lazy_data._MAX_CHUNK_SIZE *= 2

--- a/lib/improver/tests/acceptance/test_wind_downscaling.py
+++ b/lib/improver/tests/acceptance/test_wind_downscaling.py
@@ -48,7 +48,9 @@ def test_basic(tmp_path):
                    for p in ("input", "a_over_s", "sigma",
                              "highres_orog", "standard_orog")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, "1500", output_path]
+    args = [*input_paths,
+            "--model-resolution", "1500",
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -63,8 +65,9 @@ def test_vegetation(tmp_path):
                              "highres_orog", "standard_orog")]
     veg_path = kgo_dir / "veg.nc"
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, "1500", output_path,
-            "--veg_roughness_filepath", veg_path]
+    args = [*input_paths, veg_path,
+            "--model-resolution", "1500",
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -78,7 +81,9 @@ def test_realization(tmp_path):
                    for p in ("input", "a_over_s", "sigma",
                              "highres_orog", "standard_orog")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, "1500", output_path]
+    args = [*input_paths,
+            "--model-resolution", "1500",
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -92,8 +97,10 @@ def test_single_level_output(tmp_path):
                    for p in ("input", "a_over_s", "sigma",
                              "highres_orog", "standard_orog")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, "1500", output_path,
-            "--output_height_level", "10"]
+    args = [*input_paths,
+            "--model-resolution", "1500",
+            "--output-height-level", "10",
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -105,9 +112,11 @@ def test_unavailable_level(tmp_path):
                    for p in ("input", "a_over_s", "sigma",
                              "highres_orog", "standard_orog")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, "1500", output_path,
-            "--output_height_level", "9",
-            "--output_height_level_units", "m"]
+    args = [*input_paths,
+            "--model-resolution", "1500",
+            "--output-height-level", "9",
+            "--output-height-level-units", "m",
+            "--output", output_path]
     with pytest.raises(ValueError, match=".*height level.*"):
         run_cli(args)
 
@@ -121,8 +130,10 @@ def test_single_level_units(tmp_path):
                    for p in ("input", "a_over_s", "sigma",
                              "highres_orog", "standard_orog")]
     output_path = tmp_path / "output.nc"
-    args = [*input_paths, "1500", output_path,
-            "--output_height_level", "1000",
-            "--output_height_level_units", "cm"]
+    args = [*input_paths,
+            "--model-resolution", "1500",
+            "--output-height-level", "1000",
+            "--output-height-level-units", "cm",
+            "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)


### PR DESCRIPTION
(Height levels cube input is left as a kwarg, given that it is not used in the typical use case)
(cc @TomekTrzeciak)

Testing:
 - [x] Ran tests and they passed OK