### PR TITLE
IMPRO-1568: Randomised list of cli inputs.

### DIFF
--- a/improver/cli/phase_change_level.py
+++ b/improver/cli/phase_change_level.py
@@ -70,8 +70,7 @@ def process(*cubes: cli.inputcube,
     """
     from improver.psychrometric_calculations.psychrometric_calculations \
         import PhaseChangeLevel
-    from iris.cube import CubeList
 
     result = PhaseChangeLevel(
-        phase_change=phase_change).process(CubeList(cubes))
+        phase_change=phase_change).process(cubes)
     return result

--- a/improver/cli/phase_change_level.py
+++ b/improver/cli/phase_change_level.py
@@ -36,11 +36,7 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(wet_bulb_temperature: cli.inputcube,
-            wet_bulb_integral: cli.inputcube,
-            orography: cli.inputcube,
-            land_sea_mask: cli.inputcube,
-            *,
+def process(*cubes: cli.inputcube,
             phase_change):
     """Height of precipitation phase change relative to sea level.
 
@@ -49,16 +45,18 @@ def process(wet_bulb_temperature: cli.inputcube,
     threshold that is expected to correspond with the phase change.
 
     Args:
-        wet_bulb_temperature (iris.cube.Cube):
-            Cube of wet bulb temperatures on height levels.
-        wet_bulb_integral (iris.cube.Cube):
-            Cube of wet bulb temperature integrals calculated vertically
-            downwards to height levels.
-        orography (iris.cube.Cube):
-            Cube of the orography height in m.
-        land_sea_mask (iris.cube.Cube):
-            Cube containing the binary land-sea mask. Land points are set to 1,
-            sea points are set to 0.
+        cubes (iris.cube.CubeList or list of iris.cube.Cube):
+            containing:
+                wet_bulb_temperature (iris.cube.Cube):
+                    Cube of wet bulb temperatures on height levels.
+                wet_bulb_integral (iris.cube.Cube):
+                    Cube of wet bulb temperature integrals calculated
+                    vertically downwards to height levels.
+                orography (iris.cube.Cube):
+                    Cube of the orography height in m.
+                land_sea_mask (iris.cube.Cube):
+                    Cube containing the binary land-sea mask. Land points are
+                    set to 1, sea points are set to 0.
         phase_change (str):
             The desired phase change for which the altitude should be
             returned. Options are:
@@ -72,8 +70,8 @@ def process(wet_bulb_temperature: cli.inputcube,
     """
     from improver.psychrometric_calculations.psychrometric_calculations \
         import PhaseChangeLevel
+    from iris.cube import CubeList
 
     result = PhaseChangeLevel(
-        phase_change=phase_change).process(
-            wet_bulb_temperature, wet_bulb_integral, orography, land_sea_mask)
+        phase_change=phase_change).process(CubeList(cubes))
     return result

--- a/improver/cli/wet_bulb_temperature.py
+++ b/improver/cli/wet_bulb_temperature.py
@@ -69,6 +69,6 @@ def process(*cubes: cli.inputcube,
     from improver.psychrometric_calculations.psychrometric_calculations \
         import WetBulbTemperature
 
-    result = (WetBulbTemperature(precision=convergence_condition).
-              process(cubes))
+    result = WetBulbTemperature(precision=convergence_condition).process(
+        cubes)
     return result

--- a/improver/cli/wet_bulb_temperature.py
+++ b/improver/cli/wet_bulb_temperature.py
@@ -37,10 +37,7 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(temperature: cli.inputcube,
-            relative_humidity: cli.inputcube,
-            pressure: cli.inputcube,
-            *,
+def process(*cubes: cli.inputcube,
             convergence_condition=0.05):
     """Module to generate wet-bulb temperatures.
 
@@ -49,15 +46,17 @@ def process(temperature: cli.inputcube,
     to mitigate memory issues when trying to operate on multi-level data.
 
     Args:
-        temperature (iris.cube.Cube):
-            Cube of air temperatures, where these may be on multiple height
-            levels.
-        relative_humidity (iris.cube.Cube):
-            Cube of relative humidities, where these may be on multiple height
-            levels.
-        pressure (iris.cube.Cube):
-            Cube of air pressure, where these may be on multiple height
-            levels.
+        cubes (iris.cube.CubeList or list or iris.cube.Cube):
+            containing:
+                temperature (iris.cube.Cube):
+                    Cube of air temperatures, where these may be on multiple
+                    height levels.
+                relative_humidity (iris.cube.Cube):
+                    Cube of relative humidities, where these may be on multiple
+                    height levels.
+                pressure (iris.cube.Cube):
+                    Cube of air pressure, where these may be on multiple height
+                    levels.
         convergence_condition (float):
             The precision in Kelvin to which the Newton iterator must converge
             before returning wet-bulb temperatures.
@@ -69,7 +68,8 @@ def process(temperature: cli.inputcube,
     """
     from improver.psychrometric_calculations.psychrometric_calculations \
         import WetBulbTemperature
+    from iris.cube import CubeList
 
     result = (WetBulbTemperature(precision=convergence_condition).
-              process(temperature, relative_humidity, pressure))
+              process(CubeList(cubes)))
     return result

--- a/improver/cli/wet_bulb_temperature.py
+++ b/improver/cli/wet_bulb_temperature.py
@@ -68,8 +68,7 @@ def process(*cubes: cli.inputcube,
     """
     from improver.psychrometric_calculations.psychrometric_calculations \
         import WetBulbTemperature
-    from iris.cube import CubeList
 
     result = (WetBulbTemperature(precision=convergence_condition).
-              process(CubeList(cubes)))
+              process(cubes))
     return result

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -35,6 +35,7 @@ import warnings
 import iris
 import numpy as np
 from cf_units import Unit
+from iris.cube import CubeList
 from scipy.interpolate import griddata
 from scipy.spatial.qhull import QhullError
 from scipy.stats import linregress
@@ -399,9 +400,18 @@ class WetBulbTemperature(BasePlugin):
             iris.cube.Cube:
                 Cube of wet bulb temperature (K).
         """
+        names_to_extract = ["air_temperature",
+                            "relative_humidity",
+                            "air_pressure"]
+        if len(cubes) != len(names_to_extract):
+            raise ValueError(
+                f'Expected {len(names_to_extract)} cubes, found {len(cubes)}')
 
-        temperature, relative_humidity, pressure = self._extract_cubes(
-            cubes, ["air_temperature", "relative_humidity", "air_pressure"])
+        temperature, relative_humidity, pressure = tuple(
+            CubeList(cubes).extract_strict(n) for n in names_to_extract)
+
+        # temperature, relative_humidity, pressure = self._extract_cubes(
+        #     cubes, ["air_temperature", "relative_humidity", "air_pressure"])
 
         slices = self._slice_inputs(temperature, relative_humidity, pressure)
 
@@ -977,11 +987,16 @@ class PhaseChangeLevel(BasePlugin):
                 Cube of phase change level above sea level (asl).
         """
 
-        wet_bulb_temperature, wet_bulb_integral, orog, land_sea_mask = \
-            self._extract_cubes(cubes, ["wet_bulb_temperature",
-                                        "wet_bulb_temperature_integral",
-                                        "surface_altitude",
-                                        "land_binary_mask"])
+        names_to_extract = ["wet_bulb_temperature",
+                            "wet_bulb_temperature_integral",
+                            "surface_altitude",
+                            "land_binary_mask"]
+        if len(cubes) != len(names_to_extract):
+            raise ValueError(
+                f'Expected {len(names_to_extract)} cubes, found {len(cubes)}')
+
+        wet_bulb_temperature, wet_bulb_integral, orog, land_sea_mask = tuple(
+            CubeList(cubes).extract_strict(n) for n in names_to_extract)
 
         wet_bulb_temperature.convert_units('celsius')
         wet_bulb_integral.convert_units('K m')

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -410,9 +410,6 @@ class WetBulbTemperature(BasePlugin):
         temperature, relative_humidity, pressure = tuple(
             CubeList(cubes).extract_strict(n) for n in names_to_extract)
 
-        # temperature, relative_humidity, pressure = self._extract_cubes(
-        #     cubes, ["air_temperature", "relative_humidity", "air_pressure"])
-
         slices = self._slice_inputs(temperature, relative_humidity, pressure)
 
         cubelist = iris.cube.CubeList([])

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -417,12 +417,11 @@ class WetBulbTemperatureIntegral(BasePlugin):
 
     def __init__(self):
         """Initialise class."""
-        self.integration_plugin = Integration(
-            "height", direction_of_integration="negative")
+        self.integration_plugin = Integration("height")
 
     def process(self, wet_bulb_temperature):
         """
-        Calculate the vertical integal of wet bulb temperature from the input
+        Calculate the vertical integral of wet bulb temperature from the input
         wet bulb temperatures on height levels.
 
         Args:

--- a/improver/utilities/mathematical_operations.py
+++ b/improver/utilities/mathematical_operations.py
@@ -67,10 +67,9 @@ class Integration(BasePlugin):
                 continue until the last available point.
             positive_integration (bool):
                 Description of the direction in which to integrate.
-                Options are 'positive' or 'negative'.
-                'positive' corresponds to the values within the array
+                True corresponds to the values within the array
                 increasing as the array index increases.
-                'negative' corresponds to the values within the array
+                False corresponds to the values within the array
                 decreasing as the array index increases.
         """
         self.coord_name_to_integrate = coord_name_to_integrate

--- a/improver/utilities/mathematical_operations.py
+++ b/improver/utilities/mathematical_operations.py
@@ -50,7 +50,7 @@ class Integration(BasePlugin):
 
     def __init__(self, coord_name_to_integrate,
                  start_point=None, end_point=None,
-                 direction_of_integration="negative"):
+                 positive_integration=False):
         """
         Initialise class.
 
@@ -65,7 +65,7 @@ class Integration(BasePlugin):
                 Point at which to end the integration.
                 Default is None. If end_point is None, integration will
                 continue until the last available point.
-            direction_of_integration (str):
+            positive_integration (bool):
                 Description of the direction in which to integrate.
                 Options are 'positive' or 'negative'.
                 'positive' corresponds to the values within the array
@@ -76,21 +76,16 @@ class Integration(BasePlugin):
         self.coord_name_to_integrate = coord_name_to_integrate
         self.start_point = start_point
         self.end_point = end_point
-        self.direction_of_integration = direction_of_integration
-        if self.direction_of_integration not in ["positive", "negative"]:
-            msg = ("The specified direction of integration should be either "
-                   "'positive' or 'negative'. {} was specified.".format(
-                       self.direction_of_integration))
-            raise ValueError(msg)
+        self.positive_integration = positive_integration
         self.input_cube = None
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
         result = ('<Integration: coord_name_to_integrate: {}, '
                   'start_point: {}, end_point: {}, '
-                  'direction_of_integration: {}>'.format(
+                  'positive_integration: {}>'.format(
                       self.coord_name_to_integrate, self.start_point,
-                      self.end_point, self.direction_of_integration))
+                      self.end_point, self.positive_integration))
         return result
 
     def ensure_monotonic_increase_in_chosen_direction(self, cube):
@@ -109,13 +104,12 @@ class Integration(BasePlugin):
 
         """
         coord_name = self.coord_name_to_integrate
-        direction = self.direction_of_integration
         increasing_order = np.all(np.diff(cube.coord(coord_name).points) > 0)
 
-        if increasing_order and direction == "negative":
+        if increasing_order and not self.positive_integration:
             cube = sort_coord_in_cube(cube, coord_name, descending=True)
 
-        if not increasing_order and direction == "positive":
+        if not increasing_order and self.positive_integration:
             cube = sort_coord_in_cube(cube, coord_name)
 
         return cube
@@ -134,12 +128,12 @@ class Integration(BasePlugin):
                     Cube containing the lower bounds to be used during the
                     integration.
         """
-        if self.direction_of_integration == "positive":
+        if self.positive_integration:
             upper_bounds = self.input_cube.coord(
                 self.coord_name_to_integrate).points[1:]
             lower_bounds = self.input_cube.coord(
                 self.coord_name_to_integrate).points[:-1]
-        elif self.direction_of_integration == "negative":
+        else:
             upper_bounds = self.input_cube.coord(
                 self.coord_name_to_integrate).points[:-1]
             lower_bounds = self.input_cube.coord(
@@ -254,14 +248,14 @@ class Integration(BasePlugin):
             the integrated total.  All inputs (except the string "direction")
             are floats."""
             if start_point:
-                if direction == "positive" and lower_bound < start_point:
+                if direction and lower_bound < start_point:
                     return True
-                if direction == "negative" and upper_bound > start_point:
+                if not direction and upper_bound > start_point:
                     return True
             if end_point:
-                if direction == "positive" and upper_bound > end_point:
+                if direction and upper_bound > end_point:
                     return True
-                if direction == "negative" and lower_bound < end_point:
+                if not direction and lower_bound < end_point:
                     return True
             return False
 
@@ -280,7 +274,7 @@ class Integration(BasePlugin):
                 self.coord_name_to_integrate).points
 
             if skip_slice(upper_bound, lower_bound,
-                          self.direction_of_integration,
+                          self.positive_integration,
                           self.start_point, self.end_point):
                 continue
 
@@ -295,22 +289,20 @@ class Integration(BasePlugin):
 
             data.append(integral.copy())
             coord_points.append(
-                upper_bound if self.direction_of_integration == "positive" else
-                lower_bound)
+                upper_bound if self.positive_integration else lower_bound)
             coord_bounds.append([lower_bound, upper_bound])
 
         if len(data) == 0:
             msg = ("No integration could be performed for "
                    "coord_to_integrate: {}, start_point: {}, end_point: {}, "
-                   "direction_of_integration: {}. "
+                   "positive_integration: {}. "
                    "No usable data was found.".format(
                        self.coord_name_to_integrate, self.start_point,
-                       self.end_point, self.direction_of_integration))
+                       self.end_point, self.positive_integration))
             raise ValueError(msg)
 
         template = (upper_bounds_cube
-                    if self.direction_of_integration == "positive" else
-                    lower_bounds_cube)
+                    if self.positive_integration else lower_bounds_cube)
         integrated_cube = self._create_output_cube(
             template.copy(), data, coord_points, coord_bounds)
         return integrated_cube

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -584,6 +584,22 @@ class Test_process(IrisTest):
         self.assertEqual(result.units, Unit('m'))
         self.assertArrayAlmostEqual(result.data, self.expected_snow_sleet)
 
