### PR TITLE
IMPRO-1627: Filtering Advection Files

### DIFF
--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -120,7 +120,7 @@ function improver_test_licence {
 
 function improver_test_pycodestyle {
     # Pycodestyle testing.
-    ${PYCODESTYLE:-pycodestyle} $FILES_TO_TEST
+    ${PYCODESTYLE:-pycodestyle} $FILES_TO_TEST --ignore=E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,E731
     echo_ok "pycodestyle"
 }
 

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -120,7 +120,7 @@ function improver_test_licence {
 
 function improver_test_pycodestyle {
     # Pycodestyle testing.
-    ${PYCODESTYLE:-pycodestyle} $FILES_TO_TEST --ignore=E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,E731
+    ${PYCODESTYLE:-pycodestyle} $FILES_TO_TEST
     echo_ok "pycodestyle"
 }
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -229,8 +229,8 @@ def create_constrained_inputcubelist_converter(*constraint_lists):
 
         Args:
             to_convert (string or iris.cube.Cube):
-                The filename to be loaded. This is a string that will passed
-                to maybe_coerce_with
+                Cube to be extracted from or the filename to be loaded.
+                The string is a filepath to be passed onto load_cube.
 
         Returns:
             iris.cube.CubeList:
@@ -260,7 +260,7 @@ def create_constrained_inputcubelist_converter(*constraint_lists):
 
         # Finds any cubes named prefix.
         prefix_cubes = [c.name() for c in cubelist if c.name() == 'prefixes']
-        # If the list isn't empty
+        # If the list isn't empty discount the metadata cube.
         meta_length = 1 if prefix_cubes else 0
         cube_length = len(cubelist) - meta_length
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -275,7 +275,7 @@ def create_constrained_inputcubelist_converter(*constraint_lists):
             except ValueError:
                 # Unable to load a cube with all constraints. Try next list.
                 pass
-        msg = ("A full list of names was unable to be extracted" 
+        msg = ("A full list of names was unable to be extracted"
                f"Cubes must be called: {constraint_lists}")
         if partial_match:
             msg = "Some cubes could be extracted, but " + msg

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -248,9 +248,9 @@ def create_constrained_inputcubelist_converter(*constraints):
                     for j in constraint)
                 if len(to_convert) == len(constraint):
                     return cubes
-                else:
-                    partial_match = True
+                partial_match = True
             except ValueError:
+                # Unable to load a cube with that constraint. Try next list.
                 pass
         if partial_match:
             raise ValueError("Partial match found, cubes must be a whole list."

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -195,7 +195,7 @@ def inputpath(to_convert):
     return maybe_coerce_with(pathlib.Path, to_convert)
 
 
-def create_constrained_inputcubelist_converter(*constraints):
+def create_constrained_inputcubelist_converter(*constraint_lists):
     """Makes function that the input constraints are used in a loop.
 
     The function is value_converter, this means it is used by clize to convert
@@ -226,7 +226,8 @@ def create_constrained_inputcubelist_converter(*constraints):
 
         Args:
             to_convert (string):
-                The filename to be loaded.
+                The filename to be loaded. This is a string that will passed
+                to maybe_coerce_with
 
         Returns:
             iris.cube.CubeList:
@@ -241,12 +242,12 @@ def create_constrained_inputcubelist_converter(*constraints):
         from improver.utilities.load import load_cube
         from iris.cube import CubeList
         partial_match = False
-        for constraint in constraints:
+        for constraints in constraint_lists:
             try:
-                cubes = CubeList(
+                cubes = [
                     maybe_coerce_with(load_cube, to_convert, constraints=j)
-                    for j in constraint)
-                if len(to_convert) == len(constraint):
+                    for j in constraints]
+                if len(to_convert) == len(constraints):
                     return cubes
                 partial_match = True
             except ValueError:
@@ -254,9 +255,9 @@ def create_constrained_inputcubelist_converter(*constraints):
                 pass
         if partial_match:
             raise ValueError("Partial match found, cubes must be a whole list."
-                             f"Cubes must be called: {constraints}")
+                             f"Cubes must be called: {constraint_lists}")
         raise ValueError("No cubes matching the required names."
-                         f"Cubes must be called: {constraints}")
+                         f"Cubes must be called: {constraint_lists}")
 
     return constrained_inputcubelist_converter
 

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -42,7 +42,8 @@ X_Y = ['precipitation_advection_x_velocity',
 EAST_NORTH = ['grid_eastward_wind', 'grid_northward_wind']
 constraints = (X_Y, EAST_NORTH)
 # Creates the value_converter that clize needs.
-inputadvection = cli.create_constrained_inputcubelist_converter([X_Y, EAST_NORTH])
+inputadvection = cli.create_constrained_inputcubelist_converter(X_Y,
+                                                                EAST_NORTH)
 
 
 @cli.clizefy
@@ -107,7 +108,6 @@ def process(cube: cli.inputcube,
             else:
                 raise TypeError('U cube and V cube must have linked names'
                                 f'U: {u_cube.name}, V: {v_cube.name}')
-
 
     # extrapolate input data to the maximum required lead time
     forecast_cubes = CreateExtrapolationForecast(

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -34,16 +34,13 @@
 from improver import cli
 
 # The accumulation frequency in minutes.
+from improver.metadata.constants.advection_cube_names import X_Y, EAST_NORTH
+
 ACCUMULATION_FIDELITY = 1
 
-X_Y = ['precipitation_advection_x_velocity',
-       'precipitation_advection_y_velocity']
-
-EAST_NORTH = ['grid_eastward_wind', 'grid_northward_wind']
-constraints = (X_Y, EAST_NORTH)
 # Creates the value_converter that clize needs.
-inputadvection = cli.create_constrained_inputcubelist_converter(X_Y,
-                                                                EAST_NORTH)
+inputadvection = cli.create_constrained_inputcubelist_converter(
+    X_Y, EAST_NORTH)
 
 
 @cli.clizefy

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -101,14 +101,6 @@ def process(cube: cli.inputcube,
 
     u_cube, v_cube = advection_velocity
 
-    for i in constraints:
-        if u_cube.name in i:
-            if v_cube.name in i:
-                break
-            else:
-                raise TypeError('U cube and V cube must have linked names'
-                                f'U: {u_cube.name}, V: {v_cube.name}')
-
     # extrapolate input data to the maximum required lead time
     forecast_cubes = CreateExtrapolationForecast(
         cube, u_cube, v_cube, orographic_enhancement,

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -42,7 +42,7 @@ X_Y = ['precipitation_advection_x_velocity',
 EAST_NORTH = ['grid_eastward_wind', 'grid_northward_wind']
 constraints = (X_Y, EAST_NORTH)
 # Creates the value_converter that clize needs.
-inputadvection = cli.create_constrained_inputcubelist_converter(*constraints)
+inputadvection = cli.create_constrained_inputcubelist_converter([X_Y, EAST_NORTH])
 
 
 @cli.clizefy

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -33,11 +33,12 @@
 
 
 from improver import cli
+from improver.cli.nowcast_accumulate import X_Y, EAST_NORTH
 
 # Creates the value_converter that clize needs.
 inputadvection = cli.create_constrained_inputcubelist_converter(
-    ['precipitation_advection_x_velocity', 'grid_eastward_wind'],
-    ['precipitation_advection_y_velocity', 'grid_northward_wind'])
+    X_Y,
+    EAST_NORTH)
 
 
 @cli.clizefy

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -33,12 +33,11 @@
 
 
 from improver import cli
-from improver.cli.nowcast_accumulate import X_Y, EAST_NORTH
+from improver.metadata.constants.advection_cube_names import X_Y, EAST_NORTH
 
 # Creates the value_converter that clize needs.
 inputadvection = cli.create_constrained_inputcubelist_converter(
-    X_Y,
-    EAST_NORTH)
+    X_Y, EAST_NORTH)
 
 
 @cli.clizefy

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -34,7 +34,7 @@
 from improver import cli
 
 input_smoothing_coefficients = cli.create_constrained_inputcubelist_converter(
-    'smoothing_coefficient_x', 'smoothing_coefficient_y')
+    ['smoothing_coefficient_x', 'smoothing_coefficient_y'])
 
 
 @cli.clizefy

--- a/improver/metadata/constants/advection_cube_names.py
+++ b/improver/metadata/constants/advection_cube_names.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Names for advection cube pairs"""
+
+X_Y = ['precipitation_advection_x_velocity',
+       'precipitation_advection_y_velocity']
+
+EAST_NORTH = ['grid_eastward_wind',
+              'grid_northward_wind']

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -33,7 +33,6 @@
 import unittest
 from unittest.mock import patch
 
-import numpy as np
 import improver
 from improver.cli import (
     clizefy,
@@ -47,9 +46,6 @@ from improver.cli import (
     with_output,
 )
 from improver.utilities.load import load_cube
-from iris.cube import CubeList
-
-from ..set_up_test_cubes import set_up_variable_cube
 
 
 def dummy_function(first, second=0, third=2):
@@ -199,7 +195,7 @@ class Test_with_intermediate_output(unittest.TestCase):
 
 def list_of_length(length):
     """Returns a list of the length plus 1"""
-    return [x for x in range(length+1)]
+    return list(range(length+1))
 
 
 class Test_create_constrained_inputcubelist_converter(unittest.TestCase):

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -197,39 +197,6 @@ class Test_with_intermediate_output(unittest.TestCase):
         self.assertEqual(result, 4)
 
 
-def replace_load_with_extract(func, cube, constraints=None):
-    """Function to replicate the call to maybe_coerce_with within
-    create_constrained_inputcubelist_converter.
-
-    Args:
-        func:
-            Unused argument for the purpose of replicating the
-            maybe_coerce_with interface.
-        cube (iris.cube.Cube or iris.cube.CubeList):
-            Cube or CubeList to be extracted from.
-        constraints (str or None):
-            Expected name of cube for extraction.
-
-    Returns:
-        iris.cube.Cube:
-            The extracted cube.
-
-    Raises:
-        ValueError:
-            Error to replicate the behaviour of the call of maybe_coerce_with,
-            where loading a cube with an invalid constraint results in a
-            ValueError.
-    """
-    del func
-    if constraints:
-        cube = cube.extract(constraints)
-    if isinstance(cube, CubeList):
-        cube, = cube.copy()
-    if cube is None:
-        raise ValueError
-    return cube
-
-
 def list_of_length(length):
     """Returns a list of the length plus 1"""
     return [x for x in range(length+1)]
@@ -249,8 +216,8 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     @patch('improver.cli.maybe_coerce_with', side_effect=[list_of_length(2),
                                                           'cube1', 'cube2'])
     def test_basic(self, m):
-        """Tests that maybe_coerce_with is called twice. both times with
-        load_cube as the first argument, a list of 2 items as second argument
+        """Tests that maybe_coerce_with is called twice. Both times with
+        load_cube as the first argument, the 'filepath' as second argument
         and the constraint list of the two strings given to
         create_constrained_inputcubelist_converter.
 
@@ -272,7 +239,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
                                                           'cube1'])
     def test_lists(self, m):
         """Tests that maybe_coerce_with is called once with
-        load_cube as the first argument, a list of 1 item as second argument
+        load_cube as the first argument, the 'filepath' as second argument
         and the first constraint list given to
         create_constrained_inputcubelist_converter.
 
@@ -298,7 +265,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     def test_when_first_list_does_not_match(self, m):
         """Tests that maybe_coerce_with is called.
         With load_cube as the first argument,
-        a list of 2 items as second argument
+        a 'filepath' as second argument
         and the constraint of the second list given to
         create_constrained_inputcubelist_converter.
 
@@ -326,9 +293,9 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         The bigger of the two constraints is first.
         The selected list is first.
         Tests that maybe_coerce_with is called with
-        load_cube as the first argument, the list given to
-        create_constrained_inputcubelist_converter as second argument
-        and the selected constraints.
+        load_cube as the first argument,
+        'filepath' as second argument
+        and the selected constraints as third.
 
         the returned result is the first two arguments used by the Mocked
         side_effect.
@@ -355,9 +322,9 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         The bigger of the two constraints is first.
         The selected list is second.
         Tests that maybe_coerce_with is called with
-        load_cube as the first argument, the list given to
-        create_constrained_inputcubelist_converter as second argument
-        and the selected constraints.
+        load_cube as the first argument,
+        'filepath' as second argument
+        and the selected constraints as third.
 
         the returned result is the first two arguments used by the Mocked
         side_effect.
@@ -382,9 +349,9 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         The bigger of the two constraints is last.
         The selected list is first.
         Tests that maybe_coerce_with is called with
-        load_cube as the first argument, the list given to
-        create_constrained_inputcubelist_converter as second argument
-        and the selected constraints.
+        load_cube as the first argument,
+        'filepath' as second argument
+        and the selected constraints as third.
 
         the returned result is the first two arguments used by the Mocked
         side_effect.
@@ -408,9 +375,9 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         The bigger of the two constraints is last.
         The selected list is second.
         Tests that maybe_coerce_with is called with
-        load_cube as the first argument, the list given to
-        create_constrained_inputcubelist_converter as second argument
-        and the selected constraints.
+        load_cube as the first argument,
+        'filepath' as second argument
+        and the selected constraints as third.
 
         the returned result is the first two arguments used by the Mocked
         side_effect.

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -234,129 +234,226 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     """Tests the creature constraint_inputcubelist_converter"""
 
     def setUp(self):
-        data = np.zeros((2, 2), dtype=np.float32)
+        """Sets up some example names to use"""
         self.speed_name = 'wind_speed'
         self.direction_name = 'wind_from_direction'
-        self.wind_speed_cube = set_up_variable_cube(data, name=self.speed_name)
-        self.wind_dir_cube = set_up_variable_cube(
-            data, name=self.direction_name)
-        self.wind_cubes = CubeList([self.wind_speed_cube, self.wind_dir_cube])
 
-    @patch('improver.cli.maybe_coerce_with', side_effect='return')
+    @patch('improver.cli.maybe_coerce_with', side_effect=['cube1', 'cube2'])
     def test_basic(self, m):
-        """Tests that it returns a function which itself returns 2 cubes"""
-        result = create_constrained_inputcubelist_converter(
+        """Tests that maybe_coerce_with is called twice. both times with
+        load_cube as the first argument, a list of 2 items as second argument
+        and the constraint list of the two strings given to
+        create_constrained_inputcubelist_converter.
+
+        the returned result is the first two arguments used by the Mocked
+        side_effect.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name, self.direction_name])
-        foobe_list = ["foo", "bar"]
-        result(foobe_list)
-        m.assert_any_call(load_cube, foobe_list,
-                          constraints=self.speed_name)
+        foobe_list = ['foo', 'bar']
+        result = constrained_list(foobe_list)
+        m.assert_any_call(load_cube, foobe_list, constraints=self.speed_name)
         m.assert_any_call(load_cube, foobe_list,
                           constraints=self.direction_name)
         self.assertEqual(m.call_count, 2)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], 'cube1')
+        self.assertEqual(result[1], 'cube2')
 
-    @patch('improver.cli.maybe_coerce_with', side_effect='return')
+    @patch('improver.cli.maybe_coerce_with', side_effect=['cube1'])
     def test_lists(self, m):
-        """Tests that a single call to load cube with the first restraint"""
-        result = create_constrained_inputcubelist_converter(
+        """Tests that maybe_coerce_with is called once with
+        load_cube as the first argument, a list of 1 item as second argument
+        and the first constraint list given to
+        create_constrained_inputcubelist_converter.
+
+        the returned result is the first argument used by the Mocked
+        side_effect.
+
+        Because the first constraint list of speed_name returns a full match,
+        the second one gets skipped.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name], [self.direction_name])
-        result(["foo"])
-        m.assert_any_call(load_cube, ["foo"], constraints=self.speed_name)
+        result = constrained_list(['foo'])
+        m.assert_any_call(load_cube, ['foo'], constraints=self.speed_name)
         self.assertEqual(m.call_count, 1)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], 'cube1')
 
