### PR TITLE
Weighted blend memory reduction

### DIFF
--- a/improver/blending/blend_across_adjacent_points.py
+++ b/improver/blending/blend_across_adjacent_points.py
@@ -158,5 +158,6 @@ class TriangularWeightedBlendAcrossAdjacentPoints(PostProcessingPlugin):
 
         # Copy the metadata of the central cube
         blended_cube = central_point_cube.copy(blended_cube.data)
+        print(blended_cube)
 
         return blended_cube

--- a/improver/blending/blend_across_adjacent_points.py
+++ b/improver/blending/blend_across_adjacent_points.py
@@ -32,7 +32,6 @@
 opposed to collapsing the whole dimension."""
 
 import iris
-import numpy as np
 from cf_units import Unit
 from iris.cube import CubeList
 

--- a/improver/blending/blend_across_adjacent_points.py
+++ b/improver/blending/blend_across_adjacent_points.py
@@ -158,6 +158,5 @@ class TriangularWeightedBlendAcrossAdjacentPoints(PostProcessingPlugin):
 
         # Copy the metadata of the central cube
         blended_cube = central_point_cube.copy(blended_cube.data)
-        print(blended_cube)
 
         return blended_cube

--- a/improver/blending/blend_across_adjacent_points.py
+++ b/improver/blending/blend_across_adjacent_points.py
@@ -161,7 +161,4 @@ class TriangularWeightedBlendAcrossAdjacentPoints(PostProcessingPlugin):
             indices[dim_to_collapse] = subcube_index
             blended_cube.data += cube[tuple(indices)].data * weights.data[subcube_index]
 
-        if np.sum(weights.data) != 1:
-            blended_cube.data *= 1 / np.sum(weights.data)
-
         return blended_cube

--- a/improver/blending/calculate_weights_and_blend.py
+++ b/improver/blending/calculate_weights_and_blend.py
@@ -242,7 +242,6 @@ class WeightAndBlend(BasePlugin):
 
             # blend across specified dimension
             BlendingPlugin = WeightedBlendAcrossWholeDimension(self.blend_coord)
-
             result = BlendingPlugin(
                 cube,
                 weights=weights,

--- a/improver/blending/calculate_weights_and_blend.py
+++ b/improver/blending/calculate_weights_and_blend.py
@@ -243,15 +243,6 @@ class WeightAndBlend(BasePlugin):
             if spatial_weights:
                 weights = self._update_spatial_weights(cube, weights, fuzzy_length)
 
-            dims_to_collapse = set(range(cube.ndim)) - {
-                cube.coord_dims(self.blend_coord)[0]
-            }
-
-            # In the event of multiple dimensions, always use the first available one to slice over
-            dim_to_collapse = min(dims_to_collapse)
-            number_of_subcubes = cube.shape[dim_to_collapse]
-            indices = [slice(None)] * cube.ndim
-
             # blend across specified dimension
             BlendingPlugin = WeightedBlendAcrossWholeDimension(self.blend_coord)
 

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -580,7 +580,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
             )
         (blend_dim,) = cube.coord_dims(self.blend_coord)
         self.check_weights(weights_array, blend_dim)
-        return weights_array.astype(np.float32)
+        return weights_array
 
     def percentile_weights(self, cube, weights, perc_coord):
         """

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -721,7 +721,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         (collapse_dim,) = cube.coord_dims(self.blend_coord)
         slice_dim = 1 if collapse_dim == 0 else 0
 
-        slicing_threshold = 1620000  # (2, 900, 900)
+        slicing_threshold = 3e7
         allow_slicing = (
             cube.ndim > 2 and np.array(cube.shape).prod() > slicing_threshold
         )

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -720,11 +720,18 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         weights_array = self.non_percentile_weights(cube, weights)
 
         (collapse_dim,) = cube.coord_dims(self.blend_coord)
