### PR TITLE
Exclude cli/ from codecov statistics

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+# codecov options
+
+ignore:
+  - "improver/cli"  # ignore folders and all its contents


### PR DESCRIPTION
Adds a codecov yaml file to exclude the CLI directory from coverage statistics.

Testing:
 - [x] Ran tests and they passed OK
