### PR TITLE
Handle multiple possible names for nowcast advection velocity cubes

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -207,11 +207,12 @@ def create_constrained_inputcubelist_converter(*constraints):
     These cubes get loaded and returned as a CubeList.
 
     Args:
-        *constraints (str or list):
+        *constraints (tuple of str or list):
             Constraints to be used in the loading of cubes into a CubeList.
-            If multiple constraints are specified in a list, all provided
-            constraints will be tried as possible options. Only one must
-            identify valid input, otherwise an error will be raised.
+            If the tuple contains a string then the string is expected to
+            return exactly one match. If a tuple contains a list then the list
+            is treated as a group that is expected to return a single match.
+            The tuple can contain a mixture of strings and lists, as required.
 
     Returns:
         function:
@@ -232,8 +233,9 @@ def create_constrained_inputcubelist_converter(*constraints):
 
         Raises:
             ValueError:
-                If multiple possible constraints are provided using a list,
-                then only one constraint must be valid.
+                Each constraint (either a string or a list) is expected to
+                return a single match. An error is raised if no match or more
+                than one match is found.
         """
         from improver.utilities.load import load_cube
         from iris.cube import CubeList

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -223,8 +223,8 @@ def create_constrained_inputcubelist_converter(*constraints):
         """Passes the cube and constraints onto maybe_coerce_with.
 
         Args:
-            to_convert (string or iris.cube.CubeList):
-                The cube to be passed forward for returning or loading.
+            to_convert (string):
+                The filename to be loaded.
 
         Returns:
             iris.cube.CubeList:

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -209,10 +209,11 @@ def create_constrained_inputcubelist_converter(*constraints):
     Args:
         *constraints (tuple of str or list):
             Constraints to be used in the loading of cubes into a CubeList.
-            If the tuple contains a string then the string is expected to
-            return exactly one match. If a tuple contains a list then the list
-            is treated as a group that is expected to return a single match.
-            The tuple can contain a mixture of strings and lists, as required.
+            If the tuple contains a string or multiple strings, then each
+            string is expected to return exactly one match. If the tuple
+            contains a list or multiple lists, then each list is treated as a
+            group that is expected to return a single match. The tuple
+            can contain a mixture of strings and lists as required.
 
     Returns:
         function:

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -38,7 +38,8 @@ ACCUMULATION_FIDELITY = 1
 
 # Creates the value_converter that clize needs.
 inputadvection = cli.create_constrained_inputcubelist_converter(
-    'precipitation_advection_x_velocity', 'precipitation_advection_y_velocity')
+    ['precipitation_advection_x_velocity', 'grid_eastward_wind'],
+    ['precipitation_advection_y_velocity', 'grid_northward_wind'])
 
 
 @cli.clizefy
@@ -59,6 +60,9 @@ def process(cube: cli.inputcube,
             The input Cube to be processed.
         advection_velocity (iris.cube.CubeList):
             Advection cubes of U and V.
+            These must have the names of either:
+            precipitation_advection_x_velocity or grid_eastward_wind
+            precipitation_advection_y_velocity or grid_northward_wind
         orographic_enhancement (iris.cube.Cube):
             Cube containing the orographic enhancement fields. May have data
             for multiple times in the cube.

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -36,7 +36,8 @@ from improver import cli
 
 # Creates the value_converter that clize needs.
 inputadvection = cli.create_constrained_inputcubelist_converter(
-    'precipitation_advection_x_velocity', 'precipitation_advection_y_velocity')
+    ['precipitation_advection_x_velocity', 'grid_eastward_wind'],
+    ['precipitation_advection_y_velocity', 'grid_northward_wind'])
 
 
 @cli.clizefy
@@ -47,16 +48,16 @@ def process(cube: cli.inputcube,
             *,
             attributes_config: cli.inputjson = None,
             max_lead_time: int = 360, lead_time_interval: int = 15):
-    """Module  to extrapolate input cubes given advection velocity fields.
+    """Module to extrapolate input cubes given advection velocity fields.
 
     Args:
         cube (iris.cube.Cube):
             The data to be advected.
         advection_velocity (iris.cube.CubeList):
             Advection cubes of U and V.
