### PR TITLE
Silences "interpreted-text" warning when parsing apply-emos-coefficients CLI.

### DIFF
--- a/lib/improver/cli/__init__.py
+++ b/lib/improver/cli/__init__.py
@@ -76,6 +76,7 @@ def docutilize(obj):
     doc = str(NumpyDocstring(doc))
     doc = str(GoogleDocstring(doc))
     doc = doc.replace(':exc:', '')
+    doc = doc.replace(':data:', '')
     doc = doc.replace(':keyword', ':param')
     doc = doc.replace(':kwtype', ':type')
 


### PR DESCRIPTION
If you run the command `bin/improver apply-emos-coefficients --help`, you see an unhelpful extra message before the Usage is printed:
`process:23: (ERROR/3) Unknown interpreted text role "data".`

This PR silences this message.

Testing:
 - [x] Ran tests and they passed OK
