### PR TITLE
IMPRO-1623: Add forecast reference time coordinate to reliability calibration tables

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -216,7 +216,8 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
                    'forecast periods found: {}.')
             raise ValueError(msg.format(n_cycle_hours, n_forecast_periods))
 
-    def _create_unified_frt_coord(self, forecast_reference_time):
+    @staticmethod
+    def _create_unified_frt_coord(forecast_reference_time):
         """
         Constructs a forecast reference time coordinate for the reliability
         calibration cube that records the range of forecast reference times

--- a/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
@@ -331,21 +331,47 @@ class Test__check_forecast_consistency(Test_Setup):
             Plugin()._check_forecast_consistency(self.forecasts)
 
 
-class Test__create_cycle_hour_coord(Test_Setup):
+class Test__create_unified_frt_coord(Test_Setup):
 
-    """Test the _create_cycle_hour_coord method."""
+    """Test the _create_unified_frt_coord method."""
 
     def test_coordinate(self):
-        """Test the cycle hour coordinate has the expected value and type."""
+        """Test the forecast reference time coordinate has the expected point,
+        bounds, and type for an input with multiple forecast reference time
+        points."""
 
-        expected_cycle_hour = 0
-        frt = self.forecast_1.coord('forecast_reference_time')
-        result = Plugin()._create_cycle_hour_coord(frt)
+        frt = 'forecast_reference_time'
+        frt_coord = self.forecasts.coord(frt)
+
+        expected_points = self.forecast_2.coord(frt).points[0]
+        expected_bounds = [[self.forecast_1.coord(frt).points[0],
+                            expected_points]]
+        result = Plugin()._create_unified_frt_coord(frt_coord)
 
         self.assertIsInstance(result, iris.coords.DimCoord)
-        assert_array_equal(result.points, expected_cycle_hour)
-        self.assertEqual(result.name(), 'cycle_hour')
-        self.assertEqual(result.units, 'hour')
+        assert_array_equal(result.points, expected_points)
+        assert_array_equal(result.bounds, expected_bounds)
+        self.assertEqual(result.name(), frt_coord.name())
+        self.assertEqual(result.units, frt_coord.units)
+
+    def test_coordinate_single_frt_input(self):
+        """Test the forecast reference time coordinate has the expected point,
+        bounds, and type for an input with a single forecast reference time
+        point."""
+
+        frt = 'forecast_reference_time'
+        frt_coord = self.forecast_1.coord(frt)
+
+        expected_points = self.forecast_1.coord(frt).points[0]
+        expected_bounds = [[self.forecast_1.coord(frt).points[0],
+                            expected_points]]
+        result = Plugin()._create_unified_frt_coord(frt_coord)
+
+        self.assertIsInstance(result, iris.coords.DimCoord)
+        assert_array_equal(result.points, expected_points)
+        assert_array_equal(result.bounds, expected_bounds)
+        self.assertEqual(result.name(), frt_coord.name())
+        self.assertEqual(result.units, frt_coord.units)
 
 
 class Test__define_metadata(Test_Setup):


### PR DESCRIPTION
Modify reliability calibration cubes to include a forecast reference time coordinate. This replaces use of the cycle_hour coordinate. 

The forecast reference time coordinate point is equal to the latest forecast cube that contributes to populating the table. The bounds of the coordinate describe the range of forecast FRTs that contributed.

This coordinate will provide one of the two components of metadata required for determining applicability (the cycling hour), and will also act as the provenance metadata.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)