-            These must have the names of.
-            precipitation_advection_x_velocity
-            precipitation_advection_y_velocity
+            These must have the names of either:
+            precipitation_advection_x_velocity or grid_eastward_wind
+            precipitation_advection_y_velocity or grid_northward_wind
         orographic_enhancement (iris.cube.Cube):
             Cube containing orographic enhancement forecasts for the lead times
             at which an extrapolation nowcast is required.

--- a/improver_tests/acceptance/test_nowcast_accumulate.py
+++ b/improver_tests/acceptance/test_nowcast_accumulate.py
@@ -40,17 +40,34 @@ CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 
 
-def test_basic(tmp_path):
-    """
-    Test use of ECC to convert one set of percentiles to another set of
-    percentiles, and then reorder the ensemble using the raw ensemble
-    realizations
-    """
+@pytest.mark.slow
+def test_optical_flow_inputs(tmp_path):
+    """Test creating a nowcast accumulation using optical flow inputs"""
     kgo_dir = acc.kgo_root() / "nowcast-accumulate/basic"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = (kgo_dir /
                   "201811031600_radar_rainrate_composite_UK_regridded.nc")
-    uv_path = kgo_dir / "uv.nc"
+    uv_path = kgo_dir / "optical_flow_uv.nc"
+    oe_path = kgo_dir / "20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
+
+    output_path = tmp_path / "output.nc"
+
+    args = [input_path, uv_path, oe_path,
+            "--max-lead-time", "30",
+            "--output", output_path]
+
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+@pytest.mark.slow
+def test_wind_inputs(tmp_path):
+    """Test creating a nowcast accumulation using wind component inputs"""
+    kgo_dir = acc.kgo_root() / "nowcast-accumulate/basic"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = (kgo_dir /
+                  "201811031600_radar_rainrate_composite_UK_regridded.nc")
+    uv_path = kgo_dir / "wind_uv.nc"
     oe_path = kgo_dir / "20181103T1600Z-PT0003H00M-orographic_enhancement.nc"
 
     output_path = tmp_path / "output.nc"

--- a/improver_tests/acceptance/test_nowcast_extrapolate.py
+++ b/improver_tests/acceptance/test_nowcast_extrapolate.py
@@ -44,17 +44,17 @@ RAINRATE_NC = "201811031600_radar_rainrate_composite_UK_regridded.nc"
 OE = "orographic_enhancement_standard_resolution"
 
 
-def test_basic(tmp_path):
+def test_optical_flow_inputs(tmp_path):
     """Test extrapolation nowcast using optical flow inputs"""
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
-    kgo_path = kgo_dir / "single_orographic_enhancement_kgo.nc"
+    kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / ".." / RAINRATE_NC
-    oe_path_t3 = kgo_dir / "../orographic_enhancement_T3.nc"
+    oe_path = kgo_dir / "../orographic_enhancement.nc"
     uv_path = kgo_dir / "../optical_flow_uv.nc"
 
     output_path = tmp_path / "output.nc"
 
