### PR TITLE
IMPRO-1606: Ensure cycle time updated in cycle blending

### DIFF
--- a/improver/blending/calculate_weights_and_blend.py
+++ b/improver/blending/calculate_weights_and_blend.py
@@ -38,6 +38,7 @@ from improver.blending.weights import (
     ChooseDefaultWeightsLinear, ChooseDefaultWeightsNonLinear,
     ChooseWeightsLinear)
 from improver.metadata.amend import amend_attributes
+from improver.metadata.forecast_times import rebadge_forecasts_as_latest_cycle
 from improver.utilities.spatial import (
     check_if_grid_is_equal_area, convert_distance_into_number_of_grid_cells)
 
@@ -195,6 +196,7 @@ class WeightAndBlend(BasePlugin):
             result = cube.copy()
             if attributes_dict is not None:
                 amend_attributes(result, attributes_dict)
+            result, = rebadge_forecasts_as_latest_cycle([result], cycletime)
 
         # otherwise, calculate weights and blend across specified dimension
         else:

--- a/improver/blending/calculate_weights_and_blend.py
+++ b/improver/blending/calculate_weights_and_blend.py
@@ -187,9 +187,11 @@ class WeightAndBlend(BasePlugin):
             model_id_attr=model_id_attr)
         cube = merger.process(cubelist, cycletime=cycletime)
 
-        # if blend_coord has only one value, or is not present (case where only
+        # if blend_coord has only one value (for example cycle blending with
+        # only one cycle available), or is not present (case where only
         # one model has been provided for a model blend), update attributes
-        # only
+        # and ensure that the forecast reference time on the returned cube
+        # is set to the current IMPROVER processing cycle.
         coord_names = [coord.name() for coord in cube.coords()]
         if (self.blend_coord not in coord_names or
                 len(cube.coord(self.blend_coord).points) == 1):

--- a/improver_tests/acceptance/test_weighted_blending.py
+++ b/improver_tests/acceptance/test_weighted_blending.py
@@ -161,7 +161,7 @@ def test_cycletime_with_specified_frt(tmp_path):
     args = ["--coordinate", "forecast_reference_time",
             "--y0val", "1.0",
             "--ynval", "4.0",
-            "--cycletime", "20200218T0500Z",
+            "--cycletime", "20200218T0600Z",
             *input_paths,
             "--output", output_path]
     run_cli(args)

