### PR TITLE
Modify convert_to_realizations CLI to accept the raw_cube argument

### DIFF
--- a/improver/cli/convert_to_realizations.py
+++ b/improver/cli/convert_to_realizations.py
@@ -36,16 +36,31 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(cube: cli.inputcube,
+            raw_cube: cli.inputcube = None,
             *,
             realizations_count: int = None,
+            random_seed: int = None,
             ignore_ecc_bounds=False):
     """Converts an incoming cube into one containing realizations.
 
     Args:
         cube (iris.cube.Cube):
             A cube to be processed.
+        raw_cube (iris.cube.Cube):
+            Cube of raw (not post processed) weather data.
+            If this argument is given ensemble realizations will be created
+            from percentiles by reshuffling them in correspondence to the rank
+            order of the raw ensemble. Otherwise, the percentiles are rebadged
+            as realizations.
         realizations_count (int):
             The number of ensemble realizations in the output.
+        random_seed (int):
+            Option to specify a value for the random seed for testing
+            purposes, otherwise the default random seed behaviours is
+            utilised. The random seed is used in the generation of the
+            random numbers used for splitting tied values within the raw
+            ensemble, so that the values from the input percentiles can
+            be ordered to match the raw ensemble.
         ignore_ecc_bounds (bool):
             If True, where percentiles exceed the ECC bounds range, raises a
             warning rather than an exception.
@@ -59,12 +74,12 @@ def process(cube: cli.inputcube,
 
     if cube.coords('percentile'):
         output_cube = percentiles_to_realizations.process(
-            cube, realizations_count=realizations_count,
-            ignore_ecc_bounds=ignore_ecc_bounds)
+            cube, raw_cube=raw_cube, realizations_count=realizations_count,
+            random_seed=random_seed, ignore_ecc_bounds=ignore_ecc_bounds)
     elif cube.coords(var_name='threshold'):
         output_cube = probabilities_to_realizations.process(
-            cube, realizations_count=realizations_count,
-            ignore_ecc_bounds=ignore_ecc_bounds)
+            cube, raw_cube=raw_cube, realizations_count=realizations_count,
+            random_seed=random_seed, ignore_ecc_bounds=ignore_ecc_bounds)
     elif cube.coords(var_name='realization'):
         output_cube = cube
     else:

--- a/improver/cli/probabilities_to_realizations.py
+++ b/improver/cli/probabilities_to_realizations.py
@@ -42,7 +42,7 @@ def process(cube: cli.inputcube,
             realizations_count: int = None,
             random_seed: int = None,
             ignore_ecc_bounds=False):
-    """Convert probabilities to ensemble realizations using Ensemble Coupla
+    """Convert probabilities to ensemble realizations using Ensemble Copula
     Coupling.
 
     Probabilities are first converted to percentiles, which are then either
@@ -54,7 +54,7 @@ def process(cube: cli.inputcube,
         raw_cube (iris.cube.Cube):
             Cube of raw (not post processed) weather data.
             If this argument is given ensemble realizations will be created
-            from percentiles by reshuffling them in correspondance to the rank
+            from percentiles by reshuffling them in correspondence to the rank
             order of the raw ensemble. Otherwise, the percentiles are rebadged
             as realizations.
         realizations_count (int):

--- a/improver_tests/acceptance/test_convert_to_realizations.py
+++ b/improver_tests/acceptance/test_convert_to_realizations.py
@@ -80,10 +80,9 @@ def test_percentiles_reordering(tmp_path):
 def test_probabilities(tmp_path):
     """Test basic probabilities to realization conversion"""
     kgo_dir = (acc.kgo_root() /
-               "convert-to-realizations/12_realizations")
+               "convert-to-realizations/probabilities_12_realizations")
     kgo_path = kgo_dir / "kgo.nc"
-    input_dir = kgo_dir / "../basic"
-    input_path = input_dir / "input.nc"
+    input_path = kgo_dir / "input.nc"
 
     output_path = tmp_path / "output.nc"
 
@@ -97,7 +96,8 @@ def test_probabilities(tmp_path):
 @pytest.mark.slow
 def test_probabilities_reordering(tmp_path):
     """Test probabilities to realization conversion with reordering"""
-    kgo_dir = acc.kgo_root() / "convert-to-realizations/basic_reordering"
+    kgo_dir = (acc.kgo_root() /
+               "convert-to-realizations/probabilities_reordering")
     kgo_path = kgo_dir / "kgo.nc"
     raw_path = kgo_dir / "raw_ens.nc"
     input_path = kgo_dir / "input.nc"
@@ -113,7 +113,7 @@ def test_probabilities_reordering(tmp_path):
 def test_realizations(tmp_path):
     """Test basic null realization to realization conversion"""
     kgo_dir = (acc.kgo_root() /
-               "convert-to-realizations/12_realizations")
+               "convert-to-realizations/probabilities_12_realizations")
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_path
     output_path = tmp_path / "output.nc"

--- a/improver_tests/acceptance/test_convert_to_realizations.py
+++ b/improver_tests/acceptance/test_convert_to_realizations.py
@@ -59,6 +59,24 @@ def test_percentiles(tmp_path):
 
 
 @pytest.mark.slow
+def test_percentiles_reordering(tmp_path):
+    """Test percentile to realization conversion with reordering"""
+    kgo_dir = acc.kgo_root() / \
+        "percentiles-to-realizations/percentiles_reordering"
+    kgo_path = kgo_dir / "kgo.nc"
+    forecast_path = kgo_dir / "raw_forecast.nc"
+    percentiles_path = kgo_dir / "multiple_percentiles_wind_cube.nc"
+    output_path = tmp_path / "output.nc"
+    args = ["--realizations-count", "12",
+            "--random-seed", "0",
+            percentiles_path,
+            forecast_path,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+@pytest.mark.slow
 def test_probabilities(tmp_path):
     """Test basic probabilities to realization conversion"""
     kgo_dir = (acc.kgo_root() /
@@ -71,6 +89,22 @@ def test_probabilities(tmp_path):
 
     args = [input_path,
             "--realizations-count", "12",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+@pytest.mark.slow
+def test_probabilities_reordering(tmp_path):
+    """Test probabilities to realization conversion with reordering"""
+    kgo_dir = acc.kgo_root() / "probabilities-to-realizations/basic_reordering"
+    kgo_path = kgo_dir / "kgo.nc"
+    raw_path = kgo_dir / "raw_ens.nc"
+    input_path = kgo_dir / "input.nc"
+    output_path = tmp_path / "output.nc"
+    args = ["--random-seed", "0",
+            input_path,
+            raw_path,
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_convert_to_realizations.py
+++ b/improver_tests/acceptance/test_convert_to_realizations.py
@@ -45,7 +45,7 @@ run_cli = acc.run_cli(CLI)
 def test_percentiles(tmp_path):
     """Test basic percentile to realization conversion"""
     kgo_dir = (acc.kgo_root() /
-               "percentiles-to-realizations/percentiles_rebadging")
+               "convert-to-realizations/percentiles_rebadging")
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "multiple_percentiles_wind_cube.nc"
 
@@ -62,7 +62,7 @@ def test_percentiles(tmp_path):
 def test_percentiles_reordering(tmp_path):
     """Test percentile to realization conversion with reordering"""
     kgo_dir = acc.kgo_root() / \
-        "percentiles-to-realizations/percentiles_reordering"
+        "convert-to-realizations/percentiles_reordering"
     kgo_path = kgo_dir / "kgo.nc"
     forecast_path = kgo_dir / "raw_forecast.nc"
     percentiles_path = kgo_dir / "multiple_percentiles_wind_cube.nc"
@@ -80,7 +80,7 @@ def test_percentiles_reordering(tmp_path):
 def test_probabilities(tmp_path):
     """Test basic probabilities to realization conversion"""
     kgo_dir = (acc.kgo_root() /
-               "probabilities-to-realizations/12_realizations")
+               "convert-to-realizations/12_realizations")
     kgo_path = kgo_dir / "kgo.nc"
     input_dir = kgo_dir / "../basic"
     input_path = input_dir / "input.nc"
@@ -97,7 +97,7 @@ def test_probabilities(tmp_path):
 @pytest.mark.slow
 def test_probabilities_reordering(tmp_path):
     """Test probabilities to realization conversion with reordering"""
-    kgo_dir = acc.kgo_root() / "probabilities-to-realizations/basic_reordering"
+    kgo_dir = acc.kgo_root() / "convert-to-realizations/basic_reordering"
     kgo_path = kgo_dir / "kgo.nc"
     raw_path = kgo_dir / "raw_ens.nc"
     input_path = kgo_dir / "input.nc"
@@ -113,7 +113,7 @@ def test_probabilities_reordering(tmp_path):
 def test_realizations(tmp_path):
     """Test basic null realization to realization conversion"""
     kgo_dir = (acc.kgo_root() /
-               "probabilities-to-realizations/12_realizations")
+               "convert-to-realizations/12_realizations")
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_path
     output_path = tmp_path / "output.nc"
@@ -127,7 +127,7 @@ def test_realizations(tmp_path):
 def test_invalid_dataset(tmp_path):
     """Test unhandlable conversion failure."""
     input_dir = (acc.kgo_root() /
-                 "probabilities-to-realizations/invalid/")
+                 "convert-to-realizations/invalid/")
     input_path = input_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [input_path, "--output", output_path]


### PR DESCRIPTION
Description
This PR exposes the `raw_cube` and `random_seed`  arguments already supported by the `percentiles_to_realizations` and `probabilities_to_realizations` CLI.

This PR:
- Adds `raw_cube` and `random_seed` arguments to the `convert_to_realizations`. The `random_seed` argument is needed to support testing of the CLI.
- Correction of typos in `probabilities_to_realizations` CLI.
- Addition of acceptance tests for the `convert_to_realizations` CLI. These tests are copies of existing tests for the `probabilities_to_realizations` and `percentiles_to_realizations` CLIs, respectively.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

