### PR TITLE
Regrid CLI

### DIFF
--- a/improver/cli/regrid.py
+++ b/improver/cli/regrid.py
@@ -104,8 +104,8 @@ def process(
         raise ValueError(msg)
 
     return RegridLandSea(
-            regrid_mode=regrid_mode,
-            extrapolation_mode=extrapolation_mode,
-            landmask=land_sea_mask,
-            landmask_vicinity=land_sea_mask_vicinity,
+        regrid_mode=regrid_mode,
+        extrapolation_mode=extrapolation_mode,
+        landmask=land_sea_mask,
+        landmask_vicinity=land_sea_mask_vicinity,
     )(cube, target_grid, regridded_title=regridded_title)

--- a/improver/cli/regrid.py
+++ b/improver/cli/regrid.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to regrid a NetCDF file"""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(
+    cube: cli.inputcube,
+    target_grid: cli.inputcube,
+    land_sea_mask: cli.inputcube = None,
+    *,
+    regrid_mode="bilinear",
+    extrapolation_mode="nanmask",
+    land_sea_mask_vicinity: float = 25000,
+    regridded_title: str = None,
+):
+    """Regrids source cube data onto a target grid. Optional land-sea awareness.
+
+    Args:
+        cube (iris.cube.Cube):
+            Source cube to be regridded.
+        target_grid (iris.cube.Cube):
+            Cube defining the spatial grid onto which to regrid the source data.
+        land_sea_mask (iris.cube.Cube):
+            Cube describing the land_binary_mask on the source grid if land-sea
+            aware regridding is required, with land points set to one and sea points
+            set to zero.
+        regrid_mode (str):
+            Selects which regridding techniques to use. Default uses
+            iris.analysis.Linear(); "nearest" uses iris.analysis.Nearest();
+            "nearest-with-mask" uses Nearest() with land-sea awareness.
+        extrapolation_mode (str):
+            Mode to use for extrapolating data into regions beyond the limits
+            of the input cube domain. Refer to online documentation for
+            iris.analysis.
+            Modes are -
+            extrapolate - extrapolated points will take their values from the
+            nearest source point
+            nan - extrapolated points will be set to NaN
+            error - a ValueError will be raised notifying an attempt to
+            extrapolate
+            mask - extrapolated points will always be masked, even if
+            the source data is not a MaskedArray
+            nanmask - if the source data is a MaskedArray extrapolated points
+            will be masked; otherwise they will be set to NaN
+        land_sea_mask_vicinity (float):
+            Radius of vicinity to search for a coastline, in metres.
+        regridded_title (str):
+            New "title" attribute to be set if the field is being regridded
+            (since "title" may contain grid information). If None, a default
+            value is used.
+
+    Returns:
+        iris.cube.Cube:
+            Processed cube.
+
+    Raises:
+        ValueError:
+            If source land_sea_mask is supplied but regrid mode is not
+            "nearest-with-mask".
+        ValueError:
+            If regrid_mode is "nearest-with-mask" but no source land_sea_mask
+            is provided (from plugin).
+    """
+    from improver.standardise import RegridLandSea
+
+    if land_sea_mask and "nearest-with-mask" not in regrid_mode:
+        msg = (
+            "Land-mask file supplied without appropriate regrid-mode. "
+            "Use --regrid-mode nearest-with-mask."
+        )
+        raise ValueError(msg)
+
+    return RegridLandSea(
+            regrid_mode=regrid_mode,
+            extrapolation_mode=extrapolation_mode,
+            landmask=land_sea_mask,
+            landmask_vicinity=land_sea_mask_vicinity,
+    )(cube, target_grid, regridded_title=regridded_title)

--- a/improver/cli/regrid.py
+++ b/improver/cli/regrid.py
@@ -53,6 +53,8 @@ def process(
             Source cube to be regridded.
         target_grid (iris.cube.Cube):
             Cube defining the spatial grid onto which to regrid the source data.
+            If also using land_sea_mask-aware regridding then this must be
+            land_binary_mask data.
         land_sea_mask (iris.cube.Cube):
             Cube describing the land_binary_mask on the source grid if land-sea
             aware regridding is required, with land points set to one and sea points

--- a/improver/cli/standardise.py
+++ b/improver/cli/standardise.py
@@ -29,8 +29,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Script to standardise a NetCDF file by one or more of regridding, updating
-meta-data and demoting float64 data to float32"""
+"""Script to standardise a NetCDF file by updating metadata and demoting
+float64 data to float32"""
 
 from improver import cli
 
@@ -39,24 +39,17 @@ from improver import cli
 @cli.with_output
 def process(
     cube: cli.inputcube,
-    target_grid: cli.inputcube = None,
-    land_sea_mask: cli.inputcube = None,
     *,
-    regrid_mode="bilinear",
-    extrapolation_mode="nanmask",
-    land_sea_mask_vicinity: float = 25000,
-    regridded_title: str = None,
     attributes_config: cli.inputjson = None,
     coords_to_remove: cli.comma_separated_list = None,
     new_name: str = None,
     new_units: str = None,
 ):
-    """Standardises a cube by one or more of regridding, updating meta-data etc
-
-    Standardise a source cube. Available options are regridding (bi-linear or
-    nearest-neighbour, optionally with land-mask awareness), renaming,
-    converting units, updating attributes and converting float64 data to
-    float32.
+    """
+    Standardise a source cube. Available options are renaming, converting units,
+    updating attributes and removing named scalar coordinates. Remaining scalar
+    coordinates are collapsed, and data are cast to IMPROVER standard datatypes
+    and units.
 
     Deprecated behaviour:
     Translates metadata relating to the grid_id attribute from StaGE
@@ -66,40 +59,6 @@ def process(
     Args:
         cube (iris.cube.Cube):
             Source cube to be standardised
-        target_grid (iris.cube.Cube):
-            If specified, then regridding of the source against the target
-            grid is enabled. If also using land_sea_mask-aware regridding then
-            this must be land_binary_mask data.
-        land_sea_mask (iris.cube.Cube):
-            A cube describing the land_binary_mask on the source-grid if
-            coastline-aware regridding is required, with land points set to
-            one and sea points set to zero.
-        regrid_mode (str):
-            Selects which regridding techniques to use. Default uses
-            iris.analysis.Linear(); "nearest" uses Nearest() (for less
-            continuous fields, e.g precipitation); "nearest-with-mask"
-            ensures that target data are sources from points with the same
-            mask value (for coast-line-dependant variables like temperature).
-        extrapolation_mode (str):
-            Mode to use for extrapolating data into regions beyond the limits
-            of the input cube domain. Refer to online documentation for
-            iris.analysis.
-            Modes are -
-            extrapolate - extrapolated points will take their values from the
-            nearest source point
-            nan - extrapolated points will be set to NaN
-            error - a ValueError will be raised notifying an attempt to
-            extrapolate
-            mask - extrapolated points will always be masked, even if
-            the source data is not a MaskedArray
-            nanmask - if the source data is a MaskedArray extrapolated points
-            will be masked; otherwise they will be set to NaN
-        land_sea_mask_vicinity (float):
-            Radius of vicinity to search for a coastline, in metres.
-        regridded_title (str):
-            New "title" attribute to be set if the field is being regridded
-            (since "title" may contain grid information). If None, a default
-            value is used.
         attributes_config (dict):
             Dictionary containing required changes that will be applied to
             the attributes.
@@ -111,45 +70,19 @@ def process(
             Units to convert to.
 
     Returns:
-        iris.cube.Cube:
-            Processed cube.
-
-    Raises:
-        ValueError:
-            If source land_sea_mask is supplied but regrid mode is not
-            "nearest-with-mask".
-        ValueError:
-            If regrid_mode is "nearest-with-mask" but no source land_sea_mask
-            is provided (from plugin).
+        iris.cube.Cube
     """
     from improver.metadata.amend import update_stage_v110_metadata
-    from improver.standardise import StandardiseMetadata, RegridLandSea
-
-    if land_sea_mask and "nearest-with-mask" not in regrid_mode:
-        msg = (
-            "Land-mask file supplied without appropriate regrid-mode. "
-            "Use --regrid-mode nearest-with-mask."
-        )
-        raise ValueError(msg)
+    from improver.standardise import StandardiseMetadata
 
     # update_stage_v110_metadata is deprecated. Please ensure metadata is
     # StaGE version 1.2.0 compatible.
     update_stage_v110_metadata(cube)
 
-    cube = StandardiseMetadata()(
+    return StandardiseMetadata()(
         cube,
         new_name=new_name,
         new_units=new_units,
         coords_to_remove=coords_to_remove,
         attributes_dict=attributes_config,
     )
-
-    if target_grid:
-        cube = RegridLandSea(
-            regrid_mode=regrid_mode,
-            extrapolation_mode=extrapolation_mode,
-            landmask=land_sea_mask,
-            landmask_vicinity=land_sea_mask_vicinity,
-        )(cube, target_grid, regridded_title=regridded_title)
-
-    return cube

--- a/improver_tests/acceptance/test_regrid.py
+++ b/improver_tests/acceptance/test_regrid.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Tests for the regrid CLI
+"""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+GLOBAL_UK_TITLE = "Global Model Forecast on UK 2 km Standard Grid"
+UKV_GLOBAL_TITLE = "UKV Model Forecast on Global 10 km Standard Grid"
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+def test_regrid_basic(tmp_path):
+    """Test basic regridding"""
+    # KGO for this test is the same as test_regrid_check_landmask below
+    kgo_dir = acc.kgo_root() / "standardise/regrid-basic"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "global_cutout.nc"
+    target_path = kgo_dir / "ukvx_grid.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, target_path, "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_regrid_nearest(tmp_path):
+    """Test nearest neighbour regridding"""
+    kgo_dir = acc.kgo_root() / "standardise/regrid-nearest"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        target_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "nearest",
+        "--regridded-title",
+        GLOBAL_UK_TITLE,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_regrid_extrapolate(tmp_path):
+    """Test nearest neighbour regridding with extrapolation"""
+    kgo_dir = acc.kgo_root() / "standardise/regrid-extrapolate"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
+    target_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        target_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "nearest",
+        "--extrapolation-mode",
+        "extrapolate",
+        "--regridded-title",
+        UKV_GLOBAL_TITLE,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+@pytest.mark.slow
+def test_regrid_nearest_landmask(tmp_path):
+    """Test nearest neighbour regridding with land sea mask"""
+    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
+    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        target_path,
+        landmask_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "nearest-with-mask",
+        "--regridded-title",
+        GLOBAL_UK_TITLE,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+@pytest.mark.slow
+def test_regrid_check_landmask(tmp_path):
+    """Test land sea mask output matches other test"""
+    # KGO for this test is the same as test_basic above
+    kgo_dir = acc.kgo_root() / "standardise/regrid-nearest"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
+    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        target_path,
+        landmask_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "nearest-with-mask",
+        "--regridded-title",
+        GLOBAL_UK_TITLE,
+    ]
+    with pytest.warns(UserWarning, match=".*land_binary_mask.*"):
+        run_cli(args)
+    # Don't recreate output as it is the same as other test
+    acc.compare(output_path, kgo_path, recreate=False)
+
+
+def test_args_error_landmask(tmp_path):
+    """Test land sea mask specified but no regrid mode"""
+    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
+    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
+    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, target_path, landmask_path, "--output", output_path]
+    with pytest.raises(ValueError, match=".*nearest-with-mask.*"):
+        run_cli(args)
+
+
+def test_args_error_no_landmask(tmp_path):
+    """Test landmask mode but no land sea mask provided"""
+    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
+    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        target_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "nearest-with-mask",
+    ]
+    with pytest.raises(ValueError, match=".*input landmask.*"):
+        run_cli(args)
+
+
+@pytest.mark.slow
+def test_regrid_nearest_landmask_multi_realization(tmp_path):
+    """Test nearest neighbour with land sea mask and realizations"""
+    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
+    kgo_path = kgo_dir / "kgo_multi_realization.nc"
+    input_path = kgo_dir / "../regrid-basic/global_cutout_multi_realization.nc"
+    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
+    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        target_path,
+        landmask_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "nearest-with-mask",
+        "--regridded-title",
+        GLOBAL_UK_TITLE,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_regrid.py
+++ b/improver_tests/acceptance/test_regrid.py
@@ -46,8 +46,8 @@ run_cli = acc.run_cli(CLI)
 def test_regrid_basic(tmp_path):
     """Test basic regridding"""
     # KGO for this test is the same as test_regrid_check_landmask below
