### PR TITLE
IMPRO-1331: Recursive filter modified to use symmetric padding

### DIFF
--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -51,7 +51,7 @@ class RecursiveFilter(PostProcessingPlugin):
         smoothing_coefficient_x=None,
         smoothing_coefficient_y=None,
         iterations=None,
-        edge_width=1,
+        edge_width=15,
         re_mask=False,
     ):
         """
@@ -353,7 +353,10 @@ class RecursiveFilter(PostProcessingPlugin):
                 )
 
         smoothing_coefficients_cube = pad_cube_with_halo(
-            smoothing_coefficients_cube, 2 * self.edge_width, 2 * self.edge_width
+            smoothing_coefficients_cube,
+            2 * self.edge_width,
+            2 * self.edge_width,
+            pad_method="symmetric",
         )
         return smoothing_coefficients_cube
 
@@ -443,7 +446,7 @@ class RecursiveFilter(PostProcessingPlugin):
             mask = mask.data.squeeze()
 
             padded_cube = pad_cube_with_halo(
-                output, 2 * self.edge_width, 2 * self.edge_width
+                output, 2 * self.edge_width, 2 * self.edge_width, pad_method="symmetric"
             )
 
             new_cube = self._run_recursion(

--- a/improver/nbhood/square_kernel.py
+++ b/improver/nbhood/square_kernel.py
@@ -393,12 +393,8 @@ class SquareNeighbourhood:
         # Since the neighbourhood size is 2*radius + 1, this means that all
         # grid points within the original domain will have data available for
         # the full neighbourhood size.  The halo is removed later.
-        padded_cube = pad_cube_with_halo(
-            cube, grid_cells + 1, grid_cells + 1, halo_mean_data=False
-        )
-        padded_mask = pad_cube_with_halo(
-            mask, grid_cells + 1, grid_cells + 1, halo_mean_data=False
-        )
+        padded_cube = pad_cube_with_halo(cube, grid_cells + 1, grid_cells + 1)
+        padded_mask = pad_cube_with_halo(mask, grid_cells + 1, grid_cells + 1)
 
         # Check whether cube contains complex values
         is_complex = np.any(np.iscomplex(cube.data))

--- a/improver/utilities/pad_spatial.py
+++ b/improver/utilities/pad_spatial.py
@@ -228,7 +228,7 @@ def pad_cube_with_halo(cube, width_x, width_y, pad_method="constant"):
         kwargs = {}
 
     padded_data = np.pad(
-        cube.data, ((width_y, width_y), (width_x, width_x)), pad_method, **kwargs
+        cube.data, ((width_y, width_y), (width_x, width_x)), mode=pad_method, **kwargs
     )
 
     coord_x = cube.coord(axis="x")

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -185,7 +185,7 @@ class Test__set_smoothing_coefficients(Test_RecursiveFilter):
         """Test that the returned smoothing_coefficients array has the expected
         result when smoothing_coefficients_cube=None."""
         cube = iris.util.squeeze(self.cube)
-        result = RecursiveFilter()._set_smoothing_coefficients(
+        result = RecursiveFilter(edge_width=1)._set_smoothing_coefficients(
             cube, self.smoothing_coefficient_x, None
         )
         expected_result = 0.5
@@ -198,7 +198,7 @@ class Test__set_smoothing_coefficients(Test_RecursiveFilter):
     def test_smoothing_coefficients_cube_used_result(self):
         """Test that the returned smoothing_coefficients array has the expected
         result when smoothing_coefficients_cube is not None."""
-        result = RecursiveFilter()._set_smoothing_coefficients(
+        result = RecursiveFilter(edge_width=1)._set_smoothing_coefficients(
             self.cube[0, :], None, self.smoothing_coefficients_cube
         )
         expected_result = 0.5
@@ -213,7 +213,7 @@ class Test__set_smoothing_coefficients(Test_RecursiveFilter):
         of a different shape to the data cube."""
         msg = "Dimensions of smoothing_coefficients array do not match " "dimensions "
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter()._set_smoothing_coefficients(
+            RecursiveFilter(edge_width=1)._set_smoothing_coefficients(
                 self.cube, None, self.smoothing_coefficients_cube_wrong_dims
             )
 
@@ -227,7 +227,7 @@ class Test__set_smoothing_coefficients(Test_RecursiveFilter):
             "smoothing_coefficients_cube is "
         )
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter()._set_smoothing_coefficients(
+            RecursiveFilter(edge_width=1)._set_smoothing_coefficients(
                 self.cube, smoothing_coefficient, smoothing_coefficients_cube
             )
 
@@ -238,7 +238,7 @@ class Test__set_smoothing_coefficients(Test_RecursiveFilter):
         smoothing_coefficients_cube = self.smoothing_coefficients_cube
         msg = "A cube of smoothing_coefficient values and a single float " "value for"
         with self.assertRaisesRegex(ValueError, msg):
-            RecursiveFilter()._set_smoothing_coefficients(
+            RecursiveFilter(edge_width=1)._set_smoothing_coefficients(
                 self.cube, smoothing_coefficient, smoothing_coefficients_cube
             )
 
@@ -259,7 +259,7 @@ class Test__recurse_forward(Test_RecursiveFilter):
                 [0.0125, 0.03125, 0.196875, 0.03125, 0.0125],
             ]
         )
