### PR TITLE
Change non-float32 dtype enforcement

### DIFF
--- a/improver/cli/standardise.py
+++ b/improver/cli/standardise.py
@@ -49,7 +49,7 @@ def process(cube: cli.inputcube,
             coords_to_remove: cli.comma_separated_list = None,
             new_name: str = None,
             new_units: str = None,
-            fix_float64=False):
+            fix_float_dtypes=False):
     """Standardises a cube by one or more of regridding, updating meta-data etc
 
     Standardise a source cube. Available options are regridding (bi-linear or
@@ -102,10 +102,10 @@ def process(cube: cli.inputcube,
             Name of output cube.
         new_units (str):
             Units to convert to.
-        fix_float64 (bool):
-            If True, checks and fixes cube for float64 data. Without this
-            option an exception will be raised if float64 data is found but no
-            fix applied.
+        fix_float_dtypes (bool):
+            If True, checks and fixes cube floating point data to float32.
+            Without this option an exception will be raised if any floating
+            point data are found not to be float32 (and no fix is applied).
 
     Returns:
         iris.cube.Cube:
@@ -134,6 +134,6 @@ def process(cube: cli.inputcube,
     output_data = plugin.process(
         cube, target_grid, new_name=new_name, new_units=new_units,
         regridded_title=regridded_title, coords_to_remove=coords_to_remove,
-        attributes_dict=attributes_config, fix_float64=fix_float64)
+        attributes_dict=attributes_config, fix_float_dtypes=fix_float_dtypes)
 
     return output_data

--- a/improver/lapse_rate.py
+++ b/improver/lapse_rate.py
@@ -39,7 +39,7 @@ from scipy.ndimage import generic_filter
 
 from improver import BasePlugin
 from improver.constants import DALR
-from improver.metadata.check_datatypes import check_cube_not_float64
+from improver.metadata.check_datatypes import ensure_cube_floats_are_float32
 from improver.utilities.cube_checker import spatial_coords_match
 
 
@@ -370,7 +370,7 @@ class LapseRate(BasePlugin):
         temperature_cube.convert_units('K')
         orography_cube.convert_units('metres')
 
-        check_cube_not_float64(temperature_cube, fix=True)
+        ensure_cube_floats_are_float32(temperature_cube, fix=True)
 
         # Extract x/y co-ordinates.
         x_coord = temperature_cube.coord(axis='x').name()

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -42,7 +42,7 @@ from scipy.interpolate import griddata
 from improver import BasePlugin
 from improver.metadata.amend import amend_attributes
 from improver.metadata.check_datatypes import (
-    check_cube_not_float64, check_time_coordinate_metadata)
+    ensure_cube_floats_are_float32, check_time_coordinate_metadata)
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
 from improver.metadata.constants.mo_attributes import MOSG_GRID_ATTRIBUTES
 from improver.metadata.constants.time_types import (
@@ -269,7 +269,7 @@ class StandardiseGridAndMetadata(BasePlugin):
 
     def process(self, cube, target_grid=None, new_name=None, new_units=None,
                 regridded_title=None, coords_to_remove=None,
-                attributes_dict=None, fix_float64=False):
+                attributes_dict=None, fix_float_dtypes=False):
         """
         Perform regridding and metadata adjustments
 
@@ -294,8 +294,9 @@ class StandardiseGridAndMetadata(BasePlugin):
             attributes_dict (dict or None):
                 Optional dictionary of required attribute updates. Keys are
                 attribute names, and values are the required value or "remove".
-            fix_float64 (bool):
-                Flag to de-escalate float64 precision
+            fix_float_dtypes (bool):
+                Flag to ensure floating point dtypes are float32
+                (casting as necessary).
 
         Returns:
             iris.cube.Cube
@@ -324,7 +325,7 @@ class StandardiseGridAndMetadata(BasePlugin):
         if attributes_dict:
             amend_attributes(cube, attributes_dict)
 
-        check_cube_not_float64(cube, fix=fix_float64)
+        ensure_cube_floats_are_float32(cube, fix=fix_float_dtypes)
 
         return cube
 

--- a/improver/wind_calculations/wind_direction.py
+++ b/improver/wind_calculations/wind_direction.py
@@ -35,7 +35,7 @@ import numpy as np
 from iris.coords import CellMethod
 
 from improver import BasePlugin
-from improver.metadata.check_datatypes import check_cube_not_float64
+from improver.metadata.check_datatypes import ensure_cube_floats_are_float32
 from improver.nbhood.nbhood import NeighbourhoodProcessing
 from improver.utilities.cube_checker import check_cube_coordinates
 