-    kgo_dir = acc.kgo_root() / "standardise/regrid-basic"
-    kgo_path = kgo_dir / "kgo.nc"
+    kgo_dir = acc.kgo_root() / "regrid"
+    kgo_path = kgo_dir / "basic/kgo.nc"
     input_path = kgo_dir / "global_cutout.nc"
     target_path = kgo_dir / "ukvx_grid.nc"
     output_path = tmp_path / "output.nc"
@@ -58,10 +58,10 @@ def test_regrid_basic(tmp_path):
 
 def test_regrid_nearest(tmp_path):
     """Test nearest neighbour regridding"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-nearest"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
+    kgo_dir = acc.kgo_root() / "regrid"
+    kgo_path = kgo_dir / "nearest/kgo.nc"
+    input_path = kgo_dir / "global_cutout.nc"
+    target_path = kgo_dir / "ukvx_grid.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -79,10 +79,10 @@ def test_regrid_nearest(tmp_path):
 
 def test_regrid_extrapolate(tmp_path):
     """Test nearest neighbour regridding with extrapolation"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-extrapolate"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
-    target_path = kgo_dir / "../regrid-basic/global_cutout.nc"
+    kgo_dir = acc.kgo_root() / "regrid"
+    kgo_path = kgo_dir / "extrapolate/kgo.nc"
+    input_path = kgo_dir / "ukvx_grid.nc"
+    target_path = kgo_dir / "global_cutout.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -103,11 +103,11 @@ def test_regrid_extrapolate(tmp_path):
 @pytest.mark.slow
 def test_regrid_nearest_landmask(tmp_path):
     """Test nearest neighbour regridding with land sea mask"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
+    kgo_dir = acc.kgo_root() / "regrid/landmask"
     kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    input_path = kgo_dir / "../global_cutout.nc"
+    landmask_path = kgo_dir / "glm_landmask.nc"
+    target_path = kgo_dir / "ukvx_landmask.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -128,11 +128,11 @@ def test_regrid_nearest_landmask(tmp_path):
 def test_regrid_check_landmask(tmp_path):
     """Test land sea mask output matches other test"""
     # KGO for this test is the same as test_basic above
-    kgo_dir = acc.kgo_root() / "standardise/regrid-nearest"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
+    kgo_dir = acc.kgo_root() / "regrid"
+    kgo_path = kgo_dir / "nearest/kgo.nc"
+    input_path = kgo_dir / "global_cutout.nc"
+    landmask_path = kgo_dir / "landmask/glm_landmask.nc"
+    target_path = kgo_dir / "ukvx_grid.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -153,10 +153,10 @@ def test_regrid_check_landmask(tmp_path):
 
 def test_args_error_landmask(tmp_path):
     """Test land sea mask specified but no regrid mode"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    kgo_dir = acc.kgo_root() / "regrid/landmask"