-    @patch('improver.cli.maybe_coerce_with', side_effect=ValueError)
-    def test_err_when_no_match(self, m):
-        """Tests that raises an error when no cubes match any constraints"""
-        result = create_constrained_inputcubelist_converter(
-            [self.speed_name], [self.direction_name])
-        msg = 'No cubes matching'
-        with self.assertRaisesRegex(ValueError, msg):
-            result(["foo"])
-        for constraint in [self.speed_name, self.direction_name]:
-            m.assert_any_call(load_cube, ["foo"], constraints=constraint)
-        self.assertEqual(m.call_count, 2)
-
-    @patch('improver.cli.maybe_coerce_with', side_effect=[ValueError,
-                                                          True, True])
+    @patch('improver.cli.maybe_coerce_with', side_effect=[ValueError, 'cube1'])
     def test_when_first_list_does_not_match(self, m):
-        """Tests that a first call to maybe_coerce_with returns with an error
-         Returns the whole of the next list.
-         returns a function which itself returns 2 cubes"""
-        result = create_constrained_inputcubelist_converter(
-            [self.speed_name, self.direction_name], ['cats', 'dogs'])
-        foobe_list = ["foo", "bar"]
-        result(foobe_list)
-        for constraint in [self.speed_name, 'cats', 'dogs']:
-            m.assert_any_call(load_cube, foobe_list, constraints=constraint)
-        self.assertEqual(m.call_count, 3)
+        """Tests that maybe_coerce_with is called.
+        With load_cube as the first argument,
+        a list of 2 items as second argument
+        and the constraint of the second list given to
+        create_constrained_inputcubelist_converter.
 
-    @patch('improver.cli.maybe_coerce_with', return_value='return')
-    def test_different_length_constraints_big_first_select_first(self, m):
-        """Tests that when the first constraint is bigger, it still works"""
-        result = create_constrained_inputcubelist_converter(
-            [self.speed_name, self.direction_name],
-            ['cats']
-        )
-        foobe_list = ['foo', 'bar']
-        result(foobe_list)
-        for constraint in [self.speed_name, self.direction_name]:
-            m.assert_any_call(load_cube, foobe_list, constraints=constraint)
-        self.assertEqual(m.call_count, 2)
+        the returned result is the first two arguments used by the Mocked
+        side_effect.
 
-    @patch('improver.cli.maybe_coerce_with', side_effect=[ValueError,
-                                                          'return'])
-    def test_different_length_constraints_big_first_select_second(self, m):
-        """Tests that when the first constraint is bigger, it still works"""
-        result = create_constrained_inputcubelist_converter(
-            [self.speed_name, self.direction_name],
-            ['cats']
-        )
+        Because the first call to maybe_coerce_with returns a ValueError,
+        the second list of constraints will be used.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
+            [self.speed_name], ['cats'])
         foobe_list = ['foo']
-        result(foobe_list)
+        result = constrained_list(foobe_list)
         for constraint in [self.speed_name, 'cats']:
             m.assert_any_call(load_cube, foobe_list, constraints=constraint)
         self.assertEqual(m.call_count, 2)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], 'cube1')
 
-    @patch('improver.cli.maybe_coerce_with', side_effect='return')
+    @patch('improver.cli.maybe_coerce_with', side_effect=['cube1', 'cube2'])
+    def test_different_length_constraints_big_first_select_first(self, m):
+        """Tests when the two constraint lists are different sizes.
+        The bigger of the two constraints is first.
+        The selected list is first.
+        Tests that maybe_coerce_with is called with
+        load_cube as the first argument, the list given to
+        create_constrained_inputcubelist_converter as second argument
+        and the selected constraints.
+
+        the returned result is the first two arguments used by the Mocked
+        side_effect.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
+            [self.speed_name, self.direction_name],
+            ['cats']
+        )
+        foobe_list = ['foo', 'bar']
+        result = constrained_list(foobe_list)
+        for constraint in [self.speed_name, self.direction_name]:
+            m.assert_any_call(load_cube, foobe_list, constraints=constraint)
+        self.assertEqual(m.call_count, 2)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], 'cube1')
+        self.assertEqual(result[1], 'cube2')
+
+    @patch('improver.cli.maybe_coerce_with', side_effect=[ValueError,
+                                                          'cube1', 'cube2'])
+    def test_different_length_constraints_big_first_select_second(self, m):
+        """Tests when the two constraint lists are different sizes.
+        The bigger of the two constraints is first.
+        The selected list is second.
+        Tests that maybe_coerce_with is called with
+        load_cube as the first argument, the list given to
+        create_constrained_inputcubelist_converter as second argument
+        and the selected constraints.
+
+        the returned result is the first two arguments used by the Mocked
+        side_effect.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
+            [self.speed_name, self.direction_name],
+            ['cats']
+        )
+        foobe_list = ['foo']
+        result = constrained_list(foobe_list)
+        for constraint in [self.speed_name, 'cats']:
+            m.assert_any_call(load_cube, foobe_list, constraints=constraint)
+        self.assertEqual(m.call_count, 2)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], 'cube1')
+
+    @patch('improver.cli.maybe_coerce_with', side_effect=['cube1'])
     def test_different_length_constraints_big_last_select_first(self, m):
-        """Tests that when the last constraint is bigger, it still works"""
-        result = create_constrained_inputcubelist_converter(
+        """Tests when the two constraint lists are different sizes.
+        The bigger of the two constraints is last.
+        The selected list is first.
+        Tests that maybe_coerce_with is called with
+        load_cube as the first argument, the list given to
+        create_constrained_inputcubelist_converter as second argument
+        and the selected constraints.
+
+        the returned result is the first two arguments used by the Mocked
+        side_effect.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
             ['cats'],
             [self.speed_name, self.direction_name]
         )
         foobe_list = ['foo']
