### PR TITLE
Impro 1569 apply emos land sea

### DIFF
--- a/improver/calibration/utilities.py
+++ b/improver/calibration/utilities.py
@@ -206,3 +206,34 @@ def filter_non_matching_cubes(historic_forecast, truth):
         raise ValueError(msg)
     return (matching_historic_forecasts.merge_cube(),
             matching_truths.merge_cube())
+
+
+def merge_land_and_sea(calibrated_land_only, uncalibrated):
+    """
+    Merge data that has been calibrated over the land with uncalibrated data.
+    Calibrated data will have masked data over the sea which will need to be
+    filled with the uncalibrated data.
+
+    Args:
+        calibrated_land_only (iris.cube.Cube):
+            A cube that has been calibrated over the land, with sea points
+            masked out. Either realizations, probabilities or percentiles.
+            Data is modified in place.
+        uncalibrated (iris.cube.Cube):
+            A cube of uncalibrated data with valid data over the sea. Either
+            realizations, probabilities or percentiles. Dimension coordinates
+            must be the same as the calibrated_land_only cube.
+
+    Raises:
+        ValueError: If input cubes do not have the same input dimensions.
+    """
+    # Check dimensions the same on both cubes.
+    if calibrated_land_only.dim_coords != uncalibrated.dim_coords:
+        message = "Input cubes do not have the same dimension coordinates"
+        raise ValueError(message)
+    # Merge data if calibrated_land_only data is masked.
+    if np.ma.is_masked(calibrated_land_only.data):
+        new_data = calibrated_land_only.data.data
+        mask = calibrated_land_only.data.mask
+        new_data[mask] = uncalibrated.data[mask]
+        calibrated_land_only.data = new_data

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -143,6 +143,7 @@ def process(cube: cli.inputcube,
         ConvertProbabilitiesToPercentiles,
         RebadgePercentilesAsRealizations,
         ResamplePercentiles)
+    from improver.ensemble_copula_coupling.utilities import merge_land_and_sea
     from improver.metadata.probabilistic import find_percentile_coordinate
 
     current_forecast = cube
