### PR TITLE
Impro1601 wxcode consistency checks

### DIFF
--- a/improver/wxcode/wxcode_decision_tree.py
+++ b/improver/wxcode/wxcode_decision_tree.py
@@ -312,7 +312,7 @@ def wxcode_decision_tree():
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
                                        (0.1, 'mm hr-1')]],
-            'diagnostic_conditions': ['above', 'above']},
+            'diagnostic_conditions': [['above', 'above']]},
 
         # B.1
         'snow_in_vicinity_cloud': {

--- a/improver/wxcode/wxcode_decision_tree_global.py
+++ b/improver/wxcode/wxcode_decision_tree_global.py
@@ -219,7 +219,7 @@ def wxcode_decision_tree_global():
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
                                        (0.1, 'mm hr-1')]],
-            'diagnostic_conditions': ['above', 'above']},
+            'diagnostic_conditions': [['above', 'above']]},
 
         'light_sleet_shower': {
             'succeed': 17,
@@ -252,7 +252,7 @@ def wxcode_decision_tree_global():
             'diagnostic_gamma': [1.],
             'diagnostic_thresholds': [[(0.1, 'mm hr-1'),
                                        (0.1, 'mm hr-1')]],
-            'diagnostic_conditions': ['above', 'above']},
+            'diagnostic_conditions': [['above', 'above']]},
 
         'drizzle_mist': {
             'succeed': 11,

--- a/improver_tests/wxcode/wxcode/__init__.py
+++ b/improver_tests/wxcode/wxcode/__init__.py
@@ -42,7 +42,7 @@ def check_diagnostic_lists_consistency(query):
 
     Raises:
         ValueError: if diagnostic query lists have different nested list
-    structure.
+            structure.
 
     """
     diagnostic_keys = [
@@ -68,7 +68,7 @@ def check_nested_list_consistency(query):
 
     Returns:
         bool: True if diagnostic query lists have same nested list
-    structure.
+            structure.
 
     """
 

--- a/improver_tests/wxcode/wxcode/__init__.py
+++ b/improver_tests/wxcode/wxcode/__init__.py
@@ -37,7 +37,8 @@ def check_diagnostic_lists_consistency(query):
     structure. e.g. ['item'] != [['item']]
 
     Args:
-        query: dict of weather-symbols decision-making information
+        query (dict):
+            of weather-symbols decision-making information
 
     Raises:
         ValueError: if diagnostic query lists have different nested list
@@ -62,7 +63,8 @@ def check_nested_list_consistency(query):
     structure. e.g. ['item'] != [['item']]
 
     Args:
-        query: list of lists
+        query (list of lists):
+            Nested lists to check for consistency.
 
     Returns:
         bool: True if diagnostic query lists have same nested list

--- a/improver_tests/wxcode/wxcode/__init__.py
+++ b/improver_tests/wxcode/wxcode/__init__.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Utilities for Unit tests for Weather Symbols"""
+
+
+def check_diagnostic_lists_consistency(query):
+    """
+    Checks if specific input lists have same nested list
+    structure. e.g. ['item'] != [['item']]
+
+    Args:
+        query: dict of weather-symbols decision-making information
+
+    Raises:
+        ValueError: if diagnostic query lists have different nested list
+    structure.
+
+    """
+    diagnostic_keys = [
+        'diagnostic_fields',
+        'diagnostic_conditions',
+        'diagnostic_thresholds']
+    values = [query[key] for key in diagnostic_keys]
+    if not check_nested_list_consistency(values):
+        msg = f"Inconsistent list structure: \n"
+        for key in diagnostic_keys:
+            msg += f"{key} = {query[key]}; \n"
+        raise ValueError(msg)
+
+
+def check_nested_list_consistency(query):
+    """
+    Return True if all input lists have same nested list
+    structure. e.g. ['item'] != [['item']]
+
+    Args:
+        query: list of lists
+
+    Returns:
+        bool: True if diagnostic query lists have same nested list
+    structure.
+
+    """
+
+    def _checker(lists):
+        """Return True if all input lists have same nested list
+        structure. e.g. ['item'] != [['item']]."""
+        type_set = set(map(type, lists))
+        if list in type_set:
+            return (
+                    len(type_set) == 1 and
+                    len(set(map(len, lists))) == 1 and
+                    all(map(_checker, zip(*lists)))
+            )
+        return True
+
+    return _checker(query)

--- a/improver_tests/wxcode/wxcode/test_wxcode_decision_tree.py
+++ b/improver_tests/wxcode/wxcode/test_wxcode_decision_tree.py
@@ -37,6 +37,7 @@ from iris.tests import IrisTest
 from improver.wxcode.utilities import expand_nested_lists
 from improver.wxcode.wxcode_decision_tree import (
     START_NODE, wxcode_decision_tree)
+from . import check_diagnostic_lists_consistency
 
 REQUIRED_KEY_WORDS = ['succeed',
                       'fail',
@@ -132,29 +133,11 @@ class Test_wxcode_decision_tree(IrisTest):
 
     def test_diagnostic_len_match(self):
         """Test diagnostic fields, thresholds and conditions are same
-        structure."""
-
-        def check_value_consistency(values):
-            """Return True if all input lists have same nested list
-            structure. e.g. ['item'] != [['item']]."""
-            type_set = set(map(type, values))
-            if list in type_set:
-                return (
-                        len(type_set) == 1 and
-                        len(set(map(len, values))) == 1 and
-                        all(map(check_value_consistency, zip(*values)))
-                )
-            return True
-
+        nested-list structure."""
         tree = wxcode_decision_tree()
-        diagnostic_keys = [
-            'diagnostic_fields',
-            'diagnostic_conditions',
-            'diagnostic_thresholds']
         for node in tree:
             query = tree[node]
-            self.assertTrue(check_value_consistency(
-                [query[key] for key in diagnostic_keys]))
+            check_diagnostic_lists_consistency(query)
 
     def test_probability_len_match(self):
         """Test probability_thresholds list is right shape."""

--- a/improver_tests/wxcode/wxcode/test_wxcode_decision_tree.py
+++ b/improver_tests/wxcode/wxcode/test_wxcode_decision_tree.py
@@ -34,7 +34,6 @@ import unittest
 
 from iris.tests import IrisTest
 
-from improver.wxcode.utilities import expand_nested_lists
 from improver.wxcode.wxcode_decision_tree import (
     START_NODE, wxcode_decision_tree)
 from . import check_diagnostic_lists_consistency

--- a/improver_tests/wxcode/wxcode/test_wxcode_decision_tree.py
+++ b/improver_tests/wxcode/wxcode/test_wxcode_decision_tree.py
@@ -131,17 +131,50 @@ class Test_wxcode_decision_tree(IrisTest):
                 self.assertEqual(fail in tree, True)
 
     def test_diagnostic_len_match(self):
-        """Test diagnostic fields, thresholds and conditions are same len."""
+        """Test diagnostic fields, thresholds and conditions are same
+        structure."""
+
+        def check_value_consistency(values):
+            """Return True if all input lists have same nested list
+            structure. e.g. ['item'] != [['item']]."""
+            type_set = set(map(type, values))
+            if list in type_set:
+                return (
+                        len(type_set) == 1 and
+                        len(set(map(len, values))) == 1 and
+                        all(map(check_value_consistency, zip(*values)))
+                )
+            return True
+
         tree = wxcode_decision_tree()
+        diagnostic_keys = [
+            'diagnostic_fields',
+            'diagnostic_conditions',
+            'diagnostic_thresholds']
         for node in tree:
             query = tree[node]
-            diag_len = len(expand_nested_lists(query, 'diagnostic_fields'))
-            thres_len = len(expand_nested_lists(query,
-                                                'diagnostic_thresholds'))
-            cond_len = len(expand_nested_lists(query,
-                                               'diagnostic_conditions'))
-            self.assertEqual(diag_len, thres_len)
-            self.assertEqual(diag_len, cond_len)
+            self.assertTrue(check_value_consistency(
+                [query[key] for key in diagnostic_keys]))
+
+    def test_probability_len_match(self):
+        """Test probability_thresholds list is right shape."""
+        tree = wxcode_decision_tree()
+        for _, query in tree.items():
+            check_list = query['probability_thresholds']
+            self.assertTrue(all([isinstance(x, (int, float))
+                                 for x in check_list]))
+            self.assertTrue(len(check_list) == len(query['diagnostic_fields']))
+
+    def test_gamma_len_match(self):
+        """Test diagnostic_gamma list is right shape if present."""
+        tree = wxcode_decision_tree()
+        for _, query in tree.items():
+            check_list = query.get('diagnostic_gamma', None)
+            if not check_list:
+                continue
+            self.assertTrue(all([isinstance(x, (int, float))
+                                 for x in check_list]))
+            self.assertTrue(len(check_list) == len(query['diagnostic_fields']))
 
 
 if __name__ == '__main__':

--- a/improver_tests/wxcode/wxcode/test_wxcode_decision_tree_global.py
+++ b/improver_tests/wxcode/wxcode/test_wxcode_decision_tree_global.py
@@ -37,6 +37,7 @@ from iris.tests import IrisTest
 from improver.wxcode.utilities import expand_nested_lists
 from improver.wxcode.wxcode_decision_tree_global import (
     START_NODE_GLOBAL, wxcode_decision_tree_global)
+from . import check_diagnostic_lists_consistency
 
 REQUIRED_KEY_WORDS = ['succeed',
                       'fail',
@@ -119,29 +120,11 @@ class Test_wxcode_decision_tree_global(IrisTest):
 
     def test_diagnostic_len_match(self):
         """Test diagnostic fields, thresholds and conditions are same
-        structure."""
-
-        def check_value_consistency(values):
-            """Return True if all input lists have same nested list
-            structure. e.g. ['item'] != [['item']]."""
-            type_set = set(map(type, values))
-            if list in type_set:
-                return (
-                        len(type_set) == 1 and
-                        len(set(map(len, values))) == 1 and
-                        all(map(check_value_consistency, zip(*values)))
-                )
-            return True
-
+        nested-list structure."""
         tree = wxcode_decision_tree_global()
-        diagnostic_keys = [
-            'diagnostic_fields',
-            'diagnostic_conditions',
-            'diagnostic_thresholds']
         for node in tree:
             query = tree[node]
-            self.assertTrue(check_value_consistency(
-                [query[key] for key in diagnostic_keys]))
+            check_diagnostic_lists_consistency(query)
 
     def test_probability_len_match(self):
         """Test probability_thresholds list is right shape."""

--- a/improver_tests/wxcode/wxcode/test_wxcode_decision_tree_global.py
+++ b/improver_tests/wxcode/wxcode/test_wxcode_decision_tree_global.py
@@ -34,7 +34,6 @@ import unittest
 
 from iris.tests import IrisTest
 
-from improver.wxcode.utilities import expand_nested_lists
 from improver.wxcode.wxcode_decision_tree_global import (
     START_NODE_GLOBAL, wxcode_decision_tree_global)
 from . import check_diagnostic_lists_consistency


### PR DESCRIPTION
Addresses IMPRO-1601

Make weather_symbol tree definitions consistent.

Unit-tests for the weather symbols trees now include checks for consistency in the nested list structures and the similar lists that should have one fewer list-nesting level.

Updates the weather symbols trees to comply with these new tests.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the existing feature(s)
