### PR TITLE
IMPRO-1713: Restore ignore_ecc_bounds option to PDF CLIs

### DIFF
--- a/improver/cli/generate_percentiles.py
+++ b/improver/cli/generate_percentiles.py
@@ -41,6 +41,7 @@ def process(
     *,
     coordinates: cli.comma_separated_list = None,
     percentiles: cli.comma_separated_list = None,
+    ignore_ecc_bounds=False,
 ):
     r"""Collapses cube coordinates and calculate percentiled data.
 
@@ -67,6 +68,9 @@ def process(
             coordinate.
         percentiles (list):
             Optional definition of percentiles at which to calculate data.
+        ignore_ecc_bounds (bool):
+            If True, where calculated percentiles are outside the ECC bounds
+            range, raises a warning rather than an exception.
 
     Returns:
         iris.cube.Cube:
@@ -96,7 +100,9 @@ def process(
         percentiles = [float(p) for p in percentiles]
 
     if is_probability(cube):
-        result = ConvertProbabilitiesToPercentiles()(cube, percentiles=percentiles)
+        result = ConvertProbabilitiesToPercentiles(
+            ecc_bounds_warning=ignore_ecc_bounds
+        )(cube, percentiles=percentiles)
         if coordinates:
             warnings.warn(
                 "Converting probabilities to percentiles. The "

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -178,14 +178,21 @@ class ResamplePercentiles(BasePlugin):
         forecast_at_percentiles_with_endpoints = concatenate_2d_array_with_2d_array_endpoints(
             forecast_at_percentiles, lower_bound, upper_bound
         )
+
         if np.any(np.diff(forecast_at_percentiles_with_endpoints) < 0):
+            out_of_bounds_vals = forecast_at_percentiles_with_endpoints[
+                np.where(np.diff(forecast_at_percentiles_with_endpoints) < 0)
+            ]
             msg = (
-                "The end points added to the forecast at percentile "
-                "values representing each percentile must result in "
-                "an ascending order. "
-                "In this case, the forecast at percentile values {} "
-                "is outside the allowable range given by the "
-                "bounds {}".format(forecast_at_percentiles, bounds_pairing)
+                "Forecast values exist that fall outside the expected extrema "
+                "values that are defined as bounds in "
+                "ensemble_copula_coupling/constants.py. "
+                "Applying the extrema values as end points to the distribution "
+                "would result in non-monotonically increasing values. "
+                "The defined extremes are {}, whilst the following forecast "
+                "values exist outside this range: {}.".format(
+                    bounds_pairing, out_of_bounds_vals
+                )
             )
 
             if self.ecc_bounds_warning:

--- a/improver_tests/acceptance/test_generate_percentiles.py
+++ b/improver_tests/acceptance/test_generate_percentiles.py
@@ -95,5 +95,6 @@ def test_eccbounds(tmp_path):
         "25,50,75",
         "--ignore-ecc-bounds",
     ]
-    run_cli(args)
+    with pytest.warns(UserWarning, match="The calculated threshold values"):
+        run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_generate_percentiles.py
+++ b/improver_tests/acceptance/test_generate_percentiles.py
@@ -76,3 +76,24 @@ def test_probconvert(tmp_path, count):
     ]
     run_cli(args)
     acc.compare(output_path, kgo_path)
+
+
+@pytest.mark.slow
+def test_eccbounds(tmp_path):
+    """Test ECC bounds warning option"""
+    kgo_dir = acc.kgo_root() / "generate-percentiles/ecc_bounds_warning"
+    kgo_path = kgo_dir / "kgo.nc"
+    perc_input = kgo_dir / "input.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        perc_input,
+        "--output",
+        output_path,
+        "--coordinates",
+        "realization",
+        "--percentiles",
+        "25,50,75",
+        "--ignore-ecc-bounds",
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_generate_realizations.py
+++ b/improver_tests/acceptance/test_generate_realizations.py
@@ -133,7 +133,8 @@ def test_ecc_bounds_warning(tmp_path):
         "--output",
         output_path,
     ]
-    run_cli(args)
+    with pytest.warns(UserWarning, match="Forecast values exist that fall outside"):
+        run_cli(args)
     acc.compare(output_path, kgo_path)
 
 

--- a/improver_tests/acceptance/test_generate_realizations.py
+++ b/improver_tests/acceptance/test_generate_realizations.py
@@ -125,10 +125,14 @@ def test_ecc_bounds_warning(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "multiple_percentiles_wind_cube_out_of_bounds.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path,
-            "--realizations-count", "5",
-            "--ignore-ecc-bounds",
-            "--output", output_path]
+    args = [
+        input_path,
+        "--realizations-count",
+        "5",
+        "--ignore-ecc-bounds",
+        "--output",
+        output_path,
+    ]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 

--- a/improver_tests/acceptance/test_generate_realizations.py
+++ b/improver_tests/acceptance/test_generate_realizations.py
@@ -113,6 +113,26 @@ def test_realizations(tmp_path):
     acc.compare(output_path, input_path)
 
 
+@pytest.mark.slow
+def test_ecc_bounds_warning(tmp_path):
+    """
+    Test use of ECC to convert one set of percentiles to another set of
+    percentiles, and then rebadge the percentiles to be ensemble realizations.
+    Data in this input exceeds the ECC bounds and so tests ecc_bounds_warning
+    functionality.
+    """
+    kgo_dir = acc.kgo_root() / "generate-realizations/ecc_bounds_warning"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "multiple_percentiles_wind_cube_out_of_bounds.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path,
+            "--realizations-count", "5",
+            "--ignore-ecc-bounds",
+            "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
 def test_error_no_realizations_count(tmp_path):
     """Test a helpful error is raised if wrong args are set"""
     kgo_dir = acc.kgo_root() / "generate-realizations/probabilities_12_realizations"

--- a/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -133,7 +133,7 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         percentiles = np.array([5, 70, 95])
         bounds_pairing = (-40, 50)
         plugin = Plugin()
-        msg = "The end points added to the forecast at percentile"
+        msg = "Forecast values exist that fall outside the expected extrema"
         with self.assertRaisesRegex(ValueError, msg):
             plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
                 percentiles, forecast_at_percentiles, bounds_pairing
@@ -151,7 +151,7 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         percentiles = np.array([5, 70, 95])
         bounds_pairing = (-40, 50)
         plugin = Plugin(ecc_bounds_warning=True)
-        warning_msg = "The end points added to the forecast at percentile "
+        warning_msg = "Forecast values exist that fall outside the expected extrema"
         plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
             percentiles, forecast_at_percentiles, bounds_pairing
         )


### PR DESCRIPTION
The ignore_ecc_bounds option is made available via the generate_realizations and generate_percentiles CLIs. This is primarily for use with global data.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new (restored old) tests for the new feature(s)