--- a/improver_tests/acceptance/test_weighted_blending.py
+++ b/improver_tests/acceptance/test_weighted_blending.py
@@ -134,17 +134,36 @@ def test_percentile(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-@pytest.mark.slow
 def test_cycletime(tmp_path):
     """Test cycletime blending"""
     kgo_dir = acc.kgo_root() / "weighted_blending/cycletime"
     kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "input.nc"
+    input_paths = sorted((kgo_dir.glob("input_temperature*.nc")))
+    print('inputs', input_paths)
     output_path = tmp_path / "output.nc"
     args = ["--coordinate", "forecast_reference_time",
             "--y0val", "1.0",
             "--ynval", "4.0",
-            "--cycletime", "20171129T0900Z",
+            "--cycletime", "20200218T0600Z",
+            *input_paths,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_cycletime_single_file_new_frt(tmp_path):
+    """Test cycletime blending gives an updated forecast reference time when
+    provided with the relevant cycletime argument and only a single input cube
+    with a different forecast reference time. This is a slightly different
+    route through the code as no blending actually occurs."""
+    kgo_dir = acc.kgo_root() / "weighted_blending/cycletime"
+    kgo_path = kgo_dir / "kgo_single_input.nc"
+    input_path = kgo_dir / "input_temperature_0.nc"
+    output_path = tmp_path / "output.nc"
+    args = ["--coordinate", "forecast_reference_time",
+            "--y0val", "1.0",
+            "--ynval", "4.0",
+            "--cycletime", "20200218T0600Z",
             input_path,
             "--output", output_path]
     run_cli(args)

--- a/improver_tests/acceptance/test_weighted_blending.py
+++ b/improver_tests/acceptance/test_weighted_blending.py
@@ -134,28 +134,46 @@ def test_percentile(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-def test_cycletime(tmp_path):
-    """Test cycletime blending"""
+def test_cycletime_use_latest_frt(tmp_path):
+    """Test cycletime blending where the output is expected to have time
+    coordinates that match the latest of the input cubes."""
     kgo_dir = acc.kgo_root() / "weighted_blending/cycletime"
     kgo_path = kgo_dir / "kgo.nc"
     input_paths = sorted((kgo_dir.glob("input_temperature*.nc")))
-    print('inputs', input_paths)
     output_path = tmp_path / "output.nc"
     args = ["--coordinate", "forecast_reference_time",
             "--y0val", "1.0",
             "--ynval", "4.0",
-            "--cycletime", "20200218T0600Z",
             *input_paths,
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
 
-def test_cycletime_single_file_new_frt(tmp_path):
-    """Test cycletime blending gives an updated forecast reference time when
-    provided with the relevant cycletime argument and only a single input cube
+def test_cycletime_with_specified_frt(tmp_path):
+    """Test cycletime blending where a forecast reference time for the
+    returned cube is user specified."""
+    kgo_dir = acc.kgo_root() / "weighted_blending/cycletime"
+    kgo_path = kgo_dir / "kgo_specified_frt.nc"
+    input_paths = sorted((kgo_dir.glob("input_temperature*.nc")))
+    input_paths.pop(-1)
+    output_path = tmp_path / "output.nc"
+    args = ["--coordinate", "forecast_reference_time",
+            "--y0val", "1.0",
+            "--ynval", "4.0",
+            "--cycletime", "20200218T0500Z",
+            *input_paths,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_cycletime_with_specified_frt_single_input(tmp_path):
+    """Test cycletime blending where a forecast reference time for the
+    returned cube is user specified. In this case the input is a single cube
     with a different forecast reference time. This is a slightly different
-    route through the code as no blending actually occurs."""
+    route through the code to the preceding test as no blending actually
+    occurs."""
     kgo_dir = acc.kgo_root() / "weighted_blending/cycletime"
     kgo_path = kgo_dir / "kgo_single_input.nc"
     input_path = kgo_dir / "input_temperature_0.nc"

--- a/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
+++ b/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
@@ -382,7 +382,7 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result.data, self.enukx_cube.data)
         self.assertEqual(result.metadata, self.enukx_cube.metadata)
 
-    def test_one_cube_with_cycletime(self):
+    def test_one_cube_with_cycletime_model_blending(self):
         """Test the plugin returns a single input cube with an updated forecast
         reference time and period if given the "cycletime" option."""
         expected_frt = (
@@ -391,6 +391,19 @@ class Test_process(IrisTest):
         result = self.plugin_model.process(
             [self.enukx_cube], model_id_attr="mosg__model_configuration",
             cycletime='20180910T0400Z')
+        self.assertEqual(
+            result.coord("forecast_reference_time").points[0], expected_frt)
+        self.assertEqual(
+            result.coord("forecast_period").points[0], expected_fp)
+
+    def test_one_cube_with_cycletime_cycle_blending(self):
+        """Test the plugin returns a single input cube with an updated forecast
+        reference time and period if given the "cycletime" option."""
+        expected_frt = (
+            self.enukx_cube.coord("forecast_reference_time").points[0] + 3600)
+        expected_fp = self.enukx_cube.coord("forecast_period").points[0] - 3600
+        result = self.plugin_cycle.process(
+            [self.enukx_cube], cycletime='20180910T0400Z')
         self.assertEqual(
             result.coord("forecast_reference_time").points[0], expected_frt)
         self.assertEqual(


### PR DESCRIPTION
In cycle blending the latest cube is currently used to set the cycle time (forecast reference time). If a file is missing for a particular validity time in the cycle in which the blending occurs, the cycle time for the output will be set as the most recent cycle for which data was available. This results in the forecast reference times for the blended output files from a given cycle potentially differing from one another.

There is an associated suite PR which adds the ```--cycletime``` argument for cycle blending.

We may wish to consider adding a CLI test for this behaviour, but I have not had time.

This work:
- Ensures that if a cycletime argument is provided, even if we are processing a single cube in cycle blending, the cycletime of the output is updated.
- I've added a unit test to cover this behaviour.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)