### PR TITLE
Update build badge in readthedocs documentation

### DIFF
--- a/doc/source/frontpage.rst
+++ b/doc/source/frontpage.rst
@@ -8,10 +8,9 @@ IMPROVER: Probabilistic meteorological post-processing
 .. image:: https://img.shields.io/badge/python-3.6-blue.svg
    :target: https://www.python.org/downloads/release/python-360/
    :alt: Python Version
-.. image:: https://travis-ci.org/metoppv/improver.svg?branch=master
-   :target: https://travis-ci.org/metoppv/improver
+.. image:: https://github.com/metoppv/improver/workflows/Tests/badge.svg
+   :target: https://github.com/metoppv/improver/actions?query=branch%3Amaster
    :alt: Build Status
-
 
 IMPROVER_ is a project being led by the `Met Office`_ in the UK to create a probabilistic post-processing system for ensemble weather prediction models. The aim is to extract the best possible probabilistic forecasts from multiple ensemble models, combining data from convection permitting and coarser resolution forecasts into a seamless blend.
 


### PR DESCRIPTION
Changes the build badge on the docs to point at github actions. Previously we were pointing at travis, but that is now defunct and shows as failed.

Testing:
 - [x] Built documentation in fork to test
