### PR TITLE
1268 implement compression control

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ below:
 * Fiona Rust (Met Office, UK)
 * Chris Sampson (Met Office, UK)
 * Caroline Sandford (Met Office, UK)
+* Victoria Smart (Met Office, UK)
 * Eleanor Smith (Met Office, UK)
 * Tomasz Trzeciak (Met Office, UK)
 * Mark Worsfold (Met Office, UK)

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -262,8 +262,9 @@ def with_output(wrapped, *args, output=None, compression_level=1, **kwargs):
     Add `compression_level` option.
 
     This is used to add extra `output` and `compression_level` CLI options. If `output`
-    provided, it saves the result of calling `wrapped` to file and returns None, otherwise 
-    it returns the result. If `compression_level` provided, it does not compress the file.
+    provided, it saves the result of calling `wrapped` to file and returns None, otherwise
+    it returns the result. If `compression_level` provided, it compresses the data with the
+    provided compression level (or not, if `compression_level` 0).
 
     Args:
         wrapped (obj):

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -257,13 +257,13 @@ def create_constrained_inputcubelist_converter(*constraints):
 
 
 @decorator
-def with_output(wrapped, *args, output=None, no_compression=False, **kwargs):
+def with_output(wrapped, *args, output=None, compression_level=1, **kwargs):
     """Add `output` keyword only argument.
-    Add `no_compression` option.
+    Add `compression_level` option.
 
-    This is used to add extra `output` and `no_compression` CLI options. If `output` provided, it saves
-    the result of calling `wrapped` to file and returns None, otherwise it
-    returns the result. If `no_compression` provided, it does not compress the file.
+    This is used to add extra `output` and `compression_level` CLI options. If `output`
+    provided, it saves the result of calling `wrapped` to file and returns None, otherwise 
+    it returns the result. If `compression_level` provided, it does not compress the file.
 
     Args:
         wrapped (obj):
@@ -271,8 +271,8 @@ def with_output(wrapped, *args, output=None, no_compression=False, **kwargs):
         output (str, optional):
             Output file name. If not supplied, the output object will be
             printed instead.
-        no_compression (bool):
-            If given, will not compress the netCDF file when saved.
+        compression_level (int):
+            Will set the compression level (1 to 9), or disable compression (0).
 
     Returns:
         Result of calling `wrapped` or None if `output` is given.
@@ -281,8 +281,7 @@ def with_output(wrapped, *args, output=None, no_compression=False, **kwargs):
 
     result = wrapped(*args, **kwargs)
     if output:
-        compress = not no_compression
-        save_netcdf(result, output, compress)
+        save_netcdf(result, output, compression_level)
         return
     return result
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -257,12 +257,13 @@ def create_constrained_inputcubelist_converter(*constraints):
 
 
 @decorator
-def with_output(wrapped, *args, output=None, **kwargs):
+def with_output(wrapped, *args, output=None, no_compression=False, **kwargs):
     """Add `output` keyword only argument.
+    Add `no_compression` option.
 
-    This is used to add an extra `output` CLI option. If provided, it saves
+    This is used to add extra `output` and `no_compression` CLI options. If `output` provided, it saves
     the result of calling `wrapped` to file and returns None, otherwise it
-    returns the result.
+    returns the result. If `no_compression` provided, it does not compress the file.
 
     Args:
         wrapped (obj):
@@ -270,6 +271,8 @@ def with_output(wrapped, *args, output=None, **kwargs):
         output (str, optional):
             Output file name. If not supplied, the output object will be
             printed instead.
+        no_compression (bool):
+            If given, will not compress the netCDF file when saved.
 
     Returns:
         Result of calling `wrapped` or None if `output` is given.
@@ -278,7 +281,8 @@ def with_output(wrapped, *args, output=None, **kwargs):
 
     result = wrapped(*args, **kwargs)
     if output:
-        save_netcdf(result, output)
+        compress = not no_compression
+        save_netcdf(result, output, compress)
         return
     return result
 
