### PR TITLE
Run tests in Github actions via singularity container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,26 +3,12 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  Tests:
-
+  singularity:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: |
-        $CONDA/bin/conda env update -q --file environment.yml --name base
-        $CONDA/bin/pip install clize
-        $CONDA/bin/conda list --export
-
-    - name: Pycodestyle (PEP8 conventions)
-      run:  $CONDA/bin/pycodestyle -v improver improver_tests
-
-    - name: Sphinx-build (Doc test)
-      run: cd doc; make SPHINXBUILD=$CONDA/bin/sphinx-build html
-
-    - name: Pytest (Unit tests)
-      run:  $CONDA/bin/pytest -m "not acc"
-
-    - name: Pylint (More linting goodness)
-      run: $CONDA/bin/pylint -j 0 -E --rcfile=etc/pylintrc improver improver_tests
+    - run: |
+        apt install singularity-container
+        singularity build impr.sif singularity.def
+    - run: |
+        singularity exec impr.sif python -c 'import iris; print(iris.__version__)' 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,21 @@ jobs:
     - name: Pytest
       run: singularity exec impr.sif pytest
 
+  pycodestyle:
+    name: Pycodestyle
+    needs: singularity
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Container image cache
+      uses: actions/cache@v1
+      with:
+        path: imprsif
+        key: ${{ runner.os }}-${{ hashFiles('singularity.def') }}-${{ hashfiles('environment.yml') }}
+    - name: Container image setup
+      run: cat imprsif/sifpart* > impr.sif; rm -r imprsif
+    - name: Package installation
+      run: sudo apt-get install singularity-container
+    - name: Pytest
+      run: singularity exec impr.sif pycodestyle improver improver_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: |
-        apt install singularity-container
-        singularity build impr.sif singularity.def
+        sudo apt install singularity-container
+        sudo singularity build impr.sif singularity.def
     - run: |
         singularity exec impr.sif python -c 'import iris; print(iris.__version__)' 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,35 @@ jobs:
   singularity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - run: |
-        sudo apt install singularity-container
-        sudo singularity build impr.sif singularity.def
-    - run: |
-        singularity exec impr.sif python -c 'import iris; print(iris.__version__)' 
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Container image cache
+      uses: actions/cache@v1
+      with:
+        path: imprsif
+        key: ${{ runner.os }}-${{ hashFiles('singularity.def') }}-${{ hashfiles('environment.yml') }}
+    - name: Package installation
+      run: sudo apt-get install singularity-container
+    - name: Container build
+      run: sudo singularity build impr.sif singularity.def
+    - name: Container check
+      run: singularity exec impr.sif python -c 'import iris; print(iris.__version__)'
+    - name: Container image split
+      run: mkdir imprsif; split --bytes=100M impr.sif imprsif/sifpart; rm impr.sif
+  pytest:
+    needs: singularity
+    runs-on: ubuntu-latest
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Container image cache
+      uses: actions/cache@v1
+      with:
+        path: imprsif
+        key: ${{ runner.os }}-${{ hashFiles('singularity.def') }}-${{ hashfiles('environment.yml') }}
+    - name: Container image setup
+      run: cat imprsif/sifpart* > impr.sif; rm -r imprsif
+    - name: Package installation
+      run: sudo apt-get install singularity-container
+    - name: Pytest
+      run: singularity exec impr.sif pytest
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,9 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+
   singularity:
+    name: Singularity container build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -21,9 +23,12 @@ jobs:
       run: singularity exec impr.sif python -c 'import iris; print(iris.__version__)'
     - name: Container image split
       run: mkdir imprsif; split --bytes=100M impr.sif imprsif/sifpart; rm impr.sif
+
   pytest:
+    name: Pytest
     needs: singularity
     runs-on: ubuntu-latest
+    steps:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Container image cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Container image cache
+      id: sif-cache
       uses: actions/cache@v1
       with:
         path: imprsif
@@ -18,10 +19,13 @@ jobs:
     - name: Package installation
       run: sudo apt-get install singularity-container
     - name: Container build