@@ -234,4 +235,7 @@ def process(cube: cli.inputcube,
         result = EnsembleReordering().process(
             percentiles, current_forecast,
             random_ordering=randomise, random_seed=random_seed)
+    if land_sea_mask:
+        # Fill in masked sea points with uncalibrated data.
+        merge_land_and_sea(result, original_current_forecast)
     return result

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -143,7 +143,7 @@ def process(cube: cli.inputcube,
         ConvertProbabilitiesToPercentiles,
         RebadgePercentilesAsRealizations,
         ResamplePercentiles)
-    from improver.ensemble_copula_coupling.utilities import merge_land_and_sea
+    from improver.calibration.utilities import merge_land_and_sea
     from improver.metadata.probabilistic import find_percentile_coordinate
 
     current_forecast = cube

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -110,6 +110,7 @@ class RebadgePercentilesAsRealizations(BasePlugin):
         cube.coord("realization").units = "1"
         cube.coord("realization").points = (
             cube.coord("realization").points.astype(np.int32))
+        cube.coord("realization").var_name = "realization"
 
         return cube
 

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -1188,7 +1188,10 @@ class EnsembleReordering(BasePlugin):
             # of having < 32 arrays or a leading dimension < 32 in the
             # input data array. This function allows indexing of a 3d array
             # using a 3d array.
+            mask = np.ma.getmask(calfc.data)
             calfc.data = choose(ranking, calfc.data)
+            if mask is not np.ma.nomask:
+                calfc.data = np.ma.MaskedArray(calfc.data, mask)
             results.append(calfc)
         # Ensure we haven't lost any dimensional coordinates with only one
         # value in.

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -1191,7 +1191,8 @@ class EnsembleReordering(BasePlugin):
             mask = np.ma.getmask(calfc.data)
             calfc.data = choose(ranking, calfc.data)
             if mask is not np.ma.nomask:
-                calfc.data = np.ma.MaskedArray(calfc.data, mask)
+                calfc.data = np.ma.MaskedArray(
+                    calfc.data, mask, dtype=np.float32)
             results.append(calfc)
         # Ensure we haven't lost any dimensional coordinates with only one
         # value in.

--- a/improver/ensemble_copula_coupling/utilities.py
+++ b/improver/ensemble_copula_coupling/utilities.py
@@ -313,34 +313,3 @@ def restore_non_probabilistic_dimensions(
     shape_to_reshape_to = (
         [output_probabilistic_dimension_length] + shape_to_reshape_to)
     return array_to_reshape.reshape(shape_to_reshape_to)
-
-
-def merge_land_and_sea(calibrated_land_only, uncalibrated):
-    """
-    Merge data that has been calibrated over the land with uncalibrated data.
-    Calibrated data will have masked data over the sea which will need to be
-    filled with the uncalibrated data.
-
-    Args:
-        calibrated_land_only (iris.cube.Cube):
-            A cube that has been calibrated over the land, with sea points
-            masked out. Either realizations, probabilities or percentiles.
-            Data is modified in place.
-        uncalibrated (iris.cube.Cube):
-            A cube of uncalibrated data with valid data over the sea. Either
-            realizations, probabilities or percentiles. Dimension coordinates
-            must be the same as the calibrated_land_only cube.
-
-    Raises:
-        ValueError: If input cubes do not have the same input dimensions.
-    """
-    # Check dimensions the same on both cubes.
-    if calibrated_land_only.dim_coords != uncalibrated.dim_coords:
-        message = "Input cubes do not have the same dimension coordinates"
-        raise ValueError(message)
-    # Merge data if calibrated_land_only data is masked.
-    if np.ma.is_masked(calibrated_land_only.data):
-        new_data = calibrated_land_only.data.data
-        mask = calibrated_land_only.data.mask
-        new_data[mask] = uncalibrated.data[mask]
-        calibrated_land_only.data = new_data

--- a/improver/ensemble_copula_coupling/utilities.py
+++ b/improver/ensemble_copula_coupling/utilities.py
@@ -313,3 +313,34 @@ def restore_non_probabilistic_dimensions(
     shape_to_reshape_to = (
         [output_probabilistic_dimension_length] + shape_to_reshape_to)
     return array_to_reshape.reshape(shape_to_reshape_to)
+
+
+def merge_land_and_sea(calibrated_land_only, uncalibrated):
+    """
+    Merge data that has been calibrated over the land with uncalibrated data.
+    Calibrated data will have masked data over the sea which will need to be
+    filled with the uncalibrated data.
+
+    Args:
+        calibrated_land_only (iris.cube.Cube):
+            A cube that has been calibrated over the land, with sea points
+            masked out. Either realizations, probabilities or percentiles.
+            Data is modified in place.
+        uncalibrated (iris.cube.Cube):
+            A cube of uncalibrated data with valid data over the sea. Either
+            realizations, probabilities or percentiles. Dimension coordinates
+            must be the same as the calibrated_land_only cube.
+
+    Raises:
+        ValueError: If input cubes do not have the same input dimensions.
+    """
+    # Check dimensions the same on both cubes.
+    if calibrated_land_only.dim_coords != uncalibrated.dim_coords:
+        message = "Input cubes do not have the same dimension coordinates"
+        raise ValueError(message)
+    # Merge data if calibrated_land_only data is masked.
+    if np.ma.is_masked(calibrated_land_only.data):
+        new_data = calibrated_land_only.data.data
+        mask = calibrated_land_only.data.mask
+        new_data[mask] = uncalibrated.data[mask]
+        calibrated_land_only.data = new_data

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -72,6 +72,22 @@ def test_truncated_gaussian(tmp_path):
     acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
 
 
+def test_realizations_input_land_sea(tmp_path):
+    """Test realizations as input with a land sea mask"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/land_sea"
+    kgo_path = kgo_dir / "realizations_kgo.nc"
+    input_path = kgo_dir / "../gaussian/input.nc"
+    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
+    land_sea_path = kgo_dir / "landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, emos_est_path, land_sea_path,
+            "--distribution", "norm",
+            "--random-seed", "0",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
+
+
 def test_realizations_as_predictor(tmp_path):
     """Implementation of test using non-default predictor realizations"""
     kgo_dir = acc.kgo_root() / "apply-emos-coefficients/realizations"
@@ -104,6 +120,22 @@ def test_probabilities(tmp_path):
                 atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE)
 
 
+def test_probabilities_input_land_sea(tmp_path):
+    """Test probabilities as input with a land sea mask"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/land_sea"
+    kgo_path = kgo_dir / "probabilities_kgo.nc"
+    input_path = kgo_dir / "../probabilities/input.nc"
+    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
+    land_sea_path = kgo_dir / "landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, emos_est_path, land_sea_path,
+            "--distribution", "norm",
+            "--realizations-count", "18",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
+
+
 def test_probabilities_error(tmp_path):
     """Test using probabilities as input without num_realizations"""
     kgo_dir = acc.kgo_root() / "apply-emos-coefficients/probabilities"
@@ -131,6 +163,22 @@ def test_percentiles(tmp_path):
     run_cli(args)
     acc.compare(output_path, kgo_path,
                 atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE)
+
+
+def test_percentiles_input_land_sea(tmp_path):
+    """Test percentiles as input with a land sea mask"""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/land_sea"
+    kgo_path = kgo_dir / "percentiles_kgo.nc"
+    input_path = kgo_dir / "../percentiles/input.nc"
+    emos_est_path = kgo_dir / "../gaussian/gaussian_coefficients.nc"
+    land_sea_path = kgo_dir / "landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, emos_est_path, land_sea_path,
+            "--distribution", "norm",
+            "--realizations-count", "18",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
 
 
 def test_percentiles_error(tmp_path):

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -406,8 +406,7 @@ class Test_rank_ecc(IrisTest):
              [[3, 2]],
              [[2, 3]]])
 
-        cube = self.cube.copy()
-        cube = cube[:, :, :2, 0]
+        cube = self.cube[:, :, :2, 0].copy()
 
         raw_cube = cube.copy()
         raw_cube.data = raw_data
@@ -427,24 +426,23 @@ class Test_rank_ecc(IrisTest):
                          [[True, False]],
                          [[True, False]]])
         raw_data = np.array(
-            [[[1, 1]],
-             [[3, 2]],
-             [[2, 3]]])
+            [[[1, 9]],
+             [[3, 5]],
+             [[2, 7]]])
 
         calibrated_data = np.ma.MaskedArray(
-            [[[1, 1]],
-             [[2, 2]],
-             [[3, 3]]], mask=mask, dtype=np.float32)
+            [[[1, 6]],
+             [[2, 8]],
+             [[3, 10]]], mask=mask, dtype=np.float32)
 
         # Reordering of the calibrated_data array to match
         # the raw_data ordering
         result_data = np.array(
-            [[[np.nan, 1]],
-             [[np.nan, 2]],
-             [[np.nan, 3]]], dtype=np.float32)
+            [[[np.nan, 10]],
+             [[np.nan, 6]],
+             [[np.nan, 8]]], dtype=np.float32)
 
