### PR TITLE
Slim down topographic neighbourhood

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -305,25 +305,6 @@ def with_output(wrapped, *args, output=None, **kwargs):
     return result
 
 
-@decorator
-def with_intermediate_output(wrapped, *args, intermediate_output=None, **kwargs):
-    """Add `intermediate_output` keyword only argument.
-
-    Args:
-        wrapped (obj):
-            The function to be wrapped.
-        intermediate_output (str, optional):
-            Output file name for intermediate result.
-    """
-
-    from improver.utilities.save import save_netcdf
-
-    result, intermediate_result = wrapped(*args, **kwargs)
-    if intermediate_output:
-        save_netcdf(intermediate_result, intermediate_output)
-    return result
-
-
 # cli object creation
 
 

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -101,8 +101,6 @@ def process(
             A weights cube has been provided but no topographic zone.
 
     """
-    import warnings
-
     import numpy as np
 
     from improver.nbhood.nbhood import NeighbourhoodProcessing

--- a/improver/nbhood/use_nbhood.py
+++ b/improver/nbhood/use_nbhood.py
@@ -241,7 +241,7 @@ class ApplyNeighbourhoodProcessingWithAMask(PostProcessingPlugin):
                 exception_coordinates=exception_coordinates,
             )
             if collapse_plugin:
-                concatenated_cube= collapse_plugin(concatenated_cube)
+                concatenated_cube = collapse_plugin(concatenated_cube)
             result_slices.append(concatenated_cube)
         result = result_slices.merge_cube()
         exception_coordinates = find_dimension_coordinate_mismatch(
@@ -377,7 +377,7 @@ class CollapseMaskedNeighbourhoodCoordinate(BasePlugin):
         condition = np.isnan(nbhood_cube.data)
         if ma.is_masked(self.weights.data):
             condition = condition & ~self.weights.data.mask
-            
+
         self.weights.data[condition] = 0.0
         axis = nbhood_cube.coord_dims(self.coord_masked)
         self.weights.data = WeightsUtilities.normalise_weights(

--- a/improver/nbhood/use_nbhood.py
+++ b/improver/nbhood/use_nbhood.py
@@ -389,7 +389,7 @@ class CollapseMaskedNeighbourhoodCoordinate(BasePlugin):
         """
         # Mask out any NaNs in the neighbourhood data so that Iris ignores
         # them when calculating the weighted mean.
-        cube.data = ma.masked_invalid(cube.data)
+        cube.data = ma.masked_invalid(cube.data, copy=False)
         yname = cube.coord(axis="y").name()
         xname = cube.coord(axis="x").name()
 

--- a/improver_tests/acceptance/test_nbhood_land_and_sea.py
+++ b/improver_tests/acceptance/test_nbhood_land_and_sea.py
@@ -75,38 +75,6 @@ def test_radii_with_lead_times(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-@pytest.mark.slow
-@pytest.mark.parametrize("intermediate", (True, False))
-def test_topographic_bands(tmp_path, intermediate):
-    """Test land-sea with topographic bands"""
-    kgo_dir = acc.kgo_root() / "nbhood-land-and-sea/topographic_bands"
-    kgo_path = kgo_dir / "kgo.nc"
-    land_kgo_path = kgo_dir / "kgo_land.nc"
-    input_path = kgo_dir / "input.nc"
-    bands_path = kgo_dir / "topographic_bands_land.nc"
-    weights_path = kgo_dir / "weights_land.nc"
-    output_path = tmp_path / "output.nc"
-    land_output_path = tmp_path / "output_land.nc"
-    if intermediate:
-        im_args = ["--intermediate-output", land_output_path, "--return-intermediate"]
-    else:
-        im_args = []
-    args = [
-        input_path,
-        bands_path,
-        weights_path,
-        "--radii",
-        "20000",
-        *im_args,
-        "--output",
-        output_path,
-    ]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-    if intermediate:
-        acc.compare(land_output_path, land_kgo_path)
-
-
 def test_unnecessary_weights(tmp_path):
     """Test land-sea with additional unnecessary weights argument"""
     kgo_dir = acc.kgo_root() / "nbhood-land-and-sea/no_topographic_bands"

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -45,7 +45,6 @@ from improver.cli import (
     inputjson,
     maybe_coerce_with,
     unbracket,
-    with_intermediate_output,
     with_output,
 )
 from improver.utilities.load import load_cube
@@ -76,12 +75,6 @@ def dummy_function(first, second=0, third=2):
 def wrapped_with_output(first):
     """dummy function for testing with_output wrapper"""
     return dummy_function(first)
-
-
-@with_intermediate_output
-def wrapped_with_intermediate_output(first):
-    """dummy function for testing with_intermediate_output wrapper"""
-    return dummy_function(first), True
 
 
 class Test_docutilize(unittest.TestCase):
@@ -170,31 +163,6 @@ class Test_with_output(unittest.TestCase):
         result = wrapped_with_output(2, output="foo")
         m.assert_called_with(4, "foo")
         self.assertEqual(result, None)
-
-
-class Test_with_intermediate_output(unittest.TestCase):
-    """Tests the intermediate output wrapper"""
-
-    @patch("improver.utilities.save.save_netcdf")
-    def test_without_output(self, m):
-        """Tests that the wrapped function is called and result is returned"""
-        result = wrapped_with_intermediate_output(2)
-        m.assert_not_called()
-        self.assertEqual(result, 4)
-
-    @patch("improver.utilities.save.save_netcdf")
-    def test_with_output(self, m):
-        """Tests with an intermediate_output
-
-        Tests that save_netcdf is called with object and string, and
-        wrapped function returns the result.
-
-        """
-        # pylint disable is needed as it can't see the wrappers output kwarg.
-        # pylint: disable=unexpected-keyword-arg
-        result = wrapped_with_intermediate_output(2, intermediate_output="foo")
-        m.assert_called_with(True, "foo")
-        self.assertEqual(result, 4)
 
 
 def replace_load_with_extract(func, cube, constraints=None):

--- a/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -38,7 +38,10 @@ import numpy as np
 from iris.coords import DimCoord
 from iris.tests import IrisTest
 
-from improver.nbhood.use_nbhood import ApplyNeighbourhoodProcessingWithAMask
+from improver.nbhood.use_nbhood import (
+    ApplyNeighbourhoodProcessingWithAMask,
+    CollapseMaskedNeighbourhoodCoordinate,
+)
 
 from ..nbhood.test_BaseNeighbourhoodProcessing import set_up_cube
 
@@ -175,17 +178,45 @@ class Test_process(IrisTest):
                 ],
             ]
         )