+    def test_snow_sleet_phase_change_reorder_cubes(self):
+        """Test that process returns a cube with the right name, units and
+        values. In this instance the phase change is from snow to sleet. The
+        returned level is consistent across the field, despite a high point
+        that sits above the snow falling level."""
+        self.orog.data[1, 1] = 100.0
+        result = PhaseChangeLevel(phase_change='snow-sleet').process(
+            CubeList([self.wet_bulb_integral_cube,
+                      self.wet_bulb_temperature_cube,
+                      self.orog, self.land_sea])
+            )
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertEqual(result.name(), "altitude_of_snow_falling_level")
+        self.assertEqual(result.units, Unit('m'))
+        self.assertArrayAlmostEqual(result.data, self.expected_snow_sleet)
+
     def test_sleet_rain_phase_change(self):
         """Test that process returns a cube with the right name, units and
         values. In this instance the phase change is from sleet to rain. Note
@@ -596,8 +612,7 @@ class Test_process(IrisTest):
         result = PhaseChangeLevel(phase_change='sleet-rain').process(
             CubeList([self.wet_bulb_temperature_cube,
                       self.wet_bulb_integral_cube,
-                      self.orog, self.land_sea])
-            )
+                      self.orog, self.land_sea]))
         expected = np.ones((3, 3, 3), dtype=np.float32) * 49.178673
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "altitude_of_rain_falling_level")
@@ -612,8 +627,7 @@ class Test_process(IrisTest):
         result = PhaseChangeLevel(phase_change='snow-sleet').process(
             CubeList([self.wet_bulb_temperature_cube,
                       self.wet_bulb_integral_cube,
-                      self.orog, self.land_sea])
-            )
+                      self.orog, self.land_sea]))
         self.assertArrayAlmostEqual(result.data, self.expected_snow_sleet)
 
     def test_interpolation_from_sea_points(self):
@@ -630,8 +644,7 @@ class Test_process(IrisTest):
         result = PhaseChangeLevel(phase_change='snow-sleet').process(
             CubeList([self.wet_bulb_temperature_cube,
                       self.wet_bulb_integral_cube,
-                      orog, land_sea])
-            )
+                      orog, land_sea]))
         expected = np.ones((3, 3, 3), dtype=np.float32) * 65.88566
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(result.data, expected)

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -36,7 +36,6 @@ import iris
 import numpy as np
 from cf_units import Unit
 from iris.cube import CubeList
-from iris.exceptions import ConstraintMismatchError
 from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -649,9 +649,7 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result.data, expected)
 
     def test_too_many_cubes(self):
-        """
-        Tests that an error is raised if there are too many arguments.
-        """
+        """Tests that an error is raised if there are too many cubes."""
         msg = "Expected 4"
         with self.assertRaisesRegex(ValueError, msg):
             PhaseChangeLevel(phase_change='snow-sleet').process(
@@ -660,26 +658,11 @@ class Test_process(IrisTest):
                           self.orog, self.land_sea, self.orog]))
 
     def test_empty_cube_list(self):
-        """
-        Tests that an error is raised if there is an empty list.
-        """
+        """Tests that an error is raised if there is an empty list."""
         msg = "Expected 4"
         with self.assertRaisesRegex(ValueError, msg):
             PhaseChangeLevel(phase_change='snow-sleet').process(
                 CubeList([]))
-
-    def test_wrong_cube(self):
-        """
-        Tests that an error is raised if there isn't a correctly named cube.
-        """
-        orog = self.orog
-        orog.rename("Brachiosaurus")
-        msg = "Got 0 cubes for constraint.*surface_altitude"
-        with self.assertRaisesRegex(ConstraintMismatchError, msg):
-            PhaseChangeLevel(phase_change='snow-sleet').process(
-                CubeList([self.wet_bulb_temperature_cube,
-                          self.wet_bulb_integral_cube,
-                          orog, self.land_sea]))
 
 
 if __name__ == '__main__':

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -36,6 +36,7 @@ import iris
 import numpy as np
 from cf_units import Unit
 from iris.cube import CubeList
+from iris.exceptions import ConstraintMismatchError
 from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
@@ -585,10 +586,8 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result.data, self.expected_snow_sleet)
 
     def test_snow_sleet_phase_change_reorder_cubes(self):
-        """Test that process returns a cube with the right name, units and
-        values. In this instance the phase change is from snow to sleet. The
-        returned level is consistent across the field, despite a high point
-        that sits above the snow falling level."""
+        """Same test as test_snow_sleet_phase_change but the cubes are in a
+        different order"""
         self.orog.data[1, 1] = 100.0
         result = PhaseChangeLevel(phase_change='snow-sleet').process(
             CubeList([self.wet_bulb_integral_cube,
@@ -675,8 +674,8 @@ class Test_process(IrisTest):
         """
         orog = self.orog
         orog.rename("Brachiosaurus")