-        result(foobe_list)
-        for constraint in ['cats']:
-            m.assert_any_call(load_cube, foobe_list, constraints=constraint)
+        result = constrained_list(foobe_list)
+        m.assert_any_call(load_cube, foobe_list, constraints='cats')
         self.assertEqual(m.call_count, 1)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], 'cube1')
 
     @patch('improver.cli.maybe_coerce_with', side_effect=[ValueError,
-                                                          'return'])
+                                                          'cube1', 'cube2'])
     def test_different_length_constraints_big_last_select_second(self, m):
-        """Tests that when the last constraint is bigger, it still works"""
-        result = create_constrained_inputcubelist_converter(
+        """Tests when the two constraint lists are different sizes.
+        The bigger of the two constraints is last.
+        The selected list is second.
+        Tests that maybe_coerce_with is called with
+        load_cube as the first argument, the list given to
+        create_constrained_inputcubelist_converter as second argument
+        and the selected constraints.
+
+        the returned result is the first two arguments used by the Mocked
+        side_effect.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
             ['cats'],
             [self.speed_name, self.direction_name]
         )
         foobe_list = ['foo', 'bar']
-        result(foobe_list)
+        result = constrained_list(foobe_list)
         for constraint in ['cats', self.speed_name, self.direction_name]:
             m.assert_any_call(load_cube, foobe_list, constraints=constraint)
         self.assertEqual(m.call_count, 3)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], 'cube1')
+        self.assertEqual(result[1], 'cube2')
 
-    @patch('improver.cli.maybe_coerce_with', return_value='return')
+    @patch('improver.cli.maybe_coerce_with', side_effect=['cube1',
+                                                          'cube1', 'cube2'])
     def test_when_first_match_but_wrong_size(self, m):
-        """Tests when there is a match but the length is wrong, contines to
-        find a full match."""
-        result = create_constrained_inputcubelist_converter(
+        """Tests when there is a match but the length is wrong, continues to
+        find a full match.
+        Calls maybe_coerce_with three times due to the first match not being
+        the same length as the input_list.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
             ['cats'],
             ['cats', self.direction_name]
         )
         foobe_list = ['foo', 'bar']
