### PR TITLE
Nowcast extrapolate raise error if no orographic enhancement field for rainfall

### DIFF
--- a/improver/nowcasting/forecasting.py
+++ b/improver/nowcasting/forecasting.py
@@ -365,9 +365,10 @@ class CreateExtrapolationForecast(BasePlugin):
         if self.orographic_enhancement_cube:
             input_cube, = ApplyOrographicEnhancement("subtract").process(
                 input_cube, self.orographic_enhancement_cube)
-        elif "precipitation_rate" in input_cube.name():
-            msg = ("For precipitation fields, orographic enhancement "
-                   "cube must be supplied.")
+        elif ("precipitation_rate" in input_cube.name()
+              or "rainfall_rate" in input_cube.name()):
+            msg = ("For precipitation or rainfall fields, orographic "
+                   "enhancement cube must be supplied.")
             raise ValueError(msg)
         self.input_cube = input_cube
         self.advection_plugin = AdvectField(

--- a/improver_tests/acceptance/test_nowcast_extrapolate.py
+++ b/improver_tests/acceptance/test_nowcast_extrapolate.py
@@ -85,7 +85,8 @@ def test_basic_no_orographic(tmp_path):
     kgo_dir = (acc.kgo_root() /
                "nowcast-extrapolate/extrapolate_no_orographic_enhancement")
     kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / RAINRATE_NC
+    input_path = (kgo_dir /
+                  "20190101T0300Z-PT0000H00M-cloud_amount_of_total_cloud.nc")
     uv_path = kgo_dir / "../uv.nc"
 
     output_path = tmp_path / "output.nc"

--- a/improver_tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
+++ b/improver_tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
@@ -116,8 +116,18 @@ class Test__init__(SetUpCubes):
 
     def test_no_orographic_enhancement(self):
         """Test what happens if no orographic enhancement cube is provided"""
-        message = ("For precipitation fields, orographic enhancement cube "
-                   "must be supplied.")
+        message = ("For precipitation or rainfall fields, orographic "
+                   "enhancement cube must be supplied.")
+        with self.assertRaisesRegex(ValueError, message):
+            CreateExtrapolationForecast(
+                self.precip_cube, self.vel_x, self.vel_y)
+
+    def test_no_orographic_enhancement_rainfall_rate(self):
+        """Test what happens if no orographic enhancement cube is provided.
+           for rainfall_rate"""
+        message = ("For precipitation or rainfall fields, orographic "
+                   "enhancement cube must be supplied.")
+        self.precip_cube.rename("rainfall_rate")
         with self.assertRaisesRegex(ValueError, message):
             CreateExtrapolationForecast(
                 self.precip_cube, self.vel_x, self.vel_y)


### PR DESCRIPTION
IMPRO-1602

Modified test that checks extrapolate can run without orographic
    enhancement to use cloud fraction rather than rainfall rate

See ticket for acceptance test data changes

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