-        result = RecursiveFilter()._recurse_forward(
+        result = RecursiveFilter(edge_width=1)._recurse_forward(
             self.cube.data[0, :], self.smoothing_coefficients_cube.data, 0
         )
         self.assertIsInstance(result, np.ndarray)
@@ -277,7 +277,7 @@ class Test__recurse_forward(Test_RecursiveFilter):
                 [0.0, 0.000, 0.0500, 0.02500, 0.012500],
             ]
         )
-        result = RecursiveFilter()._recurse_forward(
+        result = RecursiveFilter(edge_width=1)._recurse_forward(
             self.cube.data[0, :], self.smoothing_coefficients_cube.data, 1
         )
         self.assertIsInstance(result, np.ndarray)
@@ -300,7 +300,7 @@ class Test__recurse_backward(Test_RecursiveFilter):
                 [0.0000, 0.00000, 0.100000, 0.00000, 0.0000],
             ]
         )
-        result = RecursiveFilter()._recurse_backward(
+        result = RecursiveFilter(edge_width=1)._recurse_backward(
             self.cube.data[0, :], self.smoothing_coefficients_cube.data, 0
         )
         self.assertIsInstance(result, np.ndarray)
@@ -318,7 +318,7 @@ class Test__recurse_backward(Test_RecursiveFilter):
                 [0.012500, 0.02500, 0.0500, 0.000, 0.0],
             ]
         )
