### PR TITLE
Add work-around to sleet-probability code

### DIFF
--- a/improver/calculate_sleet_prob.py
+++ b/improver/calculate_sleet_prob.py
@@ -30,8 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """A plugin to calculate probability of sleet"""
 
-import numpy as np
 import warnings
+import numpy as np
 
 from improver.metadata.utilities import (
     create_new_diagnostic_cube, generate_mandatory_attributes)

--- a/improver/calculate_sleet_prob.py
+++ b/improver/calculate_sleet_prob.py
@@ -31,13 +31,15 @@
 """A plugin to calculate probability of sleet"""
 
 import numpy as np
+import warnings
 
 from improver.metadata.utilities import (
     create_new_diagnostic_cube, generate_mandatory_attributes)
 
 
 def calculate_sleet_probability(prob_of_snow,
-                                prob_of_rain):
+                                prob_of_rain,
+                                ignore_mismatch=False):
     """
     This calculates the probability of sleet using the calculation:
     prob(sleet) = 1 - (prob(snow) + prob(rain))
@@ -48,6 +50,10 @@ def calculate_sleet_probability(prob_of_snow,
 
       prob_of_rain (iris.cube.Cube):
         Cube of the probability of rain.
+
+      ignore_mismatch (bool):
+        If set, errors relating to mismatches in the rain and snow data
+        are demoted to warnings.
 
     Returns:
       iris.cube.Cube:
@@ -60,8 +66,12 @@ def calculate_sleet_probability(prob_of_snow,
     ones = np.ones((prob_of_snow.shape), dtype="float32")
     sleet_prob = (ones - (prob_of_snow.data + prob_of_rain.data))
     if np.any(sleet_prob < 0.0):
-        msg = ("Negative values of sleet probability have been calculated.")
-        raise ValueError(msg)
+        msg = "Negative values of sleet probability have been calculated."
+        if ignore_mismatch:
+            sleet_prob = sleet_prob.clip(0., 1.)
+            warnings.warn(msg)
+        else:
+            raise ValueError(msg)
 
 # In this case we want to copy all the attributes from the prob_of_snow cube
     mandatory_attributes = generate_mandatory_attributes([

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -39,7 +39,7 @@ from improver import cli
 def process(snow: cli.inputcube,
             rain: cli.inputcube,
             *,
-            ignore_mismatch: bool = False):
+            ignore_mismatch=False):
     """Calculate sleet probability.
 
     Calculates the sleet probability using the

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -37,7 +37,9 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(snow: cli.inputcube,
-            rain: cli.inputcube):
+            rain: cli.inputcube,
+            *,
+            ignore_mismatch: bool = False):
     """Calculate sleet probability.
 
     Calculates the sleet probability using the
@@ -48,6 +50,9 @@ def process(snow: cli.inputcube,
             An iris Cube of the probability of snow.
         rain (iris.cube.Cube):
             An iris Cube of the probability of rain.
+        ignore_mismatch (bool):
+            If set, errors relating to mismatches in the rain and snow data
+            are demoted to warnings.
 
 
     Returns:
@@ -56,5 +61,6 @@ def process(snow: cli.inputcube,
     """
 
     from improver.calculate_sleet_prob import calculate_sleet_probability
-    result = calculate_sleet_probability(snow, rain)
+    result = calculate_sleet_probability(snow, rain,
+                                         ignore_mismatch=ignore_mismatch)
     return result

--- a/improver_tests/acceptance/test_sleet_probability.py
+++ b/improver_tests/acceptance/test_sleet_probability.py
@@ -51,3 +51,19 @@ def test_basic(tmp_path):
     args = [half_input_path, tenth_input_path, "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
+
+
+def test_sleet_warning(tmp_path):
+    """Test basic snow falling level calculation. When the warning is no
+    longer produced, the ignore-mismatch argument is deprecated and should be
+    removed."""
+    kgo_dir = acc.kgo_root() / "sleet_probability/warning"
+    kgo_path = kgo_dir / "kgo.nc"
+    output_path = tmp_path / "output.nc"
+    snow_input_path = kgo_dir / "snow.nc"
+    rain_input_path = kgo_dir / "rain.nc"
+    args = [snow_input_path, rain_input_path, "--ignore-mismatch",
+            "--output", output_path]
+    with pytest.warns(UserWarning, match="Negative values of sleet prob"):
+        run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/calculate_sleet_prob/test_calculate_sleet_probability.py
+++ b/improver_tests/calculate_sleet_prob/test_calculate_sleet_probability.py
@@ -36,6 +36,7 @@ import numpy as np
 from iris.tests import IrisTest
 
 from improver.calculate_sleet_prob import calculate_sleet_probability
+from improver.utilities.warnings_handler import ManageWarnings
 
 from ..set_up_test_cubes import set_up_probability_cube
 
@@ -97,6 +98,28 @@ class Test_calculate_sleet_probability(IrisTest):
         msg = "Negative values of sleet probability have been calculated."
         with self.assertRaisesRegex(ValueError, msg):
             calculate_sleet_probability(rain, high_prob)
+
+    @ManageWarnings(record=True)
+    def test_negative_values_warning(self, warning_list=None):
+        """Test that a warning is issued for negative values of
+        probability_of_sleet in the cube."""
+        rain = self.rain_prob_cube
+        high_prob = self.high_prob_cube
+        msg = "Negative values of sleet probability have been calculated."
+
+        result = calculate_sleet_probability(rain, high_prob,
+                                             ignore_mismatch=True)
+        self.assertTrue(any(item.category == UserWarning
+                            for item in warning_list))
+        self.assertTrue(any(msg in str(item)
+                            for item in warning_list))
+        expected_result = np.array([[[0.0, 0.2, 0.0],
+                                     [0.2, 0.0, 0.0],
+                                     [0.0, 0.0, 0.0]],
+                                    [[0.0, 0.2, 0.0],
+                                     [0.2, 0.0, 0.0],
+                                     [0.0, 0.0, 0.0]]], dtype=np.float32)
+        self.assertArrayAlmostEqual(result.data, expected_result)
 
     def test_name_of_cube(self):
         """Test that the name has been changed to sleet_probability"""


### PR DESCRIPTION
Adds optional argument to demote snow-rain mismatch errors to warnings and sets sleet to zero in these cases so that we can run the new sleet-chains while a separate investigation is undertaken to fix the underlying science.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)