-        cube = self.cube.copy()
-        cube = cube[:, :, :2, 0]
+        cube = self.cube[:, :, :2, 0].copy()
 
         raw_cube = cube.copy()
         raw_cube.data = raw_data
@@ -454,7 +452,6 @@ class Test_rank_ecc(IrisTest):
 
         plugin = Plugin()
         result = plugin.rank_ecc(calibrated_cube, raw_cube)
-        print(result.data)
         self.assertArrayAlmostEqual(result.data.data, result_data)
         self.assertArrayEqual(result.data.mask, mask)
         self.assertEqual(result.data.dtype, np.float32)
@@ -467,24 +464,23 @@ class Test_rank_ecc(IrisTest):
                          [[True, False]],
                          [[True, False]]])
         raw_data = np.array(
-            [[[1, 1]],
-             [[3, 2]],
-             [[2, 3]]])
+            [[[1, 9]],
+             [[3, 5]],
+             [[2, 7]]])
 
         calibrated_data = np.ma.MaskedArray(
-            [[[np.nan, 1]],
-             [[np.nan, 2]],
-             [[np.nan, 3]]], mask=mask, dtype=np.float32)
+            [[[np.nan, 6]],
+             [[np.nan, 8]],
+             [[np.nan, 10]]], mask=mask, dtype=np.float32)
 
         # Reordering of the calibrated_data array to match
         # the raw_data ordering
         result_data = np.array(
-            [[[np.nan, 1]],
-             [[np.nan, 2]],
-             [[np.nan, 3]]], dtype=np.float32)
+            [[[np.nan, 10]],
+             [[np.nan, 6]],
+             [[np.nan, 8]]], dtype=np.float32)
 
