### PR TITLE
IMPRO-1626: Speed up wet-bulb-temperature calculation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,6 @@ dependencies:
   - pycodestyle
   - filelock
   - mock
+  - numba
   - pip:
     - clize

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -89,6 +89,7 @@ def _svp_from_lookup(temperature, svpdata):
     output = output.reshape(temperature.shape)
     return output
 
+
 @numba.jit
 def calculate_svp_in_air(temperature, pressure):
     """


### PR DESCRIPTION
This PR speeds up the wet-bulb-temperature calculation plugin. It does this in the following ways:

- Use numba to speed up calculations.
- Remove unneeded use of np.where.
- Replace power with multiplication where this was found to help.

For a test case the speed up is about a factor of 2. There are small changes to the values produced.
Note that Numba is not in the current operational stack, so this may have to exist as a proof on concept for now.

Example: Single forecast leadtime, data valid at 20200228T1300Z from a 20200226T0000Z cycle

Master:
```
	User time (seconds): 353.35
	System time (seconds): 41.08
	Percent of CPU this job got: 233%
```
This branch:
```
	User time (seconds): 174.89
	System time (seconds): 29.44
	Percent of CPU this job got: 169%
```

Testing:
 - [x] Ran tests and they passed OK (using a stack with Numba)