### PR TITLE
1180 memory profiling

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -464,15 +464,17 @@ def main(prog_name: parameters.pass_name,
     on available command(s).
     """
     args = unbracket(args)
+    local_exec_com = execute_command
     if profile is not None:
         from improver.profile import profile_hook_enable
         profile_hook_enable(dump_filename=None if profile == '-' else profile)
     if memprofile is not None:
         from improver.memprofile import memory_profile_decorator
-        execute_command = memory_profile_decorator(execute_command, memprofile)
-    result = execute_command(SUBCOMMANDS_DISPATCHER,
-                             prog_name, command, *args,
-                             verbose=verbose, dry_run=dry_run)
+        local_exec_com = memory_profile_decorator(local_exec_com,
+                                                  memprofile)
+    result = local_exec_com(SUBCOMMANDS_DISPATCHER,
+                            prog_name, command, *args,
+                            verbose=verbose, dry_run=dry_run)
     return result
 
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -427,8 +427,8 @@ def execute_command(dispatcher, prog_name, *args,
 def main(prog_name: parameters.pass_name,
          command: LAST_OPTION,
          *args,
-         profile: value_converter(lambda _: _, name='FILENAME') = None,
-         memprofile: value_converter(lambda _: _, name='FILENAME') = None, 
+         profile: value_converter(lambda _: _, name='FILENAME')=None,
+         memprofile: value_converter(lambda _: _, name='FILENAME')=None,
          verbose=False,
          dry_run=False):
     """IMPROVER NWP post-processing toolbox
@@ -477,8 +477,8 @@ def main(prog_name: parameters.pass_name,
     else:
         result = execute_command(SUBCOMMANDS_DISPATCHER,
                                  prog_name, command, *args,
-                                 verbose=verbose, dry_run=dry_run) 
-    
+                                 verbose=verbose, dry_run=dry_run)
+
     return result
 
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -467,18 +467,12 @@ def main(prog_name: parameters.pass_name,
     if profile is not None:
         from improver.profile import profile_hook_enable
         profile_hook_enable(dump_filename=None if profile == '-' else profile)
-
     if memprofile is not None:
         from improver.memprofile import memory_profile_decorator
-        func = memory_profile_decorator(execute_command, memprofile)
-        result = func(SUBCOMMANDS_DISPATCHER,
-                      prog_name, command, *args,
-                      verbose=verbose, dry_run=dry_run)
-    else:
-        result = execute_command(SUBCOMMANDS_DISPATCHER,
-                                 prog_name, command, *args,
-                                 verbose=verbose, dry_run=dry_run)
-
+        execute_command = memory_profile_decorator(execute_command, memprofile)
+    result = execute_command(SUBCOMMANDS_DISPATCHER,
+                             prog_name, command, *args,
+                             verbose=verbose, dry_run=dry_run)
     return result
 
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -427,8 +427,8 @@ def execute_command(dispatcher, prog_name, *args,
 def main(prog_name: parameters.pass_name,
          command: LAST_OPTION,
          *args,
-         profile: value_converter(lambda _: _, name='FILENAME')=None,
-         memprofile: value_converter(lambda _: _, name='FILENAME')=None,
+         profile: value_converter(lambda _: _, name='FILENAME') = None,
+         memprofile: value_converter(lambda _: _, name='FILENAME') = None,
          verbose=False,
          dry_run=False):
     """IMPROVER NWP post-processing toolbox

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -464,17 +464,15 @@ def main(prog_name: parameters.pass_name,
     on available command(s).
     """
     args = unbracket(args)
-    local_exec_com = execute_command
+    exec_cmd = execute_command
     if profile is not None:
         from improver.profile import profile_hook_enable
         profile_hook_enable(dump_filename=None if profile == '-' else profile)
     if memprofile is not None:
         from improver.memprofile import memory_profile_decorator
-        local_exec_com = memory_profile_decorator(local_exec_com,
-                                                  memprofile)
-    result = local_exec_com(SUBCOMMANDS_DISPATCHER,
-                            prog_name, command, *args,
-                            verbose=verbose, dry_run=dry_run)
+        exec_cmd = memory_profile_decorator(exec_cmd, memprofile)
+    result = exec_cmd(SUBCOMMANDS_DISPATCHER, prog_name, command,
+                      *args, verbose=verbose, dry_run=dry_run)
     return result
 
 

--- a/improver/memprofile.py
+++ b/improver/memprofile.py
@@ -31,7 +31,7 @@
 """Module containing maximum memory profiling utilities."""
 
 import tracemalloc
-from queue import Queue, Empty
+from queue import Queue
 from threading import Thread
 from resource import getrusage, RUSAGE_SELF
 from datetime import datetime

--- a/improver/memprofile.py
+++ b/improver/memprofile.py
@@ -36,6 +36,7 @@ from threading import Thread
 from resource import getrusage, RUSAGE_SELF
 from datetime import datetime
 import sys
+import time
 
 
 def memory_profile_start(outfile_prefix):
@@ -74,8 +75,8 @@ def memory_monitor(queue, outfile_prefix):
     """Function to track memory usage, should be run in a separate
     thread to the main program.
 
-    Samples max_rss, if the max_rss is higher than the previous
-    max_rss, then creates a tracemalloc snapshot. There is a
+    Samples max_rss every 0.1s, if the max_rss is higher than the
+    previous max_rss, then creates a tracemalloc snapshot. There is a
     performance overhead when using this.
 
     Args:
@@ -88,6 +89,7 @@ def memory_monitor(queue, outfile_prefix):
     tracemalloc.start()
     old_max = 0
     snapshot = None
+    wait_time = 0.1
 
     fout = open("{}_MAX_TRACKER".format(outfile_prefix), 'w')
     b2mb = 1 / 1048576
@@ -97,6 +99,7 @@ def memory_monitor(queue, outfile_prefix):
 
     while True:
         if queue.empty():
+            time.sleep(wait_time)
             max_rss = getrusage(RUSAGE_SELF).ru_maxrss
             if max_rss > old_max:
                 snapshot = tracemalloc.take_snapshot()

--- a/improver/memprofile.py
+++ b/improver/memprofile.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module containing maximum memory profiling utilities."""
+
+import tracemalloc as tm
+from queue import Queue, Empty
+from threading import Thread
+from resource import getrusage, RUSAGE_SELF
+from datetime import datetime
+
+
+def memory_profile_start(outfile_prefix, timeout_time=0.1):
+    """Starts the memory tracking profiler.
+
+    Args:
+        outfile_prefix (str):
+            Prefix for the generated output. 2 files will
+            be generated: *_SNAPSHOT and *_MAX_TRACKER.
+        timeout_time (float):
+            Time the queue will look for an input.
+
+    Returns:
+        Active Thread tracking the memory.
+        Active Queue for communication to the thread.
+    """
+    queue = Queue()
+    thread = Thread(target=memory_monitor, args=(queue, timeout_time,
+                                                 outfile_prefix))
+    thread.start()
+    return thread, queue
+
+
+def memory_profile_end(queue, thread):
+    """Ends the memory tracking profiler.
+
+    Args:
+        queue (queue.Queue):
+            Active queue instance to communicate with active thread.
+        thread (thread.Thread):
+            Active thread instance running memory tracking.
+    """
+    queue.put('Stop')
+    thread.join()
+
+
+def memory_monitor(queue, timeout_time, outfile_prefix):
+    """Function to track memory usage, should be run in a separate
+    thread to the main program.
+
+    Args:
+        queue (queue.Queue):
+            Active queue instance to communicate with the thread.
+        timeout_time (float):
+            Time the queue will look for in input.
+        outfile_prefix (str):
+            Prefix for the generated output. 2 files will
+            be generated: *_SNAPSHOT and *_MAX_TRACKER.
+    """
+    tm.start()
+    old_max = 0
+    snapshot = None
+
+    fout = open("{}_MAX_TRACKER".format(outfile_prefix), 'w')
+    b2mb = 1 / 1048576
+
+    while True:
+        try:
+            queue.get(timeout=timeout_time)
+            snapshot.dump("{}_SNAPSHOT".format(outfile_prefix))
+            fout.close()
+            tm.stop()
+            return
+        except Empty:
+            max_rss = getrusage(RUSAGE_SELF).ru_maxrss
+            if max_rss > old_max:
+                snapshot = tm.take_snapshot()
+                line = "{} max RSS {:.2f} MiB".format(datetime.now(),
+                                                      max_rss * b2mb)
+                print(line, file=fout)
+
+
+def memory_profile_decorator(func, outfile_prefix):
+    """A decorator for convenience of running.
+
+    Args:
+        func:
+            function to track the maximum memory of.
+        outfile_prefix (str):
+            Prefix for the generated output. 2 files will
+            be generated: *_SNAPSHOT and *_MAX_TRACKER.
+    """
+    def wrapper(*args, **kwargs):
+        thread, queue = memory_profile_start(outfile_prefix)
+        results = func(*args, **kwargs)
+        memory_profile_end(queue, thread)
+        return results
+    return wrapper

--- a/improver/memprofile.py
+++ b/improver/memprofile.py
@@ -37,6 +37,7 @@ from resource import getrusage, RUSAGE_SELF
 from datetime import datetime
 import sys
 
+
 def memory_profile_start(outfile_prefix):
     """Starts the memory tracking profiler.
 
@@ -91,9 +92,9 @@ def memory_monitor(queue, outfile_prefix):
     fout = open("{}_MAX_TRACKER".format(outfile_prefix), 'w')
     b2mb = 1 / 1048576
     if sys.platform == 'linux':
-        #linux outputs max_rss in KB not B
+        # linux outputs max_rss in KB not B
         b2mb = 1 / 1024
-    
+
     while True:
         if queue.empty():
             max_rss = getrusage(RUSAGE_SELF).ru_maxrss


### PR DESCRIPTION
Closes #1180 memory profiling.

Description
Tracks the maximum memory usage of the code and creates a tracemalloc snapshot at the peak. I've also added a command line argument to call the memprofiling in line with the profile command: --memprofile=FILENAME.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)