-        cube = self.cube.copy()
-        cube = cube[:, :, :2, 0]
+        cube = self.cube[:, :, :2, 0].copy()
 
         raw_cube = cube.copy()
         raw_cube.data = raw_data
@@ -494,7 +490,6 @@ class Test_rank_ecc(IrisTest):
 
         plugin = Plugin()
         result = plugin.rank_ecc(calibrated_cube, raw_cube)
-        print(result.data)
         self.assertArrayAlmostEqual(result.data.data, result_data)
         self.assertArrayEqual(result.data.mask, mask)
         self.assertEqual(result.data.dtype, np.float32)
@@ -529,8 +524,7 @@ class Test_rank_ecc(IrisTest):
              [[3, 3]],
              [[2, 2]]])
 
-        cube = self.cube.copy()
-        cube = cube[:, :, :2, 0]
+        cube = self.cube[:, :, :2, 0].copy()
 
         raw_cube = cube.copy()
         raw_cube.data = raw_data
@@ -568,8 +562,7 @@ class Test_rank_ecc(IrisTest):
              [[3, 2]],
              [[2, 3]]])
 
-        cube = self.cube.copy()
-        cube = cube[:, :, :2, 0]
+        cube = self.cube[:, :, :2, 0].copy()
 
         raw_cube = cube.copy()
         raw_cube.data = raw_data
@@ -597,8 +590,7 @@ class Test_rank_ecc(IrisTest):
                                 [2],
                                 [1]])
 
-        cube = self.cube.copy()
-        cube = cube[:, :, 0, 0]
+        cube = self.cube[:, :, 0, 0].copy()
         raw_cube = cube.copy()
         raw_cube.data = raw_data
         calibrated_cube = cube.copy()
@@ -624,8 +616,7 @@ class Test_rank_ecc(IrisTest):
                                     [2],
                                     [3]])
 
-        cube = self.cube.copy()
-        cube = cube[:, :, 0, 0]
+        cube = self.cube[:, :, 0, 0].copy()
         raw_cube = cube.copy()
         raw_cube.data = raw_data
         calibrated_cube = cube.copy()

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -434,14 +434,14 @@ class Test_rank_ecc(IrisTest):
         calibrated_data = np.ma.MaskedArray(
             [[[1, 1]],
              [[2, 2]],
-             [[3, 3]]], mask=mask)
+             [[3, 3]]], mask=mask, dtype=np.float32)
 
         # Reordering of the calibrated_data array to match
         # the raw_data ordering
         result_data = np.array(
             [[[np.nan, 1]],
              [[np.nan, 2]],
-             [[np.nan, 3]]])
+             [[np.nan, 3]]], dtype=np.float32)
 
         cube = self.cube.copy()
         cube = cube[:, :, :2, 0]
@@ -457,6 +457,7 @@ class Test_rank_ecc(IrisTest):
         print(result.data)
         self.assertArrayAlmostEqual(result.data.data, result_data)
         self.assertArrayEqual(result.data.mask, mask)