+      if: steps.sif-cache.outputs.cache-hit != 'true'
       run: sudo singularity build impr.sif singularity.def
     - name: Container check
+      if: steps.sif-cache.outputs.cache-hit != 'true'
       run: singularity exec impr.sif python -c 'import iris; print(iris.__version__)'
     - name: Container image split
+      if: steps.sif-cache.outputs.cache-hit != 'true'
       run: mkdir imprsif; split --bytes=100M impr.sif imprsif/sifpart; rm impr.sif
 
   pytest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Package installation
       run: sudo apt-get install singularity-container
     - name: Sphinx
-      run: cd doc; singularity exec ../impr.sif sphinx-build html
+      run: cd doc; singularity exec ../impr.sif make html
 
   pylint:
     needs: singularity

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
 
   singularity:
-    name: Singularity container
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -30,7 +29,6 @@ jobs:
       run: mkdir imprsif; split --bytes=100M impr.sif imprsif/sifpart; rm impr.sif
 
   pytest:
-    name: Pytest
     needs: singularity
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +47,6 @@ jobs:
       run: singularity exec impr.sif pytest
 
   pycodestyle:
-    name: Pycodestyle
     needs: singularity
     runs-on: ubuntu-latest
     steps:
@@ -66,3 +63,39 @@ jobs:
       run: sudo apt-get install singularity-container
     - name: Pycodestyle
       run: singularity exec impr.sif pycodestyle improver improver_tests
+
+  sphinx:
+    needs: singularity
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Container image cache
+      uses: actions/cache@v1
+      with:
+        path: imprsif
+        key: ${{ runner.os }}-${{ hashFiles('singularity.def') }}-${{ hashfiles('environment.yml') }}
+    - name: Container image setup
+      run: cat imprsif/sifpart* > impr.sif; rm -r imprsif
+    - name: Package installation
+      run: sudo apt-get install singularity-container
+    - name: Sphinx
+      run: cd doc; singularity exec ../impr.sif sphinx-build html
+
+  pylint:
+    needs: singularity
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Container image cache
+      uses: actions/cache@v1
+      with:
+        path: imprsif
+        key: ${{ runner.os }}-${{ hashFiles('singularity.def') }}-${{ hashfiles('environment.yml') }}
+    - name: Container image setup
+      run: cat imprsif/sifpart* > impr.sif; rm -r imprsif
+    - name: Package installation
+      run: sudo apt-get install singularity-container
+    - name: Pylint
+      run: singularity exec impr.sif pylint -j 0 -E --rcfile=etc/pylintrc improver improver_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   singularity:
-    name: Singularity container build
+    name: Singularity container
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -17,6 +17,7 @@ jobs:
         path: imprsif
         key: ${{ runner.os }}-${{ hashFiles('singularity.def') }}-${{ hashfiles('environment.yml') }}
     - name: Package installation
+      if: steps.sif-cache.outputs.cache-hit != 'true'
       run: sudo apt-get install singularity-container
     - name: Container build
       if: steps.sif-cache.outputs.cache-hit != 'true'
@@ -63,5 +64,5 @@ jobs:
       run: cat imprsif/sifpart* > impr.sif; rm -r imprsif
     - name: Package installation
       run: sudo apt-get install singularity-container
-    - name: Pytest
+    - name: Pycodestyle
       run: singularity exec impr.sif pycodestyle improver improver_tests

