### PR TITLE
Remove incorrect grid attributes

### DIFF
--- a/lib/improver/standardise.py
+++ b/lib/improver/standardise.py
@@ -194,20 +194,13 @@ class StandardiseGridAndMetadata(BasePlugin):
         if self.REGRID_REQUIRES_LANDMASK[self.regrid_mode]:
             cube = self._adjust_landsea(cube, target_grid)
 
-        # identify attributes that need updating
+        # identify grid-describing attributes on source cube that need updating
         required_grid_attributes = [attr for attr in cube.attributes
                                     if attr in MOSG_GRID_ATTRIBUTES]
-        """
-        attributes_to_inherit = (
-            {key: val for (key, val) in target_grid.attributes.items()
-             if key in MOSG_GRID_ATTRIBUTES})
-        """
-        grid_attribute_changes = {}
-        for key in required_grid_attributes:
-            try:
-                grid_attribute_changes[key] = target_grid.attributes[key]
-            except KeyError:
-                grid_attribute_changes[key] = "remove"
+        # update attributes if available on target grid, otherwise remove
+        val = lambda k, t: t.attributes[k] if k in t.attributes else "remove"
+        grid_attribute_changes = {key: val(key, target_grid)
+                                  for key in required_grid_attributes}
         amend_attributes(cube, grid_attribute_changes)
 
         cube.attributes["title"] = (

--- a/lib/improver/standardise.py
+++ b/lib/improver/standardise.py
@@ -198,7 +198,8 @@ class StandardiseGridAndMetadata(BasePlugin):
         required_grid_attributes = [attr for attr in cube.attributes
                                     if attr in MOSG_GRID_ATTRIBUTES]
         # update attributes if available on target grid, otherwise remove
-        val = lambda k, t: t.attributes[k] if k in t.attributes else "remove"
+        val = (lambda k, t: t.attributes[k]
+               if k in t.attributes else "remove")  # noqa: E731
         grid_attribute_changes = {key: val(key, target_grid)
                                   for key in required_grid_attributes}
         amend_attributes(cube, grid_attribute_changes)

--- a/lib/improver/standardise.py
+++ b/lib/improver/standardise.py
@@ -194,10 +194,21 @@ class StandardiseGridAndMetadata(BasePlugin):
         if self.REGRID_REQUIRES_LANDMASK[self.regrid_mode]:
             cube = self._adjust_landsea(cube, target_grid)
 
+        # identify attributes that need updating
+        required_grid_attributes = [attr for attr in cube.attributes
+                                    if attr in MOSG_GRID_ATTRIBUTES]
+        """
         attributes_to_inherit = (
             {key: val for (key, val) in target_grid.attributes.items()
              if key in MOSG_GRID_ATTRIBUTES})
-        amend_attributes(cube, attributes_to_inherit)
+        """
+        grid_attribute_changes = {}
+        for key in required_grid_attributes:
+            try:
+                grid_attribute_changes[key] = target_grid.attributes[key]
+            except KeyError:
+                grid_attribute_changes[key] = "remove"
+        amend_attributes(cube, grid_attribute_changes)
 
         cube.attributes["title"] = (
             MANDATORY_ATTRIBUTE_DEFAULTS["title"]

--- a/lib/improver/standardise.py
+++ b/lib/improver/standardise.py
@@ -198,11 +198,11 @@ class StandardiseGridAndMetadata(BasePlugin):
         required_grid_attributes = [attr for attr in cube.attributes
                                     if attr in MOSG_GRID_ATTRIBUTES]
         # update attributes if available on target grid, otherwise remove
-        val = (lambda k, t: t.attributes[k]
-               if k in t.attributes else "remove")  # noqa: E731
-        grid_attribute_changes = {key: val(key, target_grid)
-                                  for key in required_grid_attributes}
-        amend_attributes(cube, grid_attribute_changes)
+        for key in required_grid_attributes:
+            if key in target_grid.attributes:
+                cube.attributes[key] = target_grid.attributes[key]
+            else:
+                cube.attributes.pop(key)
 
         cube.attributes["title"] = (
             MANDATORY_ATTRIBUTE_DEFAULTS["title"]

--- a/lib/improver/tests/standardise/test_StandardiseGridAndMetadata.py
+++ b/lib/improver/tests/standardise/test_StandardiseGridAndMetadata.py
@@ -323,6 +323,14 @@ class Test_process_regrid_options(IrisTest):
             attributes_dict=attribute_changes)
         self.assertDictEqual(result.attributes, expected_attributes)
 
+    def test_incorrect_grid_attributes_removed(self):
+        """Test grid attributes not present on the target cube are removed
+        after regridding"""
+        self.target_grid.attributes.pop("mosg__grid_domain")
+        result = StandardiseGridAndMetadata().process(
+            self.cube, target_grid=self.target_grid)        
+        self.assertNotIn("mosg__grid_domain", result.attributes)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/improver/tests/standardise/test_StandardiseGridAndMetadata.py
+++ b/lib/improver/tests/standardise/test_StandardiseGridAndMetadata.py
@@ -328,7 +328,7 @@ class Test_process_regrid_options(IrisTest):
         after regridding"""
         self.target_grid.attributes.pop("mosg__grid_domain")
         result = StandardiseGridAndMetadata().process(
-            self.cube, target_grid=self.target_grid)        
+            self.cube, target_grid=self.target_grid)
         self.assertNotIn("mosg__grid_domain", result.attributes)
 
 


### PR DESCRIPTION
Met Office specific grid attributes should be inherited from the target grid after regridding.  If not present on the target grid, these attributes should be removed as they are no longer correct.  This PR removes incorrect grid attributes as part of the regridding algorithm.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
