### PR TITLE
IMPRO-1566 wet-bulb temperature accuracy

### DIFF
--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -117,6 +117,10 @@ class WetBulbTemperature(BasePlugin):
     The import also brings in attributes that describe the range of
     temperatures covered by the table and the increments in the table.
 
+    References:
+        Met Office UM Documentation Paper 080, UM Version 10.8,
+        last updated 2014-12-05.
+
     """
     def __init__(self, precision=0.005):
         """
@@ -257,10 +261,6 @@ class WetBulbTemperature(BasePlugin):
 
         Method from referenced UM documentation.
 
-        References:
-            Met Office UM Documentation Paper 080, UM Version 10.8,
-            last updated 2014-12-05.
-
         Args:
             mixing_ratio (numpy.ndarray):
                 Array of mixing ratios.
@@ -287,7 +287,8 @@ class WetBulbTemperature(BasePlugin):
         the correct units.
 
         A Newton iterator is used to minimise the gradient of enthalpy
-        against temperature.
+        against temperature. Assumes that the variation of latent heat with
+        temperature can be ignored.
 
         Args:
             pressure (numpy.ndarray):
@@ -341,8 +342,6 @@ class WetBulbTemperature(BasePlugin):
             # Update saturation mixing ratio and iterators
             saturation_mixing_ratio = self._calculate_mixing_ratio(
                 wbt_data, pressure)
-            mixing_ratio = relative_humidity * saturation_mixing_ratio
-            specific_heat = self._calculate_specific_heat(mixing_ratio)
 
             delta_wbt_prev = delta_wbt
             iteration += 1

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -323,7 +323,6 @@ class WetBulbTemperature(BasePlugin):
                 and iteration < self.maximum_iterations:
 
             if iteration > 0:
-                # Update saturation mixing ratio and iterators
                 saturation_mixing_ratio = self._calculate_mixing_ratio(
                     wbt_data, pressure)
 

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -341,6 +341,8 @@ class WetBulbTemperature(BasePlugin):
             # Update saturation mixing ratio and iterators
             saturation_mixing_ratio = self._calculate_mixing_ratio(
                 wbt_data, pressure)
+            mixing_ratio = relative_humidity * saturation_mixing_ratio
+            specific_heat = self._calculate_specific_heat(mixing_ratio)
 
             delta_wbt_prev = delta_wbt
             iteration += 1

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -102,7 +102,8 @@ class Test_WetBulbTemperature(IrisTest):
 
     def setUp(self):
         """Set up test input cubes and output data values."""
