### PR TITLE
Updating units tests to use set_up_variable_cube.

### DIFF
--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -45,7 +45,7 @@ from improver.utilities.cube_checker import (
     check_cube_coordinates,
     find_dimension_coordinate_mismatch,
 )
-from improver.utilities.cube_manipulation import ConcatenateCubes
+from improver.utilities.cube_manipulation import ConcatenateCubes, MergeCubes
 
 
 class BaseNeighbourhoodProcessing(PostProcessingPlugin):
@@ -193,13 +193,10 @@ class BaseNeighbourhoodProcessing(PostProcessingPlugin):
                         cube_slice, radius, mask_cube=mask_cube
                     )
                     cubes_time.append(cube_slice)
-                if len(cubes_time) > 1:
-                    cube_new = ConcatenateCubes(coords_to_slice_over=["time"])(
-                        cubes_time
-                    )
-                else:
-                    cube_new = cubes_time[0]
+                cube_new = MergeCubes()(cubes_time)
+
             cubes_real.append(cube_new)
+
         if len(cubes_real) > 1:
             combined_cube = ConcatenateCubes(coords_to_slice_over=["realization"])(
                 cubes_real

--- a/improver_tests/convection/test_DiagnoseConvectivePrecipitation.py
+++ b/improver_tests/convection/test_DiagnoseConvectivePrecipitation.py
@@ -34,15 +34,15 @@
 import datetime
 import unittest
 
-import numpy as np
-
 import iris
+import numpy as np
 from cf_units import Unit
-from improver.convection import DiagnoseConvectivePrecipitation
-from improver_tests.set_up_test_cubes import add_coordinate, set_up_variable_cube
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 from iris.tests import IrisTest
+
+from improver.convection import DiagnoseConvectivePrecipitation
+from improver_tests.set_up_test_cubes import add_coordinate, set_up_variable_cube
 
 # Fraction to convert from mm/hr to m/s.
 # m/s are SI units, however, mm/hr values are easier to handle.

--- a/improver_tests/convection/test_DiagnoseConvectivePrecipitation.py
+++ b/improver_tests/convection/test_DiagnoseConvectivePrecipitation.py
@@ -31,22 +31,19 @@
 """Unit tests for the convection.DiagnoseConvectivePrecipitation plugin."""
 
 
-import unittest
 import datetime
+import unittest
+
+import numpy as np
 
 import iris
-import numpy as np
 from cf_units import Unit
+from improver.convection import DiagnoseConvectivePrecipitation
+from improver_tests.set_up_test_cubes import (add_coordinate,
+                                              set_up_variable_cube)
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 from iris.tests import IrisTest
-
-from improver.convection import DiagnoseConvectivePrecipitation
-
-from improver_tests.set_up_test_cubes import (
-    add_coordinate,
-    set_up_variable_cube,
-)
 
 # Fraction to convert from mm/hr to m/s.
 # m/s are SI units, however, mm/hr values are easier to handle.
@@ -71,6 +68,8 @@ def set_up_precipitation_rate_cube():
 
 # This is the new cube I set up using set_up_variable_cube
 def set_up_cube():
+    """Creates a standard cube which can be used within the
+    tests."""
     coord_points = np.array([0.0, 2000.0, 4000.0, 6000.0])
     timestep = np.array([402192.5])
     cube = set_up_variable_cube(
@@ -86,7 +85,7 @@ def set_up_cube():
         timestep,
         "time",
     )
-    cube = iris.util.new_axis(cube, 'time')   
+    cube = iris.util.new_axis(cube, 'time')
     cube.transpose([1, 0, 2, 3])
     return cube
 
@@ -311,22 +310,22 @@ class Test__calculate_convective_ratio(IrisTest):
         time2 = datetime.datetime(2015, 11, 19, 3)
         time3 = datetime.datetime(2015, 11, 19, 6)
         precip = set_up_variable_cube(
-            np.ones((1, 4, 4), dtype = np.float32),
+            np.ones((1, 4, 4), dtype=np.float32),
             "lwe_precipitation_rate",
             "m s-1",
             "equalarea",
-            time = time2,
-            frt = time1,
+            time=time2,
+            frt=time1,
         )
-        
+
         # This sets up the time coordinate, and leads to forecast_periods that are
-        # correct but set up in seconds rather than hours in the original cube. 
+        # correct but set up in seconds rather than hours in the original cube.
         precip = add_coordinate(
             precip,
             [time2, time3],
             "time",
-            order = [1, 0, 2, 3],
-            is_datetime = True,
+            order=[1, 0, 2, 3],
+            is_datetime=True,
         )
 
         # This converts the forecast_period to the correct points and hours, but this
@@ -341,9 +340,9 @@ class Test__calculate_convective_ratio(IrisTest):
         # raised. "ValueError: 'time' is not in list" (It suggests this is in
         # improver.utilities.cube_manipulation.ConcatenateCubes. However this doesn't
         # raise this ValueError. So it doesn't seem to be within IMPROVER)
-        cubelist2 = lower_higher_threshold_cubelist(
-            precip.copy(), precip.copy(), self.lower_threshold, self.higher_threshold
-        )
+#        cubelist2 = lower_higher_threshold_cubelist(
+#            precip.copy(), precip.copy(), self.lower_threshold, self.higher_threshold
+#        )
 
         cubelist = lower_higher_threshold_cubelist(
             cube.copy(), cube.copy(), self.lower_threshold, self.higher_threshold

--- a/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -614,8 +614,9 @@ class Test_process(IrisTest):
         cube = set_up_cube(
             zero_point_indices=((1, 0, 7, 7), (1, 1, 7, 7), (1, 2, 7, 7)),
             num_time_points=3,
-            num_realization_points=2)
-        time_points = cube.coord('time').points
+            num_realization_points=2,
+        )
+        time_points = cube.coord("time").points
         lead_times = [2, 3, 4]
         radii = [5600, 7600, 9500]
         cube = add_forecast_reference_time_and_forecast_period(

--- a/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -607,6 +607,43 @@ class Test_process(IrisTest):
         result = plugin(cube)
         self.assertArrayAlmostEqual(result.data, expected)
 
+    def test_radii_varying_with_lead_time_multiple_realizations(self):
+        """Test that a cube is returned for the following conditions:
+        1. The radius varies wtih lead time.
+        2. The cube contains multiple realizations."""
+        cube = set_up_cube(
+            zero_point_indices=((1, 0, 7, 7), (1, 1, 7, 7), (1, 2, 7, 7)),
+            num_time_points=3,
+            num_realization_points=2)
+        time_points = cube.coord('time').points
+        lead_times = [2, 3, 4]
+        radii = [5600, 7600, 9500]
+        cube = add_forecast_reference_time_and_forecast_period(
+            cube, time_point=time_points, fp_point=lead_times
+        )
+        expected = np.ones_like(cube.data)
+        expected[1, 0, 6:9, 6:9] = (
+            [0.91666667, 0.875, 0.91666667],
+            [0.875, 0.83333333, 0.875],
+            [0.91666667, 0.875, 0.91666667],
+        )
+        expected[1, 1, 5:10, 5:10] = SINGLE_POINT_RANGE_3_CENTROID
+        expected[1, 2, 4:11, 4:11] = (
+            [1, 0.9925, 0.985, 0.9825, 0.985, 0.9925, 1],
+            [0.9925, 0.98, 0.9725, 0.97, 0.9725, 0.98, 0.9925],
+            [0.985, 0.9725, 0.965, 0.9625, 0.965, 0.9725, 0.985],
+            [0.9825, 0.97, 0.9625, 0.96, 0.9625, 0.97, 0.9825],
+            [0.985, 0.9725, 0.965, 0.9625, 0.965, 0.9725, 0.985],
+            [0.9925, 0.98, 0.9725, 0.97, 0.9725, 0.98, 0.9925],
+            [1, 0.9925, 0.985, 0.9825, 0.985, 0.9925, 1],
+        )
+        neighbourhood_method = CircularNeighbourhood()
+        plugin = NBHood(neighbourhood_method, radii, lead_times)
+        result = plugin(cube)
+        self.assertIsInstance(result, Cube)
+        self.assertArrayEqual(result[0].data, expected[0])
+        self.assertArrayAlmostEqual(result[1].data, expected[1])
+
     def test_radii_varying_with_lead_time_with_interpolation(self):
         """Test that a cube is returned for the following conditions:
         1. The radius varies with lead time.

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -40,50 +40,9 @@ from iris.cube import Cube
 from iris.tests import IrisTest
 from numpy import ma
 
+from improver_tests.set_up_test_cubes import set_up_variable_cube
+
 from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
-
-
-def set_up_cube(
-    data,
-    phenomenon_standard_name,
-    phenomenon_units,
-    realizations=np.array([0]),
-    timesteps=1,
-    y_dimension_length=3,
-    x_dimension_length=3,
-):
-    """Create a cube containing multiple realizations."""
-    coord_placer = 0
-    cube = Cube(data, standard_name=phenomenon_standard_name, units=phenomenon_units)
-    if len(realizations) > 1:
-        realizations = DimCoord(realizations, "realization")
-        cube.add_dim_coord(realizations, coord_placer)
-        coord_placer = 1
-    else:
-        cube.add_aux_coord(AuxCoord(realizations, "realization", units="1"))
-    time_origin = "hours since 1970-01-01 00:00:00"
-    calendar = "gregorian"
-    tunit = Unit(time_origin, calendar)
-    cube.add_aux_coord(
-        AuxCoord(np.linspace(402192.5, 402292.5, timesteps), "time", units=tunit)
-    )
-    cube.add_dim_coord(
-        DimCoord(
-            np.linspace(0, 10000, y_dimension_length),
-            "projection_y_coordinate",
-            units="m",
-        ),
-        coord_placer,
-    )
-    cube.add_dim_coord(
-        DimCoord(
-            np.linspace(0, 10000, x_dimension_length),
-            "projection_x_coordinate",
-            units="m",
-        ),
-        coord_placer + 1,
-    )
-    return cube
 
 
 class Test_create_difference_cube(IrisTest):
@@ -94,7 +53,12 @@ class Test_create_difference_cube(IrisTest):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
         self.diff_in_y_array = np.array([[1, 2, 3], [3, 6, 9]])
-        self.cube = set_up_cube(data, "wind_speed", "m s-1")
+        self.cube = set_up_variable_cube(
+            data,
+            "wind_speed",
+            "m s-1",
+            "equalarea",
+        )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_y_dimension(self):
@@ -138,7 +102,12 @@ class Test_calculate_difference(IrisTest):
     def setUp(self):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
-        self.cube = set_up_cube(data, "wind_speed", "m s-1")
+        self.cube = set_up_variable_cube(
+            data,
+            "wind_speed",
+            "m s-1",
+            "equalarea",
+        )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_x_dimension(self):
@@ -161,11 +130,12 @@ class Test_calculate_difference(IrisTest):
 
     def test_missing_data(self):
         """Test that the result is as expected when data is missing."""
-        data = np.array([[1, 2, 3], [np.nan, 4, 6], [5, 10, 15]])
-        cube = set_up_cube(data, "wind_speed", "m s-1")
+        data = np.array([[1, 2, 3], [np.nan, 4, 6], [5, 10, 15]],
+            dtype=np.float32)
+        self.cube.data = data     
         expected = np.array([[np.nan, 2, 3], [np.nan, 6, 9]])
         result = self.plugin.calculate_difference(
-            cube, self.cube.coord(axis="y").name()
+            self.cube, self.cube.coord(axis="y").name()
         )
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayAlmostEqual(result, expected)
@@ -175,10 +145,10 @@ class Test_calculate_difference(IrisTest):
         data = ma.array(
             [[1, 2, 3], [2, 4, 6], [5, 10, 15]], mask=[[0, 0, 0], [1, 0, 0], [0, 0, 0]]
         )
-        cube = set_up_cube(data, "wind_speed", "m s-1")
+        self.cube.data = data
         expected = ma.array([[1, 2, 3], [3, 6, 9]], mask=[[1, 0, 0], [1, 0, 0]])
         result = self.plugin.calculate_difference(
-            cube, self.cube.coord(axis="y").name()
+            self.cube, self.cube.coord(axis="y").name()
         )
         self.assertIsInstance(result, np.ndarray)
         self.assertArrayEqual(result, expected)
@@ -192,7 +162,13 @@ class Test_process(IrisTest):
     def setUp(self):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
-        self.cube = set_up_cube(data, "wind_speed", "m s-1")
+        self.cube = set_up_variable_cube(
+            data,
+            "wind_speed",
+            "m s-1",
+            "equalarea",
+            realizations=np.array([1, 2]),
+        )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_basic(self):
@@ -231,7 +207,13 @@ class Test_process(IrisTest):
         )
         expected_x = np.array([[[1, 1], [2, 2], [5, 5]], [[1, 1], [0, 4], [5, 10]]])
         expected_y = np.array([[[1, 2, 3], [3, 6, 9]], [[1, 0, 3], [3, 8, 14]]])
-        cube = set_up_cube(data, "wind_speed", "m s-1", realizations=np.array([1, 2]))
+        cube = set_up_variable_cube(
+            data,
+            "wind_speed",
+            "m s-1",
+            "equalarea",
+            realizations=np.array([1, 2]),
+        )
         result = self.plugin.process(cube)
         self.assertIsInstance(result[0], iris.cube.Cube)
         self.assertArrayAlmostEqual(result[0].data, expected_x)

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -36,7 +36,6 @@ import numpy as np
 from numpy import ma
 
 import iris
-from cf_units import Unit
 from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
 from improver_tests.set_up_test_cubes import set_up_variable_cube
 from iris.coords import CellMethod

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -32,17 +32,16 @@
 
 import unittest
 
-import iris
 import numpy as np
-from cf_units import Unit
-from iris.coords import AuxCoord, CellMethod, DimCoord
-from iris.cube import Cube
-from iris.tests import IrisTest
 from numpy import ma
 
-from improver_tests.set_up_test_cubes import set_up_variable_cube
-
+import iris
+from cf_units import Unit
 from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
+from improver_tests.set_up_test_cubes import set_up_variable_cube
+from iris.coords import CellMethod
+from iris.cube import Cube
+from iris.tests import IrisTest
 
 
 class Test_create_difference_cube(IrisTest):
@@ -131,8 +130,8 @@ class Test_calculate_difference(IrisTest):
     def test_missing_data(self):
         """Test that the result is as expected when data is missing."""
         data = np.array([[1, 2, 3], [np.nan, 4, 6], [5, 10, 15]],
-            dtype=np.float32)
-        self.cube.data = data     
+                        dtype=np.float32)
+        self.cube.data = data
         expected = np.array([[np.nan, 2, 3], [np.nan, 6, 9]])
         result = self.plugin.calculate_difference(
             self.cube, self.cube.coord(axis="y").name()

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -51,12 +51,7 @@ class Test_create_difference_cube(IrisTest):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
         self.diff_in_y_array = np.array([[1, 2, 3], [3, 6, 9]])
-        self.cube = set_up_variable_cube(
-            data,
-            "wind_speed",
-            "m s-1",
-            "equalarea",
-        )
+        self.cube = set_up_variable_cube(data, "wind_speed", "m s-1", "equalarea",)
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_y_dimension(self):
@@ -100,12 +95,7 @@ class Test_calculate_difference(IrisTest):
     def setUp(self):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
-        self.cube = set_up_variable_cube(
-            data,
-            "wind_speed",
-            "m s-1",
-            "equalarea",
-        )
+        self.cube = set_up_variable_cube(data, "wind_speed", "m s-1", "equalarea",)
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_x_dimension(self):
@@ -128,8 +118,7 @@ class Test_calculate_difference(IrisTest):
 
     def test_missing_data(self):
         """Test that the result is as expected when data is missing."""
-        data = np.array([[1, 2, 3], [np.nan, 4, 6], [5, 10, 15]],
-                        dtype=np.float32)
+        data = np.array([[1, 2, 3], [np.nan, 4, 6], [5, 10, 15]], dtype=np.float32)
         self.cube.data = data
         expected = np.array([[np.nan, 2, 3], [np.nan, 6, 9]])
         result = self.plugin.calculate_difference(
@@ -161,11 +150,7 @@ class Test_process(IrisTest):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
         self.cube = set_up_variable_cube(
-            data,
-            "wind_speed",
-            "m s-1",
-            "equalarea",
-            realizations=np.array([1, 2]),
+            data, "wind_speed", "m s-1", "equalarea", realizations=np.array([1, 2]),
         )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
@@ -206,11 +191,7 @@ class Test_process(IrisTest):
         expected_x = np.array([[[1, 1], [2, 2], [5, 5]], [[1, 1], [0, 4], [5, 10]]])
         expected_y = np.array([[[1, 2, 3], [3, 6, 9]], [[1, 0, 3], [3, 8, 14]]])
         cube = set_up_variable_cube(
-            data,
-            "wind_speed",
-            "m s-1",
-            "equalarea",
-            realizations=np.array([1, 2]),
+            data, "wind_speed", "m s-1", "equalarea", realizations=np.array([1, 2]),
         )
         result = self.plugin.process(cube)
         self.assertIsInstance(result[0], iris.cube.Cube)

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -63,7 +63,7 @@ class Test_create_difference_cube(IrisTest):
         )
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.coord(axis="y").points, expected_y)
-        self.assertArrayAlmostEqual(result.data, self.diff_in_y_array)
+        self.assertArrayEqual(result.data, self.diff_in_y_array)
 
     def test_x_dimension(self):
         """Test differences calculated along the x dimension."""
@@ -75,7 +75,7 @@ class Test_create_difference_cube(IrisTest):
         )
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.coord(axis="x").points, expected_x)
-        self.assertArrayAlmostEqual(result.data, diff_array)
+        self.assertArrayEqual(result.data, diff_array)
 
     def test_othercoords(self):
         """Test that other coords are transferred properly"""
@@ -105,7 +105,7 @@ class Test_calculate_difference(IrisTest):
             self.cube, self.cube.coord(axis="x").name()
         )
         self.assertIsInstance(result, np.ndarray)
-        self.assertArrayAlmostEqual(result, expected)
+        self.assertArrayEqual(result, expected)
 
     def test_y_dimension(self):
         """Test differences calculated along the y dimension."""
@@ -114,7 +114,7 @@ class Test_calculate_difference(IrisTest):
             self.cube, self.cube.coord(axis="y").name()
         )
         self.assertIsInstance(result, np.ndarray)
-        self.assertArrayAlmostEqual(result, expected)
+        self.assertArrayEqual(result, expected)
 
     def test_missing_data(self):
         """Test that the result is as expected when data is missing."""
@@ -161,9 +161,9 @@ class Test_process(IrisTest):
         expected_y = np.array([[1, 2, 3], [3, 6, 9]])
         result = self.plugin.process(self.cube)
         self.assertIsInstance(result[0], Cube)
-        self.assertArrayAlmostEqual(result[0].data, expected_x)
+        self.assertArrayEqual(result[0].data, expected_x)
         self.assertIsInstance(result[1], Cube)
-        self.assertArrayAlmostEqual(result[1].data, expected_y)
+        self.assertArrayEqual(result[1].data, expected_y)
 
     def test_metadata(self):
         """Test the resulting metadata is correct."""
@@ -195,9 +195,9 @@ class Test_process(IrisTest):
         )
         result = self.plugin.process(cube)
         self.assertIsInstance(result[0], iris.cube.Cube)
-        self.assertArrayAlmostEqual(result[0].data, expected_x)
+        self.assertArrayEqual(result[0].data, expected_x)
         self.assertIsInstance(result[1], iris.cube.Cube)
-        self.assertArrayAlmostEqual(result[1].data, expected_y)
+        self.assertArrayEqual(result[1].data, expected_y)
 
 
 if __name__ == "__main__":

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -32,15 +32,15 @@
 
 import unittest
 
-import numpy as np
-from numpy import ma
-
 import iris
-from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
-from improver_tests.set_up_test_cubes import set_up_variable_cube
+import numpy as np
 from iris.coords import CellMethod
 from iris.cube import Cube
 from iris.tests import IrisTest
+from numpy import ma
+
+from improver.utilities.spatial import DifferenceBetweenAdjacentGridSquares
+from improver_tests.set_up_test_cubes import set_up_variable_cube
 
 
 class Test_create_difference_cube(IrisTest):

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -31,6 +31,7 @@
 """Unit tests for the utilities.OccurrenceWithinVicinity plugin."""
 
 import unittest
+import datetime
 
 import numpy as np
 from iris.cube import Cube
@@ -58,7 +59,8 @@ class Test_maximum_within_vicinity(IrisTest):
     def setUp(self):
         """Set up distance."""
         self.distance = 2000
-        grid_values = np.arange(0.0, 10000.0, 2000.0)
+        grid_values = np.arange(0.0, 10000.0, 2000.0,
+            dtype=np.float32)
         self.cube = set_up_variable_cube(
             np.zeros((5, 5), dtype=np.float32), spatial_grid="equalarea"
         )
@@ -157,8 +159,10 @@ class Test_process(IrisTest):
     def setUp(self):
         """Set up distance."""
         self.distance = 2000
-        coords = np.array([0.0, 2000.0, 4000.0, 6000.0])
-        self.timesteps = np.array([402192.5, 402195.5], dtype=np.float32)
+        coords = np.array([0.0, 2000.0, 4000.0, 6000.0],
+            dtype=np.float32)
+        self.timesteps = [datetime.datetime(2017, 11, 9, 12),
+            datetime.datetime(2017, 11, 9, 15)]
         self.cube = set_up_variable_cube(
             np.zeros((2, 4, 4), dtype=np.float32),
             "lwe_precipitation_rate",
@@ -203,7 +207,13 @@ class Test_process(IrisTest):
                 ],
             ]
         )
-        cube = add_coordinate(self.cube, self.timesteps, "time", order=[1, 0, 2, 3])
+        cube = add_coordinate(
+            self.cube,
+            self.timesteps,
+            "time",
+            order=[1, 0, 2, 3],
+            is_datetime=True,
+        )
         cube.data[0, 0, 2, 1] = 1.0
         cube.data[1, 1, 1, 3] = 1.0
         orig_shape = cube.data.copy().shape
@@ -257,7 +267,12 @@ class Test_process(IrisTest):
             ]
         )
         cube = self.cube[0]
-        cube = add_coordinate(cube, self.timesteps, "time",)
+        cube = add_coordinate(
+            cube,
+            self.timesteps,
+            "time",
+            is_datetime=True,
+        )
         cube.data[0, 2, 1] = 1.0
         cube.data[1, 1, 3] = 1.0
         orig_shape = cube.data.shape

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -32,7 +32,6 @@
 
 import unittest
 
-import iris
 import numpy as np
 from iris.cube import Cube
 from iris.tests import IrisTest

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -36,8 +36,7 @@ import numpy as np
 
 import iris
 from improver.utilities.spatial import OccurrenceWithinVicinity
-from improver_tests.set_up_test_cubes import (add_coordinate,
-                                              set_up_variable_cube)
+from improver_tests.set_up_test_cubes import add_coordinate, set_up_variable_cube
 from iris.cube import Cube
 from iris.tests import IrisTest
 
@@ -50,13 +49,9 @@ def set_up_cube():
         "lwe_precipitation_rate",
         "m s-1",
         "equalarea",
-        )
-    cube = add_coordinate(
-        cube,
-        timestep,
-        "time",
     )
-    cube = iris.util.new_axis(cube, 'time')
+    cube = add_coordinate(cube, timestep, "time",)
+    cube = iris.util.new_axis(cube, "time")
     cube.transpose([1, 0, 2, 3])
     return cube
 
@@ -99,8 +94,8 @@ class Test_maximum_within_vicinity(IrisTest):
         cube = set_up_cube()
         cube.data = data
         cube = cube[0, 0, :, :]
-        cube.coord('projection_y_coordinate').points = self.grid_values
-        cube.coord('projection_x_coordinate').points = self.grid_values
+        cube.coord("projection_y_coordinate").points = self.grid_values
+        cube.coord("projection_x_coordinate").points = self.grid_values
         result = OccurrenceWithinVicinity(self.distance).maximum_within_vicinity(cube)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.data, expected)
@@ -123,8 +118,8 @@ class Test_maximum_within_vicinity(IrisTest):
         cube = set_up_cube()
         cube.data = data
         cube = cube[0, 0, :, :]
-        cube.coord('projection_y_coordinate').points = self.grid_values
-        cube.coord('projection_x_coordinate').points = self.grid_values
+        cube.coord("projection_y_coordinate").points = self.grid_values
+        cube.coord("projection_x_coordinate").points = self.grid_values
         result = OccurrenceWithinVicinity(self.distance).maximum_within_vicinity(cube)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.data, expected)
@@ -147,8 +142,8 @@ class Test_maximum_within_vicinity(IrisTest):
         cube = set_up_cube()
         cube.data = data
         cube = cube[0, 0, :, :]
-        cube.coord('projection_y_coordinate').points = self.grid_values
-        cube.coord('projection_x_coordinate').points = self.grid_values
+        cube.coord("projection_y_coordinate").points = self.grid_values
+        cube.coord("projection_x_coordinate").points = self.grid_values
         distance = 4000.0
         result = OccurrenceWithinVicinity(distance).maximum_within_vicinity(cube)
         self.assertIsInstance(result, Cube)
@@ -175,8 +170,8 @@ class Test_maximum_within_vicinity(IrisTest):
         cube = set_up_cube()
         cube.data = masked_data
         cube = cube[0, 0, :, :]
-        cube.coord('projection_y_coordinate').points = self.grid_values
-        cube.coord('projection_x_coordinate').points = self.grid_values
+        cube.coord("projection_y_coordinate").points = self.grid_values
+        cube.coord("projection_x_coordinate").points = self.grid_values
         result = OccurrenceWithinVicinity(self.distance).maximum_within_vicinity(cube)
         self.assertIsInstance(result, Cube)
         self.assertIsInstance(result.data, np.ma.core.MaskedArray)
@@ -238,15 +233,10 @@ class Test_process(IrisTest):
             "m s-1",
             "equalarea",
         )
-        cube = add_coordinate(
-            cube,
-            self.timesteps,
-            "time",
-            order=[1, 0, 2, 3],
-        )
+        cube = add_coordinate(cube, self.timesteps, "time", order=[1, 0, 2, 3],)
         cube.data = data
-        cube.coord('projection_y_coordinate').points = self.coords
-        cube.coord('projection_x_coordinate').points = self.coords
+        cube.coord("projection_y_coordinate").points = self.coords
+        cube.coord("projection_x_coordinate").points = self.coords
         orig_shape = cube.data.copy().shape
         result = OccurrenceWithinVicinity(self.distance)(cube)
         self.assertIsInstance(result, Cube)
@@ -282,8 +272,8 @@ class Test_process(IrisTest):
             "equalarea",
         )
         cube.data = data
-        cube.coord('projection_y_coordinate').points = self.coords
-        cube.coord('projection_x_coordinate').points = self.coords
+        cube.coord("projection_y_coordinate").points = self.coords
+        cube.coord("projection_x_coordinate").points = self.coords
         result = OccurrenceWithinVicinity(self.distance)(cube)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.data, expected)
@@ -315,14 +305,10 @@ class Test_process(IrisTest):
             "lwe_precipitation_rate",
             "m s-1",
             "equalarea",
-            )
-        cube = add_coordinate(
-            cube,
-            self.timesteps,
-            "time",
         )
-        cube.coord('projection_y_coordinate').points = self.coords
-        cube.coord('projection_x_coordinate').points = self.coords
+        cube = add_coordinate(cube, self.timesteps, "time",)
+        cube.coord("projection_y_coordinate").points = self.coords
+        cube.coord("projection_x_coordinate").points = self.coords
         cube.data = data
         orig_shape = cube.data.shape
         result = OccurrenceWithinVicinity(self.distance)(cube)
@@ -344,13 +330,10 @@ class Test_process(IrisTest):
         data = np.zeros((4, 4), dtype=np.float32)
         data[2, 1] = 1.0
         cube = set_up_variable_cube(
-            data,
-            "lwe_precipitation_rate",
-            "m s-1",
-            "equalarea",
+            data, "lwe_precipitation_rate", "m s-1", "equalarea",
         )
-        cube.coord('projection_y_coordinate').points = self.coords
-        cube.coord('projection_x_coordinate').points = self.coords
+        cube.coord("projection_y_coordinate").points = self.coords
+        cube.coord("projection_x_coordinate").points = self.coords
         cube = iris.util.squeeze(cube)
         orig_shape = cube.data.shape
         result = OccurrenceWithinVicinity(self.distance)(cube)

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -32,22 +32,18 @@
 
 import unittest
 
-import iris
 import numpy as np
-from cf_units import Unit
-from iris.coords import DimCoord
+
+import iris
+from improver.utilities.spatial import OccurrenceWithinVicinity
+from improver_tests.set_up_test_cubes import (add_coordinate,
+                                              set_up_variable_cube)
 from iris.cube import Cube
 from iris.tests import IrisTest
 
-from improver.utilities.spatial import OccurrenceWithinVicinity
-
-from improver_tests.set_up_test_cubes import (
-    add_coordinate,
-    set_up_variable_cube,
-)
-
 
 def set_up_cube():
+    """Sets up a standard cube for the tests."""
     timestep = np.array([402192.5])
     cube = set_up_variable_cube(
         np.zeros((1, 5, 5), dtype=np.float32),
@@ -60,7 +56,7 @@ def set_up_cube():
         timestep,
         "time",
     )
-    cube = iris.util.new_axis(cube, 'time')   
+    cube = iris.util.new_axis(cube, 'time')
     cube.transpose([1, 0, 2, 3])
     return cube
 
@@ -128,7 +124,7 @@ class Test_maximum_within_vicinity(IrisTest):
         cube.data = data
         cube = cube[0, 0, :, :]
         cube.coord('projection_y_coordinate').points = self.grid_values
-        cube.coord('projection_x_coordinate').points = self.grid_values        
+        cube.coord('projection_x_coordinate').points = self.grid_values
         result = OccurrenceWithinVicinity(self.distance).maximum_within_vicinity(cube)
         self.assertIsInstance(result, Cube)
         self.assertArrayAlmostEqual(result.data, expected)
@@ -152,7 +148,7 @@ class Test_maximum_within_vicinity(IrisTest):
         cube.data = data
         cube = cube[0, 0, :, :]
         cube.coord('projection_y_coordinate').points = self.grid_values
-        cube.coord('projection_x_coordinate').points = self.grid_values 
+        cube.coord('projection_x_coordinate').points = self.grid_values
         distance = 4000.0
         result = OccurrenceWithinVicinity(distance).maximum_within_vicinity(cube)
         self.assertIsInstance(result, Cube)
@@ -196,7 +192,7 @@ class Test_process(IrisTest):
         """Set up distance."""
         self.distance = 2000
         self.coords = np.array([0.0, 2000.0, 4000.0, 6000.0])
-        self.timesteps = np.array([402192.5, 402195.5], dtype = np.float32)
+        self.timesteps = np.array([402192.5, 402195.5], dtype=np.float32)
 
     def test_with_multiple_realizations_and_times(self):
         """Test for multiple realizations and times, so that multiple
@@ -237,7 +233,7 @@ class Test_process(IrisTest):
         data[0, 0, 2, 1] = 1.0
         data[1, 1, 1, 3] = 1.0
         cube = set_up_variable_cube(
-            np.zeros((2, 4, 4), dtype = np.float32),
+            np.zeros((2, 4, 4), dtype=np.float32),
             "lwe_precipitation_rate",
             "m s-1",
             "equalarea",
@@ -246,7 +242,7 @@ class Test_process(IrisTest):
             cube,
             self.timesteps,
             "time",
-            order = [1, 0, 2, 3],
+            order=[1, 0, 2, 3],
         )
         cube.data = data
         cube.coord('projection_y_coordinate').points = self.coords
@@ -276,11 +272,11 @@ class Test_process(IrisTest):
                 ],
             ]
         )