+    input_path = kgo_dir / "../global_cutout.nc"
+    landmask_path = kgo_dir / "glm_landmask.nc"
+    target_path = kgo_dir / "ukvx_landmask.nc"
     output_path = tmp_path / "output.nc"
     args = [input_path, target_path, landmask_path, "--output", output_path]
     with pytest.raises(ValueError, match=".*nearest-with-mask.*"):
@@ -165,9 +165,9 @@ def test_args_error_landmask(tmp_path):
 
 def test_args_error_no_landmask(tmp_path):
     """Test landmask mode but no land sea mask provided"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    kgo_dir = acc.kgo_root() / "regrid/landmask"
+    input_path = kgo_dir / "../global_cutout.nc"
+    target_path = kgo_dir / "ukvx_landmask.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -184,11 +184,11 @@ def test_args_error_no_landmask(tmp_path):
 @pytest.mark.slow
 def test_regrid_nearest_landmask_multi_realization(tmp_path):
     """Test nearest neighbour with land sea mask and realizations"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
+    kgo_dir = acc.kgo_root() / "regrid/landmask"
     kgo_path = kgo_dir / "kgo_multi_realization.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout_multi_realization.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
+    input_path = kgo_dir / "global_cutout_multi_realization.nc"
+    landmask_path = kgo_dir / "glm_landmask.nc"
+    target_path = kgo_dir / "ukvx_landmask.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,

