### PR TITLE
Tidy up land sea docstrings

### DIFF
--- a/improver/cli/generate_topography_bands_mask.py
+++ b/improver/cli/generate_topography_bands_mask.py
@@ -50,7 +50,8 @@ def process(orography: cli.inputcube,
         orography (iris.cube.Cube):
             The orography on a standard grid.
         land_sea_mask (iris.cube.Cube):
-            The land mask on standard grid. If provided sea points will be set
+            The land mask on standard grid, with land points set to one and
+            sea points set to zero. If provided sea points will be set
             to zero in every band. If no land mask is provided, sea points will
             be included in the appropriate topographic band.
         bands_config (dict):

--- a/improver/cli/generate_topography_bands_weights.py
+++ b/improver/cli/generate_topography_bands_weights.py
@@ -55,7 +55,8 @@ def process(orography: cli.inputcube,
         orography (iris.cube.Cube):
             The orography on a standard grid.
         land_sea_mask (iris.cube.Cube):
-            Land mask on a standard grid. If provided, sea points will be
+            Land mask on a standard grid, with land points set to one and
+            sea points set to zero. If provided, sea points will be
             masked and set to the default fill value. If no land mask is
             provided, weights will be generated for sea points as well as land
             in the appropriate topographic band.

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -62,8 +62,8 @@ def process(cube: cli.inputcube,
             A cube to be processed.
         mask (iris.cube.Cube):
             A cube containing either a mask of topographic zones over land or
-            a land-sea mask. If this a land-sea mask land points should be set
-            to one and sea points set to zero.
+            a land-sea mask. If this is a land-sea mask, land points should be
+            set to one and sea points set to zero.
         weights (iris.cube.Cube):
             A cube containing the weights which are used for collapsing the
             dimension gained through masking. These weights must have been

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -62,7 +62,8 @@ def process(cube: cli.inputcube,
             A cube to be processed.
         mask (iris.cube.Cube):
             A cube containing either a mask of topographic zones over land or
-            a land-sea mask.
+            a land-sea mask. If this a land-sea mask land points should be set
+            to one and sea points set to zero.
         weights (iris.cube.Cube):
             A cube containing the weights which are used for collapsing the
             dimension gained through masking. These weights must have been

--- a/improver/cli/neighbour_finding.py
+++ b/improver/cli/neighbour_finding.py
@@ -67,7 +67,8 @@ def process(orography: cli.inputcube,
             being found.
         land_sea_mask (iris.cube.Cube):
             Cube of model land mask for the model grid on which neighbours are
-            being found.
+            being found, with land points set to one and sea points set to
+            zero. 
         site_list (dict):
             Dictionary that contains the spot sites for which neighbouring grid
             points are to be found.

--- a/improver/cli/neighbour_finding.py
+++ b/improver/cli/neighbour_finding.py
@@ -68,7 +68,7 @@ def process(orography: cli.inputcube,
         land_sea_mask (iris.cube.Cube):
             Cube of model land mask for the model grid on which neighbours are
             being found, with land points set to one and sea points set to
-            zero. 
+            zero.
         site_list (dict):
             Dictionary that contains the spot sites for which neighbouring grid
             points are to be found.

--- a/improver/cli/standardise.py
+++ b/improver/cli/standardise.py
@@ -71,7 +71,7 @@ def process(cube: cli.inputcube,
         land_sea_mask (iris.cube.Cube):
             A cube describing the land_binary_mask on the source-grid if
             coastline-aware regridding is required, with land points set to
-            one and sea points set to zero. 
+            one and sea points set to zero.
         regrid_mode (str):
             Selects which regridding techniques to use. Default uses
             iris.analysis.Linear(); "nearest" uses Nearest() (for less

--- a/improver/cli/standardise.py
+++ b/improver/cli/standardise.py
@@ -70,7 +70,8 @@ def process(cube: cli.inputcube,
             this must be land_binary_mask data.
         land_sea_mask (iris.cube.Cube):
             A cube describing the land_binary_mask on the source-grid if
-            coastline-aware regridding is required.
+            coastline-aware regridding is required, with land points set to
+            one and sea points set to zero. 
         regrid_mode (str):
             Selects which regridding techniques to use. Default uses
             iris.analysis.Linear(); "nearest" uses Nearest() (for less

--- a/improver/generate_ancillaries/generate_ancillary.py
+++ b/improver/generate_ancillaries/generate_ancillary.py
@@ -284,7 +284,8 @@ class GenerateOrographyBandAncils(BasePlugin):
                     {'bounds':[[0,100], [100,200]], 'units': "m"}
 
             landmask (iris.cube.Cube):
-                land mask on standard grid. If provided sea points are set to
+                land mask on standard grid, with land points set to one and
+                sea points set to zero. If provided sea points are set to
                 zero in every band.
 
         Returns:

--- a/improver/generate_ancillaries/generate_topographic_zone_weights.py
+++ b/improver/generate_ancillaries/generate_topographic_zone_weights.py
@@ -171,7 +171,8 @@ class GenerateTopographicZoneWeights(BasePlugin):
                 The expected format of the dictionary is e.g.
                 `{'bounds': [[0, 50], [50, 200]], 'units': 'm'}`
             landmask (iris.cube.Cube):
-                Land mask on standard grid. If provided sea points are masked
+                Land mask on standard grid, with land points set to one and
+                sea points set to zero. If provided sea points are masked
                 out in the output array.
         Returns:
             iris.cube.Cube:

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -970,7 +970,8 @@ class PhaseChangeLevel(BasePlugin):
                 orog (iris.cube.Cube):
                     Cube of orography (m).
                 land_sea_mask (iris.cube.Cube):
-                    Cube containing a binary land-sea mask.
+                    Cube containing a binary land-sea mask, with land points
+                    set to one and sea points set to zero. 
 
         Returns:
             iris.cube.Cube:

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -971,7 +971,7 @@ class PhaseChangeLevel(BasePlugin):
                     Cube of orography (m).
                 land_sea_mask (iris.cube.Cube):
                     Cube containing a binary land-sea mask, with land points
-                    set to one and sea points set to zero. 
+                    set to one and sea points set to zero.
 
         Returns:
             iris.cube.Cube:

--- a/improver/spotdata/neighbour_finding.py
+++ b/improver/spotdata/neighbour_finding.py
@@ -422,7 +422,8 @@ class NeighbourSelection(BasePlugin):
                 A cube of orography, used to obtain the grid point altitudes.
             land_mask (iris.cube.Cube):
                 A land mask cube for the model/grid from which grid point
-                neighbours are being selected.
+                neighbours are being selected, with land points set to one and
+                sea points set to zero.
         Returns:
             iris.cube.Cube:
                 A cube containing both the spot site information and for each

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -121,7 +121,7 @@ class StandardiseGridAndMetadata(BasePlugin):
             landmask (iris.cube.Cube or None):
                 Land-sea mask ("land_binary_mask") on the input cube grid.
                 Required for "nearest-with-mask" regridding option,
-                with land points set to one and sea points set to zero. 
+                with land points set to one and sea points set to zero.
             landmask_vicinity (float):
                 Radius of vicinity to search for a coastline, in metres
 
@@ -445,7 +445,8 @@ class AdjustLandSeaPoints:
             input_land (iris.cube.Cube):
                 Cube of land_binary_mask data on the grid from which "cube" has
                 been reprojected (it is expected that the iris.analysis.Nearest
-                method would have been used).
+                method would have been used). Land points should be set to one
+                and sea points set to zero.
                 This is used to determine where the input model data is
                 representing land and sea points.
             output_land (iris.cube.Cube):

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -120,7 +120,8 @@ class StandardiseGridAndMetadata(BasePlugin):
                 Mode to fill regions outside the domain in regridding.
             landmask (iris.cube.Cube or None):
                 Land-sea mask ("land_binary_mask") on the input cube grid.
-                Required for "nearest-with-mask" regridding option.
+                Required for "nearest-with-mask" regridding option,
+                with land points set to one and sea points set to zero. 
             landmask_vicinity (float):
                 Radius of vicinity to search for a coastline, in metres
 


### PR DESCRIPTION
Whilst doing the work for IMPRO-1569 it became obvious that it is very easy to get confused as to the convention for land-sea mask. This PR ensures that all docstrings describing land-sea inputs say that land points are set to one and sea points are set to zero in the land-sea mask cube. Hopefully this will help avoid future confusion.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