-        result(foobe_list)
+        result = constrained_list(foobe_list)
         for constraint in ['cats', 'cats', self.direction_name]:
             m.assert_any_call(load_cube, foobe_list, constraints=constraint)
         self.assertEqual(m.call_count, 3)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], 'cube1')
+        self.assertEqual(result[1], 'cube2')
+
+    @patch('improver.cli.maybe_coerce_with', side_effect=ValueError)
+    def test_err_when_no_match(self, m):
+        """Tests that raises an error when no cubes match any constraints.
+        Tests that assertEqual is called for the number of constraint lists.
+        """
+        constrained_list = create_constrained_inputcubelist_converter(
+            [self.speed_name], [self.direction_name])
+        msg = 'No cubes matching'
+        with self.assertRaisesRegex(ValueError, msg):
+            constrained_list(['foo'])
+        for constraint in [self.speed_name, self.direction_name]:
+            m.assert_any_call(load_cube, ['foo'], constraints=constraint)
+        self.assertEqual(m.call_count, 2)
+
+    @patch('improver.cli.maybe_coerce_with', side_effect=['Cube1'])
+    def test_err_when_match_wrong_size(self, m):
+        """Tests that raises an error when no cubes match any constraints"""
+        constrained_list = create_constrained_inputcubelist_converter(
+            [self.speed_name])
+        msg = 'Partial match found'
+        with self.assertRaisesRegex(ValueError, msg):
+            constrained_list(['foo', 'bar'])
+        m.assert_any_call(load_cube, ['foo', 'bar'],
+                          constraints=self.speed_name)
+        self.assertEqual(m.call_count, 1)
 
 
 class Test_clizefy(unittest.TestCase):

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -48,7 +48,6 @@ from improver.cli import (
     with_intermediate_output,
     with_output,
 )
