### PR TITLE
Switch GitHub Actions back on for PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   Tests:


### PR DESCRIPTION
Switch GitHub Actions back on for PRs - need this to get the check at the bottom of pull request pages.
