### PR TITLE
IMPRO-1577: Fix use of positive attributes on height coordinate

### DIFF
--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -847,13 +847,12 @@ class WeightedBlendAcrossWholeDimension(BasePlugin):
 
         # Ensure input cube and weights cube are ordered equivalently along
         # blending coordinate.
-        cube = sort_coord_in_cube(cube, self.blend_coord, order="ascending")
+        cube = sort_coord_in_cube(cube, self.blend_coord)
         if weights is not None:
             if not weights.coords(self.blend_coord):
                 msg = 'Coordinate to be collapsed not found in weights cube.'
                 raise CoordinateNotFoundError(msg)
-            weights = sort_coord_in_cube(weights, self.blend_coord,
-                                         order="ascending")
+            weights = sort_coord_in_cube(weights, self.blend_coord)
 
         # Check that the time coordinate is single valued if required.
         self.check_compatible_time_points(cube)

--- a/improver/blending/weights.py
+++ b/improver/blending/weights.py
@@ -640,7 +640,7 @@ class ChooseDefaultWeightsNonLinear(BasePlugin):
             # make a copy of the input cube from which to calculate weights
             inverted_cube = cube.copy()
             inverted_cube = sort_coord_in_cube(
-                inverted_cube, coord_name, order="descending")
+                inverted_cube, coord_name, True)
             cube = inverted_cube
 
         weights = self.nonlinear_weights(len(cube.coord(coord_name).points))

--- a/improver/blending/weights.py
+++ b/improver/blending/weights.py
@@ -640,7 +640,7 @@ class ChooseDefaultWeightsNonLinear(BasePlugin):
             # make a copy of the input cube from which to calculate weights
             inverted_cube = cube.copy()
             inverted_cube = sort_coord_in_cube(
-                inverted_cube, coord_name, True)
+                inverted_cube, coord_name, descending=True)
             cube = inverted_cube
 
         weights = self.nonlinear_weights(len(cube.coord(coord_name).points))

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -1057,7 +1057,7 @@ class PhaseChangeLevel(BasePlugin):
         # Ensure the wet bulb integral cube's height coordinate is in
         # descending order
         wet_bulb_integral = sort_coord_in_cube(wet_bulb_integral, 'height',
-                                               True)
+                                               descending=True)
 
         # Find highest height from height bounds.
         height_bounds = wet_bulb_integral.coord('height').bounds

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -1057,7 +1057,7 @@ class PhaseChangeLevel(BasePlugin):
         # Ensure the wet bulb integral cube's height coordinate is in
         # descending order
         wet_bulb_integral = sort_coord_in_cube(wet_bulb_integral, 'height',
-                                               order='descending')
+                                               True)
 
         # Find highest height from height bounds.
         height_bounds = wet_bulb_integral.coord('height').bounds

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -724,10 +724,6 @@ def sort_coord_in_cube(cube, coord, order="ascending"):
     index[dim] = np.argsort(coord_to_sort.points)
     if order == "descending":
         index[dim] = index[dim][::-1]