-        result = RecursiveFilter()._recurse_backward(
+        result = RecursiveFilter(edge_width=1)._recurse_backward(
             self.cube.data[0, :], self.smoothing_coefficients_cube.data, 1
         )
         self.assertIsInstance(result, np.ndarray)
@@ -333,14 +333,14 @@ class Test__run_recursion(Test_RecursiveFilter):
         """Test that the _run_recursion method returns an iris.cube.Cube."""
         edge_width = 1
         cube = iris.util.squeeze(self.cube)
-        smoothing_coefficients_x = RecursiveFilter()._set_smoothing_coefficients(
-            cube, self.smoothing_coefficient_x, None
-        )
-        smoothing_coefficients_y = RecursiveFilter()._set_smoothing_coefficients(
-            cube, self.smoothing_coefficient_y, None
-        )
+        smoothing_coefficients_x = RecursiveFilter(
+            edge_width=1
+        )._set_smoothing_coefficients(cube, self.smoothing_coefficient_x, None)
+        smoothing_coefficients_y = RecursiveFilter(
+            edge_width=1
+        )._set_smoothing_coefficients(cube, self.smoothing_coefficient_y, None)
         padded_cube = pad_cube_with_halo(cube, 2 * edge_width, 2 * edge_width)
-        result = RecursiveFilter()._run_recursion(
+        result = RecursiveFilter(edge_width=1)._run_recursion(
             padded_cube,
             smoothing_coefficients_x,
             smoothing_coefficients_y,
@@ -352,35 +352,36 @@ class Test__run_recursion(Test_RecursiveFilter):
         """Test that the _run_recursion method returns the expected value."""
         edge_width = 1
         cube = iris.util.squeeze(self.cube)
-        smoothing_coefficients_x = RecursiveFilter()._set_smoothing_coefficients(
-            cube, self.smoothing_coefficient_x, None
-        )
-        smoothing_coefficients_y = RecursiveFilter()._set_smoothing_coefficients(
-            cube, self.smoothing_coefficient_y, None
-        )
+        smoothing_coefficients_x = RecursiveFilter(
+            edge_width=edge_width
+        )._set_smoothing_coefficients(cube, self.smoothing_coefficient_x, None)
+        smoothing_coefficients_y = RecursiveFilter(
+            edge_width=edge_width
+        )._set_smoothing_coefficients(cube, self.smoothing_coefficient_y, None)
         padded_cube = pad_cube_with_halo(cube, 2 * edge_width, 2 * edge_width)
-        result = RecursiveFilter()._run_recursion(
+        result = RecursiveFilter(edge_width=edge_width)._run_recursion(
             padded_cube,
             smoothing_coefficients_x,
             smoothing_coefficients_y,
             self.iterations,
         )
-        expected_result = 0.13382206
+        expected_result = 0.12302627
         self.assertAlmostEqual(result.data[4][4], expected_result)
 
     def test_different_smoothing_coefficients(self):
         """Test that the _run_recursion method returns expected values when
         smoothing_coefficient values are different in the x and y directions"""
+        edge_width = 1
         cube = iris.util.squeeze(self.cube)
         smoothing_coefficient_y = 0.5 * self.smoothing_coefficient_x
-        smoothing_coefficients_x = RecursiveFilter()._set_smoothing_coefficients(
-            cube, self.smoothing_coefficient_x, None
-        )
-        smoothing_coefficients_y = RecursiveFilter()._set_smoothing_coefficients(
-            cube, smoothing_coefficient_y, None
-        )
-        padded_cube = pad_cube_with_halo(cube, 2, 2)
-        result = RecursiveFilter()._run_recursion(
+        smoothing_coefficients_x = RecursiveFilter(
+            edge_width=edge_width
+        )._set_smoothing_coefficients(cube, self.smoothing_coefficient_x, None)
+        smoothing_coefficients_y = RecursiveFilter(
+            edge_width=edge_width
+        )._set_smoothing_coefficients(cube, smoothing_coefficient_y, None)
+        padded_cube = pad_cube_with_halo(cube, 2 * edge_width, 2 * edge_width)
+        result = RecursiveFilter(edge_width=edge_width)._run_recursion(
             padded_cube, smoothing_coefficients_x, smoothing_coefficients_y, 1
         )
         # slice back down to the source grid - easier to visualise!
@@ -388,14 +389,14 @@ class Test__run_recursion(Test_RecursiveFilter):
 
         expected_result = np.array(
             [
-                [0.01620921, 0.02866841, 0.05077430, 0.02881413, 0.01657352],
-                [0.03978802, 0.06457599, 0.10290188, 0.06486591, 0.04051282],
-                [0.10592333, 0.15184643, 0.19869247, 0.15238355, 0.10726611],
-                [0.03978982, 0.06457873, 0.10290585, 0.06486866, 0.04051464],
-                [0.01621686, 0.02868005, 0.05079120, 0.02882582, 0.01658128],
-            ]
+                [0.01320939, 0.02454378, 0.04346254, 0.02469828, 0.01359563],
+                [0.03405095, 0.06060188, 0.09870366, 0.06100013, 0.03504659],
+                [0.0845406, 0.13908109, 0.18816182, 0.14006987, 0.08701254],
+                [0.03405397, 0.06060749, 0.09871361, 0.06100579, 0.03504971],
+                [0.01322224, 0.02456765, 0.04350482, 0.0247223, 0.01360886],
+            ],
+            dtype=np.float32,
         )
-
         self.assertArrayAlmostEqual(unpadded_result, expected_result)
 
 
@@ -427,7 +428,7 @@ class Test_process(Test_RecursiveFilter):
         result = plugin(
             self.cube, smoothing_coefficients_x=None, smoothing_coefficients_y=None
         )
-        expected = 0.13382206
+        expected = 0.14994797
         self.assertAlmostEqual(result.data[0][2][2], expected)
 
     def test_smoothing_coefficient_cubes(self):
@@ -443,7 +444,7 @@ class Test_process(Test_RecursiveFilter):
             smoothing_coefficients_x=self.smoothing_coefficients_cube,
             smoothing_coefficients_y=self.smoothing_coefficients_cube,
         )
-        expected = 0.13382206
+        expected = 0.14994797
         self.assertAlmostEqual(result.data[0][2][2], expected)
 
     def test_smoothing_coefficient_floats_nan_in_data(self):
@@ -459,7 +460,7 @@ class Test_process(Test_RecursiveFilter):
         result = plugin(
             self.cube, smoothing_coefficients_x=None, smoothing_coefficients_y=None
         )
-        expected = 0.11979733
+        expected = 0.13277836
         self.assertAlmostEqual(result.data[0][2][2], expected)
 
     def test_smoothing_coefficient_floats_nan_in_masked_data(self):
@@ -478,7 +479,7 @@ class Test_process(Test_RecursiveFilter):
         result = plugin(
             self.cube, smoothing_coefficients_x=None, smoothing_coefficients_y=None
         )
-        expected = 0.105854129
+        expected = 0.11560875
         self.assertAlmostEqual(result.data[0][2][2], expected)
 
     def test_smoothing_coefficient_cubes_masked_data(self):
@@ -497,7 +498,7 @@ class Test_process(Test_RecursiveFilter):
             smoothing_coefficients_x=self.smoothing_coefficients_cube,
             smoothing_coefficients_y=self.smoothing_coefficients_cube,
         )
-        expected = 0.11979733
+        expected = 0.13277836
         self.assertAlmostEqual(result.data[0][2][2], expected)
 
     def test_dimensions_of_output_array_is_as_expected(self):
@@ -531,12 +532,13 @@ class Test_process(Test_RecursiveFilter):
 
         expected_result = np.array(
             [
-                [0.01620921, 0.03978802, 0.10592333, 0.03978982, 0.01621686],
-                [0.02866841, 0.06457599, 0.15184643, 0.06457873, 0.02868005],
-                [0.05077430, 0.10290188, 0.19869247, 0.10290585, 0.05079120],
-                [0.02881413, 0.06486591, 0.15238355, 0.06486866, 0.02882582],
-                [0.01657352, 0.04051282, 0.10726611, 0.04051464, 0.01658128],
-            ]
+                [0.02554158, 0.05397786, 0.1312837, 0.05397786, 0.02554158],
+                [0.03596632, 0.07334216, 0.1668669, 0.07334216, 0.03596632],
+                [0.05850913, 0.11031596, 0.21073693, 0.11031596, 0.05850913],
+                [0.03596632, 0.07334216, 0.1668669, 0.07334216, 0.03596632],
+                [0.02554158, 0.05397786, 0.1312837, 0.05397786, 0.02554158],
+            ],
+            dtype=np.float32,
         )
 
         self.assertSequenceEqual(


### PR DESCRIPTION
This PR modifies the ```pad_cube_with_halo``` function to accept any np.pad method. It then uses this functionality in the ```RecursiveFilter``` plugin to implement the padding using the symmetric method.

- Unit tests are updated to reflect the change in values.
- Additional tests added to cover a few more pad options (non-exhaustive).
- KGO updated and plotted in associated notebook.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)