### PR TITLE
IMPRO-1662: Alter occurrence within vicinity fill value.

### DIFF
--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -360,7 +360,7 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
         unmasked_cube_data = cube.data.copy()
         if np.ma.is_masked(cube.data):
             unmasked_cube_data = cube.data.data.copy()
-            unmasked_cube_data[cube.data.mask] = np.nan
+            unmasked_cube_data[cube.data.mask] = -np.inf
         # The following command finds the maximum value for each grid point
         # from within a square of length "size"
         max_data = maximum_filter(unmasked_cube_data, size=grid_cells)


### PR DESCRIPTION
The ```OccurrenceWithinVicinity``` plugin should not propagate values from underneath masked regions. It attempts to do this by only modifying points that are not masked in the input cube, but the vicinity process constructs neighbourhoods that do stretch into masked regions.

The ```maximum_filter``` function, imported from scitools, does not handle nan values, but ```OccurenceWithinVicinity``` uses np.nan values to fill masked data elements in the array before applying the filter. The filter thus returns np.nan values as maximums within the neighbourhoods, and these are assigned to unmasked points about which the neighbourhoods were constructed.

This PR fixes this issue by using ```-np.inf``` as the fill value instead, meaning that the maximum_filter will never choose these values as the maximum within a neighbourhood.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)