### PR TITLE
Apply EMOS CLI fails if only a coefficients file provided.

### DIFF
--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -153,6 +153,10 @@ def process(cube: cli.inputcube,
 
     current_forecast = cube
 
+    if current_forecast.name() == 'emos_coefficients':
+        msg = "The current forecast cube has the name 'emos_coefficients'"
+        raise ValueError(msg)
+
     if coefficients is None:
         msg = ("There are no coefficients provided for calibration. The "
                "uncalibrated forecast will be returned.")
@@ -162,10 +166,6 @@ def process(cube: cli.inputcube,
     if coefficients.name() != 'emos_coefficients':
         msg = ("The current coefficients cube does not have the "
                "name 'emos_coefficients'")
-        raise ValueError(msg)
-
-    if current_forecast.name() == 'emos_coefficients':
-        msg = "The current forecast cube has the name 'emos_coefficients'"
         raise ValueError(msg)
 
     original_current_forecast = current_forecast.copy()

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -153,7 +153,7 @@ def process(cube: cli.inputcube,
 
     current_forecast = cube
 
-    if current_forecast.name() == 'emos_coefficients':
+    if current_forecast.name() in ['emos_coefficients', 'land_binary_mask']:
         msg = "The current forecast cube has the name 'emos_coefficients'"
         raise ValueError(msg)
 
@@ -166,6 +166,11 @@ def process(cube: cli.inputcube,
     if coefficients.name() != 'emos_coefficients':
         msg = ("The current coefficients cube does not have the "
                "name 'emos_coefficients'")
+        raise ValueError(msg)
+
+    if land_sea_mask and land_sea_mask.name() != 'land_binary_mask':
+        msg = ("The land_sea_mask cube does not have the "
+               "name 'land_binary_mask'")
         raise ValueError(msg)
 
     original_current_forecast = current_forecast.copy()

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -154,8 +154,8 @@ def process(cube: cli.inputcube,
     current_forecast = cube
 
     if current_forecast.name() in ['emos_coefficients', 'land_binary_mask']:
-        msg = "The current forecast cube has the name 'emos_coefficients'"
-        raise ValueError(msg)
+        msg = "The current forecast cube has the name {}"
+        raise ValueError(msg.format(current_forecast.name()))
 
     if coefficients is None:
         msg = ("There are no coefficients provided for calibration. The "

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -205,3 +205,16 @@ def test_wrong_forecast(tmp_path):
             "--output", output_path]
     with pytest.raises(ValueError, match=".*forecast cube.*"):
         run_cli(args)
+
+
+def test_fails_only_coefficients_provided(tmp_path):
+    """Test fails if coefficents cube is the only cube passed in"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/gaussian"
+    emos_est_path = kgo_dir / "gaussian_coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [emos_est_path,
+            "--distribution", "norm",
+            "--random-seed", "0",
+            "--output", output_path]
+    with pytest.raises(ValueError, match=".*forecast cube.*"):
+        run_cli(args)

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -194,12 +194,26 @@ def test_wrong_coefficients(tmp_path):
         run_cli(args)
 
 
-def test_wrong_forecast(tmp_path):
-    """Test forecast cube being a coefficients cube"""
-    kgo_dir = acc.kgo_root() / "estimate-emos-coefficients/gaussian"
-    kgo_path = kgo_dir / "kgo.nc"
+def test_wrong_land_sea_mask(tmp_path):
+    """Test wrong land_sea_mask provided"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/gaussian"
+    emos_est_path = kgo_dir / "gaussian_coefficients.nc"
+    input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
-    args = [kgo_path, kgo_path,
+    args = [input_path, emos_est_path, emos_est_path,
+            "--distribution", "norm",
+            "--random-seed", "0",
+            "--output", output_path]
+    with pytest.raises(ValueError, match=".*land_sea_mask.*"):
+        run_cli(args)
+
+
+def test_wrong_forecast_coefficients(tmp_path):
+    """Test forecast cube being a coefficients cube"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/gaussian"
+    emos_est_path = kgo_dir / "gaussian_coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [emos_est_path,
             "--distribution", "norm",
             "--random-seed", "0",
             "--output", output_path]
@@ -207,12 +221,12 @@ def test_wrong_forecast(tmp_path):
         run_cli(args)
 
 
-def test_fails_only_coefficients_provided(tmp_path):
-    """Test fails if coefficents cube is the only cube passed in"""
-    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/gaussian"
-    emos_est_path = kgo_dir / "gaussian_coefficients.nc"
+def test_wrong_forecast_land_sea(tmp_path):
+    """Test forecast cube being a land_sea_mask cube"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/land_sea"
+    land_sea_path = kgo_dir / "landmask.nc"
     output_path = tmp_path / "output.nc"
-    args = [emos_est_path,
+    args = [land_sea_path,
             "--distribution", "norm",
             "--random-seed", "0",
             "--output", output_path]

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -217,7 +217,7 @@ def test_wrong_forecast_coefficients(tmp_path):
             "--distribution", "norm",
             "--random-seed", "0",
             "--output", output_path]
-    with pytest.raises(ValueError, match=".*forecast cube.*"):
+    with pytest.raises(ValueError, match=".*forecast cube.*emos_coefficients"):
         run_cli(args)
 
 
@@ -230,5 +230,5 @@ def test_wrong_forecast_land_sea(tmp_path):
             "--distribution", "norm",
             "--random-seed", "0",
             "--output", output_path]
-    with pytest.raises(ValueError, match=".*forecast cube.*"):
+    with pytest.raises(ValueError, match=".*forecast cube.*land_binary_mask"):
         run_cli(args)


### PR DESCRIPTION
Addresses IMPRO-1613

Changed the behaviour of the Apply EMOS CLI so it fails if it is passed only a coefficients cube. Before it would return this cube unchanged as it assumed the cube was a forecast cube.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