-from improver.utilities.load import load_cube
 from improver_tests.set_up_test_cubes import set_up_variable_cube
 
 
@@ -213,21 +212,19 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         self.speed_name = 'wind_speed'
         self.direction_name = 'wind_from_direction'
         self.wind_speed_cube = set_up_variable_cube(data, name=self.speed_name)
-        self.wind_dir_cube = set_up_variable_cube(
-            data, name=self.direction_name)
-
+        self.wind_dir_cube = set_up_variable_cube(data,
+                                                  name=self.direction_name)
         self.fake_path = '/super/secret/data.nc'
 
     @patch('iris.load_raw', side_effect=[cubelist_of_length(2)])
     @patch('improver.utilities.load.load_cube', side_effect=['cube1', 'cube2'])
     def test_basic(self, load, raw):
-        """Tests that maybe_coerce_with is called twice. Both times with
-        load_cube as the first argument, the 'filepath' as second argument
-        and the constraint list of the two strings given to
-        create_constrained_inputcubelist_converter.
+        """Tests that load_cube is called twice.
+        The 'filepath' and the constraint list of the two strings given to
+        create_constrained_inputcubelist_converter as arguments.
 
-        the returned result is the first two arguments used by the Mocked
-        side_effect.
+        The returned result is the first two arguments used by the load_cube
+        Mocked side_effect.
         """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name, self.direction_name])
@@ -244,12 +241,11 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     @patch('iris.load_raw', side_effect=[cubelist_of_length(1)])
     @patch('improver.utilities.load.load_cube', side_effect=['cube1'])
     def test_lists(self, load, raw):
-        """Tests that maybe_coerce_with is called once with
-        load_cube as the first argument, the 'filepath' as second argument
-        and the first constraint list given to
-        create_constrained_inputcubelist_converter.
+        """Tests that load_cube is called once.
+        The 'filepath' and the first constraint list given to
+        create_constrained_inputcubelist_converter as arguments.
 
-        the returned result is the first argument used by the Mocked
+        The returned result is the first argument used by the load_cube Mocked
         side_effect.
 
         Because the first constraint list of speed_name returns a full match,
@@ -269,16 +265,14 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     @patch('improver.utilities.load.load_cube', side_effect=[ValueError,
                                                              'cube1'])
     def test_when_first_list_does_not_match(self, load, raw):
-        """Tests that maybe_coerce_with is called.
-        With load_cube as the first argument,
-        a 'filepath' as second argument
-        and the constraint of the second list given to
-        create_constrained_inputcubelist_converter.
+        """Tests that load_cube is called twice.
+        The 'filepath' and the constraint of the second list given to
+        create_constrained_inputcubelist_converter as arguments.
 
-        the returned result is the first two arguments used by the Mocked
-        side_effect.
+        The returned result is the first two arguments used by the load_cube
+        Mocked side_effect.
 
-        Because the first call to maybe_coerce_with returns a ValueError,
+        Because the first call to load_cube returns a ValueError,
         the second list of constraints will be used.
         """
         constrained_list = create_constrained_inputcubelist_converter(
@@ -299,13 +293,11 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """Tests when the two constraint lists are different sizes.
         The bigger of the two constraints is first.
         The selected list is first.
-        Tests that maybe_coerce_with is called with
-        load_cube as the first argument,
-        'filepath' as second argument
-        and the selected constraints as third.
+        Tests that load_cube is called twice.
+        The 'filepath' and the selected constraints as arguments.
 
-        the returned result is the first two arguments used by the Mocked
-        side_effect.
+        The returned result is the first two arguments used by the load_cube
+        Mocked side_effect.
         """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name, self.direction_name],
