### PR TITLE
IMPRO-1627: Take 2 on loading cubes or strings.

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -212,7 +212,7 @@ def create_constrained_inputcubelist_converter(*constraints):
     These cubes get loaded and returned as a CubeList.
 
     Args:
-        *constraints (tuple of str or iris.Constraint):
+        *constraints (tuple of str or callable or iris.Constraint):
             Constraints to be used in extracting the required cubes.
             Each constraint must match exactly one cube and extracted cubes
             will be sorted to match their order.

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -212,16 +212,15 @@ def create_constrained_inputcubelist_converter(*constraints):
     These cubes get loaded and returned as a CubeList.
 
     Args:
-        *constraints (callable):
-            Constraints to be used in the loading of cubes into a CubeList.
-            If the tuple contains a string or multiple strings, then each
-            string is expected to return exactly one match. If the tuple
-            contains a list or multiple lists, then each list is treated as a
-            group that is expected to return a single match. The tuple
-            can contain a mixture of strings and lists as required.
+        *constraints (tuple of str or iris.Constraint):
+            Constraints to be used in extracting the required cubes.
+            Each constraint must match exactly one cube and extracted cubes
+            will be sorted to match their order.
+            A constraint can be an iris.Constraint object or a callable
+            or cube name that can be used to construct one.
 
     Returns:
-        function:
+        callable:
             A function with the constraints used for a list comprehension.
 
     """

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -207,7 +207,7 @@ def create_constrained_inputcubelist_converter(*constraints):
     strings into objects.
     This is a way of not using the IMPROVER load_cube which will try to merge
     cubes. Iris load on the other hand won't deal with meta data properly.
-    So an example if you wanted to load an X cube and a Y cube from a cubelist
+    So an example is if you wanted to load an X cube and a Y cube from a cubelist
     of 2. You call this function with a list of constraints.
     These cubes get loaded and returned as a CubeList.
 
@@ -232,7 +232,7 @@ def create_constrained_inputcubelist_converter(*constraints):
 
         Args:
             to_convert (str or iris.cube.CubeList):
-                The filename to be loaded into a CubeList or a CubeList
+                A CubeList or a filename to be loaded into a CubeList.
 
         Returns:
             iris.cube.CubeList:
@@ -244,6 +244,7 @@ def create_constrained_inputcubelist_converter(*constraints):
         from iris.cube import CubeList
 
         cubelist = maybe_coerce_with(load_cubelist, to_convert)
+
         return CubeList(
             cubelist.extract(
                 Constraint(cube_func=constr) if callable(constr) else constr,

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -38,8 +38,10 @@ ACCUMULATION_FIDELITY = 1
 
 # Creates the value_converter that clize needs.
 inputadvection = cli.create_constrained_inputcubelist_converter(
-    ["precipitation_advection_x_velocity", "grid_eastward_wind"],
-    ["precipitation_advection_y_velocity", "grid_northward_wind"],
+    lambda cube: cube.name()
+    in ["precipitation_advection_x_velocity", "grid_eastward_wind"],
+    lambda cube: cube.name()
+    in ["precipitation_advection_y_velocity", "grid_northward_wind"],
 )
 
 

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -36,8 +36,10 @@ from improver import cli
 
 # Creates the value_converter that clize needs.
 inputadvection = cli.create_constrained_inputcubelist_converter(
-    ["precipitation_advection_x_velocity", "grid_eastward_wind"],
-    ["precipitation_advection_y_velocity", "grid_northward_wind"],
+    lambda cube: cube.name()
+    in ["precipitation_advection_x_velocity", "grid_eastward_wind"],
+    lambda cube: cube.name()
+    in ["precipitation_advection_y_velocity", "grid_northward_wind"],
 )
 
 

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -34,7 +34,7 @@
 from improver import cli
 
 input_smoothing_coefficients = cli.create_constrained_inputcubelist_converter(
-    ["smoothing_coefficient_x"], ["smoothing_coefficient_y"],
+    "smoothing_coefficient_x", "smoothing_coefficient_y",
 )
 
 

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -34,7 +34,8 @@
 from improver import cli
 
 input_smoothing_coefficients = cli.create_constrained_inputcubelist_converter(
-    "smoothing_coefficient_x", "smoothing_coefficient_y"
+    lambda cube: cube.name() in ["smoothing_coefficient_x"],
+    lambda cube: cube.name() in ["smoothing_coefficient_y"],
 )
 
 

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -34,8 +34,7 @@
 from improver import cli
 
 input_smoothing_coefficients = cli.create_constrained_inputcubelist_converter(
-    lambda cube: cube.name() in ["smoothing_coefficient_x"],
-    lambda cube: cube.name() in ["smoothing_coefficient_y"],
+    ["smoothing_coefficient_x"], ["smoothing_coefficient_y"],
 )
 
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -188,7 +188,7 @@ def setup_for_mock():
 
 
 class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
-    """Tests the create constraint_inputcubelist_converter"""
+    """Tests the create_constraint_inputcubelist_converter"""
 
     def setUp(self):
         data = np.zeros((2, 2), dtype=np.float32)
@@ -197,6 +197,15 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         self.wind_cubes = CubeList([self.wind_speed_cube, self.wind_dir_cube])
 
     def test_basic(self):
+        """Tests that providing no valid constraints raises a ConstraintMismatchError."""
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name() in ["wind_speed", "grid_eastward_wind"]
+        )
+        result = func(self.wind_cubes)
+        self.assertIn(self.wind_speed_cube, result)
+        self.assertEqual(1, len(result))
+
+    def test_two_lists(self):
         """Tests a basic creation of create_constrained_inputcubelist_converter"""
         func = create_constrained_inputcubelist_converter(
             lambda cube: cube.name() in ["wind_speed"],
@@ -223,8 +232,9 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     def test_list_two_valid(self):
         """Tests that one cube is loaded from each list."""
         func = create_constrained_inputcubelist_converter(
-            lambda cube: cube.name() in ["speed", "wind_speed"],
-            lambda cube: cube.name() in ["dir", "wind_from_direction"],
+            lambda cube: cube.name()
+            in ["airspeed_velocity_of_unladen_swallow", "wind_speed"],
+            lambda cube: cube.name() in ["direction_of_swallow", "wind_from_direction"],
         )
         result = func(self.wind_cubes)
         self.assertIn(self.wind_speed_cube, result)
@@ -237,7 +247,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         """
         func = create_constrained_inputcubelist_converter(
             lambda cube: cube.name() in ["wind_speed"],
-            lambda cube: cube.name() in ["dir", "wind_from_direction"],
+            lambda cube: cube.name() in ["direction_of_swallow", "wind_from_direction"],
         )
         result = func(self.wind_cubes)
         self.assertIn(self.wind_speed_cube, result)