-        data = np.zeros((2, 4, 4), dtype = np.float32)
+        data = np.zeros((2, 4, 4), dtype=np.float32)
         data[0, 2, 1] = 1.0
         data[1, 1, 3] = 1.0
         cube = set_up_variable_cube(
-            np.zeros((2, 4, 4), dtype = np.float32),
+            np.zeros((2, 4, 4), dtype=np.float32),
             "lwe_precipitation_rate",
             "m s-1",
             "equalarea",
@@ -311,11 +307,11 @@ class Test_process(IrisTest):
                 ],
             ]
         )
-        data = np.zeros((2, 4, 4), dtype = np.float32)
-        data[ 0, 2, 1] = 1.0
+        data = np.zeros((2, 4, 4), dtype=np.float32)
+        data[0, 2, 1] = 1.0
         data[1, 1, 3] = 1.0
         cube = set_up_variable_cube(
-            np.zeros((4, 4), dtype = np.float32),
+            np.zeros((4, 4), dtype=np.float32),
             "lwe_precipitation_rate",
             "m s-1",
             "equalarea",
@@ -345,7 +341,7 @@ class Test_process(IrisTest):
                 [1.0, 1.0, 1.0, 0.0],
             ]
         )
-        data = np.zeros((4, 4), dtype = np.float32)
+        data = np.zeros((4, 4), dtype=np.float32)
         data[2, 1] = 1.0
         cube = set_up_variable_cube(
             data,

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -30,8 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for the utilities.OccurrenceWithinVicinity plugin."""
 
-import unittest
 import datetime
+import unittest
 
 import numpy as np
 from iris.cube import Cube
@@ -59,8 +59,7 @@ class Test_maximum_within_vicinity(IrisTest):
     def setUp(self):
         """Set up distance."""
         self.distance = 2000
-        grid_values = np.arange(0.0, 10000.0, 2000.0,
-            dtype=np.float32)
+        grid_values = np.arange(0.0, 10000.0, 2000.0, dtype=np.float32)
         self.cube = set_up_variable_cube(
             np.zeros((5, 5), dtype=np.float32), spatial_grid="equalarea"
         )
@@ -159,10 +158,11 @@ class Test_process(IrisTest):
     def setUp(self):
         """Set up distance."""
         self.distance = 2000
-        coords = np.array([0.0, 2000.0, 4000.0, 6000.0],
-            dtype=np.float32)
-        self.timesteps = [datetime.datetime(2017, 11, 9, 12),
-            datetime.datetime(2017, 11, 9, 15)]
+        coords = np.array([0.0, 2000.0, 4000.0, 6000.0], dtype=np.float32)
+        self.timesteps = [
+            datetime.datetime(2017, 11, 9, 12),
+            datetime.datetime(2017, 11, 9, 15),
+        ]
         self.cube = set_up_variable_cube(
             np.zeros((2, 4, 4), dtype=np.float32),
             "lwe_precipitation_rate",
@@ -208,11 +208,7 @@ class Test_process(IrisTest):
             ]
         )
         cube = add_coordinate(
-            self.cube,
-            self.timesteps,
-            "time",
-            order=[1, 0, 2, 3],
-            is_datetime=True,
+            self.cube, self.timesteps, "time", order=[1, 0, 2, 3], is_datetime=True,
         )
         cube.data[0, 0, 2, 1] = 1.0
         cube.data[1, 1, 1, 3] = 1.0
@@ -267,12 +263,7 @@ class Test_process(IrisTest):
             ]
         )
         cube = self.cube[0]
-        cube = add_coordinate(
-            cube,
-            self.timesteps,
-            "time",
-            is_datetime=True,
-        )
+        cube = add_coordinate(cube, self.timesteps, "time", is_datetime=True,)
         cube.data[0, 2, 1] = 1.0
         cube.data[1, 1, 3] = 1.0
         orig_shape = cube.data.shape

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -32,13 +32,13 @@
 
 import unittest
 
-import numpy as np
-
 import iris
-from improver.utilities.spatial import OccurrenceWithinVicinity
-from improver_tests.set_up_test_cubes import add_coordinate, set_up_variable_cube
+import numpy as np
 from iris.cube import Cube
 from iris.tests import IrisTest
+
+from improver.utilities.spatial import OccurrenceWithinVicinity
+from improver_tests.set_up_test_cubes import add_coordinate, set_up_variable_cube
 
 
 class Test__repr__(IrisTest):

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -245,19 +245,13 @@ class Test_weather_code_attributes(IrisTest):
         data = np.array(
             [0, 1, 5, 11, 20, 5, 9, 10, 4, 2, 0, 1, 29, 30, 1, 5, 6, 6], dtype=np.int32
         ).reshape((2, 3, 3))
-        cube = set_up_variable_cube(
-            data,
-            "weather_code",
-            "1",
-        )
-        date_times = [datetime.datetime(2017, 11, 19, 0, 30),
-            datetime.datetime(2017, 11, 19, 1, 30)]
+        cube = set_up_variable_cube(data, "weather_code", "1",)
+        date_times = [
+            datetime.datetime(2017, 11, 19, 0, 30),
+            datetime.datetime(2017, 11, 19, 1, 30),
+        ]
         self.cube = add_coordinate(
-            cube,
-            date_times,
-            "time",
-            is_datetime=True,
-            order = [1, 0, 2, 3],
+            cube, date_times, "time", is_datetime=True, order=[1, 0, 2, 3],
         )
         self.wxcode = np.array(list(WX_DICT.keys()))
         self.wxmeaning = " ".join(WX_DICT.values())

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -57,7 +57,10 @@ from improver.wxcode.utilities import (
     weather_code_attributes,
 )
 
-from ...calibration.ensemble_calibration.helper_functions import set_up_cube
+from improver_tests.set_up_test_cubes import (
+    add_coordinate,
+    set_up_variable_cube,
+)
 
 
 def datetime_to_numdateval(year=2018, month=9, day=12, hour=5, minutes=43):
@@ -241,9 +244,20 @@ class Test_weather_code_attributes(IrisTest):
         """Set up cube """
         data = np.array(
             [0, 1, 5, 11, 20, 5, 9, 10, 4, 2, 0, 1, 29, 30, 1, 5, 6, 6], dtype=np.int32
-        ).reshape((2, 1, 3, 3))
-        self.cube = set_up_cube(
-            data, "weather_code", "1", realizations=np.array([0, 1], dtype=np.int32)
+        ).reshape((2, 3, 3))
+        cube = set_up_variable_cube(
+            data,
+            "weather_code",
+            "1",
+        )
+        date_times = [datetime.datetime(2017, 11, 19, 0, 30),
+            datetime.datetime(2017, 11, 19, 1, 30)]
+        self.cube = add_coordinate(
+            cube,
+            date_times,
+            "time",
+            is_datetime=True,
+            order = [1, 0, 2, 3],
         )
         self.wxcode = np.array(list(WX_DICT.keys()))
         self.wxmeaning = " ".join(WX_DICT.values())

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -56,11 +56,7 @@ from improver.wxcode.utilities import (
     update_daynight,
     weather_code_attributes,
 )
-
-from improver_tests.set_up_test_cubes import (
-    add_coordinate,
-    set_up_variable_cube,
-)
+from improver_tests.set_up_test_cubes import add_coordinate, set_up_variable_cube
 
 
 def datetime_to_numdateval(year=2018, month=9, day=12, hour=5, minutes=43):


### PR DESCRIPTION
Addresses #GitHubissuenum

Description
I changed a variety of unit tests to use the set_up_cubes.py code. However there is still a bug in test_DiagnoseConvectivePrecipitation.py. I have put comments in the code to try and explain what is happening. I don't think it is an IMPROVER issue right now.  

Testing:
 - [ ] Ran tests and they passed OK (mostly)
 - [x] Added new tests for the new feature(s)

There is a ValueError for one of the unit tests in test_DiagnoseConvectivePrecipitation which says "ValueError: 'time' is not in list"