@@ -328,12 +320,10 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """Tests when the two constraint lists are different sizes.
         The bigger of the two constraints is first.
         The selected list is second.
-        Tests that maybe_coerce_with is called with
-        load_cube as the first argument,
-        'filepath' as second argument
-        and the selected constraints as third.
+        Tests that load_cube is called twice.
+        The 'filepath' and the selected constraints as arguments.
 
-        the returned result is the first two arguments used by the Mocked
+        The returned result is the first two arguments used by the Mocked
         side_effect.
         """
         constrained_list = create_constrained_inputcubelist_converter(
@@ -344,7 +334,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         raw.assert_called_once_with(self.fake_path)
         for constr in [self.speed_name, 'cats']:
             load.assert_any_call(self.fake_path, constraints=constr)
-        # called twice more, as the first returns ValueError, next one loads.
+        # called twice, as the first returns ValueError, next one loads.
         self.assertEqual(load.call_count, 2)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], 'cube1')
@@ -356,13 +346,11 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """Tests when the two constraint lists are different sizes.
         The bigger of the two constraints is last.
         The selected list is first.
-        Tests that maybe_coerce_with is called with
-        load_cube as the first argument,
-        'filepath' as second argument
-        and the selected constraints as third.
+        Tests that load_cube is called once.
+        The 'filepath' and the selected constraints as arguments.
 
-        the returned result is the first two arguments used by the Mocked
-        side_effect.
+        the returned result is the first two arguments used by the load_cube
+        Mocked side_effect.
         """
         constrained_list = create_constrained_inputcubelist_converter(
             ['cats'],
@@ -384,12 +372,10 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """Tests when the two constraint lists are different sizes.
         The bigger of the two constraints is last.
         The selected list is second.
-        Tests that maybe_coerce_with is called with
-        load_cube as the first argument,
-        'filepath' as second argument
-        and the selected constraints as third.
+        Tests that load_cube is called three times.
+        The 'filepath' and the selected constraints as arguments.
 
-        the returned result is the first two arguments used by the Mocked
+        The returned result is the first two arguments used by the Mocked
         side_effect.
         """
         constrained_list = create_constrained_inputcubelist_converter(
@@ -411,8 +397,11 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     def test_when_first_match_but_wrong_size(self, load, raw):
         """Tests when there is a match but the length is wrong, continues to
         find a full match.
-        Calls maybe_coerce_with three times due to the first match not being
+        Calls load_cube three times due to the first match not being
         the same length as the input_list.
+
+        The returned result is the last two arguments used by the load_cube
+        Mocked side_effect.
         """
         constrained_list = create_constrained_inputcubelist_converter(
             ['cats'],
@@ -432,7 +421,9 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
                                                              ValueError])
     def test_err_when_no_match(self, load, raw):
         """Tests that raises an error when no cubes match any constraints.
-        Tests that assertEqual is called for the number of constraint lists.
+        Tests that load_cube is called twice.
+        The 'filepath' and constraints as arguments.
+        A match isn't found so a ValueError is returned.
         """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name], [self.direction_name])