@@ -407,7 +411,7 @@ def main(
     profile: value_converter(lambda _: _, name="FILENAME") = None,
     memprofile: value_converter(lambda _: _, name="FILENAME") = None,
     verbose=False,
-    dry_run=False,
+    dry_run=False
 ):
     """IMPROVER NWP post-processing toolbox
 
@@ -458,7 +462,7 @@ def main(
         command,
         *args,
         verbose=verbose,
-        dry_run=dry_run,
+        dry_run=dry_run
     )
     return result
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -411,7 +411,7 @@ def main(
     profile: value_converter(lambda _: _, name="FILENAME") = None,
     memprofile: value_converter(lambda _: _, name="FILENAME") = None,
     verbose=False,
-    dry_run=False
+    dry_run=False,
 ):
     """IMPROVER NWP post-processing toolbox
 
@@ -462,7 +462,7 @@ def main(
         command,
         *args,
         verbose=verbose,
-        dry_run=dry_run
+        dry_run=dry_run,
     )
     return result
 

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -74,7 +74,7 @@ def _check_metadata(cube):
         raise ValueError("{} has unknown units".format(cube.name()))
 
 
-def save_netcdf(cubelist, filename):
+def save_netcdf(cubelist, filename, compress=True):
     """Save the input Cube or CubeList as a NetCDF file and check metadata
     where required for integrity.
 
@@ -87,6 +87,8 @@ def save_netcdf(cubelist, filename):
             Cube or list of cubes to be saved
         filename (str):
             Filename to save input cube(s)
+        compress (bool):
+            Flag to specify whether to compress netCDF file
 
     Raises:
         warning if cubelist contains cubes of varying dimensions.
@@ -138,7 +140,7 @@ def save_netcdf(cubelist, filename):
         local_keys=local_keys,
         complevel=1,
         shuffle=True,
-        zlib=True,
+        zlib=compress,
         chunksizes=chunksizes,
     )
     os.rename(ftmp, filename)

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -148,7 +148,7 @@ def save_netcdf(cubelist, filename, compression_level=1):
         local_keys=local_keys,
         complevel=compression_level,
         shuffle=True,
-        zlib=True,
+        zlib=compression_level > 0,
         chunksizes=chunksizes,
     )
     os.rename(ftmp, filename)

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -74,7 +74,7 @@ def _check_metadata(cube):
         raise ValueError("{} has unknown units".format(cube.name()))
 
 
-def save_netcdf(cubelist, filename, compress=True):
+def save_netcdf(cubelist, filename, compression_level=1):
     """Save the input Cube or CubeList as a NetCDF file and check metadata
     where required for integrity.
 
@@ -87,8 +87,9 @@ def save_netcdf(cubelist, filename, compress=True):
             Cube or list of cubes to be saved
         filename (str):
             Filename to save input cube(s)
-        compress (bool):
-            Flag to specify whether to compress netCDF file
+        compression_level (int):
+            1-9 to specify compression level, or 0 to not compress (default compress
+            with complevel 1)
 
     Raises:
         warning if cubelist contains cubes of varying dimensions.
@@ -132,15 +133,22 @@ def save_netcdf(cubelist, filename, compress=True):
         if key not in global_keys
     }
 
+    if not isinstance(compression_level, int):
+        raise ValueError("{} is not an int between 0 and 9".format(compression_level))
+    if compression_level > 9:
+        compression_level = 9
+    elif compression_level < 0:
+        compression_level = 0
+
     # save atomically by writing to a temporary file and then renaming
     ftmp = str(filename) + ".tmp"
     iris.fileformats.netcdf.save(
         cubelist,
         ftmp,
         local_keys=local_keys,
-        complevel=1,
+        complevel=compression_level,
         shuffle=True,
-        zlib=compress,
+        zlib=True,
         chunksizes=chunksizes,
     )
     os.rename(ftmp, filename)

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -133,12 +133,10 @@ def save_netcdf(cubelist, filename, compression_level=1):
         if key not in global_keys
     }
 