--- a/singularity.def
+++ b/singularity.def
@@ -1,0 +1,85 @@
+Bootstrap: yum
+OSVersion: 7
+MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+Include: yum
+
+%post
+
+yum -y update
+yum -y install epel-release
+yum -y install \
+    autoconf automake \
+    cmake \
+    gcc gcc-c++ gcc-gfortran \
+    git \
+    make \
+    patch patchutils \
+    which
+yum -y install \
+    antlr antlr-C++ \
+    gsl gsl-devel \
+    hdf5 hdf5-devel \
+    curl libcurl-devel \
+    libgomp \
+    udunits2 udunits2-devel \
+    zlib-devel
+
+pushd /root
+
+NC_VERSION=4.7.3
+curl -L -O https://github.com/Unidata/netcdf-c/archive/v"${NC_VERSION}".tar.gz
+tar -xf v"${NC_VERSION}".tar.gz
+pushd netcdf-c-"${NC_VERSION}"
+./configure
+make -j8
+make install
+popd
+
+NCCMP_VERSION=1.8.5.0
+curl -L -O https://gitlab.com/remikz/nccmp/-/archive/"${NCCMP_VERSION}"/nccmp-"${NCCMP_VERSION}".tar.gz
+tar -xf nccmp-"${NCCMP_VERSION}".tar.gz
+pushd nccmp-"${NCCMP_VERSION}"
+./configure --with-netcdf=/root/netcdf-c-"${NC_VERSION}"
+make -j8
+make install
+popd
+
+rm -r nccmp-"${NCCMP_VERSION}".tar.gz nccmp-"${NCCMP_VERSION}"
+rm -r v"${NC_VERSION}".tar.gz netcdf-c-"${NC_VERSION}"
+ln -v -s /usr/local/lib/libnetcdf.* /usr/lib64
+popd
+
+cd /opt
+CONDA_BASE=https://repo.continuum.io/miniconda/Miniconda
+curl -L -o miniconda.sh ${CONDA_BASE}3-latest-Linux-x86_64.sh
+bash miniconda.sh -b -p /opt/conda
+rm miniconda.sh
+
+eval "$(/opt/conda/bin/conda shell.bash hook)"
+
+conda config --add channels defaults
+conda config --set always_yes yes --set changeps1 no
+conda config --set show_channel_urls True
+conda update --quiet conda
+
+conda install python=3.6
+conda install -c conda-forge iris=2.2 cftime=1.0.1 numpy=1.15.4
+conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 numpy=1.15.4 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage pytest
+pip install codacy-coverage codecov clize sigtools
+
+%test
+
+nc-config --all
+nccmp -V
+eval "$(/opt/conda/bin/conda shell.bash hook)"
+python -c 'import iris; print(iris.__version__)'
+
+%environment
+
+export PATH="/opt/conda/bin:$PATH"
+eval "$(/opt/conda/bin/conda shell.bash hook)"
+
+%help
+
+Container setup similar to the .travis.yml from IMPROVER repository
+but with nccmp tool added

--- a/singularity.def
+++ b/singularity.def
@@ -1,53 +1,15 @@
-Bootstrap: yum
-OSVersion: 7
-MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
-Include: yum
+Bootstrap: docker
+From: debian:10
+
+%files
+
+environment.yml /opt
 
 %post
 
-yum -y update
-yum -y install epel-release
-yum -y install \
-    autoconf automake \
-    cmake \
-    gcc gcc-c++ gcc-gfortran \
-    git \
-    make \
-    patch patchutils \
-    which
-yum -y install \
-    antlr antlr-C++ \
-    gsl gsl-devel \
-    hdf5 hdf5-devel \
-    curl libcurl-devel \
-    libgomp \
-    udunits2 udunits2-devel \
-    zlib-devel
-
-pushd /root
-
-NC_VERSION=4.7.3
-curl -L -O https://github.com/Unidata/netcdf-c/archive/v"${NC_VERSION}".tar.gz
-tar -xf v"${NC_VERSION}".tar.gz
-pushd netcdf-c-"${NC_VERSION}"
-./configure
-make -j8
-make install
-popd
-
-NCCMP_VERSION=1.8.5.0
-curl -L -O https://gitlab.com/remikz/nccmp/-/archive/"${NCCMP_VERSION}"/nccmp-"${NCCMP_VERSION}".tar.gz
-tar -xf nccmp-"${NCCMP_VERSION}".tar.gz
-pushd nccmp-"${NCCMP_VERSION}"
-./configure --with-netcdf=/root/netcdf-c-"${NC_VERSION}"
-make -j8
-make install
-popd
-
-rm -r nccmp-"${NCCMP_VERSION}".tar.gz nccmp-"${NCCMP_VERSION}"
-rm -r v"${NC_VERSION}".tar.gz netcdf-c-"${NC_VERSION}"
-ln -v -s /usr/local/lib/libnetcdf.* /usr/lib64
-popd
+apt update -y
+apt upgrade -y
+apt install -y git make bzip2 curl
 
 cd /opt
 CONDA_BASE=https://repo.continuum.io/miniconda/Miniconda