@@ -448,7 +439,11 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     @patch('iris.load_raw', side_effect=[cubelist_of_length(2)])
     @patch('improver.utilities.load.load_cube', side_effect=['Cube1'])
     def test_err_when_match_wrong_size(self, load, raw):
-        """Tests that raises an error when no cubes match any constraints"""
+        """Tests that raises an error when there isn't a full match of
+        constraint to cube.
+        The cubelist has two cubes but the constraint list only has 1 name.
+        Therefore not all cubes were able to be extracted.
+        """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name])
         msg = 'Some cubes'

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -447,7 +447,8 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name])
-        msg = "The cubes with \[\'wind_speed\'\]"
+        # . needed to replace square brackets[]
+        msg = "The cubes with \\[\'wind_speed\'\\]"
         with self.assertRaisesRegex(ValueError, msg):
             constrained_list(self.fake_path)
         raw.assert_called_once_with(self.fake_path)

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -447,7 +447,6 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name])
-        # . needed to replace square brackets[]
         msg = "The cubes with \\[\'wind_speed\'\\]"
         with self.assertRaisesRegex(ValueError, msg):
             constrained_list(self.fake_path)

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -230,8 +230,8 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
             [self.speed_name, self.direction_name])
         result = constrained_list(self.fake_path)
         raw.assert_called_once_with(self.fake_path)
