### PR TITLE
Fix convert to realizations for realizations

### DIFF
--- a/lib/improver/cli/convert_to_realizations.py
+++ b/lib/improver/cli/convert_to_realizations.py
@@ -61,11 +61,11 @@ def process(cube: cli.inputcube,
         output_cube = percentiles_to_realizations.process(
             cube, no_of_percentiles=no_of_realizations,
             rebadging=True, ecc_bounds_warning=ecc_bounds_warning)
-    elif cube.coord(var_name='threshold'):
+    elif cube.coords(var_name='threshold'):
         output_cube = probabilities_to_realizations.process(
             cube, no_of_realizations=no_of_realizations, rebadging=True,
             ecc_bounds_warning=ecc_bounds_warning)
-    elif cube.coord(var_name='realization'):
+    elif cube.coords(var_name='realization'):
         output_cube = cube
     else:
         raise ValueError("Unable to convert to realizations:\n" + str(cube))

--- a/lib/improver/tests/acceptance/test_convert_to_realizations.py
+++ b/lib/improver/tests/acceptance/test_convert_to_realizations.py
@@ -83,7 +83,6 @@ def test_realizations(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_path
     output_path = tmp_path / "output.nc"
-
     args = [input_path,
             "--no-of-realizations", "12",
             "--output", output_path]

--- a/lib/improver/tests/acceptance/test_convert_to_realizations.py
+++ b/lib/improver/tests/acceptance/test_convert_to_realizations.py
@@ -74,3 +74,30 @@ def test_probabilities(tmp_path):
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
+
+
+def test_realizations(tmp_path):
+    """Test basic null realization to realization conversion"""
+    kgo_dir = (acc.kgo_root() /
+               "probabilities-to-realizations/12_realizations")
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_path
+
+    output_path = tmp_path / "output.nc"
+
+    args = [input_path,
+            "--no-of-realizations", "12",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, input_path)
+
+
+def test_invalid_dataset(tmp_path):
+    """Test unhandlable conversion failure."""
+    input_dir = (acc.kgo_root() /
+                 "probabilities-to-realizations/invalid/")
+    input_path = input_dir / "input.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, "--output", output_path]
+    with pytest.raises(ValueError, match=".*Unable to convert.*"):
+        run_cli(args)

--- a/lib/improver/tests/acceptance/test_convert_to_realizations.py
+++ b/lib/improver/tests/acceptance/test_convert_to_realizations.py
@@ -82,7 +82,6 @@ def test_realizations(tmp_path):
                "probabilities-to-realizations/12_realizations")
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_path
-
     output_path = tmp_path / "output.nc"
 
     args = [input_path,


### PR DESCRIPTION
This fixes a small bug in the convert-to-realizations CLI and adds some tests.

Previously, when a realization-coordinate cube was passed in (without a threshold or percentile coordinate), an error would occur:

```python
  File "/opt/improver/lib/improver/cli/convert_to_realizations.py", line 64, in process
    elif cube.coord(var_name='threshold'):
  File "/opt/iris/cube.py", line 1463, in coord
    raise iris.exceptions.CoordinateNotFoundError(msg)
iris.exceptions.CoordinateNotFoundError: 'Expected to find exactly 1  coordinate, but found none.'
```

Now fixed by using `coords(...)`.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

I added a new invalid input file to my version of improver_tests, which is a symlink to a no-realization/no-threshold/no-percentile NetCDF file.
