### PR TITLE
Actions on pushes again (codecov fix)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: pull_request
+on: [pull_request, push]
 jobs:
   Sphinx-Pytest-Coverage:
     runs-on: ubuntu-latest
@@ -12,7 +12,7 @@ jobs:
         path: /usr/share/miniconda/envs/improver
         key: ${{ runner.os }}-conda-improver-${{ hashFiles('**/environment.yml') }}
         restore-keys: ${{ runner.OS }}-conda-improver-
-    - name: conda build
+    - name: conda env update
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'


### PR DESCRIPTION
Fixes codecov only reporting on the latest master it has a record of (which doesn't update on PRs).
Means we have duplicates tests on PRs, but GitHub actions doesn't have a nice way around this.