### PR TITLE
IMPRO-1607: Fix triangular time blending for bounded times

### DIFF
--- a/improver/blending/blend_across_adjacent_points.py
+++ b/improver/blending/blend_across_adjacent_points.py
@@ -114,7 +114,8 @@ class TriangularWeightedBlendAcrossAdjacentPoints(BasePlugin):
             Unit(self.parameter_units).convert(
                 self.central_point, cube.coord(self.coord).units))
         constr = iris.Constraint(
-            coord_values={self.coord: central_point})
+            coord_values={self.coord: lambda cell:
+                          cell.point == central_point})
         central_point_cube = cube.extract(constr)
         if central_point_cube is None:
             msg = ("The central point {} in units of {} not available "

--- a/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -54,12 +54,12 @@ def set_up_cubes_for_process_tests():
         np.array([[1., 1.], [1., 1.]], dtype=np.float32),
         name='lwe_thickness_of_precipitation_amount', units='m',
         time=dt(2017, 1, 10, 3, 0), frt=dt(2017, 1, 10, 3, 0),
-        time_bounds=(dt(2017, 1, 10, 1, 0), dt(2017, 1, 10, 4, 0)))
+        time_bounds=(dt(2017, 1, 10, 0, 0), dt(2017, 1, 10, 3, 0)))
     another_cube = set_up_variable_cube(
         np.array([[2., 2.], [2., 2.]], dtype=np.float32),
         name='lwe_thickness_of_precipitation_amount', units='m',
         time=dt(2017, 1, 10, 4, 0), frt=dt(2017, 1, 10, 3, 0),
-        time_bounds=(dt(2017, 1, 10, 2, 0), dt(2017, 1, 10, 5, 0)))
+        time_bounds=(dt(2017, 1, 10, 1, 0), dt(2017, 1, 10, 4, 0)))
     cube = iris.cube.CubeList(
         [central_cube, another_cube]).merge_cube()
     return central_cube, cube

--- a/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -53,11 +53,13 @@ def set_up_cubes_for_process_tests():
     central_cube = set_up_variable_cube(
         np.array([[1., 1.], [1., 1.]], dtype=np.float32),
         name='lwe_thickness_of_precipitation_amount', units='m',
-        time=dt(2017, 1, 10, 3, 0), frt=dt(2017, 1, 10, 3, 0))
+        time=dt(2017, 1, 10, 3, 0), frt=dt(2017, 1, 10, 3, 0),
+        time_bounds=(dt(2017, 1, 10, 1, 0), dt(2017, 1, 10, 4, 0)))
     another_cube = set_up_variable_cube(
         np.array([[2., 2.], [2., 2.]], dtype=np.float32),
         name='lwe_thickness_of_precipitation_amount', units='m',
-        time=dt(2017, 1, 10, 4, 0), frt=dt(2017, 1, 10, 3, 0))
+        time=dt(2017, 1, 10, 4, 0), frt=dt(2017, 1, 10, 3, 0),
+        time_bounds=(dt(2017, 1, 10, 2, 0), dt(2017, 1, 10, 5, 0)))
     cube = iris.cube.CubeList(
         [central_cube, another_cube]).merge_cube()
     return central_cube, cube


### PR DESCRIPTION
It was found that triangular time blending was not returning the expected cube validity time/forecast period when blending period diagnostics (those with bounds on their time coordinates).

This PR makes the iris extraction used to extract the user specified time coordinate check the time point rather than the entire time coordinate; when checking the entire coordinate if the point falls within the bounds it is deemed a match.

I've added bounds to the unit test data. These now fail without the modifications made here.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
