### PR TITLE
Remove assert usage in comparison code

### DIFF
--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -256,7 +256,12 @@ def compare_attributes(name, actual_ds, desired_ds, reporter):
     for key in check_attrs:
         actual_attr = actual_ds.getncattr(key)
         desired_attr = desired_ds.getncattr(key)
-        assert isinstance(desired_attr, type(actual_attr))
+        if not isinstance(desired_attr, type(actual_attr)):
+            msg = (
+                f"different attribute type {name}/{key} - "
+                f"{type(actual_attr)} {type(desired_attr)}"
+            )
+            reporter(msg)
         if isinstance(desired_attr, np.ndarray):
             if not np.array_equal(actual_attr, desired_attr):
                 msg = (

--- a/improver_tests/utilities/test_compare.py
+++ b/improver_tests/utilities/test_compare.py
@@ -234,6 +234,18 @@ def test_compare_netcdf_attrs(dummy_nc):
     compare.compare_attributes("root", actual_ds, expected_ds, message_collector)
     assert len(messages_reported) == 1
     assert "float_number" in messages_reported[0]
+    actual_ds.setncattr("float_number", 3.2)
+
+    # Reset attribute back to original value
+    actual_ds.setncattr("float_number", 1.5)
+    messages_reported = []
+
+    # Check changing attribute type from int to float
+    actual_ds.setncattr("whole_number", 4.0)
+    compare.compare_attributes("root", actual_ds, expected_ds, message_collector)
+    assert len(messages_reported) == 1
+    for part in ("int", "float", "whole_number"):
+        assert part in messages_reported[0]
 
 
 def test_compare_data_floats_equal(dummy_nc):


### PR DESCRIPTION
The comparison code was originally written to only be used from within tests, so used assertions to detect and report identified differences. It was converted to report errors and be usable as a CLI (outside of tests), but this instance of `assert` was missed in the conversion.
This is a minor fix to clean it up after noticing it when [reviewing other code](https://github.com/metoppv/improver/pull/1212#discussion_r414514951).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