@@ -427,7 +427,7 @@ class WindDirection(BasePlugin):
             raise ValueError(msg)
 
         # Demote input cube data and coords to float32 if float64
-        check_cube_not_float64(cube_ens_wdir, fix=True)
+        ensure_cube_floats_are_float32(cube_ens_wdir, fix=True)
 
         self.n_realizations = len(cube_ens_wdir.coord('realization').points)
         y_coord_name = cube_ens_wdir.coord(axis="y").name()

--- a/improver/wind_calculations/wind_downscaling.py
+++ b/improver/wind_calculations/wind_downscaling.py
@@ -40,7 +40,7 @@ from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
 from improver.constants import RMDI
-from improver.metadata.check_datatypes import check_cube_not_float64
+from improver.metadata.check_datatypes import ensure_cube_floats_are_float32
 
 # Scale parameter to determine reference height
 ABSOLUTE_CORRECTION_TOL = 0.04
@@ -674,7 +674,7 @@ class RoughnessCorrection(BasePlugin):
         for cube in [a_over_s_cube, sigma_cube, pporo_cube, modoro_cube,
                      z0_cube, height_levels_cube]:
             if cube is not None:
-                check_cube_not_float64(cube, fix=True)
+                ensure_cube_floats_are_float32(cube, fix=True)
 
         # Standard Python 'float' type is either single or double depending on
         # system and there is no reliable method of finding which from the
@@ -952,7 +952,7 @@ class RoughnessCorrection(BasePlugin):
         if not isinstance(input_cube, iris.cube.Cube):
             msg = "wind input is not a cube, but {}"
             raise TypeError(msg.format(type(input_cube)))
-        check_cube_not_float64(input_cube, fix=True)
+        ensure_cube_floats_are_float32(input_cube, fix=True)
         (self.x_name, self.y_name, self.z_name,
          self.t_name) = self.find_coord_names(input_cube)
         xwp, ywp, zwp, twp = self.find_coord_order(input_cube)

--- a/improver_tests/acceptance/test_standardise.py
+++ b/improver_tests/acceptance/test_standardise.py
@@ -121,13 +121,13 @@ def test_change_metadata(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-def test_fix_float64(tmp_path):
+def test_fix_float_dtypes(tmp_path):
     """Test conversion of float64 data to float32"""
     kgo_dir = acc.kgo_root() / "standardise/float64"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "float64_data.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, "--output", output_path, "--fix-float64"]
+    args = [input_path, "--output", output_path, "--fix-float-dtypes"]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -44,7 +44,7 @@ from iris.exceptions import CoordinateNotFoundError
 
 import improver.metadata.constants.time_types as ctt
 from improver.grids import GLOBAL_GRID_CCRS, STANDARD_GRID_CCRS
-from improver.metadata.check_datatypes import check_cube_not_float64
+from improver.metadata.check_datatypes import ensure_cube_floats_are_float32
 from improver.metadata.constants.mo_attributes import MOSG_GRID_DEFINITION
 from improver.metadata.forecast_times import forecast_period_coord
 
@@ -253,7 +253,7 @@ def set_up_variable_cube(data, name='air_temperature', units='K',
     cube.rename(name)
 
     # don't allow unit tests to set up invalid cubes
-    check_cube_not_float64(cube)
+    ensure_cube_floats_are_float32(cube)
 
     return cube
 

--- a/improver_tests/standardise/test_StandardiseGridAndMetadata.py
+++ b/improver_tests/standardise/test_StandardiseGridAndMetadata.py
@@ -161,10 +161,10 @@ class Test_process_no_regrid(IrisTest):
         self.assertNotIn(
             "forecast_period", [coord.name() for coord in result.coords()])
 
-    def test_fix_float64(self):
+    def test_fix_float_dtypes(self):
         """Test precision de-escalation"""
         self.cube.data = self.cube.data.astype(np.float64)
-        result = self.plugin.process(self.cube, fix_float64=True)
+        result = self.plugin.process(self.cube, fix_float_dtypes=True)
         self.assertEqual(result.data.dtype, np.float32)
 
 


### PR DESCRIPTION
Previously we had checks to make sure that the data in cubes were not float64 (explicitly), rather than checking that data were float32, which I believe is the behaviour we want to enforce.

I've refactored the code to ensure that any floating point data are treated as `float32` (`int`s are left unchanged, which will allow for integer fields, e.g: weather symbols).

(Noticed while working with radar coverage data for MONOW).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)   (added tests to show integer fields are unchanged)