-        msg = "The following .*surface_altitude"
-        with self.assertRaisesRegex(ValueError, msg):
+        msg = "Got 0 cubes for constraint.*surface_altitude"
+        with self.assertRaisesRegex(ConstraintMismatchError, msg):
             PhaseChangeLevel(phase_change='snow-sleet').process(
                 CubeList([self.wet_bulb_temperature_cube,
                           self.wet_bulb_integral_cube,

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -35,6 +35,7 @@ import unittest
 import iris
 import numpy as np
 from cf_units import Unit
+from iris.cube import CubeList
 from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
@@ -574,8 +575,10 @@ class Test_process(IrisTest):
         that sits above the snow falling level."""
         self.orog.data[1, 1] = 100.0
         result = PhaseChangeLevel(phase_change='snow-sleet').process(
-            self.wet_bulb_temperature_cube, self.wet_bulb_integral_cube,
-            self.orog, self.land_sea)
+            CubeList([self.wet_bulb_temperature_cube,
+                      self.wet_bulb_integral_cube,
+                      self.orog, self.land_sea])
+            )
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "altitude_of_snow_falling_level")
         self.assertEqual(result.units, Unit('m'))
@@ -589,10 +592,12 @@ class Test_process(IrisTest):
         consistent across the field, despite a high point that sits above the
         rain falling level."""
         self.orog.data[1, 1] = 100.0
-        self.wet_bulb_integral_cube = self.wet_bulb_integral_cube * 2.
+        self.wet_bulb_integral_cube.data *= 2.
         result = PhaseChangeLevel(phase_change='sleet-rain').process(
-            self.wet_bulb_temperature_cube, self.wet_bulb_integral_cube,
-            self.orog, self.land_sea)
+            CubeList([self.wet_bulb_temperature_cube,
+                      self.wet_bulb_integral_cube,
+                      self.orog, self.land_sea])
+            )
         expected = np.ones((3, 3, 3), dtype=np.float32) * 49.178673
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "altitude_of_rain_falling_level")
@@ -605,9 +610,10 @@ class Test_process(IrisTest):
         ascending order rather than the expected descending order."""
         self.orog.data[1, 1] = 100.0
         result = PhaseChangeLevel(phase_change='snow-sleet').process(
-            self.wet_bulb_temperature_cube,
-            self.wet_bulb_integral_cube_inverted,
-            self.orog, self.land_sea)
+            CubeList([self.wet_bulb_temperature_cube,
+                      self.wet_bulb_integral_cube,
+                      self.orog, self.land_sea])
+            )
         self.assertArrayAlmostEqual(result.data, self.expected_snow_sleet)
 
     def test_interpolation_from_sea_points(self):
@@ -622,11 +628,46 @@ class Test_process(IrisTest):
         land_sea = self.land_sea
         land_sea.data[1, 1] = 1
         result = PhaseChangeLevel(phase_change='snow-sleet').process(
-            self.wet_bulb_temperature_cube, self.wet_bulb_integral_cube,
-            orog, land_sea)
+            CubeList([self.wet_bulb_temperature_cube,
+                      self.wet_bulb_integral_cube,
+                      orog, land_sea])
+            )
         expected = np.ones((3, 3, 3), dtype=np.float32) * 65.88566
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(result.data, expected)
+
+    def test_too_many_cubes(self):
+        """
+        Tests that an error is raised if there are too many arguments.
+        """
+        msg = "Expected 4"
+        with self.assertRaisesRegex(ValueError, msg):
+            PhaseChangeLevel(phase_change='snow-sleet').process(
+                CubeList([self.wet_bulb_temperature_cube,
+                          self.wet_bulb_integral_cube,
+                          self.orog, self.land_sea, self.orog]))
+
+    def test_empty_cube_list(self):
+        """
+        Tests that an error is raised if there is an empty list.
+        """
+        msg = "Expected 4"
+        with self.assertRaisesRegex(ValueError, msg):
+            PhaseChangeLevel(phase_change='snow-sleet').process(
+                CubeList([]))
+
+    def test_wrong_cube(self):
+        """
+        Tests that an error is raised if there isn't a correctly named cube.
+        """
+        orog = self.orog
+        orog.rename("Brachiosaurus")
+        msg = "The following .*surface_altitude"
+        with self.assertRaisesRegex(ValueError, msg):
+            PhaseChangeLevel(phase_change='snow-sleet').process(
+                CubeList([self.wet_bulb_temperature_cube,
+                          self.wet_bulb_integral_cube,
+                          orog, self.land_sea]))
 
 
 if __name__ == '__main__':

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -225,25 +225,7 @@ class Test_process(Test_WetBulbTemperature):
         self.assertEqual(result.coord_dims('time')[0], 0)
         self.assertEqual(result.coord_dims('height')[0], 1)
 
-
-class Test__extract_cubes(Test_WetBulbTemperature):
-    """Test the plugins extract method for its required cubes"""
-
-    def test_basic(self):
-        """
-        Tests that the functions can take a cubelist of the right three
-        cubes and extract them.
-        """
-        temp = self.temperature
-        humid = self.relative_humidity
-        pressure = self.pressure
-        temp_result, humid_result, pressure_result = WetBulbTemperature(
-            )._extract_cubes(CubeList([temp, humid, pressure]))
-        self.assertEqual(temp, temp_result)
-        self.assertEqual(humid, humid_result)
-        self.assertEqual(pressure, pressure_result)
-
-    def test_too_many(self):
+    def test_too_many_cubes(self):
         """
         Tests that an error is raised if there are too many arguments.
         """
@@ -255,7 +237,7 @@ class Test__extract_cubes(Test_WetBulbTemperature):
             WetBulbTemperature().process(
                 CubeList([temp, humid, pressure, temp]))
 
-    def test_empty_list(self):
+    def test_empty_cube_list(self):
         """
         Tests that an error is raised if there is an empty list.
         """

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -237,9 +237,7 @@ class Test_process(Test_WetBulbTemperature):
         self.assertEqual(result.coord_dims('height')[0], 1)
 
     def test_too_many_cubes(self):
-        """
-        Tests that an error is raised if there are too many arguments.
-        """
+        """Tests that an error is raised if there are too many cubes."""
         temp = self.temperature
         humid = self.relative_humidity
         pressure = self.pressure
@@ -249,27 +247,11 @@ class Test_process(Test_WetBulbTemperature):
                 CubeList([temp, humid, pressure, temp]))
 
     def test_empty_cube_list(self):
-        """
-        Tests that an error is raised if there is an empty list.
-        """
+        """Tests that an error is raised if there is an empty list."""
         msg = "Expected 3"
         with self.assertRaisesRegex(ValueError, msg):
             WetBulbTemperature().process(
                 CubeList([]))
-
-    def test_wrong_cube(self):
-        """
-        Tests that an error is raised if there isn't a correctly named cube.
-        """
-
-        temp = self.temperature
-        humid = self.relative_humidity
-        pressure = self.pressure
-        temp.rename("diplodocus")
-        msg = "Got 0 cubes .*air_temperature"
-        with self.assertRaisesRegex(ConstraintMismatchError, msg):
-            WetBulbTemperature().process(
-                CubeList([temp, humid, pressure]))
 
 
 if __name__ == '__main__':

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -187,7 +187,7 @@ class Test_process(Test_WetBulbTemperature):
                       self.relative_humidity,
                       self.pressure]))
         self.assertArrayAlmostEqual(result.data, self.expected_wbt_data,
-                                   decimal=3)
+                                    decimal=3)
         self.assertEqual(result.units, Unit('K'))
 
     def test_values_single_level_reorder_cubes(self):
@@ -198,7 +198,7 @@ class Test_process(Test_WetBulbTemperature):
                       self.temperature,
                       self.pressure]))
         self.assertArrayAlmostEqual(result.data, self.expected_wbt_data,
-                                   decimal=3)
+                                    decimal=3)
         self.assertEqual(result.units, Unit('K'))
 
     def test_values_multi_level(self):
@@ -210,9 +210,9 @@ class Test_process(Test_WetBulbTemperature):
         result = WetBulbTemperature().process(
             CubeList([temperature, relative_humidity, pressure]))
         self.assertArrayAlmostEqual(result.data[0], self.expected_wbt_data,
-                                   decimal=3)
+                                    decimal=3)
         self.assertArrayAlmostEqual(result.data[1], self.expected_wbt_data,
-                                   decimal=3)
+                                    decimal=3)
         self.assertEqual(result.units, Unit('K'))
         self.assertArrayEqual(result.coord('height').points, [10, 20])
 

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -36,7 +36,6 @@ import iris
 import numpy as np
 from cf_units import Unit
 from iris.cube import Cube, CubeList
-from iris.exceptions import ConstraintMismatchError
 from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -186,6 +186,17 @@ class Test_process(Test_WetBulbTemperature):
         self.assertArrayAlmostEqual(result.data, self.expected_wbt_data)
         self.assertEqual(result.units, Unit('K'))
 
+    def test_values_single_level_reorder_cubes(self):
+        """Basic wet bulb temperature calculation as if calling the
+        create_wet_bulb_temperature_cube function directly with single
+        level data."""
+        result = WetBulbTemperature().process(
+            CubeList([self.relative_humidity,
+                      self.temperature,
+                      self.pressure]))
+        self.assertArrayAlmostEqual(result.data, self.expected_wbt_data)
+        self.assertEqual(result.units, Unit('K'))
+
     def test_values_multi_level(self):
         """Basic wet bulb temperature calculation using multi-level
         data."""

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -36,6 +36,7 @@ import iris
 import numpy as np
 from cf_units import Unit
 from iris.cube import Cube, CubeList
+from iris.exceptions import ConstraintMismatchError
 from iris.tests import IrisTest
 
 from improver.psychrometric_calculations.psychrometric_calculations import (
@@ -187,9 +188,8 @@ class Test_process(Test_WetBulbTemperature):
         self.assertEqual(result.units, Unit('K'))
 
     def test_values_single_level_reorder_cubes(self):
-        """Basic wet bulb temperature calculation as if calling the
-        create_wet_bulb_temperature_cube function directly with single
-        level data."""
+        """Same test as test_values_single_level but the cubes are in a
+        different order."""
         result = WetBulbTemperature().process(
             CubeList([self.relative_humidity,
                       self.temperature,
@@ -266,8 +266,8 @@ class Test_process(Test_WetBulbTemperature):
         humid = self.relative_humidity
         pressure = self.pressure
         temp.rename("diplodocus")
-        msg = "The following"
-        with self.assertRaisesRegex(ValueError, msg):
+        msg = "Got 0 cubes .*air_temperature"
+        with self.assertRaisesRegex(ConstraintMismatchError, msg):
             WetBulbTemperature().process(
                 CubeList([temp, humid, pressure]))
 

--- a/improver_tests/utilities/test_mathematical_operations.py
+++ b/improver_tests/utilities/test_mathematical_operations.py
@@ -64,20 +64,6 @@ def _set_up_height_cube(height_points, ascending=True):
     return cube
 
 
-class Test__init__(IrisTest):
-
-    """Test the init method."""
-
-    def test_raise_exception(self):
-        """Test that an error is raised, if the direction_of_integration
-        is not valid."""
-        coord_name = "height"
-        direction = "sideways"
-        msg = "The specified direction of integration"
-        with self.assertRaisesRegex(ValueError, msg):
-            Integration(coord_name, direction_of_integration=direction)
-
-
 class Test__repr__(IrisTest):
 
     """Test the repr method."""
@@ -88,7 +74,7 @@ class Test__repr__(IrisTest):
         result = str(Integration(coord_name))
         msg = ('<Integration: coord_name_to_integrate: height, '
                'start_point: None, end_point: None, '
-               'direction_of_integration: negative>')
+               'positive_integration: False>')
         self.assertEqual(result, msg)
 
 
@@ -105,9 +91,9 @@ class Test_ensure_monotonic_increase_in_chosen_direction(IrisTest):
         self.descending_cube = _set_up_height_cube(
             self.descending_height_points, ascending=False)
         self.plugin_positive = Integration(
-            "height", direction_of_integration="positive")
+            "height", positive_integration=True)
         self.plugin_negative = Integration(
-            "height", direction_of_integration="negative")
+            "height")
 
     def test_ascending_coordinate_positive(self):
         """Test that for a monotonically ascending coordinate, where the
@@ -163,10 +149,10 @@ class Test_prepare_for_integration(IrisTest):
         height_points = np.array([5., 10., 20.])
         cube = _set_up_height_cube(height_points)
         self.plugin_positive = Integration(
-            "height", direction_of_integration="positive")
+            "height", positive_integration=True)
         self.plugin_positive.input_cube = cube.copy()
         self.plugin_negative = Integration(
-            "height", direction_of_integration="negative")
+            "height")
         self.plugin_negative.input_cube = cube.copy()
 
     def test_basic(self):