-        slice_dim = 1 if collapse_dim == 0 else 0
+        if collapse_dim == 0:
+            slice_dim = 1
+        else:
+            slice_dim = 0
 
         allow_slicing = cube.ndim > 3
 
-        cube_slices = cube.slices_over(slice_dim) if allow_slicing else [cube]
+        if allow_slicing:
+            cube_slices = cube.slices_over(slice_dim)
+        else:
+            cube_slices = [cube]
+
         weights_slices = (
             np.moveaxis(weights_array, slice_dim, 0)
             if allow_slicing

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -50,6 +50,7 @@ from improver.metadata.forecast_times import (
     rebadge_forecasts_as_latest_cycle,
 )
 from improver.metadata.probabilistic import find_percentile_coordinate
+from improver.utilities.cube_checker import check_cube_coordinates
 from improver.utilities.cube_manipulation import (
     MergeCubes,
     collapsed,
@@ -911,5 +912,10 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         else:
             result = self.weighted_mean(cube, weights)
         self._update_blended_metadata(result, attributes_dict)
+
+        # Checks the coordinate dimensions match the first relevant cube in the unblended cubeList.
+        index = [slice(None)] * cube.ndim
+        index[cube.coord_dims(self.blend_coord)[0]] = 0
+        result = check_cube_coordinates(cube[tuple(index)], result)
 
         return result

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -733,6 +733,9 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
             collapsed(c_slice, self.blend_coord, iris.analysis.MEAN, weights=w_slice)
             for c_slice, w_slice in zip(cube_slices, weights_slices)
         )
+        self.has_mask = False
+        for c_slice in cube_slices:
+            if isinstance(c_slice.data, np.ma.core.MaskedArray): self.has_mask = True
 
         result = result_slices.merge_cube() if allow_slicing else result_slices[0]
 
@@ -912,7 +915,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         self._update_blended_metadata(result, attributes_dict)
 
         # Re-mask output
-        if isinstance(cube.data, np.ma.core.MaskedArray):
+        if self.has_mask:
             result.data = np.ma.array(result.data)
 
         return result

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -721,7 +721,9 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         (collapse_dim,) = cube.coord_dims(self.blend_coord)
         slice_dim = 1 if collapse_dim == 0 else 0
 
-        slicing_threshold = 3e7
+        slicing_threshold = (
+            3e7  # This allows for arrays ~100MB and smaller not to be sliced
+        )
         allow_slicing = (
             cube.ndim > 2 and np.array(cube.shape).prod() > slicing_threshold
         )

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -579,7 +579,6 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
                 np.float32
             )
         (blend_dim,) = cube.coord_dims(self.blend_coord)
-        self.check_weights(weights_array, blend_dim)
 
         return weights_array
 

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -721,12 +721,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         (collapse_dim,) = cube.coord_dims(self.blend_coord)
         slice_dim = 1 if collapse_dim == 0 else 0
 
-        slicing_threshold = (
-            3e7  # This allows for arrays ~100MB and smaller not to be sliced
-        )
-        allow_slicing = (
-            cube.ndim > 2 and np.array(cube.shape).prod() > slicing_threshold
-        )
+        allow_slicing = cube.ndim > 3
 
         cube_slices = cube.slices_over(slice_dim) if allow_slicing else [cube]
         weights_slices = (

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -579,6 +579,8 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
                 np.float32
             )
         (blend_dim,) = cube.coord_dims(self.blend_coord)
+        self.check_weights(weights_array, blend_dim)
+
         return weights_array
 
     def percentile_weights(self, cube, weights, perc_coord):

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -579,7 +579,6 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
                 np.float32
             )
         (blend_dim,) = cube.coord_dims(self.blend_coord)
-        self.check_weights(weights_array, blend_dim)
         return weights_array
 
     def percentile_weights(self, cube, weights, perc_coord):

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -647,7 +647,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         # Check the weights add up to 1 across the blending dimension.
         self.check_weights(weights_array, 0)
 