--- a/improver_tests/acceptance/test_standardise.py
+++ b/improver_tests/acceptance/test_standardise.py
@@ -41,12 +41,10 @@ CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 
 
-# TODO remove acc.kgo_root() / "standardise/metadata/kgo.nc"
-# TODO rename kgo, having removed the inappropriate one above
 def test_change_metadata(tmp_path):
     """Test applying a JSON metadata file"""
     kgo_dir = acc.kgo_root() / "standardise/metadata"
-    kgo_path = kgo_dir / "kgo_no_regrid.nc"
+    kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "input.nc"
     metadata_path = kgo_dir / "radar_metadata.json"
     output_path = tmp_path / "output.nc"
@@ -78,15 +76,13 @@ def test_fix_float64(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-# TODO regenerate this KGO
 def test_stage_v110_basic(tmp_path):
     """Test updating a file with StaGE version 1.1.0 metadata"""
     kgo_dir = acc.kgo_root() / "standardise/stage-v110"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "input.nc"
-    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, target_path, "--output", output_path]
+    args = [input_path, "--output", output_path]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 

--- a/improver_tests/acceptance/test_standardise.py
+++ b/improver_tests/acceptance/test_standardise.py
@@ -37,91 +37,12 @@ import pytest
 from . import acceptance as acc
 
 pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
