### PR TITLE
IMPRO-1554: Removing useless-object-inheritance

### DIFF
--- a/lib/improver/lapse_rate.py
+++ b/lib/improver/lapse_rate.py
@@ -115,7 +115,7 @@ def apply_gridded_lapse_rate(temperature, lapse_rate, source_orog, dest_orog):
     return iris.cube.CubeList(adjusted_temperature).merge_cube()
 
 
-class SaveNeighbourhood(object):
+class SaveNeighbourhood:
     """Saves the neighbourhood around each central point.
 
     The "generic_filter" module extracts the neighbourhood around each

--- a/lib/improver/nbhood/circular_kernel.py
+++ b/lib/improver/nbhood/circular_kernel.py
@@ -87,7 +87,7 @@ def circular_kernel(fullranges, ranges, weighted_mode):
     return kernel
 
 
-class CircularNeighbourhood(object):
+class CircularNeighbourhood:
 
     """
     Methods for use in the calculation and application of a circular
@@ -214,7 +214,7 @@ class CircularNeighbourhood(object):
         return cube
 
 
-class GeneratePercentilesFromACircularNeighbourhood(object):
+class GeneratePercentilesFromACircularNeighbourhood:
     """
     Methods for use in calculating percentiles from a 2D circular
     neighbourhood.

--- a/lib/improver/nbhood/square_kernel.py
+++ b/lib/improver/nbhood/square_kernel.py
@@ -45,7 +45,7 @@ from improver.utilities.spatial import (
 MAX_RADIUS_IN_GRID_CELLS = 500
 
 
-class SquareNeighbourhood(object):
+class SquareNeighbourhood:
 
     """
     Methods for use in application of a square neighbourhood.

--- a/lib/improver/tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
+++ b/lib/improver/tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
@@ -141,7 +141,7 @@ def set_up_cube(num_time_points=1, num_grid_points=1, num_height_levels=7,
     return cube
 
 
-class TestMultiPoint(object):
+class TestMultiPoint:
 
     """Test (typically) 3 x 1 or 3x3 point tests.
 
@@ -269,7 +269,7 @@ class TestMultiPoint(object):
         return plugin.process(self.w_cube)
 
 
-class TestSinglePoint(object):
+class TestSinglePoint:
     """Test a single 1x1 grid.
 
     A cube is a single 1x x 1y grid, however, the z dimension is not 1.

--- a/lib/improver/utilities/warnings_handler.py
+++ b/lib/improver/utilities/warnings_handler.py
@@ -34,7 +34,7 @@ import sys
 import warnings
 
 
-class ManageWarnings(object):
+class ManageWarnings:
     """
     A decorator used to manage the warnings that are raised by a function.
     Ignore a selection of warnings, and either raise any remaining warnings

--- a/lib/improver/wind_calculations/wind_downscaling.py
+++ b/lib/improver/wind_calculations/wind_downscaling.py
@@ -119,7 +119,7 @@ class FrictionVelocity(BasePlugin):
         return ustar
 
 
-class RoughnessCorrectionUtilities(object):
+class RoughnessCorrectionUtilities:
     """Class to calculate the height and roughness wind corrections.
 
     This holds functions to calculate the roughness and height


### PR DESCRIPTION
Removed the surviving classes which inherit from object.

So
```python
class My_Class(object):
```
becomes
```python
class My_Class:
```
Testing:
 - [x] Ran tests and they passed OK