+        weights_data = np.array(
+            [
+                [
+                    [0.8, 0.7, 0.0, 0.0, 0.0],
+                    [0.7, 0.3, 0.0, 0.0, 0.0],
+                    [0.3, 0.1, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                ],
+                [
+                    [0.2, 0.3, 1.0, 1.0, 1.0],
+                    [0.3, 0.7, 1.0, 1.0, 1.0],
+                    [0.7, 0.9, 1.0, 1.0, 1.0],
+                    [1.0, 1.0, 1.0, 0.9, 0.5],
+                    [1.0, 1.0, 1.0, 0.6, 0.2],
+                ],
+                [
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.1, 0.5],
+                    [0.0, 0.0, 0.0, 0.4, 0.8],
+                ],
+            ]
+        )
         topographic_zone_points = [50, 150, 250]
         topographic_zone_bounds = [[0, 100], [100, 200], [200, 300]]
 
         mask_cubes = iris.cube.CubeList([])
-        for data, point, bounds in zip(
-            mask_data, topographic_zone_points, topographic_zone_bounds
+        weights_cubes = iris.cube.CubeList([])
+        for mdata, wdata, pnt, bnd in zip(
+            mask_data, weights_data, topographic_zone_points, topographic_zone_bounds
         ):
-            mask_cubes.append(
-                set_up_topographic_zone_cube(data, point, bounds, num_grid_points=5)
-            )
+            for data, cubes in [(mdata, mask_cubes), (wdata, weights_cubes)]:
+                cubes.append(
+                    set_up_topographic_zone_cube(data, pnt, bnd, num_grid_points=5)
+                )
         self.mask_cube = mask_cubes.merge_cube()
+        self.weights_cube = weights_cubes.merge_cube()
 
     def test_basic(self):
         """Test that the expected result is returned, when the
@@ -225,7 +256,7 @@ class Test_process(IrisTest):
         self.assertEqual(result.data.shape, expected_shape)
         self.assertArrayAlmostEqual(result.data, expected)
 
-    def test_preserve_dimensions_input(self):
+    def test_collapse_preserve_dimensions_input(self):
         """Test that the dimensions on the output cube are the same as the
            input cube, apart from the additional topographic zone coordinate.
         """
@@ -235,17 +266,58 @@ class Test_process(IrisTest):
         )
         coord_for_masking = "topographic_zone"
         radii = 2000
-        result = ApplyNeighbourhoodProcessingWithAMask(coord_for_masking, radii)(
-            cube, self.mask_cube
+        uncollapsed_result = None
+        mask_data = np.array(
+            [
+                [
+                    [1, 1, 1, 1, 1],
+                    [1, 1, 0, 0, 0],
+                    [1, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0, 1],
+                    [0, 0, 1, 1, 1],
+                    [0, 0, 1, 1, 1],
+                    [1, 1, 0, 1, 0],
+                    [1, 1, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 1],
+                    [0, 0, 1, 1, 1],
+                    [0, 0, 1, 1, 1],
+                ],
+            ]
         )
-        expected_dims = list(cube.dim_coords)
-        expected_dims.insert(2, self.mask_cube.coord("topographic_zone"))
-        self.assertEqual(result.dim_coords, tuple(expected_dims))
-        self.assertEqual(result.coord_dims("realization"), (0,))
-        self.assertEqual(result.coord_dims("threshold"), (1,))
-        self.assertEqual(result.coord_dims("topographic_zone"), (2,))
-        self.assertEqual(result.coord_dims("projection_y_coordinate"), (3,))
-        self.assertEqual(result.coord_dims("projection_x_coordinate"), (4,))
+        mask_cube = self.mask_cube.copy(mask_data)
+
+        for collapse_weights in [None, self.weights_cube]:
+            coords_order = [
+                "realization",
+                "threshold",
+                "topographic_zone",
+                "projection_y_coordinate",
+                "projection_x_coordinate",
+            ]
+            result = ApplyNeighbourhoodProcessingWithAMask(
+                coord_for_masking, radii, collapse_weights=collapse_weights,
+            )(cube, mask_cube)
+            expected_dims = list(cube.dim_coords)
+            if collapse_weights is None:
+                uncollapsed_result = result
+                expected_dims.insert(2, self.mask_cube.coord("topographic_zone"))
+            else:
+                coords_order.remove("topographic_zone")
+                collapsed_result = CollapseMaskedNeighbourhoodCoordinate(
+                    coord_for_masking, collapse_weights
+                )(uncollapsed_result)
+                self.assertArrayAlmostEqual(result.data, collapsed_result.data)
+            self.assertEqual(result.dim_coords, tuple(expected_dims))
+            for dim, coord in enumerate(coords_order):
+                self.assertEqual(result.coord_dims(coord), (dim,))
 
     def test_preserve_dimensions_with_single_point(self):
         """Test that the dimensions on the output cube are the same as the

--- a/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -113,7 +113,7 @@ class Test__init__(IrisTest):
         msg = (
             "<ApplyNeighbourhoodProcessingWithAMask: coord_for_masking: "
             "topographic_zone, neighbourhood_method: square, radii: 2000, "
-            "lead_times: None, weighted_mode: True, "
+            "lead_times: None, collapse_weights: None, weighted_mode: True, "
             "sum_or_fraction: fraction, re_mask: False>"
         )
         self.assertEqual(str(result), msg)
@@ -131,7 +131,7 @@ class Test__repr__(IrisTest):
         msg = (
             "<ApplyNeighbourhoodProcessingWithAMask: coord_for_masking: "
             "topographic_zone, neighbourhood_method: square, radii: 2000, "
-            "lead_times: None, weighted_mode: True, "
+            "lead_times: None, collapse_weights: None, weighted_mode: True, "
             "sum_or_fraction: fraction, re_mask: False>"
         )
         self.assertEqual(result, msg)

--- a/improver_tests/nbhood/use_nbhood/test_CollapseMaskedNeighbourhoodCoordinate.py
+++ b/improver_tests/nbhood/use_nbhood/test_CollapseMaskedNeighbourhoodCoordinate.py
@@ -137,19 +137,13 @@ class Test_renormalize_weights(IrisTest):
             "topographic_zone", self.weights_cube
         )
 
