### PR TITLE
Alter behaviour of estimate-emos-coefficients CLI when either historic forecasts or truths missing

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -256,7 +256,7 @@ def with_output(wrapped, *args, output=None, **kwargs):
     """
     from improver.utilities.save import save_netcdf
     result = wrapped(*args, **kwargs)
-    if output:
+    if result and output:
         save_netcdf(result, output)
         return
     return result

--- a/improver/cli/estimate_emos_coefficients.py
+++ b/improver/cli/estimate_emos_coefficients.py
@@ -106,8 +106,6 @@ def process(*cubes: cli.inputcube,
             An unexpected number of distinct cube names were passed in.
         RuntimeError:
             More than one cube was identified as a land-sea mask.
-        RuntimeError:
-            Missing truth or historical forecast in input cubes.
 
     """
 
@@ -149,7 +147,9 @@ def process(*cubes: cli.inputcube,
 
     missing_inputs = ' and '.join(k for k, v in grouped_cubes.items() if not v)
     if missing_inputs:
-        raise RuntimeError('Missing ' + missing_inputs + ' input.')
+        # If either historic forecasts or truths are missing do not estimate
+        # emos coefficients.
+        return
 
     truth = MergeCubes()(grouped_cubes['truth'])
     forecast = MergeCubes()(grouped_cubes['historical forecast'])

--- a/improver_tests/acceptance/test_estimate_emos_coefficients.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients.py
@@ -36,7 +36,6 @@ rather than by shell glob expansion. There are also a some directory globs
 which expand directory names in addition to filenames.
 """
 
-import os
 import pytest
 
 from . import acceptance as acc
@@ -187,7 +186,7 @@ def test_missing_dataset(tmp_path):
             "--truth-attribute", "mosg__model_configuration=uk_det",
             "--output", output_path]
     run_cli(args)
-    assert not os.path.isfile(output_path)
+    assert not output_path.is_file()
 
 
 def test_too_many_masks(tmp_path):

--- a/improver_tests/acceptance/test_estimate_emos_coefficients.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients.py
@@ -36,6 +36,7 @@ rather than by shell glob expansion. There are also a some directory globs
 which expand directory names in addition to filenames.
 """
 
+import os
 import pytest
 
 from . import acceptance as acc
@@ -185,8 +186,8 @@ def test_missing_dataset(tmp_path):
             "--cycletime", "20170605T0300Z",
             "--truth-attribute", "mosg__model_configuration=uk_det",
             "--output", output_path]
-    with pytest.raises(RuntimeError, match="Missing historical forecast"):
-        run_cli(args)
+    run_cli(args)
+    assert not os.path.isfile(output_path)
 
 
 def test_too_many_masks(tmp_path):


### PR DESCRIPTION
Description
Alter the behaviour when either the historic forecasts or truths are missing when estimating EMOS coefficients, so that in this case, nothing will be returned, rather than raising an error. This helps support routine running given that the apply-emos-coefficients CLI already supports the EMOS coefficients being optional.

This PR:
* Updates the estimate-emos-coefficients CLI so that if either the historic forecasts or truths are missing, then nothing is returned. This helps supports routine running during a spin-up period where multiple truths might exist without any historic forecasts available.
* Make a minor edit to `improver/cli/__init__.py` to support returning nothing, even if an output is specified.
* Test that no output file is created within the relevant CLI test.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