@@ -247,12 +257,17 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
     def test_list_no_match(self):
         """Tests that providing no valid constraints raises a ConstraintMismatchError."""
         func = create_constrained_inputcubelist_converter(
-            lambda cube: cube.name()
-            in ["precipitation_advection_x_velocity", "grid_eastward_wind"],
-            lambda cube: cube.name()
-            in ["precipitation_advection_y_velocity", "grid_northward_wind"],
+            lambda cube: cube.name() in ["airspeed_velocity_of_unladen_swallow"],
         )
-        with self.assertRaisesRegex(ConstraintMismatchError, "Got 0 cubes"):
+        with self.assertRaisesRegex(ConstraintMismatchError, "^Got 0 cubes"):
+            func(self.wind_cubes)
+
+    def test_two_valid_cubes(self):
+        """Tests that providing 2 valid constraints raises a ConstraintMismatchError."""
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name() in ["wind_speed", "wind_from_direction"],
+        )
+        with self.assertRaisesRegex(ConstraintMismatchError, "^Got 2 cubes"):
             func(self.wind_cubes)
 
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -33,7 +33,6 @@
 import unittest
 from unittest.mock import patch
 
-import iris
 import numpy as np
 from iris.cube import CubeList
 from iris.exceptions import ConstraintMismatchError
@@ -209,7 +208,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         self.assertEqual(2, len(result))
 
     @patch("improver.cli.maybe_coerce_with", return_value=setup_for_mock())