-GLOBAL_UK_TITLE = "Global Model Forecast on UK 2 km Standard Grid"
-UKV_GLOBAL_TITLE = "UKV Model Forecast on Global 10 km Standard Grid"
 CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 
 
-def test_regrid_basic(tmp_path):
-    """Test basic regridding"""
-    # KGO for this test is the same as test_regrid_check_landmask below
-    kgo_dir = acc.kgo_root() / "standardise/regrid-basic"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "global_cutout.nc"
-    target_path = kgo_dir / "ukvx_grid.nc"
-    output_path = tmp_path / "output.nc"
-    args = [input_path, target_path, "--output", output_path]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
-def test_regrid_nearest(tmp_path):
-    """Test nearest neighbour regridding"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-nearest"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        "--output",
-        output_path,
-        "--regrid-mode",
-        "nearest",
-        "--regridded-title",
-        GLOBAL_UK_TITLE,
-    ]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
-def test_regrid_extrapolate(tmp_path):
-    """Test nearest neighbour regridding with extrapolation"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-extrapolate"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
-    target_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        "--output",
-        output_path,
-        "--regrid-mode",
-        "nearest",
-        "--extrapolation-mode",
-        "extrapolate",
-        "--regridded-title",
-        UKV_GLOBAL_TITLE,
-    ]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
-def test_regrid_json(tmp_path):
-    """Test regridding with a JSON metadata file"""
-    kgo_dir = acc.kgo_root() / "standardise/metadata"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
-    metadata_path = kgo_dir / "metadata.json"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        "--output",
-        output_path,
-        "--attributes-config",
-        metadata_path,
-        "--regridded-title",
-        GLOBAL_UK_TITLE,
-    ]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
+# TODO remove acc.kgo_root() / "standardise/metadata/kgo.nc"
+# TODO rename kgo, having removed the inappropriate one above
 def test_change_metadata(tmp_path):
     """Test applying a JSON metadata file"""
     kgo_dir = acc.kgo_root() / "standardise/metadata"