+        self.assertEqual(result.data.dtype, np.float32)
 
     def test_3d_cube_masked_nans(self):
         """Test that the plugin returns the correct cube data for a
@@ -473,14 +474,14 @@ class Test_rank_ecc(IrisTest):
         calibrated_data = np.ma.MaskedArray(
             [[[np.nan, 1]],
              [[np.nan, 2]],
-             [[np.nan, 3]]], mask=mask)
+             [[np.nan, 3]]], mask=mask, dtype=np.float32)
 
         # Reordering of the calibrated_data array to match
         # the raw_data ordering
         result_data = np.array(
             [[[np.nan, 1]],
              [[np.nan, 2]],
-             [[np.nan, 3]]])
+             [[np.nan, 3]]], dtype=np.float32)
 
         cube = self.cube.copy()
         cube = cube[:, :, :2, 0]
@@ -496,6 +497,7 @@ class Test_rank_ecc(IrisTest):
         print(result.data)
         self.assertArrayAlmostEqual(result.data.data, result_data)
         self.assertArrayEqual(result.data.mask, mask)
+        self.assertEqual(result.data.dtype, np.float32)
 
     def test_3d_cube_tied_values(self):
         """

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -420,6 +420,83 @@ class Test_rank_ecc(IrisTest):
 
         self.assertArrayAlmostEqual(result.data, result_data)
 
+    def test_3d_cube_masked(self):
+        """Test that the plugin returns the correct cube data for a
+        3d input cube with a mask applied to each realization."""
+        mask = np.array([[[True, False]],
+                         [[True, False]],
+                         [[True, False]]])
+        raw_data = np.array(
+            [[[1, 1]],
+             [[3, 2]],
+             [[2, 3]]])
+
+        calibrated_data = np.ma.MaskedArray(
+            [[[1, 1]],
+             [[2, 2]],
+             [[3, 3]]], mask=mask)
+
+        # Reordering of the calibrated_data array to match
+        # the raw_data ordering
+        result_data = np.array(
+            [[[np.nan, 1]],
+             [[np.nan, 2]],
+             [[np.nan, 3]]])
+
+        cube = self.cube.copy()
+        cube = cube[:, :, :2, 0]
+
+        raw_cube = cube.copy()
+        raw_cube.data = raw_data
+
+        calibrated_cube = cube.copy()
+        calibrated_cube.data = calibrated_data
+
+        plugin = Plugin()
+        result = plugin.rank_ecc(calibrated_cube, raw_cube)
+        print(result.data)
+        self.assertArrayAlmostEqual(result.data.data, result_data)
+        self.assertArrayEqual(result.data.mask, mask)
+
+    def test_3d_cube_masked_nans(self):
+        """Test that the plugin returns the correct cube data for a
+        3d input cube with a mask applied to each realization, and there are
+        nans under the mask."""
+        mask = np.array([[[True, False]],
+                         [[True, False]],
+                         [[True, False]]])
+        raw_data = np.array(
+            [[[1, 1]],
+             [[3, 2]],
+             [[2, 3]]])
+
+        calibrated_data = np.ma.MaskedArray(
+            [[[np.nan, 1]],
+             [[np.nan, 2]],
+             [[np.nan, 3]]], mask=mask)
+
+        # Reordering of the calibrated_data array to match
+        # the raw_data ordering
+        result_data = np.array(
+            [[[np.nan, 1]],
+             [[np.nan, 2]],
+             [[np.nan, 3]]])
+
+        cube = self.cube.copy()
+        cube = cube[:, :, :2, 0]
+
+        raw_cube = cube.copy()
+        raw_cube.data = raw_data
+
+        calibrated_cube = cube.copy()
+        calibrated_cube.data = calibrated_data
+
+        plugin = Plugin()
+        result = plugin.rank_ecc(calibrated_cube, raw_cube)
+        print(result.data)
+        self.assertArrayAlmostEqual(result.data.data, result_data)
+        self.assertArrayEqual(result.data.mask, mask)
+
     def test_3d_cube_tied_values(self):
         """
         Test that the plugin returns the correct cube data for a

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -72,6 +72,8 @@ class Test_process(IrisTest):
         result = plugin.process(cube)
         self.assertIsInstance(result, Cube)
         self.assertIsInstance(result.coord("realization"), DimCoord)
+        self.assertEqual(result.coord("realization").units, "1")
+        self.assertEqual(result.coord("realization").var_name, "realization")
 
     def test_specify_realization_numbers(self):
         """Use the ensemble_realization_numbers optional argument to specify

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
@@ -607,6 +607,7 @@ class Test_merge_land_and_sea(IrisTest):
             expected_cube.xml(checksum=True),
             self.percentiles_land.xml(checksum=True))
         self.assertFalse(np.ma.is_masked(self.percentiles_land.data))
