### PR TITLE
Speed up command line help

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -292,9 +292,8 @@ def clizefy(obj=None, helper_class=DocutilizeClizeHelp, **kwargs):
     if hasattr(obj, 'cli'):
         return obj
     if not callable(obj):
-        kwargs.pop('helper_class', None)
         return Clize.get_cli(obj, **kwargs)
-    return Clize.keep(obj, **kwargs)
+    return Clize.keep(obj, helper_class=helper_class, **kwargs)
 
 
 # help command

--- a/improver/cli/compare.py
+++ b/improver/cli/compare.py
@@ -33,7 +33,7 @@
 
 
 from improver import cli
-from improver.utilities.compare import DEFAULT_TOLERANCE
+from improver.constants import DEFAULT_TOLERANCE
 
 
 @cli.clizefy

--- a/improver/cli/wxcode.py
+++ b/improver/cli/wxcode.py
@@ -39,12 +39,12 @@ def _extend_help(fn):
     # (and gets executed at import time)
     from improver.wxcode.utilities import interrogate_decision_tree
     for wxtree in ('high_resolution', 'global'):
-        title = wxtree.title().replace('_', ' ') + ' tree inputs'
-        inputs = interrogate_decision_tree(wxtree).replace('\n', '\n    ')
+        title = wxtree.capitalize().replace('_', ' ') + ' tree inputs'
+        inputs = interrogate_decision_tree(wxtree).replace('\n', '\n        ')
         tree_help = f"""
-{title}:
+    {title}::
 
-    {inputs}
+        {inputs}
     """
         fn.__doc__ += tree_help
     return fn