@@ -157,111 +78,7 @@ def test_fix_float64(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-@pytest.mark.slow
-def test_regrid_nearest_landmask(tmp_path):
-    """Test nearest neighbour regridding with land sea mask"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        landmask_path,
-        "--output",
-        output_path,
-        "--regrid-mode",
-        "nearest-with-mask",
-        "--regridded-title",
-        GLOBAL_UK_TITLE,
-    ]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
-@pytest.mark.slow
-def test_regrid_check_landmask(tmp_path):
-    """Test land sea mask output matches other test"""
-    # KGO for this test is the same as test_basic above
-    kgo_dir = acc.kgo_root() / "standardise/regrid-nearest"
-    kgo_path = kgo_dir / "kgo.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-basic/ukvx_grid.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        landmask_path,
-        "--output",
-        output_path,
-        "--regrid-mode",
-        "nearest-with-mask",
-        "--regridded-title",
-        GLOBAL_UK_TITLE,
-    ]
-    with pytest.warns(UserWarning, match=".*land_binary_mask.*"):
-        run_cli(args)
-    # Don't recreate output as it is the same as other test
-    acc.compare(output_path, kgo_path, recreate=False)
-
-
-def test_args_error_landmask(tmp_path):
-    """Test land sea mask specified but no regrid mode"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
-    output_path = tmp_path / "output.nc"
-    args = [input_path, target_path, landmask_path, "--output", output_path]
-    with pytest.raises(ValueError, match=".*nearest-with-mask.*"):
-        run_cli(args)
-
-
-def test_args_error_no_landmask(tmp_path):
-    """Test landmask mode but no land sea mask provided"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
-    input_path = kgo_dir / "../regrid-basic/global_cutout.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        "--output",
-        output_path,
-        "--regrid-mode",
-        "nearest-with-mask",
-    ]
-    with pytest.raises(ValueError, match=".*input landmask.*"):
-        run_cli(args)
-
-
-@pytest.mark.slow
-def test_regrid_nearest_landmask_multi_realization(tmp_path):
-    """Test nearest neighbour with land sea mask and realizations"""
-    kgo_dir = acc.kgo_root() / "standardise/regrid-landmask"
-    kgo_path = kgo_dir / "kgo_multi_realization.nc"
-    input_path = kgo_dir / "../regrid-basic/global_cutout_multi_realization.nc"
-    landmask_path = kgo_dir / "../regrid-landmask/glm_landmask.nc"
-    target_path = kgo_dir / "../regrid-landmask/ukvx_landmask.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        target_path,
-        landmask_path,
-        "--output",
-        output_path,
-        "--regrid-mode",
-        "nearest-with-mask",
-        "--regridded-title",
-        GLOBAL_UK_TITLE,
-    ]
-    run_cli(args)
-    acc.compare(output_path, kgo_path)
-
-
+# TODO regenerate this KGO
 def test_stage_v110_basic(tmp_path):
     """Test updating a file with StaGE version 1.1.0 metadata"""
     kgo_dir = acc.kgo_root() / "standardise/stage-v110"


### PR DESCRIPTION
Splits standardise CLI out into `improver-standardise` and `improver-regrid`.  All code and tests cut & pasted from standardise to the new regrid CLI and tests.  No new code; one KGO file renamed and one removed.

Used existing CLI tests with one exception (where regridding and standardisation functionality were called in the same test).

Testing:
 - [x] Ran tests and they passed OK
