### PR TITLE
Prevent removal of bounds when combining cubes

### DIFF
--- a/improver/cli/combine.py
+++ b/improver/cli/combine.py
@@ -44,6 +44,7 @@ def process(*cubes: cli.inputcube,
     r"""Combine input cubes.
 
     Combine the input cubes into a single cube using the requested operation.
+    The first cube in the input list provides the template for output metadata.
 
     Args:
         cubes (iris.cube.CubeList or list of iris.cube.Cube):

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -140,6 +140,18 @@ class CubeCombiner(BasePlugin):
         first cube in the input list provides the template for the combined
         cube metadata.
 
+        NOTE the behaviour for the "multiply" operation is different from
+        other types of cube combination.  The only valid use case for
+        "multiply" is to apply a factor that conditions an input probability
+        field - that is, to apply Bayes Theorem.  The input probability is
+        therefore used as the source of ALL input metadata, and should always
+        be the first cube in the input list.  The factor(s) by which this is
+        multiplied are not compared for any mis-match in scalar coordinates,
+        neither do they to contribute to expanded bounds.
+
+        TODO the "multiply" case should be factored out into a separate plugin
+        given its substantial differences from other combine use cases.
+
         Args:
             cube_list (iris.cube.CubeList or list):
                 List of cubes to combine.

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -170,11 +170,12 @@ class CubeCombiner(BasePlugin):
         if self.operation == 'mean':
             result.data = result.data / len(cube_list)
 
-        # update any coordinates that have been expanded, and rename output
-        expanded_coord_names = self._get_expanded_coord_names(cube_list)
-        if expanded_coord_names:
-            result = expand_bounds(result, cube_list, expanded_coord_names,
-                                   use_midpoint=use_midpoint)
+        if self.operation != 'multiply':
+            expanded_coord_names = self._get_expanded_coord_names(cube_list)
+            if expanded_coord_names:
+                result = expand_bounds(result, cube_list, expanded_coord_names,
+                                       use_midpoint=use_midpoint)
+
         result.rename(new_diagnostic_name)
 
         return result

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -170,6 +170,8 @@ class CubeCombiner(BasePlugin):
         if self.operation == 'mean':
             result.data = result.data / len(cube_list)
 
+        # where the operation is "multiply", retain all coordinate metadata
+        # from the first cube in the list; otherwise expand coordinate bounds
         if self.operation != 'multiply':
             expanded_coord_names = self._get_expanded_coord_names(cube_list)
             if expanded_coord_names:

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -136,7 +136,9 @@ class CubeCombiner(BasePlugin):
     def process(self, cube_list, new_diagnostic_name, use_midpoint=False):
         """
         Combine data and metadata from a list of input cubes into a single
-        cube, using the specified operation to combine the cube data.
+        cube, using the specified operation to combine the cube data.  The
+        first cube in the input list provides the template for the combined
+        cube metadata.
 
         Args:
             cube_list (iris.cube.CubeList or list):

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -876,6 +876,9 @@ def expand_bounds(result_cube, cubelist, coord_names, use_midpoint=False):
 
         bounds = ([cube.coord(coord).bounds for cube in cubelist])
         if any(b is None for b in bounds):
+            if not all(b is None for b in bounds):
+                raise ValueError('cannot expand bounds for a mixture of '
+                                 'bounded / unbounded coordinates')
             points = ([cube.coord(coord).points for cube in cubelist])
             new_low_bound = np.min(points)
             new_top_bound = np.max(points)

--- a/improver_tests/utilities/cube_manipulation/test_expand_bounds.py
+++ b/improver_tests/utilities/cube_manipulation/test_expand_bounds.py
@@ -178,6 +178,15 @@ class Test_expand_bounds(IrisTest):
             expand_bounds(
                 self.cubelist[0], self.cubelist, ['latitude'])
 
+    def test_error_remove_bounds(self):
+        """Test the expand_bounds function fails if its effect would be
+        to remove bounds from a bounded coordinate, ie if a mixture of
+        bounded and unbounded coordinates are input"""
+        self.cubelist[1].coord("time").bounds = None
+        msg = 'cannot expand bounds for a mixture of bounded / unbounded'
+        with self.assertRaisesRegex(ValueError, msg):
+            expand_bounds(self.cubelist[0], self.cubelist, ['time'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was an issue when calculating precipitation type rates and accumulations by multiplying a total precip rate / accumulation by probability of precipitation type (eg probability of snow).  Since the probability of type was a point time, the bounds on the time coordinate were being incorrectly removed.  This change prevents removal of bounds when combining cubes, and causes `expand_bounds` to raise an error if it would cause the removal of valid bounds from a coordinate.

Description

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)