### PR TITLE
IMPRO-1646: Accumulation cell method added to nowcast accumulations

### DIFF
--- a/improver/nowcasting/accumulation.py
+++ b/improver/nowcasting/accumulation.py
@@ -301,6 +301,9 @@ class Accumulation(BasePlugin):
             ["time", "forecast_period"])
         accumulation_cube.rename(cube_name)
         accumulation_cube.units = 'm'
+        accumulation_cell_method = iris.coords.CellMethod(
+            'sum', coords=accumulation_cube.coord('time'))
+        accumulation_cube.add_cell_method(accumulation_cell_method)
         return accumulation_cube
 
     def process(self, cubes):

--- a/improver_tests/nowcasting/accumulation/test_Accumulation.py
+++ b/improver_tests/nowcasting/accumulation/test_Accumulation.py
@@ -339,6 +339,8 @@ class Test__set_metadata(rate_cube_set_up):
                                  datetime.datetime(2017, 11, 10, 4, 10))]
         expected_fp_point = 600
         expected_fp_bounds = [[0, 600]]
+        expected_cell_method = iris.coords.CellMethod('sum', coords='time')
+
         result = Accumulation()._set_metadata(self.cubes)
         self.assertEqual(result.name(), expected_name)
         self.assertEqual(result.units, expected_units)
@@ -350,6 +352,7 @@ class Test__set_metadata(rate_cube_set_up):
         self.assertEqual(bounds, expected_time_bounds)
         self.assertArrayAlmostEqual(
             result.coord("forecast_period").bounds, expected_fp_bounds)
+        self.assertEqual(result.cell_methods[0], expected_cell_method)
 
 
 class Test_process(rate_cube_set_up):


### PR DESCRIPTION
This PR adds the ```sum: time``` cell method to cubes produced by nowcast-accumulate. This cell method does **not** include an interval, as specified by the metadata standards document.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