-    def test_basic(self):
-        """Test weights_cube is still a cube after the function call"""
-        nbhooded_cube = self.weights_cube.copy()
-        self.plugin.renormalize_weights(nbhooded_cube)
-        self.assertIsInstance(self.weights_cube, iris.cube.Cube)
-
     def test_no_NaNs_in_nbhooded_cube(self):
         """No NaNs in the neighbourhood cube, so no renormalization is
            needed"""
         nbhooded_cube = self.weights_cube.copy()
         expected_weights = self.weights_cube.data.copy()
-        self.plugin.renormalize_weights(nbhooded_cube)
-        self.assertArrayAlmostEqual(expected_weights, self.weights_cube.data)
+        weights = self.plugin.renormalize_weights(nbhooded_cube)
+        self.assertArrayAlmostEqual(expected_weights, weights)
 
     def test_all_NaNs_in_nbhooded_cube(self):
         """Test an error is raised when all NaNs in the nbhood cube so cannot
@@ -169,9 +163,9 @@ class Test_renormalize_weights(IrisTest):
             self.weights_cube.data, mask=self.mask
         )
         expected_weights = self.weights_cube.data.copy()
-        self.plugin.renormalize_weights(nbhooded_cube)
-        self.assertArrayAlmostEqual(expected_weights.data, self.weights_cube.data.data)
-        self.assertArrayAlmostEqual(expected_weights.mask, self.weights_cube.data.mask)
+        weights = self.plugin.renormalize_weights(nbhooded_cube)
+        self.assertArrayAlmostEqual(expected_weights.data, weights.data)
+        self.assertArrayAlmostEqual(expected_weights.mask, weights.mask)
 
     def test_some_NaNs_in_nbhooded_cube(self):
         """Some NaNs in the neighbourhood cube, so renormalization is needed"""
@@ -205,8 +199,8 @@ class Test_renormalize_weights(IrisTest):
             ]
         )
         nbhooded_cube = self.weights_cube.copy(nbhood_data)
-        self.plugin.renormalize_weights(nbhooded_cube)
-        self.assertArrayAlmostEqual(expected_weights, self.weights_cube.data)
+        weights = self.plugin.renormalize_weights(nbhooded_cube)
+        self.assertArrayAlmostEqual(expected_weights, weights)
 
     def test_some_NaNs_in_nbhooded_cube_and_masked_weights(self):
         """Some NaNs in the neighbourhood cube, so renormalization is needed.
