### PR TITLE
Pass multiple orographic enhancement files to nowcast-extrapolate CLI

### DIFF
--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -56,7 +56,7 @@ def process(cube: cli.inputcube,
             These must have the names of.
             precipitation_advection_x_velocity
             precipitation_advection_y_velocity
-        orographic_enhancement (tuple):
+        orographic_enhancement (list of iris.cube.Cube):
             Tuple of cubes containing orographic enhancement forecasts for the
             lead times at which an extrapolation nowcast is required.
         attributes_config (dict):

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -57,7 +57,7 @@ def process(cube: cli.inputcube,
             precipitation_advection_x_velocity
             precipitation_advection_y_velocity
         orographic_enhancement (list of iris.cube.Cube):
-            Tuple of cubes containing orographic enhancement forecasts for the
+            List of cubes containing orographic enhancement forecasts for the
             lead times at which an extrapolation nowcast is required.
         attributes_config (dict):
             Dictionary containing the required changes to the attributes.

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -43,8 +43,7 @@ inputadvection = cli.create_constrained_inputcubelist_converter(
 @cli.with_output
 def process(cube: cli.inputcube,
             advection_velocity: inputadvection,
-            orographic_enhancement: cli.inputcube = None,
-            *,
+            *orographic_enhancement: cli.inputcube,
             attributes_config: cli.inputjson = None,
             max_lead_time: int = 360, lead_time_interval: int = 15):
     """Module  to extrapolate input cubes given advection velocity fields.
@@ -57,9 +56,9 @@ def process(cube: cli.inputcube,
             These must have the names of.
             precipitation_advection_x_velocity
             precipitation_advection_y_velocity
-        orographic_enhancement (iris.cube.Cube):
-            Cube containing orographic enhancement forecasts for the lead times
-            at which an extrapolation nowcast is required.
+        orographic_enhancement (tuple):
+            Tuple of cubes containing orographic enhancement forecasts for the
+            lead times at which an extrapolation nowcast is required.
         attributes_config (dict):
             Dictionary containing the required changes to the attributes.
         max_lead_time (int):
@@ -71,11 +70,13 @@ def process(cube: cli.inputcube,
         iris.cube.CubeList:
             New cubes with updated time and extrapolated data.
     """
+    from iris.cube import CubeList
     from improver.nowcasting.forecasting import CreateExtrapolationForecast
     from improver.utilities.cube_manipulation import merge_cubes
 
     u_cube, v_cube = advection_velocity
-
+    if orographic_enhancement:
+        orographic_enhancement = CubeList(orographic_enhancement).merge_cube()
     # extrapolate input data to required lead times
     forecast_plugin = CreateExtrapolationForecast(
         cube, u_cube, v_cube, orographic_enhancement,

--- a/improver_tests/acceptance/test_nowcast_extrapolate.py
+++ b/improver_tests/acceptance/test_nowcast_extrapolate.py
@@ -47,14 +47,32 @@ OE = "orographic_enhancement_standard_resolution"
 def test_basic(tmp_path):
     """Test basic extrapolation nowcast"""
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
-    kgo_path = kgo_dir / "kgo.nc"
+    kgo_path = kgo_dir / "single_orographic_enhancement_kgo.nc"
     input_path = kgo_dir / ".." / RAINRATE_NC
-    oe_path = kgo_dir / "../orographic_enhancement.nc"
+    oe_path_t3 = kgo_dir / "../orographic_enhancement_T3.nc"
     uv_path = kgo_dir / "../uv.nc"
 
     output_path = tmp_path / "output.nc"
 
-    args = [input_path, uv_path, oe_path,
+    args = [input_path, uv_path, oe_path_t3,
+            "--max-lead-time", "30",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_multiple_oe_files(tmp_path):
+    """Test basic extrapolation nowcast"""
+    kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
+    kgo_path = kgo_dir / "multiple_orographic_enhancements_kgo.nc"
+    input_path = kgo_dir / ".." / RAINRATE_NC
+    oe_path_t3 = kgo_dir / "../orographic_enhancement_T3.nc"
+    oe_path_t4 = kgo_dir / "../orographic_enhancement_T4.nc"
+    uv_path = kgo_dir / "../uv.nc"
+
+    output_path = tmp_path / "output.nc"
+
+    args = [input_path, uv_path, oe_path_t3, oe_path_t4,
             "--max-lead-time", "90",
             "--output", output_path]
     run_cli(args)
@@ -66,13 +84,13 @@ def test_metadata(tmp_path):
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/metadata"
     kgo_path = kgo_dir / "kgo_with_metadata.nc"
     input_path = kgo_dir / ".." / RAINRATE_NC
-    oe_path = kgo_dir / "../orographic_enhancement.nc"
+    oe_path_t3 = kgo_dir / "../orographic_enhancement_T3.nc"
     meta_path = kgo_dir / "precip.json"
     uv_path = kgo_dir / "../uv.nc"
 
     output_path = tmp_path / "output.nc"
 
-    args = [input_path, uv_path, oe_path,
+    args = [input_path, uv_path, oe_path_t3,
             "--attributes-config", meta_path,
             "--max-lead-time", "30",
             "--output", output_path]


### PR DESCRIPTION
Description
Edits to support passing multiple orographic enhancement files into the nowcast extrapolate CLI, rather than a single file with multiple leadtimes.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