-    if coord in ["height"] and order == "ascending":
-        cube.coord(coord).attributes["positive"] = "up"
-    elif coord in ["height"] and order == "descending":
-        cube.coord(coord).attributes["positive"] = "down"
     return cube[tuple(index)]
 
 

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -689,7 +689,7 @@ def build_coordinate(data, long_name=None,
     return crd_out
 
 
-def sort_coord_in_cube(cube, coord, order="ascending"):
+def sort_coord_in_cube(cube, coord, descending=False):
     """Sort a cube based on the ordering within the chosen coordinate.
     Sorting can either be in ascending or descending order.
     This code is based upon https://gist.github.com/pelson/9763057.
@@ -699,9 +699,8 @@ def sort_coord_in_cube(cube, coord, order="ascending"):
             The input cube to be sorted.
         coord (str):
             Name of the coordinate to be sorted.
-        order (str):
-            Choice of how to order the sorted coordinate.
-            Options are either "ascending" or "descending".
+        descending (bool):
+            If True it will be sorted in descending order.
 
     Returns:
         iris.cube.Cube:
@@ -722,7 +721,7 @@ def sort_coord_in_cube(cube, coord, order="ascending"):
     dim, = cube.coord_dims(coord_to_sort)
     index = [slice(None)] * cube.ndim
     index[dim] = np.argsort(coord_to_sort.points)
-    if order == "descending":
+    if descending:
         index[dim] = index[dim][::-1]
     return cube[tuple(index)]
 

--- a/improver/utilities/mathematical_operations.py
+++ b/improver/utilities/mathematical_operations.py
@@ -112,7 +112,7 @@ class Integration(BasePlugin):
         increasing_order = np.all(np.diff(cube.coord(coord_name).points) > 0)
 
         if increasing_order and direction == "negative":
-            cube = sort_coord_in_cube(cube, coord_name, True)
+            cube = sort_coord_in_cube(cube, coord_name, descending=True)
 
         if not increasing_order and direction == "positive":
             cube = sort_coord_in_cube(cube, coord_name)

--- a/improver/utilities/mathematical_operations.py
+++ b/improver/utilities/mathematical_operations.py
@@ -112,7 +112,7 @@ class Integration(BasePlugin):
         increasing_order = np.all(np.diff(cube.coord(coord_name).points) > 0)
 
         if increasing_order and direction == "negative":
-            cube = sort_coord_in_cube(cube, coord_name, order="descending")
+            cube = sort_coord_in_cube(cube, coord_name, True)
 
         if not increasing_order and direction == "positive":
             cube = sort_coord_in_cube(cube, coord_name)

--- a/improver_tests/psychrometric_calculations/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -573,7 +573,7 @@ class Test_process(IrisTest):
             coord_units='m', attributes=height_attribute)
         self.wet_bulb_integral_cube_inverted.data = wbti_data
         self.wet_bulb_integral_cube = sort_coord_in_cube(
-            self.wet_bulb_integral_cube_inverted, 'height', order='descending')
+            self.wet_bulb_integral_cube_inverted, 'height', True)
 
     def test_snow_sleet_phase_change(self):
         """Test that process returns a cube with the right name, units and

--- a/improver_tests/psychrometric_calculations/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -573,7 +573,7 @@ class Test_process(IrisTest):
             coord_units='m', attributes=height_attribute)
         self.wet_bulb_integral_cube_inverted.data = wbti_data
         self.wet_bulb_integral_cube = sort_coord_in_cube(
-            self.wet_bulb_integral_cube_inverted, 'height', True)
+            self.wet_bulb_integral_cube_inverted, 'height', descending=True)
 
     def test_snow_sleet_phase_change(self):
         """Test that process returns a cube with the right name, units and

--- a/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
+++ b/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
@@ -107,7 +107,7 @@ class Test_sort_coord_in_cube(IrisTest):
         expected_data = np.flip(self.data)
         coord_name = "height"
         result = sort_coord_in_cube(
-            self.ascending_cube, coord_name, True)
+            self.ascending_cube, coord_name, descending=True)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(self.descending_cube.coord_dims(coord_name),
                          result.coord_dims(coord_name))
@@ -136,7 +136,7 @@ class Test_sort_coord_in_cube(IrisTest):
         expected_data = self.data
         coord_name = "height"
         result = sort_coord_in_cube(
-            self.descending_cube, coord_name, True)
+            self.descending_cube, coord_name, descending=True)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(self.descending_cube.coord_dims(coord_name),
                          result.coord_dims(coord_name))
@@ -162,7 +162,7 @@ class Test_sort_coord_in_cube(IrisTest):
         expected_points = np.flip(self.ascending_cube.coord("latitude").points)
         coord_name = "latitude"
         result = sort_coord_in_cube(
-            self.ascending_cube, coord_name, True)
+            self.ascending_cube, coord_name, descending=True)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(
             self.ascending_cube.coord_dims(coord_name),
@@ -179,7 +179,7 @@ class Test_sort_coord_in_cube(IrisTest):
         coord_name = "latitude"
         self.ascending_cube.coord(coord_name).circular = True
         result = sort_coord_in_cube(
-            self.ascending_cube, coord_name, True)
+            self.ascending_cube, coord_name, descending=True)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
         warning_msg = "The latitude coordinate is circular."

--- a/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
+++ b/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
@@ -107,7 +107,7 @@ class Test_sort_coord_in_cube(IrisTest):
         expected_data = np.flip(self.data)
         coord_name = "height"
         result = sort_coord_in_cube(
-            self.ascending_cube, coord_name, order="descending")
+            self.ascending_cube, coord_name, True)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(self.descending_cube.coord_dims(coord_name),
                          result.coord_dims(coord_name))
@@ -136,7 +136,7 @@ class Test_sort_coord_in_cube(IrisTest):
         expected_data = self.data
         coord_name = "height"
         result = sort_coord_in_cube(
-            self.descending_cube, coord_name, order="descending")
+            self.descending_cube, coord_name, True)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(self.descending_cube.coord_dims(coord_name),
                          result.coord_dims(coord_name))
@@ -162,7 +162,7 @@ class Test_sort_coord_in_cube(IrisTest):
         expected_points = np.flip(self.ascending_cube.coord("latitude").points)
         coord_name = "latitude"
         result = sort_coord_in_cube(
-            self.ascending_cube, coord_name, order="descending")
+            self.ascending_cube, coord_name, True)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(
             self.ascending_cube.coord_dims(coord_name),
@@ -179,7 +179,7 @@ class Test_sort_coord_in_cube(IrisTest):
         coord_name = "latitude"
         self.ascending_cube.coord(coord_name).circular = True
         result = sort_coord_in_cube(
-            self.ascending_cube, coord_name, order="descending")
+            self.ascending_cube, coord_name, True)
         self.assertTrue(any(item.category == UserWarning
                             for item in warning_list))
         warning_msg = "The latitude coordinate is circular."

--- a/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
+++ b/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
@@ -80,9 +80,6 @@ class Test_sort_coord_in_cube(IrisTest):
         self.assertArrayAlmostEqual(
             self.ascending_height_points,
             result.coord(coord_name).points)
-        self.assertDictEqual(
-            self.ascending_cube.coord(coord_name).attributes,
-            {"positive": "up"})
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_auxcoord(self):
@@ -116,8 +113,6 @@ class Test_sort_coord_in_cube(IrisTest):
                          result.coord_dims(coord_name))
         self.assertArrayAlmostEqual(
             self.descending_height_points, result.coord(coord_name).points)
-        self.assertDictEqual(
-            result.coord(coord_name).attributes, {"positive": "down"})
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_descending_then_ascending(self):
@@ -132,8 +127,6 @@ class Test_sort_coord_in_cube(IrisTest):
                          result.coord_dims(coord_name))
         self.assertArrayAlmostEqual(
             self.ascending_height_points, result.coord(coord_name).points)
-        self.assertDictEqual(
-            result.coord(coord_name).attributes, {"positive": "up"})
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_descending_then_descending(self):
@@ -149,8 +142,6 @@ class Test_sort_coord_in_cube(IrisTest):
                          result.coord_dims(coord_name))
         self.assertArrayAlmostEqual(
             self.descending_height_points, result.coord(coord_name).points)
-        self.assertDictEqual(
-            result.coord(coord_name).attributes, {"positive": "down"})
         self.assertArrayAlmostEqual(result.data, expected_data)
 
     def test_latitude(self):

--- a/improver_tests/utilities/test_mathematical_operations.py
+++ b/improver_tests/utilities/test_mathematical_operations.py
@@ -58,7 +58,7 @@ def _set_up_height_cube(height_points, ascending=True):
     cube.data = data.astype(np.float32)
 
     if not ascending:
-        cube = sort_coord_in_cube(cube, "height", True)
+        cube = sort_coord_in_cube(cube, "height", descending=True)
         cube.coord("height").attributes["positive"] = "down"
 
     return cube

--- a/improver_tests/utilities/test_mathematical_operations.py
+++ b/improver_tests/utilities/test_mathematical_operations.py
@@ -58,7 +58,7 @@ def _set_up_height_cube(height_points, ascending=True):
     cube.data = data.astype(np.float32)
 
     if not ascending:
-        cube = sort_coord_in_cube(cube, "height", order="descending")
+        cube = sort_coord_in_cube(cube, "height", True)
         cube.coord("height").attributes["positive"] = "down"
 
     return cube


### PR DESCRIPTION
Fix use of positive attributes on height coordinate
Changed the use of a string that can be 2 options to use a bool instead.
It may be best to view via the two different commits.


Testing:
 - [x] Ran tests and they passed OK