-        return weights_array.astype(np.float32)
+        return weights_array
 
     def percentile_weighted_mean(self, cube, weights, perc_coord):
         """

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -921,8 +921,8 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         self._update_blended_metadata(result, attributes_dict)
 
         # Checks the coordinate dimensions match the first relevant cube in the unblended cubeList.
-        index = [slice(None)] * cube.ndim
-        index[cube.coord_dims(self.blend_coord)[0]] = 0
-        result = check_cube_coordinates(cube[tuple(index)], result)
+        result = check_cube_coordinates(
+            next(cube.slices_over(self.blend_coord)), result
+        )
 
         return result

--- a/improver_tests/acceptance/test_weighted_blending.py
+++ b/improver_tests/acceptance/test_weighted_blending.py
@@ -147,7 +147,7 @@ def test_invalid_nonlin_lin(tmp_path):
         run_cli(args)
 
 
-@pytest.mark.xfail(reason="takes ~5 minutes to run")
+@pytest.mark.xfail(run=False, reason="takes ~5 minutes to run")
 def test_percentile(tmp_path):
     """Test percentile blending"""
     kgo_dir = acc.kgo_root() / "weighted_blending/percentiles"
@@ -165,7 +165,6 @@ def test_percentile(tmp_path):
         "--output",
         output_path,
     ]
-    pytest.fail()
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -345,7 +344,7 @@ def test_weights_dict(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-@pytest.mark.xfail(reason="takes ~5 minutes to run")
+@pytest.mark.xfail(run=False, reason="takes ~5 minutes to run")
 def test_percentile_weights_dict(tmp_path):
     """Test percentile blending with weights dictionary"""
     kgo_dir = acc.kgo_root() / "weighted_blending/percentile_weights_from_dict"
@@ -370,7 +369,6 @@ def test_percentile_weights_dict(tmp_path):
         "--output",
         output_path,
     ]
-    pytest.fail()
     run_cli(args)
     acc.compare(output_path, kgo_path)
 

--- a/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -231,6 +231,38 @@ class Test_process(IrisTest):
         self.assertEqual(cube, original_cube)
 
     @ManageWarnings(ignored_messages=["Collapsing a non-contiguous coordinate."])
+    def test_promoted_dimension(self):
+        """Test that the plugin retains the single height point from the input
+           cube and promotes it to a dim coord."""
+
+        # Creates a cube containing the expected outputs.
+        fill_value = 1 + 1 / 3.0
+        data = np.full((2, 2), fill_value)
+
+        # Take a slice of the time coordinate.
+        expected_cube = self.cube[0].copy(data.astype(np.float32))
+
+        # Add height axis to expected output cube.
+        expected_cube = add_coordinate(expected_cube, [0.5], "height", coord_units="m")
+        expected_cube = iris.util.new_axis(expected_cube, "height")
+
+        # Add height axis to standard input cube.
+        cube = add_coordinate(self.cube.copy(), [0.5], "height", coord_units="m")
+        cube = iris.util.new_axis(cube, "height")
+
+        width = 2.0
+        plugin = TriangularWeightedBlendAcrossAdjacentPoints(
+            "forecast_period", self.forecast_period, "hours", width
+        )
+        result = plugin(cube)
+
+        # Test that the result cube retains height co-ordinates
+        # from original cube.
+        self.assertEqual(expected_cube.coord("height"), result.coord("height"))
+        self.assertArrayEqual(expected_cube.data, result.data)
+        self.assertEqual(expected_cube, result)
+
+    @ManageWarnings(ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_extra_dimension(self):
         """Test that the plugin retains the single height point from the input
            cube."""

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -598,6 +598,34 @@ class Test_weighted_mean(Test_weighted_blend):
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(result.data, expected)
 
+    @ManageWarnings(ignored_messages=[COORD_COLLAPSE_WARNING])
+    def test_collapse_dims_with_weights(self):
+        """Test function matches when the blend coordinate is first or second."""
+
+        coord = "forecast_reference_time"
+
+        # Create a new axis.
+        new_cube = add_coordinate(self.cube, [0.5], "height", coord_units="m")
+        new_cube = iris.util.new_axis(new_cube, "height")
+
+        plugin = WeightedBlendAcrossWholeDimension(coord)
+
+        result_blend_coord_second = plugin.weighted_mean(new_cube, self.weights1d)
+
+        # Reorder the axis to move the blending coordinate to the front.
+        order = np.array([1, 0, 2, 3])
+        new_cube.transpose(order)
+        result_blend_coord_first = plugin.weighted_mean(new_cube, self.weights1d)
+
+        expected = np.full((2, 2), 1.5)
+
+        self.assertIsInstance(result_blend_coord_first, iris.cube.Cube)
+        self.assertIsInstance(result_blend_coord_second, iris.cube.Cube)
+        self.assertArrayAlmostEqual(
+            result_blend_coord_first.data, result_blend_coord_second.data
+        )
+        self.assertArrayAlmostEqual(result_blend_coord_first.data, expected)
+
 
 class Test_process(Test_weighted_blend):
 

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -794,6 +794,7 @@ class Test_process(Test_weighted_blend):
         result = plugin(new_cube, self.weights1d)
 
         # Getting the final value of the iterator
+        expected_output = None
         for expected_output in new_cube.slices_over(coord):
             pass
 

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -783,32 +783,21 @@ class Test_process(Test_weighted_blend):
 
     @ManageWarnings(ignored_messages=[COORD_COLLAPSE_WARNING])
     def test_threshold_cube_with_promoted_dimension_weighted_mean(self):
-        """Test weighted_mean method works collapsing a cube with a threshold
-        dimension when the blending is over a different coordinate. Note that
-        this test is in process to include the slicing."""
+        """Test weighted_mean method works with an additional promoted dimension with size 1."""
         coord = "forecast_reference_time"
         plugin = WeightedBlendAcrossWholeDimension(coord)
 
-        new_cube = add_coordinate(self.cube_threshold, [0.5], "height", coord_units="m")
-        new_cube = iris.util.new_axis(new_cube, "height")
-        result = plugin(new_cube, self.weights1d)
+        # Set up an input cube with one threshold as a dimension coordinate
+        input_cube = self.cube_threshold[0]
+        input_cube = iris.util.new_axis(input_cube, "precipitation_amount")
 
-        # Getting the final value of the iterator
-        expected_output = None
-        for expected_output in new_cube.slices_over(coord):
-            pass
+        result = plugin(input_cube, self.weights1d)
 
-        expected_result_array = np.ones((2, 2, 2)) * 0.3
-        expected_result_array[1, :, :] = 0.5
-
-        # Expecting an additional dimension for our "height" dimension
-        expected_output.data = expected_result_array[np.newaxis, ...]
-
+        expected_result_array = np.ones((1, 2, 2)) * 0.3
         expected_frt = int(self.cube.coord("forecast_reference_time").points[-1])
         expected_forecast_period = int(self.cube.coord("forecast_period").points[-1])
 
-        self.assertEqual(expected_output.coord("height"), result.coord("height"))
-        self.assertArrayAlmostEqual(result.data, expected_output.data)
+        self.assertArrayAlmostEqual(result.data, expected_result_array)
         self.assertEqual(result.attributes, self.expected_attributes)
         self.assertEqual(result.coord("time").points, expected_frt)
         self.assertEqual(


### PR DESCRIPTION
Addresses #1246 

Reducing the memory requirements for weighted blending by slicing the data and not creating large weights arrays.

## Benchmarking 

Feels like temperature:
 - Before:
   - 5148.673 MB
   - 26.708 s
 - After
   - 225.746 MB
   - 33.633 s

Blend adjacent points:
 - Before:
   - 1006.643 MB
   - 11.041 s
 - After
   - 312.639 MB
   - 10.754 s

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)