### PR TITLE
Change codacy action to check environment variable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: pytest unit-tests & cov-report
       run: pytest -m "not acc" --cov=improver --cov-report xml:coverage.xml
     - name: codacy-coverage
-      if: github.actor == 'repo-owner'
+      if: env.CODACY_PROJECT_TOKEN
       run: python-codacy-coverage -v -r coverage.xml
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
Coverage is not currently being reported to Codacy from PRs or master branch. This appears to be due to the 'repo-owner' condition not being met.

Based on some trials in my personal fork, this check for the CODACY_PROJECT_TOKEN environment variable appears to work as intended. I was unable to get the if-condition to directly check `secrets`.

The actions run https://github.com/tjtg/improver/actions/runs/73630023 with this change correctly skipped codacy reporting and the run https://github.com/tjtg/improver/actions/runs/73635114 picked up the environment variable correctly but (intentionally) failed due to using a dummy/invalid codacy API token from secrets in my personal fork. Both of those actions runs are on the same commit ID as this PR - 9a1252a.

Testing:
 - [x] Ran tests and they passed OK