-    args = [input_path, uv_path, oe_path_t3,
+    args = [input_path, uv_path, oe_path,
             "--max-lead-time", "30",
             "--output", output_path]
     run_cli(args)
@@ -67,12 +67,12 @@ def test_wind_inputs(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / ".." / RAINRATE_NC
     oe_path = kgo_dir / "../orographic_enhancement.nc"
-    uv_path = kgo_dir / "../uv.nc"
+    uv_path = kgo_dir / "../wind_uv.nc"
 
     output_path = tmp_path / "output.nc"
 
     args = [input_path, uv_path, oe_path,
-            "--max-lead-time", "90",
+            "--max-lead-time", "30",
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_nowcast_extrapolate.py
+++ b/improver_tests/acceptance/test_nowcast_extrapolate.py
@@ -45,7 +45,24 @@ OE = "orographic_enhancement_standard_resolution"
 
 
 def test_basic(tmp_path):
-    """Test basic extrapolation nowcast"""
+    """Test extrapolation nowcast using optical flow inputs"""
+    kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
+    kgo_path = kgo_dir / "single_orographic_enhancement_kgo.nc"
+    input_path = kgo_dir / ".." / RAINRATE_NC
+    oe_path_t3 = kgo_dir / "../orographic_enhancement_T3.nc"
+    uv_path = kgo_dir / "../optical_flow_uv.nc"
+
+    output_path = tmp_path / "output.nc"
+
+    args = [input_path, uv_path, oe_path_t3,
+            "--max-lead-time", "30",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_wind_inputs(tmp_path):
+    """Test extrapolation nowcast using wind component inputs"""
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / ".." / RAINRATE_NC
@@ -68,7 +85,7 @@ def test_metadata(tmp_path):
     input_path = kgo_dir / ".." / RAINRATE_NC
     oe_path = kgo_dir / "../orographic_enhancement.nc"
     meta_path = kgo_dir / "precip.json"
-    uv_path = kgo_dir / "../uv.nc"
+    uv_path = kgo_dir / "../optical_flow_uv.nc"
 
     output_path = tmp_path / "output.nc"
 
@@ -87,7 +104,7 @@ def test_basic_no_orographic(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = (kgo_dir /
                   "20190101T0300Z-PT0000H00M-cloud_amount_of_total_cloud.nc")
-    uv_path = kgo_dir / "../uv.nc"
+    uv_path = kgo_dir / "../optical_flow_uv.nc"
 
     output_path = tmp_path / "output.nc"
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -206,6 +206,17 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         m.assert_any_call(load_cube, "foo", constraints='wind_from_direction')
         self.assertEqual(m.call_count, 2)
 
+    @patch('improver.cli.maybe_coerce_with', return_value='return')
+    def test_list(self, m):
+        """Tests that a list returns a function which itself returns 2 cubes"""
+        result = create_constrained_inputcubelist_converter(
+            ['wind_speed'], ['wind_from_direction'])
+        result("foo")
+        m.assert_any_call(load_cube, "foo", constraints='wind_speed')
+        m.assert_any_call(
+            load_cube, "foo", constraints='wind_from_direction')
+        self.assertEqual(m.call_count, 2)
+
 
 class Test_clizefy(unittest.TestCase):
     """Test the clizefy decorator function"""

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -196,24 +196,34 @@ class Test_with_intermediate_output(unittest.TestCase):
         m.assert_called_with(True, 'foo')
         self.assertEqual(result, 4)
 
-
+# pylint: disable=W0613
 def replace_load_with_extract(function, cube, constraints=None):
-    """Function to replicate the call to merge_coerce_with within
+    """Function to replicate the call to maybe_coerce_with within
     create_constrained_inputcubelist_converter.
 
     Args:
         function:
             Unused argument for the purpose of replicating the
-            merge_coerce_with interface.
+            maybe_coerce_with interface.
         cube (iris.cube.Cube or iris.cube.CubeList):
             Cube or CubeList to be extracted from.
         constraints (str or None):
             Expected name of cube for extraction.
+
+    Returns:
+        iris.cube.Cube:
+            The extracted cube.
+
+    Raises:
+        ValueError:
+            Error to replicate the behaviour of the call of maybe_coerce_with,
+            where loading a cube with an invalid constraint results in a
+            ValueError.
     """
     if constraints:
         cube = cube.extract(constraints)
     if isinstance(cube, CubeList):
-        cube, = cube
+        cube, = cube.copy()
     if cube is None:
         raise ValueError
     return cube

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -196,13 +196,13 @@ class Test_with_intermediate_output(unittest.TestCase):
         m.assert_called_with(True, 'foo')
         self.assertEqual(result, 4)
 
-# pylint: disable=W0613
-def replace_load_with_extract(function, cube, constraints=None):
+
+def replace_load_with_extract(func, cube, constraints=None):
     """Function to replicate the call to maybe_coerce_with within
     create_constrained_inputcubelist_converter.
 
     Args:
-        function:
+        func:
             Unused argument for the purpose of replicating the
             maybe_coerce_with interface.
         cube (iris.cube.Cube or iris.cube.CubeList):
@@ -220,6 +220,7 @@ def replace_load_with_extract(function, cube, constraints=None):
             where loading a cube with an invalid constraint results in a
             ValueError.
     """
+    del func
     if constraints:
         cube = cube.extract(constraints)
     if isinstance(cube, CubeList):

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -33,6 +33,7 @@
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 import improver
 from improver.cli import (
     clizefy,
@@ -46,6 +47,9 @@ from improver.cli import (
     with_output,
 )
 from improver.utilities.load import load_cube
+from iris.cube import CubeList
+
+from ..set_up_test_cubes import set_up_variable_cube
 
 
 def dummy_function(first, second=0, third=2):
@@ -193,8 +197,37 @@ class Test_with_intermediate_output(unittest.TestCase):
         self.assertEqual(result, 4)
 
 
+def replace_load_with_extract(function, cube, constraints=None):
+    """Function to replicate the call to merge_coerce_with within
+    create_constrained_inputcubelist_converter.
+
+    Args:
+        function:
+            Unused argument for the purpose of replicating the
+            merge_coerce_with interface.
+        cube (iris.cube.Cube or iris.cube.CubeList):
+            Cube or CubeList to be extracted from.
+        constraints (str or None):
+            Expected name of cube for extraction.
+    """
+    if constraints:
+        cube = cube.extract(constraints)
+    if isinstance(cube, CubeList):
+        cube, = cube
+    if cube is None:
+        raise ValueError
+    return cube
+
+
 class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     """Tests the creature constraint_inputcubelist_converter"""
+
+    def setUp(self):
+        data = np.zeros((2,2), dtype=np.float32)
+        self.wind_speed_cube = set_up_variable_cube(data, name="wind_speed")
+        self.wind_dir_cube = set_up_variable_cube(
+            data, name="wind_from_direction")
+        self.wind_cubes = CubeList([self.wind_speed_cube, self.wind_dir_cube])
 
     @patch('improver.cli.maybe_coerce_with', return_value='return')
     def test_basic(self, m):
@@ -216,6 +249,48 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         m.assert_any_call(
             load_cube, "foo", constraints='wind_from_direction')
         self.assertEqual(m.call_count, 2)
+
+    @patch('improver.cli.maybe_coerce_with', new=replace_load_with_extract)
+    def test_list_one_valid(self):
+        """Tests that a list returns a function which itself returns 1 cube
+        that matches the constraints provided."""
+        obj = create_constrained_inputcubelist_converter(
+            ['wind_speed', 'nonsense'])
+        result = obj(self.wind_speed_cube)
+        self.assertEqual(result, [self.wind_speed_cube])
+
+    @patch('improver.cli.maybe_coerce_with', new=replace_load_with_extract)
+    def test_list_two_valid(self):
+        """Tests that providing two valid constraints raises a ValueError."""
+        obj = create_constrained_inputcubelist_converter(
+            ['wind_speed', 'wind_from_direction'])
+        msg = 'Incorrect number of valid inputs available'
+        with self.assertRaisesRegex(ValueError, msg):
+            obj(self.wind_cubes)
+
+    @patch('improver.cli.maybe_coerce_with', new=replace_load_with_extract)
+    def test_list_no_match(self):
+        """Tests that providing no valid constraints raises a ValueError."""
+        obj = create_constrained_inputcubelist_converter(['nonsense'])
+        msg = 'Incorrect number of valid inputs available'
+        with self.assertRaisesRegex(ValueError, msg):
+            obj(self.wind_cubes)
+
+    @patch('improver.cli.maybe_coerce_with', new=replace_load_with_extract)
+    def test_list_one_optional_constraint(self):
+        """Tests that a list returns a function which itself returns 2 cubes"""
+        obj = create_constrained_inputcubelist_converter(
+            ['wind_speed', 'nonsense'], 'wind_from_direction')
+        result = obj(self.wind_cubes)
+        self.assertEqual(result, self.wind_cubes)
+
+    @patch('improver.cli.maybe_coerce_with', new=replace_load_with_extract)
+    def test_list_mismatching_lengths(self):
+        """Tests that a list returns a function which itself returns 2 cubes"""
+        obj = create_constrained_inputcubelist_converter(
+            ['wind_speed', 'nonsense'], ['wind_from_direction'])
+        result = obj(self.wind_cubes)
+        self.assertEqual(result, self.wind_cubes)
 
 
 class Test_clizefy(unittest.TestCase):

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -223,7 +223,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     """Tests the creature constraint_inputcubelist_converter"""
 
     def setUp(self):
-        data = np.zeros((2,2), dtype=np.float32)
+        data = np.zeros((2, 2), dtype=np.float32)
         self.wind_speed_cube = set_up_variable_cube(data, name="wind_speed")
         self.wind_dir_cube = set_up_variable_cube(
             data, name="wind_from_direction")


### PR DESCRIPTION
This PR is currently dependent on #1166 

Description
This PR modifies `create_constrained_inputcubelist_converter` so that multiple possible constraints can be provided, as long as only one constraint is valid. The purpose of this is to support multiple possible inputs being provided to the nowcast-extrapolate and nowcast-accumulate CLIs.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

