### PR TITLE
Read the docs fixes

### DIFF
--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -10,3 +10,7 @@ dependencies:
   - iris=2.1
   - cf_units
   - python-stratify
+  - sphinx
+  - pip
+  - pip:
+    - clize

--- a/improver/memprofile.py
+++ b/improver/memprofile.py
@@ -45,7 +45,7 @@ def memory_profile_start(outfile_prefix):
     Args:
         outfile_prefix (str):
             Prefix for the generated output. 2 files will
-            be generated: *_SNAPSHOT and *_MAX_TRACKER.
+            be generated: \\*_SNAPSHOT and \\*_MAX_TRACKER.
 
     Returns:
         Active Thread tracking the memory.
@@ -83,7 +83,7 @@ def memory_monitor(queue, outfile_prefix):
             Active queue instance to communicate with the thread.
         outfile_prefix (str):
             Prefix for the generated output. 2 files will
-            be generated: *_SNAPSHOT and *_MAX_TRACKER.
+            be generated: \\*_SNAPSHOT and \\*_MAX_TRACKER.
     """
     tracemalloc.start()
     old_max = 0
@@ -120,7 +120,7 @@ def memory_profile_decorator(func, outfile_prefix):
             function to track the maximum memory of.
         outfile_prefix (str):
             Prefix for the generated output. 2 files will
-            be generated: *_SNAPSHOT and *_MAX_TRACKER.
+            be generated: \\*_SNAPSHOT and \\*_MAX_TRACKER.
     """
 
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Addresses #1229

Two minor documentation fixes:
- CLI documentation is not available on readthedocs. This is due to the readthedocs environment not including clize, so sphinx fails when processing the CLI modules which use clize. The fix here is to add clize to the environment.yml used for the docs generation.
- The asterisks in memprofile docstrings cause sphinx warnings as it attempts to interpret them as italics but they don't follow the expected format. The fix is to add escape slashes before each asterisk.
