### PR TITLE
Ensure number of realizations output by the apply_emos_coefficients CLI matches the input

### DIFF
--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -97,10 +97,24 @@ def test_probabilities(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [input_path, emos_est_path,
             "--distribution", "norm",
+            "--realizations-count", "18",
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path,
                 atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE)
+
+
+def test_probabilities_error(tmp_path):
+    """Test using probabilities as input without num_realizations"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/probabilities"
+    input_path = kgo_dir / "input.nc"
+    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, emos_est_path,
+            "--distribution", "norm",
+            "--output", output_path]
+    with pytest.raises(ValueError, match=".*provided as probabilities.*"):
+        run_cli(args)
 
 
 def test_percentiles(tmp_path):
@@ -112,10 +126,24 @@ def test_percentiles(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [input_path, emos_est_path,
             "--distribution", "norm",
+            "--realizations-count", "18",
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path,
                 atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE)
+
+
+def test_percentiles_error(tmp_path):
+    """Test using percentiles as input"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/percentiles"
+    input_path = kgo_dir / "input.nc"
+    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, emos_est_path,
+            "--distribution", "norm",
+            "--output", output_path]
+    with pytest.raises(ValueError):
+        run_cli(args)
 
 
 def test_rebadged_percentiles(tmp_path):
@@ -126,6 +154,7 @@ def test_rebadged_percentiles(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [kgo_dir / "../rebadged_percentiles/input.nc", emos_est_path,
             "--distribution", "norm",
+            "--realizations-count", "18",
             "--output", output_path]
     run_cli(args)
     # The known good output in this case is the same as when passing in

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -97,24 +97,10 @@ def test_probabilities(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [input_path, emos_est_path,
             "--distribution", "norm",
-            "--realizations-count", "18",
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path,
                 atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE)
-
-
-def test_probabilities_error(tmp_path):
-    """Test using probabilities as input without num_realizations"""
-    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/probabilities"
-    input_path = kgo_dir / "input.nc"
-    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
-    output_path = tmp_path / "output.nc"
-    args = [input_path, emos_est_path,
-            "--distribution", "norm",
-            "--output", output_path]
-    with pytest.raises(ValueError, match=".*provided as probabilities.*"):
-        run_cli(args)
 
 
 def test_percentiles(tmp_path):
@@ -126,24 +112,10 @@ def test_percentiles(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [input_path, emos_est_path,
             "--distribution", "norm",
-            "--realizations-count", "18",
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path,
                 atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE)
-
-
-def test_percentiles_error(tmp_path):
-    """Test using percentiles as input"""
-    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/percentiles"
-    input_path = kgo_dir / "input.nc"
-    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
-    output_path = tmp_path / "output.nc"
-    args = [input_path, emos_est_path,
-            "--distribution", "norm",
-            "--output", output_path]
-    with pytest.raises(ValueError):
-        run_cli(args)
 
 
 def test_rebadged_percentiles(tmp_path):
@@ -154,7 +126,6 @@ def test_rebadged_percentiles(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [kgo_dir / "../rebadged_percentiles/input.nc", emos_est_path,
             "--distribution", "norm",
-            "--realizations-count", "18",
             "--output", output_path]
     run_cli(args)
     # The known good output in this case is the same as when passing in


### PR DESCRIPTION
Addresses #GitHubissuenum

Remove the use of the realizations_count option when re-creating the realizations within the apply_emos_coefficients cli.

Testing:
 - [x] Ran tests and they passed OK
