### PR TITLE
Round

### DIFF
--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -57,6 +57,7 @@ from improver.utilities.cube_manipulation import (
     get_dim_coord_names,
     sort_coord_in_cube,
 )
+from improver.utilities.round import round_close
 from improver.utilities.temporal import cycletime_to_number
 
 
@@ -753,7 +754,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         cycletime_point = cycletime_to_number(
             cycletime, time_unit=frt_units, calendar=frt_calendar
         )
-        return np.round(cycletime_point).astype(np.int64)
+        return round_close(cycletime_point, dtype=np.int64)
 
     def _set_coords_to_remove(self, input_cube):
         """

--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -40,6 +40,7 @@ from iris.exceptions import CoordinateNotFoundError
 from improver.metadata.check_datatypes import check_mandatory_standards
 from improver.metadata.constants import FLOAT_TYPES
 from improver.metadata.constants.time_types import TIME_COORDS
+from improver.utilities.round import round_close
 from improver.utilities.temporal import cycletime_to_datetime
 
 
@@ -148,9 +149,9 @@ def _calculate_forecast_period(
     result_coord.convert_units(coord_spec.units)
 
     if coord_spec.dtype not in FLOAT_TYPES:
-        result_coord.points = np.around(result_coord.points)
+        result_coord.points = round_close(result_coord.points)
         if result_coord.bounds is not None:
-            result_coord.bounds = np.around(result_coord.bounds)
+            result_coord.bounds = round_close(result_coord.bounds)
 
     result_coord.points = result_coord.points.astype(coord_spec.dtype)
     if result_coord.bounds is not None:
@@ -227,8 +228,8 @@ def unify_cycletime(cubes, cycletime):
         frt_coord_name = "forecast_reference_time"
         coord_type_spec = TIME_COORDS[frt_coord_name]
         coord_units = Unit(coord_type_spec.units)
-        frt_points = np.around([coord_units.date2num(cycletime)]).astype(
-            coord_type_spec.dtype
+        frt_points = round_close(
+            [coord_units.date2num(cycletime)], dtype=coord_type_spec.dtype
         )
         frt_coord = cube.coord(frt_coord_name).copy(points=frt_points)
         cube.remove_coord(frt_coord_name)

--- a/improver/nowcasting/forecasting.py
+++ b/improver/nowcasting/forecasting.py
@@ -48,6 +48,7 @@ from improver.metadata.utilities import (
 )
 from improver.nowcasting.optical_flow import check_input_coords
 from improver.nowcasting.utilities import ApplyOrographicEnhancement
+from improver.utilities.round import round_close
 
 
 class AdvectField(BasePlugin):
@@ -255,7 +256,7 @@ class AdvectField(BasePlugin):
         time_coord = advected_cube.coord(time_coord_name)
         time_coord.points = new_time
         time_coord.convert_units(time_coord_spec.units)
-        time_coord.points = np.around(time_coord.points).astype(time_coord_spec.dtype)
+        time_coord.points = round_close(time_coord.points, dtype=time_coord_spec.dtype)
 
     @staticmethod
     def _add_forecast_reference_time(input_time, advected_cube):
@@ -269,7 +270,7 @@ class AdvectField(BasePlugin):
         frt_coord = input_time.copy()
         frt_coord.rename(frt_coord_name)
         frt_coord.convert_units(frt_coord_spec.units)
-        frt_coord.points = np.around(frt_coord.points).astype(frt_coord_spec.dtype)
+        frt_coord.points = round_close(frt_coord.points, dtype=frt_coord_spec.dtype)
         advected_cube.add_aux_coord(frt_coord)
 
     @staticmethod

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -51,6 +51,7 @@ from improver.metadata.constants.mo_attributes import MOSG_GRID_ATTRIBUTES
 from improver.metadata.constants.time_types import TIME_COORDS
 from improver.threshold import BasicThreshold
 from improver.utilities.cube_checker import spatial_coords_match
+from improver.utilities.round import round_close
 from improver.utilities.spatial import OccurrenceWithinVicinity
 
 
@@ -170,11 +171,11 @@ class StandardiseMetadata(BasePlugin):
             req_dtype = get_required_dtype(coord)
             # ensure points and bounds have the same dtype
             if np.issubdtype(req_dtype, np.integer):
-                coord.points = np.around(coord.points)
+                coord.points = round_close(coord.points)
             coord.points = as_correct_dtype(coord.points, req_dtype)
             if coord.has_bounds():
                 if np.issubdtype(req_dtype, np.integer):
-                    coord.bounds = np.around(coord.bounds)
+                    coord.bounds = round_close(coord.bounds)
                 coord.bounds = as_correct_dtype(coord.bounds, req_dtype)
 
     def process(

--- a/improver/utilities/round.py
+++ b/improver/utilities/round.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Rounding utility"""
+
+import numpy as np
+
+
+def round_close(data, dtype=np.int64):
+    """Casts input data to the nearest integer value, where the input
+    data is expected to be very close to the nearest integer.
+
+    Args:
+        data (np.ndarray of float or float)
+            Data that is very close to the nearest integer value
+        dtype (type):
+            Required integer datatype
+
+    Returns:
+        np.ndarray of int or int:
+            Rounded data value
+
+    Raises:
+        ValueError: If rounding would significantly change the input value
+    """
+    new_data = np.around(data).astype(dtype)
+    if not np.allclose(np.array(data), np.array(new_data), atol=1e-7):
+        msg = "Input to 'round_close' {} is not integer-equivalent"
+        raise ValueError(msg.format(data))
+    return new_data

--- a/improver/wind_calculations/wind_direction.py
+++ b/improver/wind_calculations/wind_direction.py
@@ -196,10 +196,7 @@ class WindDirection(BasePlugin):
         angle = np.where(angle < 0, angle + 360, angle)
 
         # If angle == 360 - set to zero degrees.
-        # Due to floating point - need to round value before using
-        # equal operator.
-        round_angle = np.around(angle, 2)
-        angle = np.where(round_angle == 360, 0.0, angle)
+        angle = np.where(np.isclose(angle, 360, atol=0.001), 0.0, angle)
 
         # We don't need 64 bit precision.
         angle = angle.astype(np.float32)

--- a/improver_tests/utilities/test_round.py
+++ b/improver_tests/utilities/test_round.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the "round" module"""
+
+
+import numpy as np
+import pytest
+
+from improver.utilities.round import round_close
+
+
+def test_round_close():
+    """Test output when input is nearly an integer"""
+    result = round_close(29.99999)
+    assert result == 30
+    assert isinstance(result, np.int64)
+
+
+def test_dtype():
+    """Test near-integer output with specific dtype"""
+    result = round_close(29.99999, dtype=np.int32)
+    assert result == 30
+    assert isinstance(result, np.int32)
+
+
+def test_round_close_array():
+    """Test near-integer output from array input"""
+    expected = np.array([30, 4], dtype=int)
+    result = round_close(np.array([29.999999, 4.0000001]))
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_error_not_close():
+    """Test error when output would require significant rounding"""
+    with pytest.raises(ValueError):
+        round_close(29.9)


### PR DESCRIPTION
- Tidies up rounding where it's used inappropriately (replaced with `np.isclose` for float comparison).  This changes some acceptance test data at the float precision level: see JIRA ticket for details.
- Adds check when rounding time coordinates that the rounded numbers were close to the nearest integer.  This is in the form of a new `round_close()` utility.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
