### PR TITLE
Updates pycodestyle to 2.4.0 in line with default-current

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ install:
   - conda install -c conda-forge iris=2.2 cftime=1.0.1 numpy=1.15.4
 
   # Install our own extra dependencies (+ filelock for Iris test).
-  - conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 numpy=1.15.4 pycodestyle=2.3.1 pylint=2.1.1 pandas=0.23.4 python-stratify=0.1 sphinx=1.8.1 coverage pytest pytest-cov
+  - conda install -c conda-forge astroid=2.1.0 filelock mock netcdf4=1.4.1 numpy=1.15.4 pycodestyle=2.4.0 pylint=2.1.1 pandas=0.23.4 python-stratify=0
+  .1 sphinx=1.8.1 coverage pytest pytest-cov
   - pip install codacy-coverage codecov clize sigtools
 
   # List the name and version of all the dependencies within the conda environment.

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -398,7 +398,7 @@ def execute_command(dispatcher, prog_name, *args,
 def main(prog_name: parameters.pass_name,
          command: LAST_OPTION,
          *args,
-         profile: value_converter(lambda _: _, name='FILENAME') = None,
+         profile: value_converter(lambda _: _, name = 'FILENAME') = None,
          verbose=False,
          dry_run=False):
     """IMPROVER NWP post-processing toolbox

--- a/improver/cli/extract.py
+++ b/improver/cli/extract.py
@@ -39,7 +39,7 @@ from improver.cli import parameters
 @cli.with_output
 def process(cube: cli.inputcube,
             *,
-            constraints: parameters.multi(min=1),
+            constraints: parameters.multi(min = 1),
             units: cli.comma_separated_list = None,
             ignore_failure=False):
     """ Extract a subset of a single cube.


### PR DESCRIPTION
Met Office local scitools stack has updated pycodestyle to 2.4.0 which picks up a couple of extra things. This PR updates Travis to the same version and fixes the two style issues found.

Testing:
 - [ ] Ran tests and they passed OK
