### PR TITLE
IMPRO-1560: fix assigntment-from-none pylint error

### DIFF
--- a/lib/improver/tests/metadata/test_amend.py
+++ b/lib/improver/tests/metadata/test_amend.py
@@ -87,16 +87,15 @@ class Test_update_stage_v110_metadata(IrisTest):
     def test_basic(self):
         """Test that cube is unchanged and function returns False"""
         result = self.cube.copy()
-        output = update_stage_v110_metadata(result)
+        update_stage_v110_metadata(result)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayEqual(result.data, self.cube.data)
         self.assertEqual(result.attributes, self.cube.attributes)
-        self.assertFalse(output)
 
     def test_update_ukv(self):
         """Test that cube attributes from ukv 1.1.0 are updated"""
         self.cube.attributes['grid_id'] = 'ukvx_standard_v1'
-        output = update_stage_v110_metadata(self.cube)
+        update_stage_v110_metadata(self.cube)
         self.assertTrue('mosg__grid_type' in self.cube.attributes.keys())
         self.assertTrue('mosg__model_configuration' in
                         self.cube.attributes.keys())
@@ -109,7 +108,6 @@ class Test_update_stage_v110_metadata(IrisTest):
         self.assertEqual('uk_extended',
                          self.cube.attributes['mosg__grid_domain'])
         self.assertEqual('1.1.0', self.cube.attributes['mosg__grid_version'])
-        self.assertTrue(output)
 
 
 class Test_amend_attributes(IrisTest):


### PR DESCRIPTION
fixed assignment-from-none error in a test due to a change of it returning None rather than a bool.

Testing:
 - [x] Ran tests and they passed OK