-        temperature = np.array([[185.0, 260.65, 273.15, 338.15]], dtype=np.float32)
+        temperature = np.array([[185.0, 260.65, 273.15, 338.15]],
+                               dtype=np.float32)
         self.temperature = set_up_variable_cube(temperature)
         humidity = np.array([[60., 70., 75., 80.]], dtype=np.float32)
         self.relative_humidity = set_up_variable_cube(

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -61,7 +61,7 @@ class Test_psychrometric_variables(IrisTest):
         """Test latent heat calculation"""
         expected = [2707271., 2530250., 2348900.]
         result = WetBulbTemperature()._calculate_latent_heat(self.temperature)
-        self.assertArrayAlmostEqual(result.data, expected)
+        self.assertArrayAlmostEqual(result.data, expected, decimal=0)
 
     def test_calculate_mixing_ratio(self):
         """Test mixing ratio calculation"""
@@ -69,14 +69,14 @@ class Test_psychrometric_variables(IrisTest):
         expected = [6.06744631e-08, 1.31079322e-03, 1.77063149e-01]
         result = WetBulbTemperature()._calculate_mixing_ratio(
             self.temperature, pressure)
-        self.assertArrayAlmostEqual(result, expected)
+        self.assertArrayAlmostEqual(result, expected, decimal=7)
 
     def test_calculate_specific_heat(self):
         """Test specific heat calculation"""
         expected = np.array([1089.5, 1174., 1258.5], dtype=np.float32)
         result = WetBulbTemperature()._calculate_specific_heat(
             self.mixing_ratio)
-        self.assertArrayAlmostEqual(result, expected)
+        self.assertArrayAlmostEqual(result, expected, decimal=2)
 
     def test_calculate_enthalpy(self):
         """Basic calculation of some enthalpies. Comparison adjusted for
@@ -102,19 +102,19 @@ class Test_WetBulbTemperature(IrisTest):
 
     def setUp(self):
         """Set up test input cubes and output data values."""
-        temperature = np.array([[185.0, 260.65, 338.15]], dtype=np.float32)
+        temperature = np.array([[185.0, 260.65, 273.15, 338.15]], dtype=np.float32)
         self.temperature = set_up_variable_cube(temperature)
-        humidity = np.array([[60., 70., 80.]], dtype=np.float32)
+        humidity = np.array([[60., 70., 75., 80.]], dtype=np.float32)
         self.relative_humidity = set_up_variable_cube(
             humidity, name='relative_humidity', units='%')
-        pressure = np.array([[1.E5, 9.9E4, 9.8E4]], dtype=np.float32)
+        pressure = np.array([[1.E5, 9.9E4, 9.85E4, 9.8E4]], dtype=np.float32)
         self.pressure = set_up_variable_cube(
             pressure, name='air_pressure', units='Pa')
-        mixing_ratio = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+        mixing_ratio = np.array([[0.1, 0.2, 0.25, 0.3]], dtype=np.float32)
         self.mixing_ratio = set_up_variable_cube(
             mixing_ratio, name='humidity_mixing_ratio', units='1')
         self.expected_wbt_data = np.array(
-            [[185.0, 259.88306, 333.96066]], dtype=np.float32)
+            [[185.0, 259.88306, 271.78006, 333.96066]], dtype=np.float32)
 
 
 class Test_create_wet_bulb_temperature_cube(Test_WetBulbTemperature):
@@ -133,7 +133,8 @@ class Test_create_wet_bulb_temperature_cube(Test_WetBulbTemperature):
         """Basic wet bulb temperature calculation."""
         result = WetBulbTemperature().create_wet_bulb_temperature_cube(
             self.temperature, self.relative_humidity, self.pressure)
-        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data)
+        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data,
+                                    decimal=3)
 
     def test_different_units(self):
         """Wet bulb temperature calculation with unit conversion."""
@@ -142,7 +143,8 @@ class Test_create_wet_bulb_temperature_cube(Test_WetBulbTemperature):
         self.pressure.convert_units('kPa')
         result = WetBulbTemperature().create_wet_bulb_temperature_cube(
             self.temperature, self.relative_humidity, self.pressure)
-        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data)
+        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data,
+                                    decimal=3)
         self.assertEqual(result.units, Unit('K'))
 
 
@@ -181,7 +183,8 @@ class Test_process(Test_WetBulbTemperature):
         level data."""
         result = WetBulbTemperature().process(
             self.temperature, self.relative_humidity, self.pressure)
-        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data)
+        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data,
+                                    decimal=3)
         self.assertEqual(result.units, Unit('K'))
 
     def test_values_multi_level(self):
@@ -192,8 +195,10 @@ class Test_process(Test_WetBulbTemperature):
         pressure = self._make_multi_level(self.pressure)
         result = WetBulbTemperature().process(
             temperature, relative_humidity, pressure)
-        self.assertArrayAlmostEqual(result.data[0], self.expected_wbt_data)
-        self.assertArrayAlmostEqual(result.data[1], self.expected_wbt_data)
+        self.assertArrayAlmostEqual(result.data[0], self.expected_wbt_data,
+                                    decimal=3)
+        self.assertArrayAlmostEqual(result.data[1], self.expected_wbt_data,
+                                    decimal=3)
         self.assertEqual(result.units, Unit('K'))
         self.assertArrayEqual(result.coord('height').points, [10, 20])
 


### PR DESCRIPTION
The result of an investigation into whether the iteration should include updates to the latent heat term as the temperature value is adjusted. See IMPRO-1566 for full details.

This ticket contains a commit where the iteration does include this update so that a notebook could be derived to see its impact. The impact is only significant where the relative humidity is low, which is unlikely to be where precipitation is falling, so will not have an adverse effect on the discrimination between snow, sleet and rain phases.

Testing:
 - [x] Ran tests and they passed OK