+        self.assertEqual(self.percentiles_land.data.dtype, np.float32)
 
     def test_nothing_to_merge(self):
         """Test case where there is no missing data to fill in."""
@@ -620,6 +621,7 @@ class Test_merge_land_and_sea(IrisTest):
             expected_cube.xml(checksum=True),
             self.percentiles_land.xml(checksum=True))
         self.assertFalse(np.ma.is_masked(self.percentiles_land.data))
+        self.assertEqual(self.percentiles_land.data.dtype, np.float32)
 
     def test_input_not_masked(self):
         """Test case where input cube is not masked."""
@@ -631,6 +633,7 @@ class Test_merge_land_and_sea(IrisTest):
         self.assertEqual(
             expected_cube.xml(checksum=True),
             self.percentiles_land.xml(checksum=True))
+        self.assertEqual(self.percentiles_land.data.dtype, np.float32)
 
 
 if __name__ == '__main__':

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
@@ -40,17 +40,20 @@ from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
+from iris.util import squeeze
 
 from improver.ensemble_copula_coupling.utilities import (
     choose_set_of_percentiles, concatenate_2d_array_with_2d_array_endpoints,
     create_cube_with_percentiles, get_bounds_of_distribution,
     insert_lower_and_upper_endpoint_to_1d_array,
-    restore_non_probabilistic_dimensions)
+    restore_non_probabilistic_dimensions, merge_land_and_sea)
 
 from ...calibration.ensemble_calibration.helper_functions import (
     add_forecast_reference_time_and_forecast_period, set_up_cube,
     set_up_probability_above_threshold_temperature_cube,
     set_up_spot_temperature_cube, set_up_temperature_cube)
+
+from ...set_up_test_cubes import set_up_percentile_cube
 
 
 class Test_concatenate_2d_array_with_2d_array_endpoints(IrisTest):
@@ -551,6 +554,83 @@ class Test_restore_non_probabilistic_dimensions(IrisTest):
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             restore_non_probabilistic_dimensions(
                 cube.data, cube, "nonsense", plen)