-    if not isinstance(compression_level, int):
-        raise ValueError("{} is not an int between 0 and 9".format(compression_level))
-    if compression_level > 9:
-        compression_level = 9
-    elif compression_level < 0:
-        compression_level = 0
+    if compression_level not in range(10):
+        raise ValueError(
+            "Compression level must be an integer value between 0 and 9 (0 to disable compression)"
+        )
 
     # save atomically by writing to a temporary file and then renaming
     ftmp = str(filename) + ".tmp"

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -157,11 +157,20 @@ class Test_with_output(unittest.TestCase):
 
     @patch("improver.utilities.save.save_netcdf")
     def test_with_output(self, m):
-        """Tests that save_netcdf it called with object and string"""
+        """Tests that save_netcdf it called with object and string and compress=True"""
         # pylint disable is needed as it can't see the wrappers output kwarg.
         # pylint: disable=E1123
         result = wrapped_with_output(2, output="foo")
-        m.assert_called_with(4, "foo")
+        m.assert_called_with(4, "foo", True)
+        self.assertEqual(result, None)
+
+    @patch("improver.utilities.save.save_netcdf")
+    def test_with_output_no_compression(self, m):
+        """Tests that save_netcdf it called with object and string and compress=False"""
+        # pylint disable is needed as it can't see the wrappers output kwarg.
+        # pylint: disable=E1123
+        result = wrapped_with_output(2, output="foo", no_compression=True)
+        m.assert_called_with(4, "foo", False)
         self.assertEqual(result, None)
 
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -157,21 +157,30 @@ class Test_with_output(unittest.TestCase):
 
     @patch("improver.utilities.save.save_netcdf")
     def test_with_output(self, m):
-        """Tests that save_netcdf is called with object and string and compress=True"""
+        """Tests that save_netcdf is called with object and string and default
+        compression_level=1"""
         # pylint disable is needed as it can't see the wrappers output kwarg.
         # pylint: disable=E1123
         result = wrapped_with_output(2, output="foo")
-        m.assert_called_with(4, "foo", True)
+        m.assert_called_with(4, "foo", 1)
+        self.assertEqual(result, None)
+
+    @patch("improver.utilities.save.save_netcdf")
+    def test_with_output_compression_level(self, m):
+        """Tests that save_netcdf is called with object and string and compression_level=9"""
+        # pylint disable is needed as it can't see the wrappers output kwarg.
+        # pylint: disable=E1123
+        result = wrapped_with_output(2, output="foo", compression_level=9)
+        m.assert_called_with(4, "foo", 9)
         self.assertEqual(result, None)
 
     @patch("improver.utilities.save.save_netcdf")
     def test_with_output_no_compression(self, m):
-        """Tests that save_netcdf is called with object and string and compress=False
-        when `no_compression` option given """
+        """Tests that save_netcdf is called with object and string and compression_level=0 """
         # pylint disable is needed as it can't see the wrappers output kwarg.
         # pylint: disable=E1123
-        result = wrapped_with_output(2, output="foo", no_compression=True)
-        m.assert_called_with(4, "foo", False)
+        result = wrapped_with_output(2, output="foo", compression_level=0)
+        m.assert_called_with(4, "foo", 0)
         self.assertEqual(result, None)
 
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -157,7 +157,7 @@ class Test_with_output(unittest.TestCase):
 
     @patch("improver.utilities.save.save_netcdf")
     def test_with_output(self, m):
-        """Tests that save_netcdf it called with object and string and compress=True"""
+        """Tests that save_netcdf is called with object and string and compress=True"""
         # pylint disable is needed as it can't see the wrappers output kwarg.
         # pylint: disable=E1123
         result = wrapped_with_output(2, output="foo")
@@ -166,7 +166,8 @@ class Test_with_output(unittest.TestCase):
 
     @patch("improver.utilities.save.save_netcdf")
     def test_with_output_no_compression(self, m):
-        """Tests that save_netcdf it called with object and string and compress=False"""
+        """Tests that save_netcdf is called with object and string and compress=False
+        when `no_compression` option given """
         # pylint disable is needed as it can't see the wrappers output kwarg.
         # pylint: disable=E1123
         result = wrapped_with_output(2, output="foo", no_compression=True)

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -111,6 +111,7 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
 
         data = Dataset(self.filepath, mode="r")