@@ -241,10 +227,10 @@ class Test_perform_integration(IrisTest):
               [32.50, 32.50, 32.50]]])
 
         self.plugin_positive = Integration(
-            "height", direction_of_integration="positive")
+            "height", positive_integration=True)
         self.plugin_positive.input_cube = cube.copy()
         self.plugin_negative = Integration(
-            "height", direction_of_integration="negative")
+            "height")
         self.plugin_negative.input_cube = cube.copy()
 
     def test_basic(self):
@@ -452,7 +438,7 @@ class Test_process(IrisTest):
         cube.data = data
         self.cube = cube
         self.plugin = Integration(
-            "height", direction_of_integration="negative")
+            "height")
 
     def test_basic(self):
         """Test that a cube with the points on the chosen coordinate are

--- a/improver_tests/utilities/test_mathematical_operations.py
+++ b/improver_tests/utilities/test_mathematical_operations.py
@@ -176,7 +176,6 @@ class Test_prepare_for_integration(IrisTest):
     def test_negative_points(self):
         """Test that the expected coordinate points are returned for each
         cube when the direction of integration is negative."""
-        direction = "negative"
         self.plugin_negative.input_cube.coord("height").points = (
             np.array([20., 10., 5.]))
         result = self.plugin_negative.prepare_for_integration()

--- a/improver_tests/utilities/test_mathematical_operations.py
+++ b/improver_tests/utilities/test_mathematical_operations.py
@@ -52,8 +52,7 @@ def _set_up_height_cube(height_points, ascending=True):
 
     cube = set_up_variable_cube(data[0].astype(np.float32))
     height_points = np.sort(height_points)
-    cube = add_coordinate(
-        cube, height_points, "height", coord_units="m")
+    cube = add_coordinate(cube, height_points, "height", coord_units="m")
     cube.coord("height").attributes["positive"] = "up"
     cube.data = data.astype(np.float32)
 
@@ -90,10 +89,8 @@ class Test_ensure_monotonic_increase_in_chosen_direction(IrisTest):
         self.descending_height_points = np.array([20., 10., 5.])
         self.descending_cube = _set_up_height_cube(
             self.descending_height_points, ascending=False)
-        self.plugin_positive = Integration(
-            "height", positive_integration=True)
-        self.plugin_negative = Integration(
-            "height")
+        self.plugin_positive = Integration("height", positive_integration=True)
+        self.plugin_negative = Integration("height")
 
     def test_ascending_coordinate_positive(self):
         """Test that for a monotonically ascending coordinate, where the