-        for constr in [self.speed_name, self.direction_name]:
-            load.assert_any_call(self.fake_path, constraints=constr)
+        for constraint in [self.speed_name, self.direction_name]:
+            load.assert_any_call(self.fake_path, constraints=constraint)
         # Called twice for each item in the list
         self.assertEqual(load.call_count, 2)
         self.assertEqual(len(result), 2)
@@ -437,7 +437,8 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         self.assertEqual(load.call_count, 2)
 
     @patch('iris.load_raw', side_effect=[cubelist_of_length(2)])
-    @patch('improver.utilities.load.load_cube', side_effect=['Cube1'])
+    @patch('improver.utilities.load.load_cube',
+           side_effect=cubelist_of_length(1))
     def test_err_when_match_wrong_size(self, load, raw):
         """Tests that raises an error when there isn't a full match of
         constraint to cube.
@@ -446,7 +447,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """
         constrained_list = create_constrained_inputcubelist_converter(
             [self.speed_name])
-        msg = 'Some cubes'
+        msg = "The cubes with \[\'wind_speed\'\]"
         with self.assertRaisesRegex(ValueError, msg):
             constrained_list(self.fake_path)
         raw.assert_called_once_with(self.fake_path)


### PR DESCRIPTION
Update on #1171 

### Improvements:
- extendable
    - for a new set of arguments, just requires a new list of constraints
        - If removing a set of constraints, no need to check the other constraints that have been given
- Improves on the loading of mismatched lists by being able to return different length CubeLists.
- Now able to extract from a cubelist
    - This was always meant to be possible but infact it would return a cubelist of all the cubes for each constraint rather than the constrained cube
#### Mock
- `side_effect`

> If you pass in an iterable, it is used to retrieve an iterator which must yield a value on every call. This value can either be an exception instance to be raised, or a value to be returned from the call to the mock (DEFAULT handling is identical to the function case).
> - [Mock Docs](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.side_effect)


### problems
- It does require loading the cubelist to get the length of what is being passed in.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
