### PR TITLE
Support applying reliability calibration without a reliability table

### DIFF
--- a/improver/cli/apply_reliability_calibration.py
+++ b/improver/cli/apply_reliability_calibration.py
@@ -38,14 +38,16 @@ from improver import cli
 @cli.with_output
 def process(
     forecast: cli.inputcube,
-    reliability_table: cli.inputcube,
+    reliability_table: cli.inputcube = None,
     *,
     minimum_forecast_count=200,
 ):
     """
     Calibrate a probability forecast using the provided reliability calibration
     table. This calibration is designed to improve the reliability of
-    probability forecasts without significantly degrading their resolution.
+    probability forecasts without significantly degrading their resolution. If
+    a reliability table is not provided, the input forecast is returned
+    unchanged.
 
     The method implemented here is described in Flowerdew J. 2014. Calibrating
     ensemble reliability whilst preserving spatial structure. Tellus, Ser. A
@@ -68,6 +70,9 @@ def process(
             Calibrated forecast.
     """
     from improver.calibration.reliability_calibration import ApplyReliabilityCalibration
+
+    if reliability_table is None:
+        return forecast
 
     plugin = ApplyReliabilityCalibration(minimum_forecast_count=minimum_forecast_count)
     return plugin(forecast, reliability_table)

--- a/improver_tests/acceptance/test_apply_reliability_calibration.py
+++ b/improver_tests/acceptance/test_apply_reliability_calibration.py
@@ -51,3 +51,15 @@ def test_calibration(tmp_path):
     args = [forecast_path, table_path, "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
+
+
+def test_no_calibration(tmp_path):
+    """
+    Test applying reliability calibration without a reliability table.
+    """
+    kgo_dir = acc.kgo_root() / "apply-reliability-calibration/basic"
+    forecast_path = kgo_dir / "forecast.nc"
+    output_path = tmp_path / "output.nc"
+    args = [forecast_path, "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, forecast_path)


### PR DESCRIPTION
Description
This PR aims to update the `apply_reliability_calibration` CLI to support not supplying a reliability table. In this instance, the uncalibrated forecast will be passed through. 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