+        # pylint: disable=unsubscriptable-object
         filters = data.variables["air_temperature"].filters()
 
         self.assertTrue(filters["zlib"])

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -106,6 +106,24 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
         self.assertTrue(os.path.exists(self.filepath))
 
+    def test_compression(self):
+        """ Test data gets compressed when saved """
+        save_netcdf(self.cube, self.filepath)
+
+        data = Dataset(self.filepath, mode="r")
+        filters = data.variables['air_temperature'].filters()
+
+        self.assertTrue(filters['zlib'])
+
+    def test_no_compression(self):
+        """ Test data does not get compressed when saved with compress=False """
+        save_netcdf(self.cube, self.filepath, compress=False)
+        
+        data = Dataset(self.filepath, mode="r")
+        filters = data.variables['air_temperature'].filters()
+
+        self.assertFalse(filters['zlib'])
+
     def test_basic_cube_list(self):
         """
         Test functionality for saving iris.cube.CubeList

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -142,28 +142,12 @@ class Test_save_netcdf(IrisTest):
     def test_compression_level_invalid(self):
         """ Test ValueError raised when invalid compression_level """
         with self.assertRaises(ValueError):
-            save_netcdf(self.cube, self.filepath, compression_level="ten")
+            save_netcdf(self.cube, self.filepath, compression_level="one")
 
     def test_compression_level_out_of_range(self):
-        """ Test data data compressed with complevel 9 when compression_level > 9 """
-        save_netcdf(self.cube, self.filepath, compression_level=10)
-
-        data = Dataset(self.filepath, mode="r")
-        # pylint: disable=unsubscriptable-object
-        filters = data.variables["air_temperature"].filters()
-
-        self.assertTrue(filters["zlib"])
-        self.assertEqual(filters["complevel"], 9)
-
-    def test_compression_level_negative(self):
-        """ Test data does not get compressed when compression_level < 0 """
-        save_netcdf(self.cube, self.filepath, compression_level=-1)
-
-        data = Dataset(self.filepath, mode="r")
-        # pylint: disable=unsubscriptable-object
-        filters = data.variables["air_temperature"].filters()
-
-        self.assertFalse(filters["zlib"])
+        """ Test ValueError raised when compression_level out of range """
+        with self.assertRaises(ValueError):
+            save_netcdf(self.cube, self.filepath, compression_level=10)
 
     def test_basic_cube_list(self):
         """

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -121,6 +121,7 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath, compress=False)
 
         data = Dataset(self.filepath, mode="r")
+        # pylint: disable=unsubscriptable-object
         filters = data.variables["air_temperature"].filters()
 
         self.assertFalse(filters["zlib"])

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -111,18 +111,18 @@ class Test_save_netcdf(IrisTest):
         save_netcdf(self.cube, self.filepath)
 
         data = Dataset(self.filepath, mode="r")
-        filters = data.variables['air_temperature'].filters()
+        filters = data.variables["air_temperature"].filters()
 
-        self.assertTrue(filters['zlib'])
+        self.assertTrue(filters["zlib"])
 
     def test_no_compression(self):
         """ Test data does not get compressed when saved with compress=False """
         save_netcdf(self.cube, self.filepath, compress=False)
-        
-        data = Dataset(self.filepath, mode="r")
-        filters = data.variables['air_temperature'].filters()
 
-        self.assertFalse(filters['zlib'])
+        data = Dataset(self.filepath, mode="r")
+        filters = data.variables["air_temperature"].filters()
+
+        self.assertFalse(filters["zlib"])
 
     def test_basic_cube_list(self):
         """


### PR DESCRIPTION
Addresses #GitHubissuenum

Description
Add `no_compression` option across all CLIs. Went with `no_compression`  as `zlib` was originally hardcoded True, so set compression as default.
Created unit tests.

closes #1268

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

CLA
 - [x] If a new developer, signed up to CLA
