### PR TITLE
IMPRO-1506: Plugin for applying reliability calibration.

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -639,9 +639,9 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
                      observation_frequencies):
         """
         Perform interpolation of the forecast probabilities using the
-        calibration data to produce the calibrated forecast. Where necessary
-        linear extrapolation will be applied. Any mask in place on the
-        forecast_threshold data is removed and reapplied after calibration.
+        reliability table data to produce the calibrated forecast. Where
+        necessary linear extrapolation will be applied. Any mask in place on
+        the forecast_threshold data is removed and reapplied after calibration.
 
         Args:
             forecast_threshold (numpy.ndarray):
@@ -654,9 +654,9 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
 
         Returns:
             numpy.ndarray:
-                The calibrated forecast probabilites. The final results are
+                The calibrated forecast probabilities. The final results are
                 clipped to ensure any extrapolation has not yielded
-                probabilties outside the range 0 to 1.
+                probabilities outside the range 0 to 1.
         """
         shape = forecast_threshold.shape
         mask = (forecast_threshold.mask if np.ma.is_masked(forecast_threshold)

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -425,7 +425,7 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         return MergeCubes()(reliability_tables)
 
 
-class AggregateReliabilityCalibrationTables:
+class AggregateReliabilityCalibrationTables(BasePlugin):
 
     """This plugin enables the aggregation of multiple reliability calibration
     tables, and/or the aggregation over coordinates in the tables."""

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -38,7 +38,7 @@ import iris
 from iris.exceptions import CoordinateNotFoundError
 import numpy as np
 
-from improver import BasePlugin
+from improver import BasePlugin, PostProcessingPlugin
 from improver.utilities.cube_manipulation import MergeCubes, collapsed
 from improver.metadata.utilities import generate_mandatory_attributes
 from improver.metadata.probabilistic import find_threshold_coordinate
@@ -494,7 +494,7 @@ class AggregateReliabilityCalibrationTables:
         return result
 
 
-class ApplyReliabilityCalibration:
+class ApplyReliabilityCalibration(PostProcessingPlugin):
 
     """
     A plugin for the application of reliability calibration to probability

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the ApplyReliabilityCalibration plugin."""
+
+import unittest
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from improver.calibration.reliability_calibration import (
+    ApplyReliabilityCalibration as Plugin)
+
+from improver.calibration.reliability_calibration import (
+    ConstructReliabilityCalibrationTables as CalPlugin)
+from improver_tests.calibration.reliability_calibration.\
+    test_ConstructReliabilityCalibrationTables import Test_Setup
+
+
+class Test_Aggregation(Test_Setup):
+
+    """Test class for the Test_ApplyReliabilityCalibration tests,
+    setting up cubes to use as inputs."""
+
+    def setUp(self):
+        """Create reliability calibration tables for testing."""
+
+        super().setUp()
+        reliability_cube_format = CalPlugin()._create_reliability_table_cube(
+            self.forecasts, self.expected_threshold_coord)
+        self.reliability_cube = reliability_cube_format.copy(
+            data=self.expected_table)
+        self.different_frt = self.reliability_cube.copy()
+        new_frt = self.different_frt.coord('forecast_reference_time')
+        new_frt.points = new_frt.points + 48*3600
+        new_frt.bounds = new_frt.bounds + 48*3600
+
+        self.overlapping_frt = self.reliability_cube.copy()
+        new_frt = self.overlapping_frt.coord('forecast_reference_time')
+        new_frt.points = new_frt.points + 6*3600
+        new_frt.bounds = new_frt.bounds + 6*3600
+
+        self.lat_lon_collapse = np.array([[0., 0., 1., 2., 1.],
+                                          [0., 0.375, 1.5, 1.625, 1.],
+                                          [1., 2., 3., 2., 1.]])
+
+
+class Test__init__(unittest.TestCase):
+
+    """Test the __init__ method."""
+
+    def test_using_defaults(self):
+        """Test without providing any arguments."""
+        plugin = Plugin()
+        self.assertEqual(plugin.minimum_forecast_count, 200)
+
+    def test_with_arguments(self):
+        """Test with specified arguments."""
+        plugin = Plugin(minimum_forecast_count=500)
+        self.assertEqual(plugin.minimum_forecast_count, 500)
+
+
+class Test__repr__(unittest.TestCase):
+
+    """Test the __repr__ method."""
+
+    def test_basic(self):
+        """Test repr is as expected."""
+        expected = '<ApplyReliabilityCalibration: minimum_forecast_count: 200>'
+        self.assertEqual(str(Plugin()), expected)
+
+
+class Test__check_frt_coord(Test_Aggregation):
+
+    """Test the _check_frt_coord method."""
+
+    def test_valid_bounds(self):
+        """Test that no exception is raised if the input cubes have forecast
+        reference time bounds that do not overlap."""
+
+        plugin = Plugin()
+        plugin._check_frt_coord([self.reliability_cube, self.different_frt])
+
+    def test_invalid_bounds(self):
+        """Test that an exception is raised if the input cubes have forecast
+        reference time bounds that overlap."""
+
+        plugin = Plugin()
+        msg = "Reliability calibration tables have overlapping"
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin._check_frt_coord([self.reliability_cube,
+                                     self.overlapping_frt])
+
+
+class Test_process(Test_Aggregation):
+
+    """Test the process method."""
+
+    def test_aggregating_multiple_cubes(self):
+        """Test of aggregating two cubes without any additional coordinate
+        collapsing."""
+
+        frt = 'forecast_reference_time'
+        expected_points = self.different_frt.coord(frt).points
+        expected_bounds = [[self.reliability_cube.coord(frt).bounds[0][0],
+                            self.different_frt.coord(frt).bounds[-1][1]]]
+
+        plugin = Plugin()
+        result = plugin.process([self.reliability_cube, self.different_frt])
+        assert_array_equal(result.data, self.expected_table * 2)
+        assert_array_equal(result.shape, (3, 5, 3, 3))
+        self.assertEqual(result.coord(frt).points, expected_points)
+        assert_array_equal(result.coord(frt).bounds, expected_bounds)
+
+    def test_aggregating_cubes_with_overlapping_frt(self):
+        """Test that attempting to aggregate reliability calibration tables
+        with overlapping forecast reference time bounds raises an exception.
+        The presence of overlapping forecast reference time bounds indicates
+        that the same forecast data has contributed to both tables, thus
+        aggregating them would double count these contributions."""
+
+        plugin = Plugin()
+        msg = "Reliability calibration tables have overlapping"
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin.process([self.reliability_cube, self.overlapping_frt])
+
+    def test_aggregating_over_single_cube_coordinates(self):
+        """Test of aggregating over coordinates of a single cube. In this
+        instance the latitude and longitude coordinates are collapsed."""
+
+        frt = 'forecast_reference_time'
+        expected_points = self.reliability_cube.coord(frt).points
+        expected_bounds = self.reliability_cube.coord(frt).bounds
+
+        plugin = Plugin()
+        result = plugin.process([self.reliability_cube],
+                                coordinates=['latitude', 'longitude'])
+        assert_array_equal(result.data, self.lat_lon_collapse)
+        self.assertEqual(result.coord(frt).points, expected_points)
+        assert_array_equal(result.coord(frt).bounds, expected_bounds)
+
+    def test_aggregating_over_cubes_and_coordinates(self):
+        """Test of aggregating over coordinates and cubes in a single call. In
+        this instance the latitude and longitude coordinates are collapsed and
+        the values from two input cube combined."""
+
+        frt = 'forecast_reference_time'
+        expected_points = self.different_frt.coord(frt).points
+        expected_bounds = [[self.reliability_cube.coord(frt).bounds[0][0],
+                            self.different_frt.coord(frt).bounds[-1][1]]]
+
+        plugin = Plugin()
+        result = plugin.process([self.reliability_cube, self.different_frt],
+                                coordinates=['latitude', 'longitude'])
+        assert_array_equal(result.data, self.lat_lon_collapse * 2)
+        self.assertEqual(result.coord(frt).points, expected_points)
+        assert_array_equal(result.coord(frt).bounds, expected_bounds)
+
+    def test_single_cube(self):
+        """Test the plugin returns an unaltered cube if only one is passed in
+        and no coordinates are given."""
+
+        plugin = Plugin()
+
+        expected = self.reliability_cube.copy()
+        result = plugin.process([self.reliability_cube])
+
+        self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This plugin applies reliability calibration for the simple case of a consolidated (collapsed x/y) reliability table to a forecast cube. This consolidation helps ensure a sufficient sample count in the reliability table, which avoids issues such as unpopulated bins etc. It also allows a very fast application of the calibration using ```np.interp```.

An associated notebook demonstrates how the code can be extended to work with non-consolidated reliability tables.

There are currently no new unit tests as I would appreciate a review of the simplifications assumed before writing these in case the code changes substantially.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)