### PR TITLE
More memory efficient threshold

### DIFF
--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -152,18 +152,13 @@ def process(
             WeightAndBlend(collapse_coord, "linear", y0val=1.0, ynval=1.0)
         )
 
-    def each_threshold_func(cube):
-        for func in each_threshold_func_list:
-            cube = func(cube)
-        return cube
-
     result = BasicThreshold(
         thresholds,
         fuzzy_factor=fuzzy_factor,
         fuzzy_bounds=fuzzy_bounds,
         threshold_units=threshold_units,
         comparison_operator=comparison_operator,
-        each_threshold_func=each_threshold_func,
+        each_threshold_func=each_threshold_func_list,
     )(cube)
 
     if vicinity is not None:

--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -140,29 +140,37 @@ def process(
         thresholds = [np.float32(x) for x in threshold_values]
         fuzzy_bounds = None
 
-    result_no_collapse_coord = BasicThreshold(
+    each_threshold_func_list = []
+
+    if vicinity is not None:
+        # smooth thresholded occurrences over local vicinity
+        each_threshold_func_list.append(OccurrenceWithinVicinity(vicinity))
+
+    if collapse_coord is not None:
+        # Take a weighted mean across realizations with equal weights
+        each_threshold_func_list.append(
+            WeightAndBlend(collapse_coord, "linear", y0val=1.0, ynval=1.0)
+        )
+
+    def each_threshold_func(cube):
+        for func in each_threshold_func_list:
+            cube = func(cube)
+        return cube
+
+    result = BasicThreshold(
         thresholds,
         fuzzy_factor=fuzzy_factor,
         fuzzy_bounds=fuzzy_bounds,
         threshold_units=threshold_units,
         comparison_operator=comparison_operator,
+        each_threshold_func=each_threshold_func,
     )(cube)
 
     if vicinity is not None:
-        # smooth thresholded occurrences over local vicinity
-        result_no_collapse_coord = OccurrenceWithinVicinity(vicinity)(
-            result_no_collapse_coord
-        )
-        new_cube_name = in_vicinity_name_format(result_no_collapse_coord.name())
-        result_no_collapse_coord.rename(new_cube_name)
-
-    if collapse_coord is None:
-        return result_no_collapse_coord
+        result.rename(in_vicinity_name_format(result.name()))
 
     # Raise warning if result_no_collapse_coord is masked array
-    if np.ma.isMaskedArray(result_no_collapse_coord.data):
-        warnings.warn("Collapse-coord option not fully tested with " "masked data.")
-    # Take a weighted mean across realizations with equal weights
-    plugin = WeightAndBlend(collapse_coord, "linear", y0val=1.0, ynval=1.0)
+    if collapse_coord is not None and np.ma.isMaskedArray(result.data):
+        warnings.warn("Collapse-coord option not fully tested with masked data.")
 
-    return plugin(result_no_collapse_coord)
+    return result

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -60,6 +60,7 @@ class BasicThreshold(PostProcessingPlugin):
         fuzzy_bounds=None,
         threshold_units=None,
         comparison_operator=">",
+        each_threshold_func=None,
     ):
         """
         Set up for processing an in-or-out of threshold field, including the
@@ -112,6 +113,8 @@ class BasicThreshold(PostProcessingPlugin):
                 evaluate data < threshold. When using fuzzy thresholds, there
                 is no difference between < and <= or > and >=.
                 Valid choices: > >= < <= gt ge lt le.
+            each_threshold_func (callable):
+                Function to apply on each threshold cube before concatenating.
 
         Raises:
             ValueError: If a threshold of 0.0 is requested when using a fuzzy
@@ -214,6 +217,8 @@ class BasicThreshold(PostProcessingPlugin):
         )
         self.comparison_operator_string = comparison_operator
         self._decode_comparison_operator_string()
+
+        self.each_threshold_func = each_threshold_func
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -369,6 +374,10 @@ class BasicThreshold(PostProcessingPlugin):
             if np.ma.is_masked(cube.data):
                 cube.data[input_cube.data.mask] = input_cube.data[input_cube.data.mask]
             cube = self._add_threshold_coord(cube, threshold)
+
+            if self.each_threshold_func:
+                cube = self.each_threshold_func(cube)
+
             thresholded_cubes.append(cube)
 
         (cube,) = thresholded_cubes.concatenate()

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -60,7 +60,7 @@ class BasicThreshold(PostProcessingPlugin):
         fuzzy_bounds=None,
         threshold_units=None,
         comparison_operator=">",
-        each_threshold_func=None,
+        each_threshold_func=(),
     ):
         """
         Set up for processing an in-or-out of threshold field, including the
@@ -113,8 +113,9 @@ class BasicThreshold(PostProcessingPlugin):
                 evaluate data < threshold. When using fuzzy thresholds, there
                 is no difference between < and <= or > and >=.
                 Valid choices: > >= < <= gt ge lt le.
-            each_threshold_func (callable):
-                Function to apply on each threshold cube before concatenating.
+            each_threshold_func (callable or sequence of callables):
+                Callable or sequence of callables to apply to each threshold
+                cube before concatenating.
 
         Raises:
             ValueError: If a threshold of 0.0 is requested when using a fuzzy
@@ -218,6 +219,8 @@ class BasicThreshold(PostProcessingPlugin):
         self.comparison_operator_string = comparison_operator
         self._decode_comparison_operator_string()
 
+        if callable(each_threshold_func):
+            each_threshold_func = (each_threshold_func,)
         self.each_threshold_func = each_threshold_func
 
     def __repr__(self):
@@ -375,8 +378,8 @@ class BasicThreshold(PostProcessingPlugin):
                 cube.data[input_cube.data.mask] = input_cube.data[input_cube.data.mask]
             cube = self._add_threshold_coord(cube, threshold)
 
-            if self.each_threshold_func:
-                cube = self.each_threshold_func(cube)
+            for func in self.each_threshold_func:
+                cube = func(cube)
 
             thresholded_cubes.append(cube)
 

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -599,6 +599,15 @@ class Test_process(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             plugin(self.cube)
 
+    def test_each_threshold_func(self):
+        """Test user supplied func is applied on each threshold cube."""
+        # Need to copy the cube as we're adjusting the data.
+        plugin = Threshold(
+            2.0, each_threshold_func=lambda cube: cube.rename("new_name") or cube
+        )
+        result = plugin(self.cube)
+        self.assertTrue("new_name" in result.name())
+
 
 class Test__init__(IrisTest):
 


### PR DESCRIPTION
Adds ability to process each threshold cube while they are generated, rather than afterwords. Avoids creating large, intermediate arrays if there are many thresholds and realizations.

Resource use for engl feelsliketemp:
master:  mem 28GB, walltime 1:05 (user: 27s, system: 37s)
this PR: mem 1.3GB, walltime: 0:44 (user: 18s, system: 24s)