@@ -56,21 +18,13 @@ bash miniconda.sh -b -p /opt/conda
 rm miniconda.sh
 
 eval "$(/opt/conda/bin/conda shell.bash hook)"
-
-conda config --add channels defaults
-conda config --set always_yes yes --set changeps1 no
-conda config --set show_channel_urls True
-conda update --quiet conda
-
-conda install python=3.6
-conda install -c conda-forge iris=2.2 cftime=1.0.1 numpy=1.15.4
-conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 numpy=1.15.4 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage pytest
+conda update -n base -c defaults conda
+conda env update --name base --file /opt/environment.yml
 pip install codacy-coverage codecov clize sigtools
+conda clean -afy
 
 %test
 
-nc-config --all
-nccmp -V
 eval "$(/opt/conda/bin/conda shell.bash hook)"
 python -c 'import iris; print(iris.__version__)'
 
@@ -81,5 +35,4 @@ eval "$(/opt/conda/bin/conda shell.bash hook)"
 
 %help
 
-Container setup similar to the .travis.yml from IMPROVER repository
-but with nccmp tool added
+Container setup using conda and environment.yml from IMPROVER repository

--- a/singularity.def
+++ b/singularity.def
@@ -9,7 +9,7 @@ environment.yml /opt
 
 apt update -y
 apt upgrade -y
-apt install -y git make bzip2 curl
+apt install -y bash git make bzip2 curl
 
 cd /opt
 CONDA_BASE=https://repo.continuum.io/miniconda/Miniconda
@@ -18,20 +18,21 @@ bash miniconda.sh -b -p /opt/conda
 rm miniconda.sh
 
 eval "$(/opt/conda/bin/conda shell.bash hook)"
-conda update -n base -c defaults conda
-conda env update --name base --file /opt/environment.yml
+conda env create --name impr --file /opt/environment.yml
+conda activate impr
 pip install codacy-coverage codecov clize sigtools
 conda clean -afy
 
 %test
 
 eval "$(/opt/conda/bin/conda shell.bash hook)"
+conda activate impr
 python -c 'import iris; print(iris.__version__)'
 
 %environment
 
-export PATH="/opt/conda/bin:$PATH"
 eval "$(/opt/conda/bin/conda shell.bash hook)"
+conda activate impr
 
 %help
 

--- a/singularity.def
+++ b/singularity.def
@@ -7,9 +7,9 @@ environment.yml /opt
 
 %post
 
-apt update -y
-apt upgrade -y
-apt install -y bash git make bzip2 curl
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y bash git make bzip2 curl
 
 cd /opt
 CONDA_BASE=https://repo.continuum.io/miniconda/Miniconda


### PR DESCRIPTION
This PR adds a [Singularity container recipe](https://sylabs.io/guides/2.6/user-guide/) for IMPROVER and its dependencies, builds that container on Github actions and uses the container to run the test suite.

The container build is [cached](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows) so that it will not need to be rebuilt for each test run, unless the Singularity or Conda configuration is changed. The tests are run in parallel using multiple Github actions jobs, so that the total time to complete the test suite is reduced.

The singularity container is intended as a way for contributors to easily set up an environment for running IMPROVER, which will help address issues #883 and #888. It would still be nice to make IMPROVER installable as a package via pip and/or conda in the future.
As the singularity container is used for running the test suite, if there are issues with missing dependencies in the conda `environment.yml` or the Singularity container, this should be quickly noticed and fixed.

Testing:
 - [x] Ran tests and they passed OK