@@ -220,9 +214,9 @@ class Test_renormalize_weights(IrisTest):
             self.weights_cube.data, mask=self.mask
         )
         expected_weights = self.weights_cube.data.copy()
-        self.plugin.renormalize_weights(nbhooded_cube)
-        self.assertArrayAlmostEqual(expected_weights.data, self.weights_cube.data.data)
-        self.assertArrayAlmostEqual(expected_weights.mask, self.weights_cube.data.mask)
+        weights = self.plugin.renormalize_weights(nbhooded_cube)
+        self.assertArrayAlmostEqual(expected_weights.data, weights.data)
+        self.assertArrayAlmostEqual(expected_weights.mask, weights.mask)
 
     def test_coordinate_not_found(self):
         """Coordinate not found on the cube."""
@@ -302,8 +296,8 @@ class Test_renormalize_weights(IrisTest):
         plugin = CollapseMaskedNeighbourhoodCoordinate(
             "projection_x_coordinate", weights_cube
         )
-        plugin.renormalize_weights(nbhooded_cube)
-        self.assertArrayAlmostEqual(expected_weights, weights_cube.data)
+        weights = plugin.renormalize_weights(nbhooded_cube)
+        self.assertArrayAlmostEqual(expected_weights, weights)
 
 
 class Test_process(IrisTest):


### PR DESCRIPTION
The idea - collapse over topographic bands while looping over x-y slices rather than afterwards to avoid large intermediates.

Doesn't work yet, complains about zero weight sum during weight normalisation. @fionaRust, could you have a look and see if anything obvious jumps out.

CC: @BelligerG