-    def test_basic_given_str(self, m):
+    def test_basic_given_str(self, mocked_maybe_coerce):
         """Tests that a str is given to maybe_coerce_with which would return a CubeList."""
         func = create_constrained_inputcubelist_converter(
             lambda cube: cube.name() in ["wind_speed"],
@@ -219,7 +218,7 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         self.assertIn(self.wind_speed_cube, result)
         self.assertIn(self.wind_dir_cube, result)
         self.assertEqual(2, len(result))
-        m.assert_called_once()
+        mocked_maybe_coerce.assert_called_once()
 
     def test_list_two_valid(self):
         """Tests that one cube is loaded from each list."""

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -48,7 +48,6 @@ from improver.cli import (
     unbracket,
     with_output,
 )
-from improver.utilities.load import load_cube
 
 from ..set_up_test_cubes import set_up_variable_cube
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -33,8 +33,10 @@
 import unittest
 from unittest.mock import patch
 
+import iris
 import numpy as np
 from iris.cube import CubeList
+from iris.exceptions import ConstraintMismatchError
 
 import improver
 from improver.cli import (
@@ -165,41 +167,29 @@ class Test_with_output(unittest.TestCase):
         self.assertEqual(result, None)
 
 
-def replace_load_with_extract(func, cube, constraints=None):
-    """Function to replicate the call to maybe_coerce_with within
-    create_constrained_inputcubelist_converter.
+def setup_for_mock():
+    """Function that returns a CubeList of wind_speed and wind_from_direction
 
-    Args:
-        func:
-            Unused argument for the purpose of replicating the
-            maybe_coerce_with interface.
-        cube (iris.cube.Cube or iris.cube.CubeList):
-            Cube or CubeList to be extracted from.
-        constraints (str or None):
-            Expected name of cube for extraction.
+    These cubes should be the same as the setup cubes.
 
     Returns:
-        iris.cube.Cube:
-            The extracted cube.
-
-    Raises:
-        ValueError:
-            Error to replicate the behaviour of the call of maybe_coerce_with,
-            where loading a cube with an invalid constraint results in a
-            ValueError.
+        iris.cube.CubeList:
+            The CubeList.
     """
-    del func
-    if constraints:
-        cube = cube.extract(constraints)
-    if isinstance(cube, CubeList):
-        (cube,) = cube.copy()
-    if cube is None:
-        raise ValueError
-    return cube
+    return CubeList(
+        [
+            set_up_variable_cube(
+                data=np.zeros((2, 2), dtype=np.float32), name="wind_speed"
+            ),
+            set_up_variable_cube(
+                data=np.zeros((2, 2), dtype=np.float32), name="wind_from_direction"
+            ),
+        ]
+    )
 
 
 class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
-    """Tests the creature constraint_inputcubelist_converter"""
+    """Tests the create constraint_inputcubelist_converter"""
 
     def setUp(self):
         data = np.zeros((2, 2), dtype=np.float32)
@@ -207,71 +197,64 @@ class Test_create_constrained_inputcubelist_converter(unittest.TestCase):
         self.wind_dir_cube = set_up_variable_cube(data, name="wind_from_direction")
         self.wind_cubes = CubeList([self.wind_speed_cube, self.wind_dir_cube])
 
-    @patch("improver.cli.maybe_coerce_with", return_value="return")
-    def test_basic(self, m):
-        """Tests that it returns a function which itself returns 2 cubes"""
-        result = create_constrained_inputcubelist_converter(
-            "wind_speed", "wind_from_direction"
+    def test_basic(self):
+        """Tests a basic creation of create_constrained_inputcubelist_converter"""
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name() in ["wind_speed"],
+            lambda cube: cube.name() in ["wind_from_direction"],
         )
-        result("foo")
-        m.assert_any_call(load_cube, "foo", constraints="wind_speed")
-        m.assert_any_call(load_cube, "foo", constraints="wind_from_direction")
-        self.assertEqual(m.call_count, 2)
+        result = func(self.wind_cubes)
+        self.assertIn(self.wind_speed_cube, result)
+        self.assertIn(self.wind_dir_cube, result)
+        self.assertEqual(2, len(result))
 
-    @patch("improver.cli.maybe_coerce_with", return_value="return")
-    def test_list(self, m):
-        """Tests that a list returns a function which itself returns 2 cubes"""
-        result = create_constrained_inputcubelist_converter(
-            ["wind_speed"], ["wind_from_direction"]
+    @patch("improver.cli.maybe_coerce_with", return_value=setup_for_mock())
+    def test_basic_given_str(self, m):
+        """Tests that a str is given to maybe_coerce_with which would return a CubeList."""
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name() in ["wind_speed"],
+            lambda cube: cube.name() in ["wind_from_direction"],
         )
-        result("foo")
-        m.assert_any_call(load_cube, "foo", constraints="wind_speed")
-        m.assert_any_call(load_cube, "foo", constraints="wind_from_direction")
-        self.assertEqual(m.call_count, 2)
+        result = func(self.wind_cubes)
+        self.assertIn(self.wind_speed_cube, result)
+        self.assertIn(self.wind_dir_cube, result)
+        self.assertEqual(2, len(result))
+        m.assert_called_once()
 
-    @patch("improver.cli.maybe_coerce_with", new=replace_load_with_extract)
-    def test_list_one_valid(self):
-        """Tests that a list returns a function which itself returns 1 cube
-        that matches the constraints provided."""
-        obj = create_constrained_inputcubelist_converter(["wind_speed", "nonsense"])
-        result = obj(self.wind_speed_cube)
-        self.assertEqual(result, [self.wind_speed_cube])
-
-    @patch("improver.cli.maybe_coerce_with", new=replace_load_with_extract)
     def test_list_two_valid(self):
-        """Tests that providing two valid constraints raises a ValueError."""
-        obj = create_constrained_inputcubelist_converter(
-            ["wind_speed", "wind_from_direction"]
+        """Tests that one cube is loaded from each list."""
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name() in ["speed", "wind_speed"],
+            lambda cube: cube.name() in ["dir", "wind_from_direction"],
         )
-        msg = "Incorrect number of valid inputs available"
-        with self.assertRaisesRegex(ValueError, msg):
-            obj(self.wind_cubes)
+        result = func(self.wind_cubes)
+        self.assertIn(self.wind_speed_cube, result)
+        self.assertIn(self.wind_dir_cube, result)
+        self.assertEqual(2, len(result))
 
-    @patch("improver.cli.maybe_coerce_with", new=replace_load_with_extract)
+    def test_list_two_diff_shapes(self):
+        """Tests that one cube is loaded from each list
+        when the two lists are different sizes.
+        """
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name() in ["wind_speed"],
+            lambda cube: cube.name() in ["dir", "wind_from_direction"],
+        )
+        result = func(self.wind_cubes)
+        self.assertIn(self.wind_speed_cube, result)
+        self.assertIn(self.wind_dir_cube, result)
+        self.assertEqual(2, len(result))
+
     def test_list_no_match(self):
-        """Tests that providing no valid constraints raises a ValueError."""
-        obj = create_constrained_inputcubelist_converter(["nonsense"])
-        msg = "Incorrect number of valid inputs available"
-        with self.assertRaisesRegex(ValueError, msg):
-            obj(self.wind_cubes)
-
-    @patch("improver.cli.maybe_coerce_with", new=replace_load_with_extract)
-    def test_list_one_optional_constraint(self):
-        """Tests that a list returns a function which itself returns 2 cubes"""
-        obj = create_constrained_inputcubelist_converter(
-            ["wind_speed", "nonsense"], "wind_from_direction"
+        """Tests that providing no valid constraints raises a ConstraintMismatchError."""
+        func = create_constrained_inputcubelist_converter(
+            lambda cube: cube.name()
+            in ["precipitation_advection_x_velocity", "grid_eastward_wind"],
+            lambda cube: cube.name()
+            in ["precipitation_advection_y_velocity", "grid_northward_wind"],
         )
-        result = obj(self.wind_cubes)
-        self.assertEqual(result, self.wind_cubes)
-
-    @patch("improver.cli.maybe_coerce_with", new=replace_load_with_extract)
-    def test_list_mismatching_lengths(self):
-        """Tests that a list returns a function which itself returns 2 cubes"""
-        obj = create_constrained_inputcubelist_converter(
-            ["wind_speed", "nonsense"], ["wind_from_direction"]
-        )
-        result = obj(self.wind_cubes)
-        self.assertEqual(result, self.wind_cubes)
+        with self.assertRaisesRegex(ConstraintMismatchError, "Got 0 cubes"):
+            func(self.wind_cubes)
 
 
 class Test_clizefy(unittest.TestCase):


### PR DESCRIPTION
Second attempt at loading multiple named cubes or strings.
This makes use of the new load_cube [PR #1228](#1228).

Error handling is weak due to how clize deals with errors.

Replaces #1183.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