@@ -148,11 +145,9 @@ class Test_prepare_for_integration(IrisTest):
         """Set up the cube."""
         height_points = np.array([5., 10., 20.])
         cube = _set_up_height_cube(height_points)
-        self.plugin_positive = Integration(
-            "height", positive_integration=True)
+        self.plugin_positive = Integration("height", positive_integration=True)
         self.plugin_positive.input_cube = cube.copy()
-        self.plugin_negative = Integration(
-            "height")
+        self.plugin_negative = Integration("height")
         self.plugin_negative.input_cube = cube.copy()
 
     def test_basic(self):
@@ -225,11 +220,9 @@ class Test_perform_integration(IrisTest):
               [32.50, 32.50, 32.50],
               [32.50, 32.50, 32.50]]])
 
-        self.plugin_positive = Integration(
-            "height", positive_integration=True)
+        self.plugin_positive = Integration("height", positive_integration=True)
         self.plugin_positive.input_cube = cube.copy()
-        self.plugin_negative = Integration(
-            "height")
+        self.plugin_negative = Integration("height")
         self.plugin_negative.input_cube = cube.copy()
 
     def test_basic(self):
@@ -436,8 +429,7 @@ class Test_process(IrisTest):
         data[0, 0, 0] = 6
         cube.data = data
         self.cube = cube
