### PR TITLE
generate-orographic-alphas CLI

### DIFF
--- a/lib/improver/cli/generate_orographic_alphas.py
+++ b/lib/improver/cli/generate_orographic_alphas.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""CLI for generating orographic alphas."""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(orography: cli.inputcube,
+            *,
+            min_alpha: float = 0.0,
+            max_alpha: float = 1.0,
+            coefficient: float = 1.0,
+            power: float = 1.0,
+            invert_alphas=True):
+    """Generate alpha smoothing parameters for recursive filtering based on
+    orography gradients.
+
+    Args:
+        min_alpha (float):
+            The minimum value of alpha that you want to go into the
+            recursive filter.
+        max_alpha (float):
+            The maximum value of alpha that you want to go into the
+            recursive filter
+        coefficient (float):
+            The coefficient for the alpha calculation
+        power (float):
+            What power you want for your alpha equation
+        invert_alphas (bool):
+            If True then the max and min alpha values will be swapped.
+
+    Returns:
+        iris.cube.CubeList:
+            Processed CubeList containing alpha_x and alpha_y cubes.
+    """
+    from improver.utilities.ancillary_creation import OrographicAlphas
+    return OrographicAlphas(min_alpha, max_alpha, coefficient, power,
+                            invert_alphas).process(orography)

--- a/lib/improver/tests/acceptance/test_generate_orographic_alphas.py
+++ b/lib/improver/tests/acceptance/test_generate_orographic_alphas.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Tests for the generate-orographic-alphas CLI
+"""
+
+import pytest
+
+from improver.tests.acceptance import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+def test_basic(tmp_path):
+    """Test basic generate orographic alphas processing"""
+    kgo_dir = acc.kgo_root() / "generate-orographic-alphas"
+    input_path = kgo_dir / "orography.nc"
+    kgo_path = kgo_dir / "kgo.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/lib/improver/tests/utilities/test_OrographicAlphas.py
+++ b/lib/improver/tests/utilities/test_OrographicAlphas.py
@@ -159,7 +159,7 @@ class Test_gradient_to_alpha(IrisTest):
 
         result = self.plugin.gradient_to_alpha(self.gradient_x,
                                                self.gradient_y)
-        self.assertEqual(result[0].name(), 'alphas')
+        self.assertEqual(result[0].name(), 'alpha_x')
         self.assertArrayAlmostEqual(result[0].data, expected)
         self.assertNotIn('forecast_period', [coord.name()
                          for coord in result[0].coords()])

--- a/lib/improver/utilities/ancillary_creation.py
+++ b/lib/improver/utilities/ancillary_creation.py
@@ -128,7 +128,7 @@ class OrographicAlphas(BasePlugin):
         return alphas_cube
 
     @staticmethod
-    def update_alphas_metadata(alphas_cube):
+    def update_alphas_metadata(alphas_cube, cube_name):
         """
         Update metadata in alphas cube.  Remove any time coordinates and
         rename.
@@ -136,12 +136,14 @@ class OrographicAlphas(BasePlugin):
         Args:
             alphas_cube (iris.cube.Cube):
                 A cube of alphas with "gradient" metadata
+            cube_name (str):
+                A name for the resultant cube
 
         Returns:
             iris.cube.Cube:
                 A cube of alphas with adjusted metadata
         """
-        alphas_cube.rename('alphas')
+        alphas_cube.rename(cube_name)
         for coord in alphas_cube.coords(dim_coords=False):
             if 'time' in coord.name() or 'period' in coord.name():
                 alphas_cube.remove_coord(coord)
@@ -177,8 +179,8 @@ class OrographicAlphas(BasePlugin):
             alpha_x, alpha_y = self.scale_alphas([alpha_x, alpha_y],
                                                  min_output=self.min_alpha,
                                                  max_output=self.max_alpha)
-        alpha_x = self.update_alphas_metadata(alpha_x)
-        alpha_y = self.update_alphas_metadata(alpha_y)
+        alpha_x = self.update_alphas_metadata(alpha_x, 'alpha_x')
+        alpha_y = self.update_alphas_metadata(alpha_y, 'alpha_y')
 
         return alpha_x, alpha_y
 
@@ -197,7 +199,7 @@ class OrographicAlphas(BasePlugin):
                 for.
 
         Returns:
-            (tuple): tuple containing:
+            (iris.cube.CubeList): containing:
                 **alpha_x** (iris.cube.Cube): A cube of orography-dependent
                     alphas calculated in the x direction.
 
@@ -216,7 +218,7 @@ class OrographicAlphas(BasePlugin):
             DifferenceBetweenAdjacentGridSquares(gradient=True).process(cube)
         alpha_x, alpha_y = self.gradient_to_alpha(gradient_x, gradient_y)
 
-        return alpha_x, alpha_y
+        return iris.cube.CubeList([alpha_x, alpha_y])
 
 
 class SaturatedVapourPressureTable(BasePlugin):


### PR DESCRIPTION
We already had the code for this, but no corresponding CLI.
I created this because:
 * There is a desire to put both "alphas" cubes into a single file to simplify the clize version of the recursive-filter CLI
 * The "alphas" files might want to be generated alongside the other ancillaries (e.g: at startup in the suite).

TO-DO (later work):
  * The docstring was copied from the underlying plugin (and adapted slightly), it could do with being improved but I don't have the background knowledge of the underlying processing, so would need to consult with someone with some expertise on this.
  * On a related note: "alpha" or "alphas" is a fairly terrible name and presumably relates to a constant in an equation - can we come up with name that's more descriptive?
  * The `invert_alphas` option seems kind of pointless, maybe remove this?

I don't think the stuff in the to-do section should necessarily block this PR being merged - we can always catch this stuff at a later date.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)