### PR TITLE
Fixed standardise bug and added unit test to cover broken case

### DIFF
--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -209,11 +209,8 @@ class StandardiseMetadata(BasePlugin):
         Returns:
             iris.cube.Cube
         """
-        # standard metadata updates
         cube = self._collapse_scalar_dimensions(cube)
-        self._standardise_dtypes_and_units(cube)
 
-        # optional metadata updates
         if new_name:
             cube.rename(new_name)
         if new_units:
@@ -222,6 +219,10 @@ class StandardiseMetadata(BasePlugin):
             self._remove_scalar_coords(cube, coords_to_remove)
         if attributes_dict:
             amend_attributes(cube, attributes_dict)
+
+        # this must be done after unit conversion as if the input is an integer
+        # field, unit conversion outputs the new data as float64
+        self._standardise_dtypes_and_units(cube)
 
         return cube
 

--- a/improver_tests/standardise/test_StandardiseMetadata.py
+++ b/improver_tests/standardise/test_StandardiseMetadata.py
@@ -148,7 +148,17 @@ class Test_process(IrisTest):
         cube.data = cube.data.astype(np.float64)
         result = self.plugin.process(cube)
         self.assertEqual(result.data.dtype, np.float32)
-        self.assertArrayAlmostEqual(self.cube.data, result.data, decimal=4)
+        self.assertArrayAlmostEqual(result.data, self.cube.data, decimal=4)
+
+    def test_float_deescalation_with_unit_change(self):
+        """Covers the bug where unit conversion from an integer input field causes
+        float64 escalation"""
+        cube = set_up_variable_cube(
+            np.ones((5, 5), dtype=np.int16), name="rainrate", units="mm h-1"
+        )
+        result = self.plugin.process(cube, new_units="m s-1")
+        self.assertEqual(cube.dtype, np.float32)
+        self.assertEqual(result.data.dtype, np.float32)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Located standardise bug to the case where an input field is an integer, but unit conversion escalates that to float.  Fixed bug by simple re-ordering, added comment and unit test.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