-        self.plugin = Integration(
-            "height")
+        self.plugin = Integration("height")
 
     def test_basic(self):
         """Test that a cube with the points on the chosen coordinate are


### PR DESCRIPTION
Due to extra task on the ticket.
### Commit 1 [287eb4f ](https://github.com/metoppv/improver/commit/287eb4f0238a290e9501bef4f1fe71e532eae79c)

Address the use of a string for a binary value.

### Commit 2 and 3 [5e16414](https://github.com/metoppv/improver/commit/5e164145b55d7b586bb8f02d9856ed60e6a9b911) & [d25824c](https://github.com/metoppv/improver/commit/d25824c9d42c251907f6ff027d6c7afacccc11e5)

Address makeing the individual plugins extract the required cubes they need from a CubeList.
- WetBulbTemperature uses all [CF standard names](http://cfconventions.org/Data/cf-standard-names/70/build/cf-standard-name-table.html)
- PhaseChangeLevel uses `wet_bulb_temperature_integral` which is not a CF standard.

### Commit 4+ [167b07d](https://github.com/metoppv/improver/pull/1146/commits/167b07d0855a6422846396a0d06970d6d71753c6) [a6fb83](https://github.com/metoppv/improver/pull/1146/commits/a6fbf83c402fed1771032a076e41e6554a0db540) [021dc71](https://github.com/metoppv/improver/pull/1146/commits/021dc712b0009a91d1fa471af835512ae588d588)

Use generator instead of a function
Adds randomised order to a test.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)