### PR TITLE
IMPRO-1618: Interpolation using a difference field

### DIFF
--- a/improver/calculate_sleet_prob.py
+++ b/improver/calculate_sleet_prob.py
@@ -30,7 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """A plugin to calculate probability of sleet"""
 
-import warnings
 import numpy as np
 
 from improver.metadata.utilities import (
@@ -38,8 +37,7 @@ from improver.metadata.utilities import (
 
 
 def calculate_sleet_probability(prob_of_snow,
-                                prob_of_rain,
-                                ignore_mismatch=False):
+                                prob_of_rain):
     """
     This calculates the probability of sleet using the calculation:
     prob(sleet) = 1 - (prob(snow) + prob(rain))
@@ -47,33 +45,24 @@ def calculate_sleet_probability(prob_of_snow,
     Args:
       prob_of_snow (iris.cube.Cube):
         Cube of the probability of snow.
-
       prob_of_rain (iris.cube.Cube):
         Cube of the probability of rain.
-
-      ignore_mismatch (bool):
-        If set, errors relating to mismatches in the rain and snow data
-        are demoted to warnings.
 
     Returns:
       iris.cube.Cube:
         Cube of the probability of sleet.
 
-        Raises:
-            ValueError: If the cube contains negative values for the the
-            probability of sleet.
+    Raises:
+        ValueError: If the cube contains negative values for the the
+                    probability of sleet.
     """
     ones = np.ones((prob_of_snow.shape), dtype="float32")
     sleet_prob = (ones - (prob_of_snow.data + prob_of_rain.data))
     if np.any(sleet_prob < 0.0):
         msg = "Negative values of sleet probability have been calculated."
-        if ignore_mismatch:
-            sleet_prob = sleet_prob.clip(0., 1.)
-            warnings.warn(msg)
-        else:
-            raise ValueError(msg)
+        raise ValueError(msg)
 
-# In this case we want to copy all the attributes from the prob_of_snow cube
+    # Copy all of the attributes from the prob_of_snow cube
     mandatory_attributes = generate_mandatory_attributes([
         prob_of_rain, prob_of_snow])
     probability_of_sleet = create_new_diagnostic_cube(

--- a/improver/cli/interpolate_using_difference.py
+++ b/improver/cli/interpolate_using_difference.py
@@ -45,10 +45,10 @@ def process(cube: cli.inputcube,
     """
     Uses interpolation to fill holes in the data contained within the input
     cube. This is achieved by calculating the difference between the input cube
-    and a complete (filling the whole domain) reference cube. The difference
-    between the data in regions where they overlap is calculated and this
-    difference field is then interpolated across the domain. Any holes in the
-    input cube data are then filled with data calculated as the reference
+    and a complete (i.e. complete across the whole domain) reference cube. The
+    difference between the data in regions where they overlap is calculated and
+    this difference field is then interpolated across the domain. Any holes in
+    the input cube data are then filled with data calculated as the reference
     cube data minus the interpolated difference field.
 
     Args:
@@ -60,10 +60,11 @@ def process(cube: cli.inputcube,
             interpolated. The data in this cube must be complete across the
             entire domain.
         limit (iris.cube.Cube):
-            A cube containing limiting values for the interpolated data that
-            is used to fill holes in the cube of data. These limits may be
-            minima or maxima, depending upon how the flag limit_as_maximum is
-            set.
+            A cube of limiting values to apply to the cube that is being filled
+            in. This can be used to ensure that the resulting values do not
+            fall below / exceed the limiting values; whether the limit values
+            should be used as minima or maxima is determined by the
+            limit_as_maximum option.
         limit_as_maximum (bool):
             If True the limit values are treated as maxima for the data in the
             interpolated regions. If False the limit values are treated as

--- a/improver/cli/interpolate_using_difference.py
+++ b/improver/cli/interpolate_using_difference.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to fill holes in a field using interpolation of the difference
+between it and a reference field."""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(cube: cli.inputcube,
+            reference_cube: cli.inputcube,
+            limit: cli.inputcube = None,
+            *,
+            limit_as_maximum=True):
+    """
+    Uses interpolation to fill holes in the data contained within the input
+    cube. This is achieved by calculating the difference between the input cube
+    and a complete (filling the whole domain) reference cube. The difference
+    between the data in regions where they overlap is calculated and this
+    difference field is then interpolated across the domain. Any holes in the
+    input cube data are then filled with data calculated as the reference
+    cube data minus the interpolated difference field.
+
+    Args:
+        cube (iris.cube.Cube):
+            A cube containing data in which there are holes to be filled. These
+            holes are denoted by a mask.
+        reference_cube (iris.cube.Cube):
+            A cube containing data in the same units as the cube of data to be
+            interpolated. The data in this cube must be complete across the
+            entire domain.
+        limit (iris.cube.Cube):
+            A cube containing limiting values for the interpolated data that
+            is used to fill holes in the cube of data. These limits may be
+            minima or maxima, depending upon how the flag limit_as_maximum is
+            set.
+        limit_as_maximum (bool):
+            If True the limit values are treated as maxima for the data in the
+            interpolated regions. If False the limit values are treated as
+            minima.
+    Returns:
+        iris.cube.Cube:
+            Processed cube with the holes filled in through interpolation.
+    """
+    from improver.utilities.interpolation import InterpolateUsingDifference
+
+    result = InterpolateUsingDifference().process(
+        cube, reference_cube, limit=limit, limit_as_maximum=limit_as_maximum)
+    return result

--- a/improver/cli/interpolate_using_difference.py
+++ b/improver/cli/interpolate_using_difference.py
@@ -77,6 +77,6 @@ def process(cube: cli.inputcube,
     """
     from improver.utilities.interpolation import InterpolateUsingDifference
 
-    result = InterpolateUsingDifference().process(
+    result = InterpolateUsingDifference()(
         cube, reference_cube, limit=limit, limit_as_maximum=limit_as_maximum)
     return result

--- a/improver/cli/interpolate_using_difference.py
+++ b/improver/cli/interpolate_using_difference.py
@@ -29,8 +29,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Script to fill holes in a field using interpolation of the difference
-between it and a reference field."""
+"""Script to fill masked regions in a field using interpolation of the
+difference between it and a reference field."""
 
 from improver import cli
 
@@ -43,18 +43,19 @@ def process(cube: cli.inputcube,
             *,
             limit_as_maximum=True):
     """
-    Uses interpolation to fill holes in the data contained within the input
-    cube. This is achieved by calculating the difference between the input cube
-    and a complete (i.e. complete across the whole domain) reference cube. The
-    difference between the data in regions where they overlap is calculated and
-    this difference field is then interpolated across the domain. Any holes in
-    the input cube data are then filled with data calculated as the reference
-    cube data minus the interpolated difference field.
+    Uses interpolation to fill masked regions in the data contained within the
+    input cube. This is achieved by calculating the difference between the
+    input cube and a complete (i.e. complete across the whole domain) reference
+    cube. The difference between the data in regions where they overlap is
+    calculated and this difference field is then interpolated across the
+    domain. Any masked regions in the input cube data are then filled with data
+    calculated as the reference cube data minus the interpolated difference
+    field.
 
     Args:
         cube (iris.cube.Cube):
-            A cube containing data in which there are holes to be filled. These
-            holes are denoted by a mask.
+            A cube containing data in which there are masked regions to be
+            filled.
         reference_cube (iris.cube.Cube):
             A cube containing data in the same units as the cube of data to be
             interpolated. The data in this cube must be complete across the
@@ -71,7 +72,8 @@ def process(cube: cli.inputcube,
             minima.
     Returns:
         iris.cube.Cube:
-            Processed cube with the holes filled in through interpolation.
+            Processed cube with the masked regions filled in through
+            interpolation.
     """
     from improver.utilities.interpolation import InterpolateUsingDifference
 

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -37,9 +37,7 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(snow: cli.inputcube,
-            rain: cli.inputcube,
-            *,
-            ignore_mismatch=False):
+            rain: cli.inputcube):
     """Calculate sleet probability.
 
     Calculates the sleet probability using the
@@ -50,10 +48,6 @@ def process(snow: cli.inputcube,
             An iris Cube of the probability of snow.
         rain (iris.cube.Cube):
             An iris Cube of the probability of rain.
-        ignore_mismatch (bool):
-            If set, errors relating to mismatches in the rain and snow data
-            are demoted to warnings.
-
 
     Returns:
         iris.cube.Cube:
@@ -61,6 +55,6 @@ def process(snow: cli.inputcube,
     """
 
     from improver.calculate_sleet_prob import calculate_sleet_probability
-    result = calculate_sleet_probability(snow, rain,
-                                         ignore_mismatch=ignore_mismatch)
+
+    result = calculate_sleet_probability(snow, rain)
     return result

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -91,25 +91,17 @@ def interpolate_missing_data(
 
     if limit is not None:
         index = ~np.isfinite(data) & np.isfinite(data_filled)
-        limit_data_values(data_filled, index, limit, limit_as_maximum)
+        if limit_as_maximum:
+            data_filled[index] = np.clip(data_filled[index], None,
+                                         limit[index])
+        else:
+            data_filled[index] = np.clip(data_filled[index], limit[index],
+                                         None)
 
     index = ~np.isfinite(data)
     data[index] = data_filled[index]
 
     return data
-
-
-def limit_data_values(data, index, limit, limit_as_maximum):
-    """
-    Impose a limit on data.
-    """
-    index = index.copy()
-    if limit_as_maximum:
-        data_violating_limit = (data[index] > limit[index])
-    else:
-        data_violating_limit = (data[index] < limit[index])
-    index[index] = data_violating_limit
-    data[index] = limit[index]
 
 
 class InterpolateUsingDifference:
@@ -210,7 +202,13 @@ class InterpolateUsingDifference:
             interpolated_difference[invalid_points])
 
         if limit is not None:
-            limit_data_values(result.data, invalid_points, limit.data,
-                              limit_as_maximum)
+            if limit_as_maximum:
+                result.data[invalid_points] = np.clip(
+                    result.data[invalid_points], None,
+                    limit.data[invalid_points])
+            else:
+                result.data[invalid_points] = np.clip(
+                    result.data[invalid_points], limit.data[invalid_points],
+                    None)
 
         return result

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -108,10 +108,10 @@ class InterpolateUsingDifference:
     """
     Uses interpolation to fill holes in the data contained within the input
     cube. This is achieved by calculating the difference between the input cube
-    and a complete (filling the whole domain) reference cube. The difference
-    between the data in regions where they overlap is calculated and this
-    difference field is then interpolated across the domain. Any holes in the
-    input cube data are then filled with data calculated as the reference
+    and a complete (i.e. complete across the whole domain) reference cube. The
+    difference between the data in regions where they overlap is calculated and
+    this difference field is then interpolated across the domain. Any holes in
+    the input cube data are then filled with data calculated as the reference
     cube data minus the interpolated difference field.
     """
 
@@ -150,13 +150,11 @@ class InterpolateUsingDifference:
                 A cube that covers the entire domain that it shares with
                 cube.
             limit (iris.cube.Cube or None):
-                A cube used to calculate limiting values that the difference
-                cube should not violate following interpolation. This can be
-                used to ensure that the interpolated field does not get too
-                close to or too far away from the reference cube. Any points
-                in the interpolated difference field violating the limit are
-                set back to the calculated limiting value, ``reference_cube -
-                limit``.
+                A cube of limiting values to apply to the cube that is being
+                filled in. This can be used to ensure that the resulting values
+                do not fall below / exceed the limiting values; whether the
+                limit values should be used as a minima or maxima is
+                determined by the limit_as_maximum option.
             limit_as_maximum (bool):
                 If True the test against the values allowed by the limit array
                 is that if the interpolated values exceed the limit they should

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -66,8 +66,8 @@ def interpolate_missing_data(
 
     Returns:
         numpy.ndarray:
-            The original data plus interpolated data in holes where it was
-            possible to fill these in.
+            The original data plus interpolated data in masked regions where it
+            was possible to fill these in.
     """
     if valid_points is None:
         valid_points = np.full_like(data, True, dtype=np.bool)
@@ -107,13 +107,14 @@ def interpolate_missing_data(
 
 class InterpolateUsingDifference:
     """
-    Uses interpolation to fill holes in the data contained within the input
-    cube. This is achieved by calculating the difference between the input cube
-    and a complete (i.e. complete across the whole domain) reference cube. The
-    difference between the data in regions where they overlap is calculated and
-    this difference field is then interpolated across the domain. Any holes in
-    the input cube data are then filled with data calculated as the reference
-    cube data minus the interpolated difference field.
+    Uses interpolation to fill masked regions in the data contained within the
+    input cube. This is achieved by calculating the difference between the
+    input cube and a complete (i.e. complete across the whole domain) reference
+    cube. The difference between the data in regions where they overlap is
+    calculated and this difference field is then interpolated across the
+    domain. Any masked regions in the input cube data are then filled with data
+    calculated as the reference cube data minus the interpolated difference
+    field.
     """
 
     def __repr__(self):
@@ -134,10 +135,10 @@ class InterpolateUsingDifference:
             reference_cube.convert_units(cube.units)
             if limit is not None:
                 limit.convert_units(cube.units)
-        except ValueError:
-            raise ValueError(
+        except ValueError as err:
+            raise type(err)(
                 'Reference cube and/or limit do not have units compatible with'
-                ' cube.')
+                ' cube. ' + str(err))
 
     def process(self, cube, reference_cube, limit=None, limit_as_maximum=True):
         """
@@ -145,7 +146,8 @@ class InterpolateUsingDifference:
 
         Args:
             cube (iris.cube.Cube):
-                cube for which interpolation is required to fill holes.
+                Cube for which interpolation is required to fill masked
+                regions.
             reference_cube (iris.cube.Cube):
                 A cube that covers the entire domain that it shares with
                 cube.

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -196,6 +196,14 @@ class InterpolateUsingDifference:
         interpolated_difference = interpolate_missing_data(
                 difference_field, valid_points=valid_points)
 
+        # If any invalid points remain in the difference field, use nearest
+        # neighbour interpolation to fill these with the nearest difference.
+        remain_invalid = np.isnan(interpolated_difference)
+        if remain_invalid.any():
+            interpolated_difference = interpolate_missing_data(
+                    difference_field, valid_points=~remain_invalid,
+                    method='nearest')
+
         result = cube.copy()
         result.data[invalid_points] = (
             reference_cube.data[invalid_points] -

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -92,3 +92,43 @@ def interpolate_missing_data(
     data[index] = data_filled[index]
 
     return data
+
+
+class InterpolateUsingDifference:
+    """
+    Calculates the difference between the field that is to be interpolated and
+    a complete (filling the whole domain) reference field. The difference
+    between the fields in regions where they overlap is calculated and this
+    difference is then interpolated across the domain. Any holes in the data
+    being interpolated are then filled with data calculated as the reference
+    field minus the interpolated difference field.
+    """
+    # def __init__(self):
+    #     """Initialise plugin."""
+    #
+    # def __repr__(self):
+    #     """String representation of plugin."""
+
+    def process(self, field, reference_field, limit=None):
+        """Apply plugin to input data.
+
+        Args:
+            field (iris.cube.Cube):
+                Field for which interpolation is required to fill holes.
+            reference_field (iris.cube.Cube):
+                A field that covers the entire domain that it shares with
+                field.
+            limit (iris.cube.Cube or None):
+                A field that sets a maximum value that can be returned in the
+                final interpolated field at any given point. Any points
+                exceeding this limit will be set to the value given by limit.
+        """
+        if np.isnan(reference_field).any():
+            raise ValueError('Reference field incomplete')
+
+        difference_field = reference_field.data - field
+
+        interpolated_difference = interpolate_missing_data(
+                difference_field, limit=limit)
+        return field.copy(
+             data=reference_field.data - interpolated_difference)

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -33,6 +33,7 @@
 import warnings
 import numpy as np
 import iris
+from improver import BasePlugin
 from scipy.interpolate import griddata
 from scipy.spatial.qhull import QhullError
 
@@ -105,7 +106,7 @@ def interpolate_missing_data(
     return data
 
 
-class InterpolateUsingDifference:
+class InterpolateUsingDifference(BasePlugin):
     """
     Uses interpolation to fill masked regions in the data contained within the
     input cube. This is achieved by calculating the difference between the

--- a/improver_tests/acceptance/test_interpolate_using_difference.py
+++ b/improver_tests/acceptance/test_interpolate_using_difference.py
@@ -87,3 +87,19 @@ def test_filling_with_minimum_limit(tmp_path):
             "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
+
+
+def test_filling_with_nearest_use(tmp_path):
+    """Test filling masked areas using difference interpolation, in this case
+    with a hole in the corner of the data that requires use of nearest
+    neighbour interpolation."""
+    kgo_dir = acc.kgo_root() / f"{CLI}/basic"
+    kgo_path = kgo_dir / "sleet_rain_nearest_filled_kgo.nc"
+    output_path = tmp_path / "output.nc"
+    input_paths = [kgo_dir / x for x in
+                   ("sleet_rain_unfilled_corner.nc",
+                    "snow_sleet.nc")]
+    args = [*input_paths,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_interpolate_using_difference.py
+++ b/improver_tests/acceptance/test_interpolate_using_difference.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Tests for the interpolate-using-difference CLI
+"""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+def test_filling_without_limit(tmp_path):
+    """Test filling masked areas using difference interpolation, with no limits
+    on the returned values."""
+    kgo_dir = acc.kgo_root() / f"{CLI}/basic"
+    kgo_path = kgo_dir / "sleet_rain_unlimited_kgo.nc"
+    output_path = tmp_path / "output.nc"
+    input_paths = [kgo_dir / x for x in
+                   ("sleet_rain_unfilled.nc",
+                    "snow_sleet.nc")]
+    args = [*input_paths,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_filling_with_maximum_limit(tmp_path):
+    """Test filling masked areas using difference interpolation, with an
+    orography field used to limit the maximum of returned values."""
+    kgo_dir = acc.kgo_root() / f"{CLI}/basic"
+    kgo_path = kgo_dir / "sleet_rain_max_limited_kgo.nc"
+    output_path = tmp_path / "output.nc"
+    input_paths = [kgo_dir / x for x in
+                   ("sleet_rain_unfilled.nc",
+                    "snow_sleet.nc",
+                    "orog.nc")]
+    args = [*input_paths,
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_filling_with_minimum_limit(tmp_path):
+    """Test filling masked areas using difference interpolation, with an
+    orography field used to limit the minimum of returned values."""
+    kgo_dir = acc.kgo_root() / f"{CLI}/basic"
+    kgo_path = kgo_dir / "sleet_rain_min_limited_kgo.nc"
+    output_path = tmp_path / "output.nc"
+    input_paths = [kgo_dir / x for x in
+                   ("sleet_rain_unfilled.nc",
+                    "snow_sleet.nc",
+                    "orog.nc")]
+    args = [*input_paths,
+            "--limit-as-maximum", "False",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_sleet_probability.py
+++ b/improver_tests/acceptance/test_sleet_probability.py
@@ -51,19 +51,3 @@ def test_basic(tmp_path):
     args = [half_input_path, tenth_input_path, "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
-
-
-def test_sleet_warning(tmp_path):
-    """Test basic snow falling level calculation. When the warning is no
-    longer produced, the ignore-mismatch argument is deprecated and should be
-    removed."""
-    kgo_dir = acc.kgo_root() / "sleet_probability/warning"
-    kgo_path = kgo_dir / "kgo.nc"
-    output_path = tmp_path / "output.nc"
-    snow_input_path = kgo_dir / "snow.nc"
-    rain_input_path = kgo_dir / "rain.nc"
-    args = [snow_input_path, rain_input_path, "--ignore-mismatch",
-            "--output", output_path]
-    with pytest.warns(UserWarning, match="Negative values of sleet prob"):
-        run_cli(args)
-    acc.compare(output_path, kgo_path)

--- a/improver_tests/calculate_sleet_prob/test_calculate_sleet_probability.py
+++ b/improver_tests/calculate_sleet_prob/test_calculate_sleet_probability.py
@@ -99,28 +99,6 @@ class Test_calculate_sleet_probability(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             calculate_sleet_probability(rain, high_prob)
 
-    @ManageWarnings(record=True)
-    def test_negative_values_warning(self, warning_list=None):
-        """Test that a warning is issued for negative values of
-        probability_of_sleet in the cube."""
-        rain = self.rain_prob_cube
-        high_prob = self.high_prob_cube
-        msg = "Negative values of sleet probability have been calculated."
-
-        result = calculate_sleet_probability(rain, high_prob,
-                                             ignore_mismatch=True)
-        self.assertTrue(any(item.category == UserWarning
-                            for item in warning_list))
-        self.assertTrue(any(msg in str(item)
-                            for item in warning_list))
-        expected_result = np.array([[[0.0, 0.2, 0.0],
-                                     [0.2, 0.0, 0.0],
-                                     [0.0, 0.0, 0.0]],
-                                    [[0.0, 0.2, 0.0],
-                                     [0.2, 0.0, 0.0],
-                                     [0.0, 0.0, 0.0]]], dtype=np.float32)
-        self.assertArrayAlmostEqual(result.data, expected_result)
-
     def test_name_of_cube(self):
         """Test that the name has been changed to sleet_probability"""
         result = calculate_sleet_probability(

--- a/improver_tests/utilities/test_InterpolateUsingDifference.py
+++ b/improver_tests/utilities/test_InterpolateUsingDifference.py
@@ -91,7 +91,7 @@ class Test__check_inputs(Test_Setup):
             InterpolateUsingDifference()._check_inputs(
                 self.sleet_rain, self.snow_sleet, None)
 
-    def test_incompatible_refence_cube_units(self):
+    def test_incompatible_reference_cube_units(self):
         """Test an exception is raised if the reference cube has units that
         are incompatible with the input cube."""
 

--- a/improver_tests/utilities/test_InterpolateUsingDifference.py
+++ b/improver_tests/utilities/test_InterpolateUsingDifference.py
@@ -28,18 +28,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Unit tests for the functions within interpolation.py"""
+"""Unit tests for the InterpolateUsingDifference plugin."""
 
 import unittest
 
 import numpy as np
 from iris.tests import IrisTest
 
-from improver.utilities.interpolation import interpolate_missing_data
+from improver.utilities.interpolation import InterpolateUsingDifference
 
 
-class Test_interpolate_missing_data(IrisTest):
-    """Test the interpolate_missing_data method"""
+class Test_InterpolateUsingDifference(IrisTest):
+
+    """Test the InterpolateUsingDifference plugin"""
+
     def setUp(self):
         """ Set up arrays for testing."""
         self.data = np.array([[1.0, 1.0, 2.0],
@@ -118,7 +120,7 @@ class Test_interpolate_missing_data(IrisTest):
                          [np.nan, np.nan, np.nan],
                          [np.nan, 1, np.nan]])
 
-        data_updated = interpolate_missing_data(data.copy())
+        data_updated = interpolate_missing_data(data)
 
         self.assertArrayEqual(data_updated, data)
 
@@ -144,7 +146,7 @@ class Test_interpolate_missing_data(IrisTest):
                          [np.nan, 1, np.nan],
                          [np.nan, 1, np.nan]])
 
-        data_updated = interpolate_missing_data(data.copy())
+        data_updated = interpolate_missing_data(data)
 
         self.assertArrayEqual(data_updated, data)
 

--- a/improver_tests/utilities/test_InterpolateUsingDifference.py
+++ b/improver_tests/utilities/test_InterpolateUsingDifference.py
@@ -163,6 +163,29 @@ class Test_process(unittest.TestCase):
         assert_array_equal(result_unlimited.data, expected_unlimited)
         assert_array_equal(result_limited.data, expected_limited)
 
+    def test_linear_failure(self):
+        """Test that if the use of linear interpolation does not result in a
+        complete difference field, and thus a complete field of interest, the
+        secondary use of nearest neighbour interpolation completes the
+        field."""
+
+        sleet_rain = np.array([[np.nan, np.nan, 4.0],
+                               [np.nan, np.nan, np.nan],
+                               [3.0, 3.0, 3.0]], dtype=np.float32)
+        sleet_rain = np.ma.masked_invalid(sleet_rain)
+        self.sleet_rain.data = sleet_rain
+
+        expected = np.array([[3.5, 4.0, 4.0],
+                             [8.5, 8.5, 8.5],
+                             [3.0, 3.0, 3.0]], dtype=np.float32)
+
+        result = InterpolateUsingDifference().process(self.sleet_rain,
+                                                      self.snow_sleet)
+
+        assert_array_equal(result.data, expected)
+        self.assertEqual(result.coords(), self.sleet_rain.coords())
+        self.assertEqual(result.metadata, self.sleet_rain.metadata)
+
     @ManageWarnings(record=True)
     def test_unmasked_input_cube(self, warning_list=None):
         """Test a warning is raised if the input cube is not masked and that


### PR DESCRIPTION
Designed for use with phase-change-levels, this new plugin and CLI allow masked values in a field to be filled. The values used are calculated by subtracting the field where available from a complete reference field and then interpolating this difference field. The masked regions are replaced with the result of ```reference_field - interpolated_difference_field```, the rest of the field if left unchanged.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)