### PR TITLE
Disable codecov PR status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,10 @@
 # codecov options
 
+coverage:
+  status:
+    project:
+      default:
+          base: "parent"
+          informational: true
 ignore:
   - "improver/cli"  # ignore folders and all its contents


### PR DESCRIPTION
We frequently run into issues where coverage appears to drop vs current master, but actually has not. We think this is based on a comparison between the very latest master and the PR, where the addition of extra tests on master since the PR base makes the coverage appear to decrease.

Tried to make codecov report against PR parent commits (https://docs.codecov.io/docs/commit-status#base), and always pass PR status (https://docs.codecov.io/docs/commit-status#informational).

Testing:
 - [x] Ran tests and they passed OK