### PR TITLE
IMPRO-1562: enforce_coordinate_ordering in place only

### DIFF
--- a/improver/cli/neighbour_finding.py
+++ b/improver/cli/neighbour_finding.py
@@ -196,7 +196,7 @@ def process(orography: cli.inputcube,
     else:
         result = NeighbourSelection(**kwargs).process(*fargs)
 
-    result = enforce_coordinate_ordering(
+    enforce_coordinate_ordering(
         result,
         ['spot_index', 'neighbour_selection_method', 'grid_attributes'])
 

--- a/improver/ensemble_calibration/ensemble_calibration.py
+++ b/improver/ensemble_calibration/ensemble_calibration.py
@@ -225,9 +225,7 @@ class ContinuousRankedProbabilityScoreMinimisers:
             forecast_predictor_data = flatten_ignoring_masked_data(
                 forecast_predictor.data)
         elif predictor_of_mean_flag.lower() == "realizations":
-            forecast_predictor = (
-                enforce_coordinate_ordering(
-                    forecast_predictor, "realization"))
+            enforce_coordinate_ordering(forecast_predictor, "realization")
             # Need to transpose this array so there are columns for each
             # ensemble member rather than rows.
             forecast_predictor_data = flatten_ignoring_masked_data(
@@ -698,7 +696,7 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
                 initial_guess = [0, 1, intercept, gradient]
             elif predictor_of_mean_flag.lower() == "realizations":
                 if self.statsmodels_found:
-                    forecast_predictor = enforce_coordinate_ordering(
+                    enforce_coordinate_ordering(
                         forecast_predictor, "realization")
                     forecast_predictor_flattened = (
                         flatten_ignoring_masked_data(

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -232,9 +232,8 @@ class ResamplePercentiles(BasePlugin):
 
         # Ensure that the percentile dimension is first, so that the
         # conversion to a 2d array produces data in the desired order.
-        forecast_at_percentiles = (
-            enforce_coordinate_ordering(
-                forecast_at_percentiles, percentile_coord_name))
+        enforce_coordinate_ordering(
+            forecast_at_percentiles, percentile_coord_name)
         forecast_at_reshaped_percentiles = convert_cube_data_to_2d(
             forecast_at_percentiles, coord=percentile_coord_name)
 
@@ -456,9 +455,8 @@ class GeneratePercentilesFromProbabilities(BasePlugin):
 
         # Ensure that the percentile dimension is first, so that the
         # conversion to a 2d array produces data in the desired order.
-        forecast_probabilities = (
-            enforce_coordinate_ordering(
-                forecast_probabilities, threshold_coord.name()))
+        enforce_coordinate_ordering(
+            forecast_probabilities, threshold_coord.name())
         prob_slices = convert_cube_data_to_2d(
             forecast_probabilities, coord=threshold_coord.name())
 
@@ -740,12 +738,10 @@ class GeneratePercentilesFromMeanAndVariance(BasePlugin, FromMeanAndVariance):
             ValueError: If any of the resulting percentile values are
                 nans and these nans are not caused by a zero variance.
         """
-        calibrated_forecast_predictor = (
-            enforce_coordinate_ordering(
-                calibrated_forecast_predictor, "realization"))
-        calibrated_forecast_variance = (
-            enforce_coordinate_ordering(
-                calibrated_forecast_variance, "realization"))
+        enforce_coordinate_ordering(
+            calibrated_forecast_predictor, "realization")
+        enforce_coordinate_ordering(
+            calibrated_forecast_variance, "realization")
 
         calibrated_forecast_predictor_data = (
             calibrated_forecast_predictor.data.flatten())
@@ -1204,24 +1200,21 @@ class EnsembleReordering(BasePlugin):
         percentile_coord_name = (
             find_percentile_coordinate(post_processed_forecast).name())
 
-        post_processed_forecast_percentiles = (
-            enforce_coordinate_ordering(
-                post_processed_forecast, percentile_coord_name))
-        raw_forecast_realizations = enforce_coordinate_ordering(
-            raw_forecast, "realization")
-        raw_forecast_realizations = (
+        enforce_coordinate_ordering(
+            post_processed_forecast, percentile_coord_name)
+        enforce_coordinate_ordering(raw_forecast, "realization")
+        raw_forecast = (
             self._recycle_raw_ensemble_realizations(
-                post_processed_forecast_percentiles, raw_forecast_realizations,
+                post_processed_forecast, raw_forecast,
                 percentile_coord_name))
         post_processed_forecast_realizations = self.rank_ecc(
-            post_processed_forecast_percentiles, raw_forecast_realizations,
+            post_processed_forecast, raw_forecast,
             random_ordering=random_ordering,
             random_seed=random_seed)
         post_processed_forecast_realizations = (
             RebadgePercentilesAsRealizations.process(
                 post_processed_forecast_realizations))
 
-        post_processed_forecast_realizations = (
-            enforce_coordinate_ordering(
-                post_processed_forecast_realizations, "realization"))
+        enforce_coordinate_ordering(
+            post_processed_forecast_realizations, "realization")
         return post_processed_forecast_realizations

--- a/improver/orographic_enhancement.py
+++ b/improver/orographic_enhancement.py
@@ -174,7 +174,7 @@ class OrographicEnhancement(BasePlugin):
             var_cube = sort_coord_in_cube(
                 var_cube, var_cube.coord(axis=axis))
 
-        var_cube = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             var_cube, [var_cube.coord(axis='y').name(),
                        var_cube.coord(axis='x').name()])
 
@@ -212,7 +212,7 @@ class OrographicEnhancement(BasePlugin):
         for axis in ['x', 'y']:
             topography = sort_coord_in_cube(
                 topography, topography.coord(axis=axis))
-        topography = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             topography, [topography.coord(axis='y').name(),
                          topography.coord(axis='x').name()])
         self.topography = topography.copy(

--- a/improver/spotdata/neighbour_finding.py
+++ b/improver/spotdata/neighbour_finding.py
@@ -446,10 +446,10 @@ class NeighbourSelection(BasePlugin):
             raise ValueError(msg)
 
         # Enforce x-y coordinate order for input cubes.
-        orography = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             orography, [orography.coord(axis='x').name(),
                         orography.coord(axis='y').name()])
-        land_mask = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             land_mask, [land_mask.coord(axis='x').name(),
                         land_mask.coord(axis='y').name()])
 

--- a/improver/spotdata/spot_extraction.py
+++ b/improver/spotdata/spot_extraction.py
@@ -120,7 +120,7 @@ class SpotExtraction(BasePlugin):
                 An array of diagnostic values at the grid coordinates found
                 within the coordinate cube.
         """
-        diagnostic_cube = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             diagnostic_cube, [diagnostic_cube.coord(axis='x').name(),
                               diagnostic_cube.coord(axis='y').name()])
         spot_values = diagnostic_cube.data[tuple(coordinate_cube.data.T)]

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -349,7 +349,7 @@ class BasicThreshold(BasePlugin):
                 self.comparison_operator['spp_string']))
         cube.units = Unit(1)
 
-        cube = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             cube, ["realization", "percentile"])
 
         return cube

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -732,10 +732,6 @@ def enforce_coordinate_ordering(cube, coord_names, anchor_start=True):
             end. For example, if the specified coordinate names are
             ["time", "realization"] then "realization" will be the last
             coordinate within the cube, whilst "time" will be the last but one.
-
-    Returns:
-        iris.cube.Cube:
-            Cube with reordered dimensions.
     """
     if isinstance(coord_names, str):
         coord_names = [coord_names]
@@ -774,8 +770,6 @@ def enforce_coordinate_ordering(cube, coord_names, anchor_start=True):
 
     # transpose cube using new coordinate order
     cube.transpose(new_dims)
-
-    return cube
 
 
 def clip_cube_data(cube, minimum_value, maximum_value):

--- a/improver/utilities/load.py
+++ b/improver/utilities/load.py
@@ -96,12 +96,12 @@ def load_cube(filepath, constraints=None, no_lazy_load=False,
 
     # Ensure the probabilistic coordinates are the first coordinates within a
     # cube and are in the specified order.
-    cube = enforce_coordinate_ordering(
+    enforce_coordinate_ordering(
         cube, ["realization", "percentile", "threshold"])
     # Ensure the y and x dimensions are the last dimensions within the cube.
     y_name = cube.coord(axis="y").name()
     x_name = cube.coord(axis="x").name()
-    cube = enforce_coordinate_ordering(
+    enforce_coordinate_ordering(
         cube, [y_name, x_name], anchor_start=False)
     if no_lazy_load:
         # Force the cube's data into memory by touching the .data attribute.

--- a/improver/utilities/pad_spatial.py
+++ b/improver/utilities/pad_spatial.py
@@ -284,7 +284,7 @@ def remove_cube_halo(cube, halo_radius):
             result = iris.util.new_axis(result, coord)
 
     # re-order (needed if scalar dimensions have been re-added)
-    result = enforce_coordinate_ordering(result, req_dims)
+    enforce_coordinate_ordering(result, req_dims)
 
     return result
 

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -398,11 +398,11 @@ class Test_process(Test_RecursiveFilter):
         """Test that x and y alphas still apply to the right coordinate when
         the input cube spatial dimensions are (x, y) not (y, x)"""
         alpha_y = 0.5*self.alpha_x
-        cube = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.cube, ["realization", "longitude", "latitude"])
         plugin = RecursiveFilter(alpha_x=self.alpha_x, alpha_y=alpha_y,
                                  iterations=self.iterations)
-        result = plugin.process(cube)
+        result = plugin.process(self.cube)
 
         expected_result = np.array(
             [[0.01620921, 0.03978802, 0.10592333, 0.03978982, 0.01621686],

--- a/improver_tests/spotdata/spotdata/test_SpotLapseRateAdjust.py
+++ b/improver_tests/spotdata/spotdata/test_SpotLapseRateAdjust.py
@@ -219,13 +219,13 @@ class Test_process(Test_SpotLapseRateAdjust):
         plugin = SpotLapseRateAdjust()
         expected = np.array(
             [280 + (2 * DALR), 270, 280 - DALR]).astype(np.float32)
-        lapse_rate_cube = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.lapse_rate_cube, ['projection_x_coordinate',
                                    'projection_y_coordinate'])
 
         result = plugin.process(self.spot_temperature_nearest,
                                 self.neighbour_cube,
-                                lapse_rate_cube)
+                                self.lapse_rate_cube)
         self.assertArrayEqual(result.data, expected)
 
 

--- a/improver_tests/utilities/cube_manipulation/test_enforce_coordinate_ordering.py
+++ b/improver_tests/utilities/cube_manipulation/test_enforce_coordinate_ordering.py
@@ -63,16 +63,16 @@ class Test_enforce_coordinate_ordering(IrisTest):
 
     def test_basic(self):
         """Test that the function returns an iris.cube.Cube."""
-        result = enforce_coordinate_ordering(self.cube, "realization")
-        self.assertIsInstance(result, Cube)
+        enforce_coordinate_ordering(self.cube, "realization")
+        self.assertIsInstance(self.cube, Cube)
 
     def test_move_coordinate_to_start_when_already_at_start(self):
         """Test that a cube with the expected data contents is returned when
         the coordinate to be reordered is already in the desired position."""
         expected = self.cube.copy()
-        result = enforce_coordinate_ordering(self.cube, "realization")
-        self.assertEqual(result.coord_dims("realization")[0], 0)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        enforce_coordinate_ordering(self.cube, "realization")
+        self.assertEqual(self.cube.coord_dims("realization")[0], 0)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_move_coordinate_to_start(self):
         """Test that a cube with the expected data contents is returned when
@@ -80,11 +80,11 @@ class Test_enforce_coordinate_ordering(IrisTest):
         cube."""
         expected = self.cube.copy()
         expected.transpose([1, 0, 2, 3])
-        result = enforce_coordinate_ordering(self.cube, "time")
-        self.assertEqual(result.coord_dims("time")[0], 0)
+        enforce_coordinate_ordering(self.cube, "time")
+        self.assertEqual(self.cube.coord_dims("time")[0], 0)
         # test associated aux coord is moved along with time dimension
-        self.assertEqual(result.coord_dims("forecast_period")[0], 0)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        self.assertEqual(self.cube.coord_dims("forecast_period")[0], 0)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_move_coordinate_to_end(self):
         """Test that a cube with the expected data contents is returned when
@@ -92,10 +92,10 @@ class Test_enforce_coordinate_ordering(IrisTest):
         the cube."""
         expected = self.cube.copy()
         expected.transpose([1, 2, 3, 0])
-        result = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.cube, "realization", anchor_start=False)
-        self.assertEqual(result.coord_dims("realization")[0], 3)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        self.assertEqual(self.cube.coord_dims("realization")[0], 3)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_move_coordinate_to_start_with_list(self):
         """Test that a cube with the expected data contents is returned when
@@ -103,9 +103,9 @@ class Test_enforce_coordinate_ordering(IrisTest):
         cube."""
         expected = self.cube.copy()
         expected.transpose([1, 0, 2, 3])
-        result = enforce_coordinate_ordering(self.cube, ["time"])
-        self.assertEqual(result.coord_dims("time")[0], 0)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        enforce_coordinate_ordering(self.cube, ["time"])
+        self.assertEqual(self.cube.coord_dims("time")[0], 0)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_move_multiple_coordinate_to_start_with_list(self):
         """Test that a cube with the expected data contents is returned when
@@ -113,11 +113,11 @@ class Test_enforce_coordinate_ordering(IrisTest):
         coordinates in the cube."""
         expected = self.cube.copy()
         expected.transpose([1, 0, 2, 3])
-        result = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.cube, ["time", "realization"])
-        self.assertEqual(result.coord_dims("time")[0], 0)
-        self.assertEqual(result.coord_dims("realization")[0], 1)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        self.assertEqual(self.cube.coord_dims("time")[0], 0)
+        self.assertEqual(self.cube.coord_dims("realization")[0], 1)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_move_multiple_coordinate_to_end_with_list(self):
         """Test that a cube with the expected data contents is returned when
@@ -126,11 +126,11 @@ class Test_enforce_coordinate_ordering(IrisTest):
         specified as a list."""
         expected = self.cube.copy()
         expected.transpose([2, 3, 1, 0])
-        result = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.cube, ["time", "realization"], anchor_start=False)
-        self.assertEqual(result.coord_dims("time")[0], 2)
-        self.assertEqual(result.coord_dims("realization")[0], 3)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        self.assertEqual(self.cube.coord_dims("time")[0], 2)
+        self.assertEqual(self.cube.coord_dims("realization")[0], 3)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_full_reordering(self):
         """Test that a cube with the expected data contents is returned when
@@ -138,13 +138,13 @@ class Test_enforce_coordinate_ordering(IrisTest):
         specified by the names within the input list."""
         expected = self.cube.copy()
         expected.transpose([2, 0, 3, 1])
-        result = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.cube, ["latitude", "realization", "longitude", "time"])
-        self.assertEqual(result.coord_dims("latitude")[0], 0)
-        self.assertEqual(result.coord_dims("realization")[0], 1)
-        self.assertEqual(result.coord_dims("longitude")[0], 2)
-        self.assertEqual(result.coord_dims("time")[0], 3)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        self.assertEqual(self.cube.coord_dims("latitude")[0], 0)
+        self.assertEqual(self.cube.coord_dims("realization")[0], 1)
+        self.assertEqual(self.cube.coord_dims("longitude")[0], 2)
+        self.assertEqual(self.cube.coord_dims("time")[0], 3)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_include_extra_coordinates(self):
         """Test that a cube with the expected data contents is returned when
@@ -152,28 +152,29 @@ class Test_enforce_coordinate_ordering(IrisTest):
         are not present within the cube."""
         expected = self.cube.copy()
         expected.transpose([1, 0, 2, 3])
-        result = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             self.cube, ["time", "realization", "nonsense"])
-        self.assertEqual(result.coord_dims("time")[0], 0)
-        self.assertEqual(result.coord_dims("realization")[0], 1)
-        self.assertArrayAlmostEqual(result.data, expected.data)
+        self.assertEqual(self.cube.coord_dims("time")[0], 0)
+        self.assertEqual(self.cube.coord_dims("realization")[0], 1)
+        self.assertArrayAlmostEqual(self.cube.data, expected.data)
 
     def test_no_impact_scalar(self):
         """Test that a cube with the expected data contents is returned when
         reordered on a scalar coordinate."""
         cube = self.cube[0, :, :, :]
-        result = enforce_coordinate_ordering(cube, "realization")
-        self.assertFalse(result.coord_dims("realization"))
-        self.assertArrayAlmostEqual(result.data, cube.data)
+        expected = cube.copy()
+        enforce_coordinate_ordering(cube, "realization")
+        self.assertFalse(cube.coord_dims("realization"))
+        self.assertArrayAlmostEqual(cube.data, expected.data)
 
     def test_handles_threshold(self):
         """Test a probability cube is correctly handled"""
         thresholds = np.array([278, 279, 280], dtype=np.float32)
         data = 0.03*np.arange(27).reshape((3, 3, 3))
         cube = set_up_probability_cube(data.astype(np.float32), thresholds)
-        result = enforce_coordinate_ordering(
+        enforce_coordinate_ordering(
             cube, ["threshold"], anchor_start=False)
-        self.assertEqual(result.coord_dims("air_temperature")[0], 2)
+        self.assertEqual(cube.coord_dims("air_temperature")[0], 2)
 
 
 if __name__ == '__main__':

--- a/improver_tests/utilities/cube_manipulation/test_enforce_coordinate_ordering.py
+++ b/improver_tests/utilities/cube_manipulation/test_enforce_coordinate_ordering.py
@@ -61,11 +61,6 @@ class Test_enforce_coordinate_ordering(IrisTest):
             cube, time_points, "time", coord_units=TIME_REFERENCE_UNIT,
             dtype=np.int64, order=[1, 0, 2, 3])
 
-    def test_basic(self):
-        """Test that the function returns an iris.cube.Cube."""
-        enforce_coordinate_ordering(self.cube, "realization")
-        self.assertIsInstance(self.cube, Cube)
-
     def test_move_coordinate_to_start_when_already_at_start(self):
         """Test that a cube with the expected data contents is returned when
         the coordinate to be reordered is already in the desired position."""


### PR DESCRIPTION
- Removed the return statement from the enforce_coordinate_ordering function which acts in place anyway.
- Updated all uses of the function to remove any assignment to new variable names.
- Updated the names of variables where necessary due to the removal of assignment.
- Deleted return type test for enforce_coordinate_ordering function.

Testing:
 - [x] Ran tests and they passed OK
