### PR TITLE
RECREATE_KGO user friendliness

### DIFF
--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -76,10 +76,18 @@ def compare_netcdfs(actual_path, desired_path, rtol, atol,
     if reporter is None:
         reporter = raise_reporter
 
-    actual_ds = netCDF4.Dataset(str(actual_path), mode='r')
-    actual_ds.set_auto_maskandscale(False)
-    desired_ds = netCDF4.Dataset(str(desired_path), mode='r')
-    desired_ds.set_auto_maskandscale(False)
+    try:
+        actual_ds = netCDF4.Dataset(str(actual_path), mode='r')
+        actual_ds.set_auto_maskandscale(False)
+    except OSError as e:
+        reporter(str(e))
+        return
+    try:
+        desired_ds = netCDF4.Dataset(str(desired_path), mode='r')
+        desired_ds.set_auto_maskandscale(False)
+    except OSError as e:
+        reporter(str(e))
+        return
 
     compare_datasets("", actual_ds, desired_ds, rtol, atol,
                      exclude_vars, reporter)

--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -78,17 +78,16 @@ def compare_netcdfs(actual_path, desired_path, rtol, atol,
 
     try:
         actual_ds = netCDF4.Dataset(str(actual_path), mode='r')
-        actual_ds.set_auto_maskandscale(False)
     except OSError as e:
         reporter(str(e))
         return
     try:
         desired_ds = netCDF4.Dataset(str(desired_path), mode='r')
-        desired_ds.set_auto_maskandscale(False)
     except OSError as e:
         reporter(str(e))
         return
-
+    desired_ds.set_auto_maskandscale(False)
+    actual_ds.set_auto_maskandscale(False)
     compare_datasets("", actual_ds, desired_ds, rtol, atol,
                      exclude_vars, reporter)
 

--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -106,6 +106,7 @@ def compare_datasets(name, actual_ds, desired_ds, rtol, atol,
         desired_ds (netCDF.Dataset): dataset considered good
         rtol (float): relative tolerance
         atol (float): absolute tolerance
+        exclude_vars (List[str]): variable names to exclude from comparison
         reporter (Callable[[str], None]): callback function for
             reporting differences
 
@@ -140,6 +141,7 @@ def compare_dims(name, actual_ds, desired_ds, exclude_vars, reporter):
         name (str): group name
         actual_ds (netCDF.Dataset): dataset produced by test run
         desired_ds (netCDF.Dataset): dataset considered good
+        exclude_vars (List[str]): variable names to exclude from comparison
         reporter (Callable[[str], None]): callback function for
             reporting differences
 
@@ -178,6 +180,9 @@ def compare_vars(name, actual_ds, desired_ds, rtol, atol,
         name (str): group name
         actual_ds (netCDF.Dataset): dataset produced by test run
         desired_ds (netCDF.Dataset): dataset considered good
+        rtol (float): relative tolerance
+        atol (float): absolute tolerance
+        exclude_vars (List[str]): variable names to exclude from comparison
         reporter (Callable[[str], None]): callback function for
             reporting differences
 
@@ -272,6 +277,8 @@ def compare_data(name, actual_var, desired_var, rtol, atol, reporter):
         name (str): variable name
         actual_var (netCDF.Variable): variable produced by test run
         desired_var (netCDF.Variable): variable considered good
+        rtol (float): relative tolerance
+        atol (float): absolute tolerance
         reporter (Callable[[str], None]): callback function for
             reporting differences
 
@@ -279,7 +286,7 @@ def compare_data(name, actual_var, desired_var, rtol, atol, reporter):
         None
     """
     if actual_var.dtype != desired_var.dtype:
-        msg = (f"different type {name} - {actual_var.type} {desired_var.type}")
+        msg = f"different type {name} - {actual_var.type} {desired_var.type}"
         reporter(msg)
     actual_data = actual_var[:]
     desired_data = desired_var[:]

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -33,6 +33,7 @@
 import importlib
 import os
 import pathlib
+import shlex
 import shutil
 
 import pytest
@@ -108,25 +109,36 @@ def recreate_if_needed(output_path, kgo_path):
         kgo_path (pathlib.Path): Path to expected/original KGO file
 
     Returns:
-        pathlib.Path: Path to re-created KGO file
+        bool: True if KGO was recreated
     """
     if not kgo_recreate():
-        return
+        return False
     if not kgo_path.is_absolute():
         raise IOError("KGO path is not absolute")
     kgo_root_dir = kgo_root()
-    recreate_dir = os.environ[RECREATE_DIR]
+    recreate_dir = pathlib.Path(os.environ[RECREATE_DIR])
     if kgo_root_dir not in kgo_path.parents:
-        raise IOError("Provided KGO path is not within KGO root directory")
+        raise IOError("KGO path for test is not within KGO root directory")
+    if not recreate_dir.is_absolute():
+        raise IOError("Recreate KGO path is not absolute")
+    print("Comparison found differences - recreating KGO for this test")
+    print(f"Original KGO file is at {kgo_path}")
     kgo_relative = kgo_path.relative_to(kgo_root_dir)
     recreate_path = recreate_dir / kgo_relative
-    print(f"Recreating KGO originally at {kgo_path}")
-    kgo_path.parent.mkdir(exist_ok=True)
+    recreate_path.parent.mkdir(exist_ok=True, parents=True)
     if recreate_path.exists():
         recreate_path.unlink()
     shutil.copyfile(str(output_path), str(recreate_path))
-    print(f"Updated KGO file is {recreate_path}")
-    return recreate_path
+    print(f"Updated KGO file is at {recreate_path}")
+    if recreate_path.resolve() == kgo_path.resolve():
+        print("KGO updated in place, rerunning this test should now pass")
+    else:
+        print(f"Put the updated KGO file in {ACC_TEST_DIR} to make this"
+              f" test pass. For example:")
+        quoted_kgo = shlex.quote(str(kgo_path))
+        quoted_recreate = shlex.quote(str(recreate_path))
+        print(f"cp {quoted_recreate} {quoted_kgo}")
+    return True
 
 
 def statsmodels_available():

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -115,6 +115,8 @@ def recreate_if_needed(output_path, kgo_path):
         return False
     if not kgo_path.is_absolute():
         raise IOError("KGO path is not absolute")
+    if not output_path.is_file():
+        raise IOError("Expected output file not created by running test")
     kgo_root_dir = kgo_root()
     recreate_dir = pathlib.Path(os.environ[RECREATE_DIR])
     if kgo_root_dir not in kgo_path.parents:

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -41,8 +41,8 @@ import pytest
 from improver import cli
 from improver.utilities.compare import DEFAULT_TOLERANCE, compare_netcdfs
 
-RECREATE_DIR = "RECREATE_KGO"
-ACC_TEST_DIR = "IMPROVER_ACC_TEST_DIR"
+RECREATE_DIR_ENVVAR = "RECREATE_KGO"
+ACC_TEST_DIR_ENVVAR = "IMPROVER_ACC_TEST_DIR"
 
 
 def run_cli(cli_name, verbose=True):
@@ -82,13 +82,13 @@ def cli_name_with_dashes(dunder_file):
 
 def kgo_recreate():
     """True if KGO should be re-created"""
-    return RECREATE_DIR in os.environ
+    return RECREATE_DIR_ENVVAR in os.environ
 
 
 def kgo_root():
     """Path to the root of the KGO directories"""
     try:
-        test_dir = os.environ[ACC_TEST_DIR]
+        test_dir = os.environ[ACC_TEST_DIR_ENVVAR]
     except KeyError:
         pytest.skip()
         return pathlib.Path("/")
@@ -97,7 +97,7 @@ def kgo_root():
 
 def kgo_exists():
     """True if KGO files exist"""
-    return ACC_TEST_DIR in os.environ
+    return ACC_TEST_DIR_ENVVAR in os.environ
 
 
 def recreate_if_needed(output_path, kgo_path):
@@ -118,7 +118,7 @@ def recreate_if_needed(output_path, kgo_path):
     if not output_path.is_file():
         raise IOError("Expected output file not created by running test")
     kgo_root_dir = kgo_root()
-    recreate_dir = pathlib.Path(os.environ[RECREATE_DIR])
+    recreate_dir = pathlib.Path(os.environ[RECREATE_DIR_ENVVAR])
     if kgo_root_dir not in kgo_path.parents:
         raise IOError("KGO path for test is not within KGO root directory")
     if not recreate_dir.is_absolute():
@@ -138,7 +138,7 @@ def recreate_if_needed(output_path, kgo_path):
     if recreate_path.resolve() == kgo_path.resolve():
         print("KGO updated in place, rerunning this test should now pass")
     else:
-        print(f"Put the updated KGO file in {ACC_TEST_DIR} to make this"
+        print(f"Put the updated KGO file in {ACC_TEST_DIR_ENVVAR} to make this"
               f" test pass. For example:")
         quoted_kgo = shlex.quote(str(kgo_path))
         quoted_recreate = shlex.quote(str(recreate_path))

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -124,7 +124,10 @@ def recreate_if_needed(output_path, kgo_path):
     if not recreate_dir.is_absolute():
         raise IOError("Recreate KGO path is not absolute")
     print("Comparison found differences - recreating KGO for this test")
-    print(f"Original KGO file is at {kgo_path}")
+    if kgo_path.exists():
+        print(f"Original KGO file is at {kgo_path}")
+    else:
+        print("Original KGO file does not exist")
     kgo_relative = kgo_path.relative_to(kgo_root_dir)
     recreate_path = recreate_dir / kgo_relative
     recreate_path.parent.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
### Previous behaviour:
If the RECREATE_KGO environment variable is set (to any value), the KGO files get updated in place in IMPROVER_ACC_TEST_DIR. This arrangement had issues with symlinks to central KGO stores, as the overwrite would follow symlinks before writing.
The KGO update is done **before comparison** between test output and KGO, so tests that update KGOs will pass.

### New behaviour:
The RECREATE_KGO environment variable specifies a path where updated KGO files will be placed. This could be a new directory in order to easily identify and collect the updated files, or it could be the same directory as IMPROVER_ACC_TEST_DIR.
The KGO update is done **after comparison** between test output and KGO, so only missing KGOs or comparison failures now result in updated KGOs. Tests that result in updated KGOs will fail, with a printed message explaining what has been done and if anything needs to be done to make the test pass when re-running.
The destination file is removed before writing the updated KGO, so the result will always be a real file in the destination, rather than potentially following a symlink to another location.
If RECREATE_KGO points to the same location as IMPROVER_ACC_TEST_DIR, then the new KGO will NOT be written there. This is to reduce the chance of a developer doing something inappropriate.