### PR TITLE
IMPRO-1632: Ensure all mosg__ attributes are set as globals

### DIFF
--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -164,9 +164,10 @@ def save_netcdf(cubelist, filename):
         warnings.warn(msg)
 
     global_keys = ['title', 'um_version', 'grid_id', 'source', 'Conventions',
-                   'mosg__grid_type', 'mosg__model_configuration',
-                   'mosg__grid_domain', 'mosg__grid_version',
                    'institution', 'history', 'bald__isPrefixedBy']
+    global_keys.extend([key for key in cube.attributes.keys()
+                        if 'mosg__' in key])
+
     local_keys = {key for cube in cubelist
                   for key in cube.attributes.keys()
                   if key not in global_keys}


### PR DESCRIPTION
Modified save wrapper to include all attributes on a cube that include ```mosg__``` as global attributes.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)