+
+
+class Test_merge_land_and_sea(IrisTest):
+
+    """Test merge_land_and_sea"""
+
+    def setUp(self):
+        """Set up a percentile cube"""
+        # Create a percentile cube
+        land_data = np.ones((2, 3, 4), dtype=np.float32)
+        sea_data = np.ones((2, 3, 4), dtype=np.float32)*3.0
+        mask = np.array([[[True, False, False, False],
+                          [True, False, False, False],
+                          [False, False, False, True]],
+                         [[True, False, False, False],
+                          [True, False, False, False],
+                          [False, False, False, True]]])
+        land_data = np.ma.MaskedArray(land_data, mask)
+        self.percentiles_land = set_up_percentile_cube(land_data, [30, 60])
+        self.percentiles_sea = set_up_percentile_cube(sea_data, [30, 60])
+
+    def test_missing_dim(self):
+        """Check that an error is raised if missing dimensional coordinate"""
+        single_percentile = squeeze(self.percentiles_land[0])
+        message = "Input cubes do not have the same dimension coordinates"
+        with self.assertRaisesRegex(ValueError, message):
+            merge_land_and_sea(single_percentile, self.percentiles_sea)
+
+    def test_mismatch_dim_length(self):
+        """Check an error is raised if a dim coord has a different length"""
+        land_slice = self.percentiles_land[:, 1:, :]
+        message = "Input cubes do not have the same dimension coordinates"
+        with self.assertRaisesRegex(ValueError, message):
+            merge_land_and_sea(land_slice, self.percentiles_sea)
+
+    def test_merge(self):
+        """Test merged data."""
+        expected_merged_data = np.array(
+            [[[3.0, 1.0, 1.0, 1.0],
+              [3.0, 1.0, 1.0, 1.0],
+              [1.0, 1.0, 1.0, 3.0]],
+             [[3.0, 1.0, 1.0, 1.0],
+              [3.0, 1.0, 1.0, 1.0],
+              [1.0, 1.0, 1.0, 3.0]]], dtype=np.float32)
+        expected_cube = self.percentiles_land.copy()
+        expected_cube.data = expected_merged_data
+        merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
+        self.assertArrayAlmostEqual(
+            self.percentiles_land.data, expected_merged_data)
+        self.assertEqual(
+            expected_cube.xml(checksum=True),
+            self.percentiles_land.xml(checksum=True))
+        self.assertFalse(np.ma.is_masked(self.percentiles_land.data))
+
+    def test_nothing_to_merge(self):
+        """Test case where there is no missing data to fill in."""
+        input_mask = np.ones((2, 3, 4)) * False
+        self.percentiles_land.data.mask = input_mask
+        expected_cube = self.percentiles_land.copy()
+        merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
+        self.assertArrayAlmostEqual(
+            self.percentiles_land.data, expected_cube.data)
+        self.assertEqual(
+            expected_cube.xml(checksum=True),
+            self.percentiles_land.xml(checksum=True))
+        self.assertFalse(np.ma.is_masked(self.percentiles_land.data))
+
+    def test_input_not_masked(self):
+        """Test case where input cube is not masked."""
+        self.percentiles_land.data = np.ones((2, 3, 4), dtype=np.float32)
+        expected_cube = self.percentiles_land.copy()
+        merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
+        self.assertArrayAlmostEqual(
+            self.percentiles_land.data, expected_cube.data)
+        self.assertEqual(
+            expected_cube.xml(checksum=True),
+            self.percentiles_land.xml(checksum=True))
 
 
 if __name__ == '__main__':

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
@@ -601,7 +601,7 @@ class Test_merge_land_and_sea(IrisTest):
         expected_cube = self.percentiles_land.copy()
         expected_cube.data = expected_merged_data
         merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
