### PR TITLE
IMPRO-1725: Provide a list of ignorable attributes to the netcdf compare utility

### DIFF
--- a/improver/cli/compare.py
+++ b/improver/cli/compare.py
@@ -42,6 +42,8 @@ def process(
     desired: cli.inputpath,
     rtol: float = DEFAULT_TOLERANCE,
     atol: float = DEFAULT_TOLERANCE,
+    *,
+    ignored_attributes: cli.comma_separated_list = None,
 ) -> None:
     """
     Compare two netcdf files
@@ -51,10 +53,18 @@ def process(
         desired: path to desired/known good data netcdf file
         rtol: relative tolerance for data in variables
         atol: absolute tolerance for data in variables
+        ignored_attributes: list of attributes to ignore in the comparison
 
     Returns:
         None
     """
     from improver.utilities import compare
 
-    compare.compare_netcdfs(actual, desired, rtol=rtol, atol=atol, reporter=print)
+    compare.compare_netcdfs(
+        actual,
+        desired,
+        rtol=rtol,
+        atol=atol,
+        ignored_attributes=ignored_attributes,
+        reporter=print,
+    )

--- a/improver/cli/compare.py
+++ b/improver/cli/compare.py
@@ -49,11 +49,18 @@ def process(
     Compare two netcdf files
 
     Args:
-        actual: path to output data netcdf file
-        desired: path to desired/known good data netcdf file
-        rtol: relative tolerance for data in variables
-        atol: absolute tolerance for data in variables
-        ignored_attributes: list of attributes to ignore in the comparison
+        actual:
+            Path to output data netcdf file
+        desired:
+            Path to desired/known good data netcdf file
+        rtol:
+            Relative tolerance for data in variables
+        atol:
+            Absolute tolerance for data in variables
+        ignored_attributes:
+            List of attributes to ignore in the comparison. This option allows for
+            attributes such as "history" to be ignored, where such attributes often
+            vary between files without indicating any differences in the data.
 
     Returns:
         None

--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -57,6 +57,7 @@ def compare_netcdfs(
     atol=DEFAULT_TOLERANCE,
     exclude_vars=None,
     reporter=None,
+    ignored_attributes=None,
 ):
     """
     Compare two netCDF files.
@@ -69,6 +70,8 @@ def compare_netcdfs(
         exclude_vars (Iterable[str]): variable names to exclude from comparison
         reporter (Callable[[str], None]): callback function for
             reporting differences
+        ignored_attributes (Optional(List[str])): list of attributes to exclude
+            from comparison.
 
     Returns:
         None
@@ -94,10 +97,28 @@ def compare_netcdfs(
         return
     desired_ds.set_auto_maskandscale(False)
     actual_ds.set_auto_maskandscale(False)
-    compare_datasets("", actual_ds, desired_ds, rtol, atol, exclude_vars, reporter)
+    compare_datasets(
+        "",
+        actual_ds,
+        desired_ds,
+        rtol,
+        atol,
+        exclude_vars,
+        reporter,
+        ignored_attributes=ignored_attributes,
+    )
 
 
-def compare_datasets(name, actual_ds, desired_ds, rtol, atol, exclude_vars, reporter):
+def compare_datasets(
+    name,
+    actual_ds,
+    desired_ds,
+    rtol,
+    atol,
+    exclude_vars,
+    reporter,
+    ignored_attributes=None,
+):
     """
     Compare netCDF datasets.
     This function can call itself recursively to handle nested groups in
@@ -113,11 +134,15 @@ def compare_datasets(name, actual_ds, desired_ds, rtol, atol, exclude_vars, repo
         exclude_vars (List[str]): variable names to exclude from comparison
         reporter (Callable[[str], None]): callback function for
             reporting differences
+        ignored_attributes (Optional(List[str])): list of attributes to exclude
+            from comparison.
 
     Returns:
         None
     """
-    compare_attributes("root", actual_ds, desired_ds, reporter)
+    compare_attributes(
+        "root", actual_ds, desired_ds, reporter, ignored_attributes=ignored_attributes
+    )
     actual_groups = set(actual_ds.groups.keys())
     desired_groups = set(desired_ds.groups.keys())
 
@@ -128,7 +153,11 @@ def compare_datasets(name, actual_ds, desired_ds, rtol, atol, exclude_vars, repo
     check_groups = actual_groups.intersection(desired_groups)
     for group in check_groups:
         compare_attributes(
-            group, actual_ds.groups[group], desired_ds.groups[group], reporter
+            group,
+            actual_ds.groups[group],
+            desired_ds.groups[group],
+            reporter,
+            ignored_attributes=ignored_attributes,
         )
         compare_datasets(
             group,
@@ -138,6 +167,7 @@ def compare_datasets(name, actual_ds, desired_ds, rtol, atol, exclude_vars, repo
             atol,
             exclude_vars,
             reporter,
+            ignored_attributes=ignored_attributes,
         )
 
     compare_dims(name, actual_ds, desired_ds, exclude_vars, reporter)
@@ -179,7 +209,16 @@ def compare_dims(name, actual_ds, desired_ds, exclude_vars, reporter):
             reporter(msg)
 
 
-def compare_vars(name, actual_ds, desired_ds, rtol, atol, exclude_vars, reporter):
+def compare_vars(
+    name,
+    actual_ds,
+    desired_ds,
+    rtol,
+    atol,
+    exclude_vars,
+    reporter,
+    ignored_attributes=None,
+):
     """
     Compare variables in a netCDF dataset/group.
 
@@ -192,6 +231,8 @@ def compare_vars(name, actual_ds, desired_ds, rtol, atol, exclude_vars, reporter
         exclude_vars (List[str]): variable names to exclude from comparison
         reporter (Callable[[str], None]): callback function for
             reporting differences
+        ignored_attributes (Optional(List[str])): list of attributes to exclude
+            from comparison.
 
     Returns:
         None
@@ -217,14 +258,20 @@ def compare_vars(name, actual_ds, desired_ds, rtol, atol, exclude_vars, reporter
         var_path = f"{name}/{var}"
         actual_var = actual_ds.variables[var]
         desired_var = desired_ds.variables[var]
-        compare_attributes(var_path, actual_var, desired_var, reporter)
+        compare_attributes(
+            var_path,
+            actual_var,
+            desired_var,
+            reporter,
+            ignored_attributes=ignored_attributes,
+        )
         if var in coord_vars:
             compare_data(var_path, actual_var, desired_var, 0.0, 0.0, reporter)
         else:
             compare_data(var_path, actual_var, desired_var, rtol, atol, reporter)
 
 
-def compare_attributes(name, actual_ds, desired_ds, reporter):
+def compare_attributes(name, actual_ds, desired_ds, reporter, ignored_attributes=None):
     """
     Compare attributes in a netCDF dataset/group.
 
@@ -234,6 +281,8 @@ def compare_attributes(name, actual_ds, desired_ds, reporter):
         desired_ds (netCDF.Dataset): dataset considered good
         reporter (Callable[[str], None]): callback function for
             reporting differences
+        ignored_attributes (Optional(List[str])): list of attributes to exclude
+            from comparison.
 
     Returns:
         None
@@ -242,8 +291,10 @@ def compare_attributes(name, actual_ds, desired_ds, reporter):
     desired_attrs = set(desired_ds.ncattrs())
     # ignore history attribute - this often contain datestamps and other
     # overly specific details
-    actual_attrs.discard("history")
-    desired_attrs.discard("history")
+    if ignored_attributes is not None:
+        for attr in ignored_attributes:
+            actual_attrs.discard(attr)
+            desired_attrs.discard(attr)
 
     if actual_attrs != desired_attrs:
         msg = (

--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -56,8 +56,8 @@ def compare_netcdfs(
     rtol=DEFAULT_TOLERANCE,
     atol=DEFAULT_TOLERANCE,
     exclude_vars=None,
-    reporter=None,
     ignored_attributes=None,
+    reporter=None,
 ):
     """
     Compare two netCDF files.
@@ -68,10 +68,10 @@ def compare_netcdfs(
         rtol (float): relative tolerance
         atol (float): absolute tolerance
         exclude_vars (Iterable[str]): variable names to exclude from comparison
-        reporter (Callable[[str], None]): callback function for
-            reporting differences
         ignored_attributes (Optional(List[str])): list of attributes to exclude
             from comparison.
+        reporter (Callable[[str], None]): callback function for
+            reporting differences
 
     Returns:
         None
@@ -104,20 +104,13 @@ def compare_netcdfs(
         rtol,
         atol,
         exclude_vars,
+        ignored_attributes,
         reporter,
-        ignored_attributes=ignored_attributes,
     )
 
 
 def compare_datasets(
-    name,
-    actual_ds,
-    desired_ds,
-    rtol,
-    atol,
-    exclude_vars,
-    reporter,
-    ignored_attributes=None,
+    name, actual_ds, desired_ds, rtol, atol, exclude_vars, ignored_attributes, reporter,
 ):
     """
     Compare netCDF datasets.
@@ -132,17 +125,15 @@ def compare_datasets(
         rtol (float): relative tolerance
         atol (float): absolute tolerance
         exclude_vars (List[str]): variable names to exclude from comparison
-        reporter (Callable[[str], None]): callback function for
-            reporting differences
         ignored_attributes (Optional(List[str])): list of attributes to exclude
             from comparison.
+        reporter (Callable[[str], None]): callback function for
+            reporting differences
 
     Returns:
         None
     """
-    compare_attributes(
-        "root", actual_ds, desired_ds, reporter, ignored_attributes=ignored_attributes
-    )
+    compare_attributes("root", actual_ds, desired_ds, ignored_attributes, reporter)
     actual_groups = set(actual_ds.groups.keys())
     desired_groups = set(desired_ds.groups.keys())
 
@@ -156,8 +147,8 @@ def compare_datasets(
             group,
             actual_ds.groups[group],
             desired_ds.groups[group],
+            ignored_attributes,
             reporter,
-            ignored_attributes=ignored_attributes,
         )
         compare_datasets(
             group,
@@ -166,12 +157,20 @@ def compare_datasets(
             rtol,
             atol,
             exclude_vars,
+            ignored_attributes,
             reporter,
-            ignored_attributes=ignored_attributes,
         )
-
     compare_dims(name, actual_ds, desired_ds, exclude_vars, reporter)
-    compare_vars(name, actual_ds, desired_ds, rtol, atol, exclude_vars, reporter)
+    compare_vars(
+        name,
+        actual_ds,
+        desired_ds,
+        rtol,
+        atol,
+        exclude_vars,
+        ignored_attributes,
+        reporter,
+    )
 
 
 def compare_dims(name, actual_ds, desired_ds, exclude_vars, reporter):
@@ -210,14 +209,7 @@ def compare_dims(name, actual_ds, desired_ds, exclude_vars, reporter):
 
 
 def compare_vars(
-    name,
-    actual_ds,
-    desired_ds,
-    rtol,
-    atol,
-    exclude_vars,
-    reporter,
-    ignored_attributes=None,
+    name, actual_ds, desired_ds, rtol, atol, exclude_vars, ignored_attributes, reporter,
 ):
     """
     Compare variables in a netCDF dataset/group.
@@ -229,10 +221,10 @@ def compare_vars(
         rtol (float): relative tolerance
         atol (float): absolute tolerance
         exclude_vars (List[str]): variable names to exclude from comparison
-        reporter (Callable[[str], None]): callback function for
-            reporting differences
         ignored_attributes (Optional(List[str])): list of attributes to exclude
             from comparison.
+        reporter (Callable[[str], None]): callback function for
+            reporting differences
 
     Returns:
         None
@@ -259,11 +251,7 @@ def compare_vars(
         actual_var = actual_ds.variables[var]
         desired_var = desired_ds.variables[var]
         compare_attributes(
-            var_path,
-            actual_var,
-            desired_var,
-            reporter,
-            ignored_attributes=ignored_attributes,
+            var_path, actual_var, desired_var, ignored_attributes, reporter,
         )
         if var in coord_vars:
             compare_data(var_path, actual_var, desired_var, 0.0, 0.0, reporter)
@@ -271,7 +259,7 @@ def compare_vars(
             compare_data(var_path, actual_var, desired_var, rtol, atol, reporter)
 
 
-def compare_attributes(name, actual_ds, desired_ds, reporter, ignored_attributes=None):
+def compare_attributes(name, actual_ds, desired_ds, ignored_attributes, reporter):
     """
     Compare attributes in a netCDF dataset/group.
 
@@ -279,10 +267,10 @@ def compare_attributes(name, actual_ds, desired_ds, reporter, ignored_attributes
         name (str): group name
         actual_ds (netCDF.Dataset): dataset produced by test run
         desired_ds (netCDF.Dataset): dataset considered good
-        reporter (Callable[[str], None]): callback function for
-            reporting differences
         ignored_attributes (Optional(List[str])): list of attributes to exclude
             from comparison.
+        reporter (Callable[[str], None]): callback function for
+            reporting differences
 
     Returns:
         None

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -48,6 +48,7 @@ RECREATE_DIR_ENVVAR = "RECREATE_KGO"
 ACC_TEST_DIR_ENVVAR = "IMPROVER_ACC_TEST_DIR"
 ACC_TEST_DIR_MISSING = pathlib.Path("/dev/null")
 DEFAULT_CHECKSUM_FILE = pathlib.Path(__file__).parent / "SHA256SUMS"
+IGNORED_ATTRIBUTES = ["history", "Conventions"]
 
 
 def run_cli(cli_name, verbose=True):
@@ -358,6 +359,7 @@ def compare(
         rtol=rtol,
         exclude_vars=exclude_vars,
         reporter=message_recorder,
+        ignored_attributes=IGNORED_ATTRIBUTES,
     )
     if difference_found:
         if recreate:

--- a/improver_tests/acceptance/test_compare.py
+++ b/improver_tests/acceptance/test_compare.py
@@ -62,3 +62,14 @@ def test_different(capsys):
     assert "different dimension size" in captured.out
     assert "different variables" in captured.out
     assert "different data" in captured.out
+
+
+def test_ignored_attributes(capsys):
+    """Ensure attribute differences are not reported if explicity excluded."""
+    kgo_dir = acc.kgo_root()
+    a_file = kgo_dir / "spot-extract/inputs/all_methods_uk.nc"
+    b_file = kgo_dir / "spot-extract/inputs/all_methods_global.nc"
+    args = [a_file, b_file, "--ignored-attributes=model_grid_hash"]
+    run_cli(args)
+    captured = capsys.readouterr()
+    assert "different attribute value" not in captured.out

--- a/improver_tests/utilities/test_compare.py
+++ b/improver_tests/utilities/test_compare.py
@@ -151,7 +151,7 @@ def test_compare_vars_renamed(dummy_nc):
         messages_reported.append(message)
 
     compare.compare_vars(
-        "root", actual_ds, expected_ds, 0.0, 0.0, [], message_collector
+        "root", actual_ds, expected_ds, 0.0, 0.0, [], None, message_collector
     )
     assert len(messages_reported) == 1
     assert DEWPOINT in messages_reported[0]
@@ -171,7 +171,7 @@ def test_compare_groups_renamed(dummy_nc):
         messages_reported.append(message)
 
     compare.compare_datasets(
-        "grp", actual_ds, expected_ds, 0.0, 0.0, [DEWPOINT], message_collector
+        "grp", actual_ds, expected_ds, 0.0, 0.0, [DEWPOINT], None, message_collector
     )
     assert len(messages_reported) == 1
     assert SCALARS in messages_reported[0]
@@ -190,12 +190,12 @@ def test_compare_netcdf_attrs(dummy_nc):
         messages_reported.append(message)
 
     # Check that attributes initially match - message_collector is not called
-    compare.compare_attributes("root", actual_ds, expected_ds, message_collector)
+    compare.compare_attributes("root", actual_ds, expected_ds, None, message_collector)
     assert len(messages_reported) == 0
 
     # Check modifying a simple attribute
     actual_ds.setncattr("float_number", 3.2)
-    compare.compare_attributes("root", actual_ds, expected_ds, message_collector)
+    compare.compare_attributes("root", actual_ds, expected_ds, None, message_collector)
     assert len(messages_reported) == 1
     assert "float_number" in messages_reported[0]
     assert "3.2" in messages_reported[0]
@@ -208,7 +208,7 @@ def test_compare_netcdf_attrs(dummy_nc):
     # Check modifying an array attribute
     actual_ds[CAT].setncattr("additional_numbers", np.linspace(0.0, 0.8, 11))
     compare.compare_attributes(
-        "root", actual_ds[CAT], expected_ds[CAT], message_collector
+        "root", actual_ds[CAT], expected_ds[CAT], None, message_collector
     )
     assert len(messages_reported) == 1
     assert "additional_numbers" in messages_reported[0]
@@ -219,7 +219,9 @@ def test_compare_netcdf_attrs(dummy_nc):
 
     # Check adding another attribute
     actual_ds.setncattr("extra", "additional")
-    compare.compare_attributes("longer name", actual_ds, expected_ds, message_collector)
+    compare.compare_attributes(
+        "longer name", actual_ds, expected_ds, None, message_collector
+    )
     assert len(messages_reported) == 1
     assert "longer name" in messages_reported[0]
     # The difference message should mention the attribute which was added
@@ -231,7 +233,7 @@ def test_compare_netcdf_attrs(dummy_nc):
 
     # Check removing an attribute
     actual_ds.delncattr("float_number")
-    compare.compare_attributes("root", actual_ds, expected_ds, message_collector)
+    compare.compare_attributes("root", actual_ds, expected_ds, None, message_collector)
     assert len(messages_reported) == 1
     assert "float_number" in messages_reported[0]
     actual_ds.setncattr("float_number", 3.2)
@@ -242,7 +244,7 @@ def test_compare_netcdf_attrs(dummy_nc):
 
     # Check changing attribute type from int to float
     actual_ds.setncattr("whole_number", 4.0)
-    compare.compare_attributes("root", actual_ds, expected_ds, message_collector)
+    compare.compare_attributes("root", actual_ds, expected_ds, None, message_collector)
     assert len(messages_reported) == 1
     for part in ("int", "float", "whole_number"):
         assert part in messages_reported[0]
@@ -262,11 +264,7 @@ def test_ignore_netcdf_attrs(dummy_nc):
     # Check modifying a simple attribute
     actual_ds.setncattr("float_number", 3.2)
     compare.compare_attributes(
-        "root",
-        actual_ds,
-        expected_ds,
-        message_collector,
-        ignored_attributes=["float_number"],
+        "root", actual_ds, expected_ds, ["float_number"], message_collector,
     )
     assert len(messages_reported) == 0
 
@@ -280,8 +278,8 @@ def test_ignore_netcdf_attrs(dummy_nc):
         "root",
         actual_ds[CAT],
         expected_ds[CAT],
+        ["additional_numbers"],
         message_collector,
-        ignored_attributes=["additional_numbers"],
     )
     assert len(messages_reported) == 0
 
@@ -292,11 +290,7 @@ def test_ignore_netcdf_attrs(dummy_nc):
     # Check adding another attribute
     actual_ds.setncattr("extra", "additional")
     compare.compare_attributes(
-        "longer name",
-        actual_ds,
-        expected_ds,
-        message_collector,
-        ignored_attributes=["extra"],
+        "longer name", actual_ds, expected_ds, ["extra"], message_collector,
     )
     assert len(messages_reported) == 0
 
@@ -307,11 +301,7 @@ def test_ignore_netcdf_attrs(dummy_nc):
     # Check removing an attribute
     actual_ds.delncattr("float_number")
     compare.compare_attributes(
-        "root",
-        actual_ds,
-        expected_ds,
-        message_collector,
-        ignored_attributes=["float_number"],
+        "root", actual_ds, expected_ds, ["float_number"], message_collector,
     )
     assert len(messages_reported) == 0
 
@@ -573,7 +563,7 @@ def test_compare_data_type(dummy_nc, tchange):
         messages_reported.append(message)
 
     compare.compare_vars(
-        "root", actual_ds, expected_ds, 0.0, 0.0, None, message_collector
+        "root", actual_ds, expected_ds, 0.0, 0.0, None, None, message_collector
     )
     assert len(messages_reported) == 1
     assert "type" in messages_reported[0]

--- a/improver_tests/utilities/test_compare.py
+++ b/improver_tests/utilities/test_compare.py
@@ -272,21 +272,6 @@ def test_ignore_netcdf_attrs(dummy_nc):
     actual_ds.setncattr("float_number", 1.5)
     messages_reported = []
 
-    # Check modifying an array attribute
-    actual_ds[CAT].setncattr("additional_numbers", np.linspace(0.0, 0.8, 11))
-    compare.compare_attributes(
-        "root",
-        actual_ds[CAT],
-        expected_ds[CAT],
-        ["additional_numbers"],
-        message_collector,
-    )
-    assert len(messages_reported) == 0
-
-    # Reset attribute back to original value
-    actual_ds[CAT].setncattr("additional_numbers", np.linspace(0.0, 1.0, 11))
-    messages_reported = []
-
     # Check adding another attribute
     actual_ds.setncattr("extra", "additional")
     compare.compare_attributes(
@@ -304,10 +289,6 @@ def test_ignore_netcdf_attrs(dummy_nc):
         "root", actual_ds, expected_ds, ["float_number"], message_collector,
     )
     assert len(messages_reported) == 0
-
-    # Reset attribute back to original value
-    actual_ds.setncattr("float_number", 1.5)
-    messages_reported = []
 
 
 def test_compare_data_floats_equal(dummy_nc):


### PR DESCRIPTION
This change enables us to set a variety of attributes as ignorable, 
which will reduce the number of times we must update acceptance test 
data for trivial changes that are unimportant for checking data 
integrity.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