@@ -62,8 +62,7 @@ def process(*cubes: cli.inputcube,
             A cubelist containing the diagnostics required for the
             weather symbols decision tree, these at co-incident times.
         wxtree (str):
-            Weather Code tree.
-            Choices are high_resolution or global.
+            Weather Code tree: high_resolution or global.
 
     Returns:
         iris.cube.Cube:

--- a/improver/constants.py
+++ b/improver/constants.py
@@ -30,6 +30,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module to contain generally useful constants."""
 
+# Cube comparison tolerances
+TIGHT_TOLERANCE = 1e-5
+DEFAULT_TOLERANCE = 1e-4
+LOOSE_TOLERANCE = 1e-3
 
 # Real Missing Data Indicator
 RMDI = -32767.0

--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -47,9 +47,11 @@ or raise an appropriate exception.
 import netCDF4
 import numpy as np
 
-TIGHT_TOLERANCE = 1e-5
-DEFAULT_TOLERANCE = 1e-4
-LOOSE_TOLERANCE = 1e-3
+from improver.constants import (
+    TIGHT_TOLERANCE,
+    DEFAULT_TOLERANCE,
+    LOOSE_TOLERANCE,
+)
 
 
 def compare_netcdfs(actual_path, desired_path, rtol, atol,

--- a/improver/wxcode/utilities.py
+++ b/improver/wxcode/utilities.py
@@ -198,22 +198,19 @@ def interrogate_decision_tree(wxtree):
 
     # Diagnostic names and threshold values.
     requirements = {}
-
     for query in queries.values():
         diagnostics = expand_nested_lists(query, 'diagnostic_fields')
         thresholds = expand_nested_lists(query, 'diagnostic_thresholds')
         for diagnostic, threshold in zip(diagnostics, thresholds):
-            unique_thresholds = requirements.setdefault(diagnostic, [])
-            if threshold not in unique_thresholds:
-                unique_thresholds.append(threshold)
+            requirements.setdefault(diagnostic, set()).add(threshold)
 
     # Create a list of formatted strings that will be printed as part of the
     # CLI help.
     output = []
-    for requirement, unique_thresholds in sorted(requirements.items()):
-        units, = set(u for (_, u) in unique_thresholds)  # enforces same units
-        thresh_str = ', '.join(str(v) for (v, _) in unique_thresholds)
-        output.append('{} ({}) at: {}'.format(requirement, units, thresh_str))
+    for requirement, uniq_thresh in sorted(requirements.items()):
+        units, = set(u for (_, u) in uniq_thresh)  # enforces same units
+        thresh_str = ', '.join(map(str, sorted(v for (v, _) in uniq_thresh)))
+        output.append('{} ({}): {}'.format(requirement, units, thresh_str))
 
     n_files = len(output)
     formatted_string = ('{}\n'*n_files)

--- a/improver/wxcode/wxcode_decision_tree.py
+++ b/improver/wxcode/wxcode_decision_tree.py
@@ -30,8 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing weather symbol decision tree"""
 
-from iris.coords import AuxCoord
-
 # Start node for the high resolution wxcode decision tree.
 START_NODE = 'lightning'
 
@@ -90,7 +88,7 @@ def wxcode_decision_tree():
             'diagnostic_fields':
                 ['probability_of_number_of_lightning_flashes_'
                  'per_unit_area_in_vicinity_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.0, units="m-2")],
+            'diagnostic_thresholds': [(0.0, "m-2")],
             'diagnostic_conditions': ['above']},
 
         'lightning_cloud': {
@@ -101,7 +99,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'heavy_precipitation': {
@@ -113,8 +111,8 @@ def wxcode_decision_tree():
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
                  'probability_of_lwe_snowfall_rate_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1'),
-                                      AuxCoord(1.0, units='mm hr-1')],
+            'diagnostic_thresholds': [(1.0, 'mm hr-1'),
+                                      (1.0, 'mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
 
         'heavy_precipitation_cloud': {
@@ -125,7 +123,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'heavy_sleet_continuous': {
@@ -140,10 +138,10 @@ def wxcode_decision_tree():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')],
-                                      [AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')],
+                                      [(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -159,10 +157,10 @@ def wxcode_decision_tree():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')],
-                                      [AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')],
+                                      [(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -176,8 +174,8 @@ def wxcode_decision_tree():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above']]},
 
         'heavy_rain_or_snow_shower': {
@@ -190,8 +188,8 @@ def wxcode_decision_tree():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above']]},
 
         'light_precipitation': {
@@ -203,8 +201,8 @@ def wxcode_decision_tree():
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
                  'probability_of_lwe_snowfall_rate_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.1, units='mm hr-1'),
-                                      AuxCoord(0.1, units='mm hr-1')],
+            'diagnostic_thresholds': [(0.1, 'mm hr-1'),
+                                      (0.1, 'mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
 
         'light_precipitation_cloud': {
@@ -215,7 +213,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'light_sleet_continuous': {
@@ -230,10 +228,10 @@ def wxcode_decision_tree():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')],
-                                      [AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')],
+                                      [(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -247,8 +245,8 @@ def wxcode_decision_tree():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': ['above', 'above']},
 
         'light_sleet_shower': {
@@ -263,10 +261,10 @@ def wxcode_decision_tree():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')],
-                                      [AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')],
+                                      [(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -280,8 +278,8 @@ def wxcode_decision_tree():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': ['above', 'above']},
 
         'drizzle_mist': {
@@ -293,8 +291,8 @@ def wxcode_decision_tree():
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
                  'probability_of_visibility_in_air_below_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
-                                      AuxCoord(5000., units='m')],
+            'diagnostic_thresholds': [(0.03, 'mm hr-1'),
+                                      (5000., 'm')],
             'diagnostic_conditions': ['above', 'below']},
 
         'drizzle_cloud': {
@@ -307,8 +305,8 @@ def wxcode_decision_tree():
                 ['probability_of_rainfall_rate_above_threshold',
                  ('probability_of_low_type_cloud_area_fraction_'
                   'above_threshold')],
-            'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
-                                      AuxCoord(0.85, units=1)],
+            'diagnostic_thresholds': [(0.03, 'mm hr-1'),
+                                      (0.85, 1)],
             'diagnostic_conditions': ['above', 'above']},
 
         'no_precipitation_cloud': {
@@ -319,7 +317,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'overcast_cloud': {
@@ -331,7 +329,7 @@ def wxcode_decision_tree():
             'diagnostic_fields':
                 [('probability_of_low_type_cloud_area_fraction_'
                   'above_threshold')],
-            'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
+            'diagnostic_thresholds': [(0.85, 1)],
             'diagnostic_conditions': ['above']},
 
         'partly_cloudy': {
@@ -342,7 +340,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.1875, units=1)],
+            'diagnostic_thresholds': [(0.1875, 1)],
             'diagnostic_conditions': ['above']},
 
         'precipitation_in_vicinity': {
@@ -355,8 +353,8 @@ def wxcode_decision_tree():
                 'probability_of_rainfall_rate_in_vicinity_above_threshold',
                 'probability_of_lwe_snowfall_rate_in_vicinity_'
                 'above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.1, units='mm hr-1'),
-                                      AuxCoord(0.1, units='mm hr-1')],
+            'diagnostic_thresholds': [(0.1, 'mm hr-1'),
+                                      (0.1, 'mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
 
         'sleet_in_vicinity': {
@@ -373,10 +371,10 @@ def wxcode_decision_tree():
                  'probability_of_lwe_snowfall_rate_in_vicinity_'
                  'above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')],
-                                      [AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')],
+                                      [(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -391,8 +389,8 @@ def wxcode_decision_tree():
                  'above_threshold',
                  'probability_of_rainfall_rate_in_vicinity_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': ['above', 'above']},
 
         'snow_in_vicinity_cloud': {
@@ -403,7 +401,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'heavy_snow_continuous_in_vicinity': {
@@ -415,7 +413,7 @@ def wxcode_decision_tree():
             'diagnostic_fields': [
                 'probability_of_lwe_snowfall_rate_in_vicinity_'
                 'above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
+            'diagnostic_thresholds': [(1.0, 'mm hr-1')],
             'diagnostic_conditions': ['above']},
 
         'heavy_snow_shower_in_vicinity': {
@@ -427,7 +425,7 @@ def wxcode_decision_tree():
             'diagnostic_fields': [
                 'probability_of_lwe_snowfall_rate_in_vicinity_'
                 'above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
+            'diagnostic_thresholds': [(1.0, 'mm hr-1')],
             'diagnostic_conditions': ['above']},
 
         'rain_in_vicinity_cloud': {
@@ -438,7 +436,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'heavy_rain_continuous_in_vicinity': {
@@ -449,7 +447,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields': [
                 'probability_of_rainfall_rate_in_vicinity_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
+            'diagnostic_thresholds': [(1.0, 'mm hr-1')],
             'diagnostic_conditions': ['above']},
 
         'heavy_rain_shower_in_vicinity': {
@@ -460,7 +458,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields': [
                 'probability_of_rainfall_rate_in_vicinity_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1')],
+            'diagnostic_thresholds': [(1.0, 'mm hr-1')],
             'diagnostic_conditions': ['above']},
 
         'mist_conditions': {
@@ -471,7 +469,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_visibility_in_air_below_threshold'],
-            'diagnostic_thresholds': [AuxCoord(5000., units='m')],
+            'diagnostic_thresholds': [(5000., 'm')],
             'diagnostic_conditions': ['below']},
 
         'fog_conditions': {
@@ -482,7 +480,7 @@ def wxcode_decision_tree():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_visibility_in_air_below_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1000., units='m')],
+            'diagnostic_thresholds': [(1000., 'm')],
             'diagnostic_conditions': ['below']},
     }
 

--- a/improver/wxcode/wxcode_decision_tree_global.py
+++ b/improver/wxcode/wxcode_decision_tree_global.py
@@ -30,8 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing weather symbol decision tree for Global data"""
 
-from iris.coords import AuxCoord
-
 # Start node for the Global wxcode decision tree.
 START_NODE_GLOBAL = 'heavy_precipitation'
 
@@ -85,8 +83,8 @@ def wxcode_decision_tree_global():
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
                  'probability_of_lwe_snowfall_rate_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1.0, units='mm hr-1'),
-                                      AuxCoord(1.0, units='mm hr-1')],
+            'diagnostic_thresholds': [(1.0, 'mm hr-1'),
+                                      (1.0, 'mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
 
         'heavy_precipitation_cloud': {
@@ -97,7 +95,7 @@ def wxcode_decision_tree_global():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'heavy_sleet_continuous': {
@@ -112,10 +110,10 @@ def wxcode_decision_tree_global():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')],
-                                      [AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')],
+                                      [(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -131,10 +129,10 @@ def wxcode_decision_tree_global():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')],
-                                      [AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')],
+                                      [(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -148,8 +146,8 @@ def wxcode_decision_tree_global():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above']]},
 
         'heavy_rain_or_snow_shower': {
@@ -162,8 +160,8 @@ def wxcode_decision_tree_global():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(1.0, units='mm hr-1'),
-                                       AuxCoord(1.0, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(1.0, 'mm hr-1'),
+                                       (1.0, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above']]},
 
         'light_precipitation': {
@@ -175,8 +173,8 @@ def wxcode_decision_tree_global():
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
                  'probability_of_lwe_snowfall_rate_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.1, units='mm hr-1'),
-                                      AuxCoord(0.1, units='mm hr-1')],
+            'diagnostic_thresholds': [(0.1, 'mm hr-1'),
+                                      (0.1, 'mm hr-1')],
             'diagnostic_conditions': ['above', 'above']},
 
         'light_precipitation_cloud': {
@@ -187,7 +185,7 @@ def wxcode_decision_tree_global():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'light_sleet_continuous': {
@@ -202,10 +200,10 @@ def wxcode_decision_tree_global():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')],
-                                      [AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')],
+                                      [(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -219,8 +217,8 @@ def wxcode_decision_tree_global():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': ['above', 'above']},
 
         'light_sleet_shower': {
@@ -235,10 +233,10 @@ def wxcode_decision_tree_global():
                  ['probability_of_rainfall_rate_above_threshold',
                   'probability_of_lwe_snowfall_rate_above_threshold']],
             'diagnostic_gamma': [0.7, 1.0],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')],
-                                      [AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')],
+                                      [(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': [['above', 'above'],
                                       ['above', 'above']]},
 
@@ -252,8 +250,8 @@ def wxcode_decision_tree_global():
                 [['probability_of_lwe_snowfall_rate_above_threshold',
                   'probability_of_rainfall_rate_above_threshold']],
             'diagnostic_gamma': [1.],
-            'diagnostic_thresholds': [[AuxCoord(0.1, units='mm hr-1'),
-                                       AuxCoord(0.1, units='mm hr-1')]],
+            'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
+                                       (0.1, 'mm hr-1')]],
             'diagnostic_conditions': ['above', 'above']},
 
         'drizzle_mist': {
@@ -265,8 +263,8 @@ def wxcode_decision_tree_global():
             'diagnostic_fields':
                 ['probability_of_rainfall_rate_above_threshold',
                  'probability_of_visibility_in_air_below_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
-                                      AuxCoord(5000., units='m')],
+            'diagnostic_thresholds': [(0.03, 'mm hr-1'),
+                                      (5000., 'm')],
             'diagnostic_conditions': ['above', 'below']},
 
         'drizzle_cloud': {
@@ -279,8 +277,8 @@ def wxcode_decision_tree_global():
                 ['probability_of_rainfall_rate_above_threshold',
                  ('probability_of_low_type_cloud_area_fraction_'
                   'above_threshold')],
-            'diagnostic_thresholds': [AuxCoord(0.03, units='mm hr-1'),
-                                      AuxCoord(0.85, units=1)],
+            'diagnostic_thresholds': [(0.03, 'mm hr-1'),
+                                      (0.85, 1)],
             'diagnostic_conditions': ['above', 'above']},
 
         'no_precipitation_cloud': {
@@ -291,7 +289,7 @@ def wxcode_decision_tree_global():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.8125, units=1)],
+            'diagnostic_thresholds': [(0.8125, 1)],
             'diagnostic_conditions': ['above']},
 
         'overcast_cloud': {
@@ -303,7 +301,7 @@ def wxcode_decision_tree_global():
             'diagnostic_fields':
                 [('probability_of_low_type_cloud_area_fraction_'
                   'above_threshold')],
-            'diagnostic_thresholds': [AuxCoord(0.85, units=1)],
+            'diagnostic_thresholds': [(0.85, 1)],
             'diagnostic_conditions': ['above']},
 
         'partly_cloudy': {
@@ -314,7 +312,7 @@ def wxcode_decision_tree_global():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_cloud_area_fraction_above_threshold'],
-            'diagnostic_thresholds': [AuxCoord(0.1875, units=1)],
+            'diagnostic_thresholds': [(0.1875, 1)],
             'diagnostic_conditions': ['above']},
 
         'mist_conditions': {
@@ -325,7 +323,7 @@ def wxcode_decision_tree_global():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_visibility_in_air_below_threshold'],
-            'diagnostic_thresholds': [AuxCoord(5000., units='m')],
+            'diagnostic_thresholds': [(5000., 'm')],
             'diagnostic_conditions': ['below']},
 
         'fog_conditions': {
@@ -336,7 +334,7 @@ def wxcode_decision_tree_global():
             'condition_combination': '',
             'diagnostic_fields':
                 ['probability_of_visibility_in_air_below_threshold'],
-            'diagnostic_thresholds': [AuxCoord(1000., units='m')],
+            'diagnostic_thresholds': [(1000., 'm')],
             'diagnostic_conditions': ['below']},
     }
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -35,9 +35,16 @@ from unittest.mock import patch
 
 import improver
 from improver.cli import (
-    create_constrained_inputcubelist_converter, docutilize, inputcube,
-    inputjson, maybe_coerce_with, unbracket, with_intermediate_output,
-    with_output)
+    clizefy,
+    create_constrained_inputcubelist_converter,
+    docutilize,
+    inputcube,
+    inputjson,
+    maybe_coerce_with,
+    unbracket,
+    with_intermediate_output,
+    with_output,
+)
 from improver.utilities.load import load_cube
 
 
@@ -198,6 +205,26 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         m.assert_any_call(load_cube, "foo", constraints='wind_speed')
         m.assert_any_call(load_cube, "foo", constraints='wind_from_direction')
         self.assertEqual(m.call_count, 2)
+
+
+class Test_clizefy(unittest.TestCase):
+    """Test the clizefy decorator function"""
+
+    @patch('improver.cli.docutilize', return_value=None)
+    def test_basic(self, m):
+        """Tests basic behaviour"""
+
+        def func():
+            """Dummy"""
+
+        clizefied = clizefy(func)
+        self.assertIs(func, clizefied)
+        self.assertTrue(hasattr(clizefied, 'cli'))
+        clizefied_cli = clizefied.cli
+        clizefied_again = clizefy()(clizefied)
+        self.assertIs(clizefied_cli, clizefied_again.cli)
+        clizefied_cli('argv[0]', '--help')
+        m.assert_called_with(func.__doc__)
 
 
 class Test_unbracket(unittest.TestCase):


### PR DESCRIPTION
Speed up command line help by avoiding importing heavy modules and reinstate Google docstring processing after #1101 broke it.

| command | master[*] | this branch |
|-|:-:|:-:|
| `improver help` | 4.438s | 2.977s |
| `improver help wxcode` | 2.733s | 1.257s |

[*] after applying fix to `clizefy` from this PR.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for fixed bug