-        self.assertArrayAlmostEqual(
+        self.assertArrayEqual(
             self.percentiles_land.data, expected_merged_data)
         self.assertEqual(
             expected_cube.xml(checksum=True),
@@ -615,7 +615,7 @@ class Test_merge_land_and_sea(IrisTest):
         self.percentiles_land.data.mask = input_mask
         expected_cube = self.percentiles_land.copy()
         merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
-        self.assertArrayAlmostEqual(
+        self.assertArrayEqual(
             self.percentiles_land.data, expected_cube.data)
         self.assertEqual(
             expected_cube.xml(checksum=True),
@@ -628,7 +628,7 @@ class Test_merge_land_and_sea(IrisTest):
         self.percentiles_land.data = np.ones((2, 3, 4), dtype=np.float32)
         expected_cube = self.percentiles_land.copy()
         merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
-        self.assertArrayAlmostEqual(
+        self.assertArrayEqual(
             self.percentiles_land.data, expected_cube.data)
         self.assertEqual(
             expected_cube.xml(checksum=True),

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_utilities.py
@@ -40,20 +40,18 @@ from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
-from iris.util import squeeze
+
 
 from improver.ensemble_copula_coupling.utilities import (
     choose_set_of_percentiles, concatenate_2d_array_with_2d_array_endpoints,
     create_cube_with_percentiles, get_bounds_of_distribution,
     insert_lower_and_upper_endpoint_to_1d_array,
-    restore_non_probabilistic_dimensions, merge_land_and_sea)
+    restore_non_probabilistic_dimensions)
 
 from ...calibration.ensemble_calibration.helper_functions import (
     add_forecast_reference_time_and_forecast_period, set_up_cube,
     set_up_probability_above_threshold_temperature_cube,
     set_up_spot_temperature_cube, set_up_temperature_cube)
-
-from ...set_up_test_cubes import set_up_percentile_cube
 
 
 class Test_concatenate_2d_array_with_2d_array_endpoints(IrisTest):
@@ -554,86 +552,6 @@ class Test_restore_non_probabilistic_dimensions(IrisTest):
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             restore_non_probabilistic_dimensions(
                 cube.data, cube, "nonsense", plen)
-
-
-class Test_merge_land_and_sea(IrisTest):
-
-    """Test merge_land_and_sea"""
-
-    def setUp(self):
-        """Set up a percentile cube"""
-        # Create a percentile cube
-        land_data = np.ones((2, 3, 4), dtype=np.float32)
-        sea_data = np.ones((2, 3, 4), dtype=np.float32)*3.0
-        mask = np.array([[[True, False, False, False],
-                          [True, False, False, False],
-                          [False, False, False, True]],
-                         [[True, False, False, False],
-                          [True, False, False, False],
-                          [False, False, False, True]]])
-        land_data = np.ma.MaskedArray(land_data, mask)
-        self.percentiles_land = set_up_percentile_cube(land_data, [30, 60])
-        self.percentiles_sea = set_up_percentile_cube(sea_data, [30, 60])
-
-    def test_missing_dim(self):
-        """Check that an error is raised if missing dimensional coordinate"""
-        single_percentile = squeeze(self.percentiles_land[0])
-        message = "Input cubes do not have the same dimension coordinates"
-        with self.assertRaisesRegex(ValueError, message):
-            merge_land_and_sea(single_percentile, self.percentiles_sea)
-
-    def test_mismatch_dim_length(self):
-        """Check an error is raised if a dim coord has a different length"""
-        land_slice = self.percentiles_land[:, 1:, :]
-        message = "Input cubes do not have the same dimension coordinates"
-        with self.assertRaisesRegex(ValueError, message):
-            merge_land_and_sea(land_slice, self.percentiles_sea)
-
-    def test_merge(self):
-        """Test merged data."""
-        expected_merged_data = np.array(
-            [[[3.0, 1.0, 1.0, 1.0],
-              [3.0, 1.0, 1.0, 1.0],
-              [1.0, 1.0, 1.0, 3.0]],
-             [[3.0, 1.0, 1.0, 1.0],
-              [3.0, 1.0, 1.0, 1.0],
-              [1.0, 1.0, 1.0, 3.0]]], dtype=np.float32)
-        expected_cube = self.percentiles_land.copy()
-        expected_cube.data = expected_merged_data
-        merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
-        self.assertArrayEqual(
-            self.percentiles_land.data, expected_merged_data)
-        self.assertEqual(
-            expected_cube.xml(checksum=True),
-            self.percentiles_land.xml(checksum=True))
-        self.assertFalse(np.ma.is_masked(self.percentiles_land.data))
-        self.assertEqual(self.percentiles_land.data.dtype, np.float32)
-
-    def test_nothing_to_merge(self):
-        """Test case where there is no missing data to fill in."""
-        input_mask = np.ones((2, 3, 4)) * False
-        self.percentiles_land.data.mask = input_mask
-        expected_cube = self.percentiles_land.copy()
-        merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
-        self.assertArrayEqual(
-            self.percentiles_land.data, expected_cube.data)
-        self.assertEqual(
-            expected_cube.xml(checksum=True),
-            self.percentiles_land.xml(checksum=True))
-        self.assertFalse(np.ma.is_masked(self.percentiles_land.data))
-        self.assertEqual(self.percentiles_land.data.dtype, np.float32)
-
-    def test_input_not_masked(self):
-        """Test case where input cube is not masked."""
-        self.percentiles_land.data = np.ones((2, 3, 4), dtype=np.float32)
-        expected_cube = self.percentiles_land.copy()
-        merge_land_and_sea(self.percentiles_land, self.percentiles_sea)
-        self.assertArrayEqual(
-            self.percentiles_land.data, expected_cube.data)
-        self.assertEqual(
-            expected_cube.xml(checksum=True),
-            self.percentiles_land.xml(checksum=True))
-        self.assertEqual(self.percentiles_land.data.dtype, np.float32)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses the last points of IMPRO-1569:
* Ensures that EnsembleReordering plugin handles masked data.
* Adds a function for combining calibrated land data with uncalibrated sea data.
* Adds CLI tests using the land sea option for apply-emos-coefficients CLI - a notebook showing the new data will follow

There were a couple of other minor changes I made, which are in separate commits so it's easier to see what they are.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

