### PR TITLE
Modify set_up_test_cubes.py to allow for grid setup to be specified

### DIFF
--- a/improver/grids.py
+++ b/improver/grids.py
@@ -46,3 +46,19 @@ STANDARD_GRID_CCRS = LambertAzimuthalEqualArea(
     false_northing=0.0,
     ellipsoid=ELLIPSOID,
 )
+
+# Metadata for different spatial grids
+GRID_COORD_ATTRIBUTES = {
+    "latlon": {
+        "xname": "longitude",
+        "yname": "latitude",
+        "units": "degrees",
+        "coord_system": GLOBAL_GRID_CCRS,
+    },
+    "equalarea": {
+        "xname": "projection_x_coordinate",
+        "yname": "projection_y_coordinate",
+        "units": "metres",
+        "coord_system": STANDARD_GRID_CCRS,
+    },
+}

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -323,7 +323,7 @@ def set_up_variable_cube(
             Grid resolution (degrees for latlon or metres for equalarea).
         domain_corner (Optional[List[int] or List[float]]):
             Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea).
-    
+
     Returns:
         iris.cube.Cube:
             Cube containing a single variable field
@@ -414,7 +414,7 @@ def set_up_percentile_cube(
             first dimension on the input data cube
         **kwargs:
             Additional keyword arguments passed to 'set_up_variable_cube' function
-    
+
     Returns:
         iris.cube.Cube:
             Cube containing percentiles
@@ -460,7 +460,7 @@ def set_up_probability_cube(
             required for IMPROVER probability cubes.
         **kwargs:
             Additional keyword arguments passed to 'set_up_variable_cube' function
-    
+
     Returns:
         iris.cube.Cube:
             Cube containing probabilities at thresholds

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -63,9 +63,9 @@ def construct_xy_coords(
         spatial_grid (str):
             Specifier to produce either a "latlon" or "equalarea" grid
         grid_spacing (int or float):
-            Grid resolution (degrees or m).
+            Grid resolution (degrees or metres).
         domain_corner (list of int or float):
-            Bottom left corner of grid domain (degrees or m).
+            Bottom left corner of grid domain [y,x] (degrees or metres).
 
     Returns:
         y_coord, x_coord (tuple):
@@ -75,9 +75,9 @@ def construct_xy_coords(
 
     if grid_spacing is not None:
         if domain_corner is None:
-            x_start = 0 - ((xpoints - 1) * grid_spacing) / 2
             y_start = 0 - ((ypoints - 1) * grid_spacing) / 2
-            domain_corner = [x_start, y_start]
+            x_start = 0 - ((xpoints - 1) * grid_spacing) / 2
+            domain_corner = [y_start, x_start]
 
         y_array, x_array = _create_y_x_arrays(
             ypoints, xpoints, domain_corner, grid_spacing
@@ -107,7 +107,7 @@ def construct_xy_coords(
         # use UK eastings and northings on standard grid
         # round grid spacing to nearest integer to avoid precision issues
         if domain_corner is None and grid_spacing is None:
-            domain_corner = [-400000, -100000]
+            domain_corner = [-100000, -400000]
             grid_spacing = np.around(1000000.0 / ypoints)
 
             y_array, x_array = _create_y_x_arrays(
@@ -134,7 +134,7 @@ def construct_xy_coords(
 
 def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
     """
-    Creates arrays for constructing x and y DimCoords.
+    Creates arrays for constructing y and x DimCoords.
 
     Args:
         ypoints (int):
@@ -142,16 +142,16 @@ def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
         xpoints (int):
             Number of grid points required along the x-axis
         domain_corner (list of int or float):
-            Bottom left corner of grid domain (degrees or m)
+            Bottom left corner of grid domain [y,x] (degrees or metres)
         grid_spacing (int or float):
-            Grid resolution (degrees or m)
+            Grid resolution (degrees or metres)
 
     Returns:
         y_coord, x_coord (tuple):
             Tuple of numpy.ndarrays
     """
-    y_points_array = [domain_corner[1] + i * grid_spacing for i in range(ypoints)]
-    x_points_array = [domain_corner[0] + i * grid_spacing for i in range(xpoints)]
+    y_points_array = [domain_corner[0] + i * grid_spacing for i in range(ypoints)]
+    x_points_array = [domain_corner[1] + i * grid_spacing for i in range(xpoints)]
     y_array = np.array(y_points_array, dtype=np.float32)
     x_array = np.array(x_points_array, dtype=np.float32)
 
@@ -285,9 +285,9 @@ def set_up_variable_cube(
             Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
             'gl_det' or 'gl_ens'.
         grid_spacing (int or float):
-            Grid resolution (degrees or m).
+            Grid resolution (degrees or metres).
         domain_corner (list of int or float):
-            Bottom left corner of grid domain (degrees or m).
+            Bottom left corner of grid domain [y,x] (degrees or metres).
     """
     # construct spatial dimension coordimates
     ypoints = data.shape[-2]

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -141,10 +141,10 @@ def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
             Number of grid points required along the y-axis
         xpoints (int):
             Number of grid points required along the x-axis
-        domain_corner (str):
-            Bottom left corner of domain grid (degrees or m)
-        grid_spacing ():
-            Resolution of grid (degrees or m)
+        domain_corner (list of int or float):
+            Bottom left corner of grid domain (degrees or m)
+        grid_spacing (int or float):
+            Grid resolution (degrees or m)
 
     Returns:
         y_coord, x_coord (tuple):
@@ -288,7 +288,6 @@ def set_up_variable_cube(
             Grid resolution (degrees or m).
         domain_corner (list of int or float):
             Bottom left corner of grid domain (degrees or m).
-
     """
     # construct spatial dimension coordimates
     ypoints = data.shape[-2]

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -62,9 +62,9 @@ def construct_yx_coords(
             Number of grid points required along the x-axis
         spatial_grid (str):
             Specifier to produce either a "latlon" or "equalarea" grid
-        grid_spacing (Optional[int or float]):
+        grid_spacing (Optional[float]):
             Grid resolution (degrees for latlon or metres for equalarea).
-        domain_corner (Optional[Tuple[int, int] or Tuple[float, float]]):
+        domain_corner (Optional[Tuple[float, float]]):
             Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea). If not
             provided, a grid is created centred around (0,0).
 
@@ -107,16 +107,6 @@ def _create_yx_arrays(ypoints, xpoints, domain_corner, grid_spacing):
     """
     Creates arrays for constructing y and x DimCoords.
 
-    Args:
-        ypoints (int):
-            Number of grid points required along the y-axis
-        xpoints (int):
-            Number of grid points required along the x-axis
-        domain_corner (Tuple[int, int] or Tuple[float, float]):
-            Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea)
-        grid_spacing (int or float):
-            Grid resolution (degrees for latlon or metres for equalarea)
-
     Returns:
         Tuple[numpy.ndarray, numpy.ndarray]:
             Tuple containing arrays of y and x coordinate values
@@ -133,16 +123,8 @@ def _set_domain_corner(ypoints, xpoints, grid_spacing):
     """
     Set domain corner to create a grid around 0,0.
 
-    Args:
-        ypoints (int):
-            Number of grid points required along the y-axis
-        xpoints (int):
-            Number of grid points required along the x-axis
-        grid_spacing (int or float):
-            Grid resolution (degrees for latlon or metres for equalarea).
-
     Returns:
-        Tuple[int, int] or Tuple[float, float]:
+        Tuple[float, float]:
             (y,x) values of the bottom left corner of the domain
     """
     y_start = 0 - ((ypoints - 1) * grid_spacing) / 2
@@ -154,14 +136,6 @@ def _set_domain_corner(ypoints, xpoints, grid_spacing):
 def _default_grid(ypoints, xpoints, spatial_grid):
     """
     Create default grid.
-
-    Args:
-        ypoints (int):
-            Number of grid points required along the y-axis
-        xpoints (int):
-            Number of grid points required along the x-axis
-        spatial_grid (str):
-            Specifier to produce either a "latlon" or "equalarea" grid
 
     Returns:
         Tuple[numpy.ndarray, numpy.ndarray]:
@@ -192,9 +166,6 @@ def _create_time_point(time):
     """Returns a coordinate point with appropriate units and datatype
     from a datetime.datetime instance.
 
-    Args:
-        time (datetime.datetime)
-
     Returns:
         Any:
             Returns coordinate point as datatype specified in TIME_COORDS["time"]
@@ -211,7 +182,7 @@ def construct_scalar_time_coords(time, time_bounds, frt):
     Args:
         time (datetime.datetime):
             Single time point
-        time_bounds (Tuple[datetime.datetime, datetime.datetime] or List[datetime.datetime] or None):
+        time_bounds (Sequence[datetime.datetime] or None):
             Lower and upper bound on time point, if required
         frt (datetime.datetime):
             Single forecast reference time point
@@ -303,7 +274,7 @@ def set_up_variable_cube(
             "latlon" or "equalarea".
         time (Optional[datetime.datetime]):
             Single cube validity time
-        time_bounds (Optional[Tuple[datetime.datetime, datetime.datetime] or List[datetime.datetime]]):
+        time_bounds (Optional[Sequence[datetime.datetime]]):
             Lower and upper bound on time point, if required
         frt (Optional[datetime.datetime]):
             Single cube forecast reference time
@@ -318,9 +289,9 @@ def set_up_variable_cube(
             Recognised mosg__model_configuration for which to set up Met
             Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
             'gl_det' or 'gl_ens'.
-        grid_spacing (Optional[int or float]):
+        grid_spacing (Optional[float]):
             Grid resolution (degrees for latlon or metres for equalarea).
-        domain_corner (Optional[Tuple[int, int] or Tuple[float, float]]):
+        domain_corner (Optional[Tuple[float, float]]):
             Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea).
 
     Returns:
@@ -408,7 +379,7 @@ def set_up_percentile_cube(
     Args:
         data (numpy.ndarray):
             3D (percentile-y-x ordered) array of data to put into the cube
-        percentiles (List[int] or List[float] or numpy.ndarray):
+        percentiles (List[float] or numpy.ndarray):
             List of int / float percentile values whose length must match the
             first dimension on the input data cube
         **kwargs:
@@ -446,7 +417,7 @@ def set_up_probability_cube(
     Args:
         data (numpy.ndarray):
             3D (threshold-y-x ordered) array of data to put into the cube
-        thresholds (List[int] or List[float] or numpy.ndarray):
+        thresholds (List[float] or numpy.ndarray):
             List of int / float threshold values whose length must match the
             first dimension on the input data cube
         variable_name (Optional[str]):

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -134,7 +134,7 @@ def construct_xy_coords(
 
 def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
     """
-    Creates arrays for 
+    Creates arrays for constructing x and y DimCoords.
 
     Args:
         ypoints (int):
@@ -148,7 +148,7 @@ def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
 
     Returns:
         y_coord, x_coord (tuple):
-            Tuple of iris.coords.DimCoord instances
+            Tuple of numpy.ndarrays
     """
     y_points_array = [domain_corner[1] + i * grid_spacing for i in range(ypoints)]
     x_points_array = [domain_corner[0] + i * grid_spacing for i in range(xpoints)]

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -49,11 +49,11 @@ from improver.metadata.constants.time_types import TIME_COORDS
 from improver.metadata.forecast_times import forecast_period_coord
 
 
-def construct_xy_coords(
+def construct_yx_coords(
     ypoints, xpoints, spatial_grid, grid_spacing=None, domain_corner=None
 ):
     """
-    Construct x/y spatial dimension coordinates
+    Construct y/x spatial dimension coordinates
 
     Args:
         ypoints (int):
@@ -83,7 +83,7 @@ def construct_xy_coords(
     else:
         if domain_corner is None:
             domain_corner = _set_domain_corner(ypoints, xpoints, grid_spacing)
-        y_array, x_array = _create_y_x_arrays(
+        y_array, x_array = _create_yx_arrays(
             ypoints, xpoints, domain_corner, grid_spacing
         )
 
@@ -103,7 +103,7 @@ def construct_xy_coords(
     return y_coord, x_coord
 
 
-def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
+def _create_yx_arrays(ypoints, xpoints, domain_corner, grid_spacing):
     """
     Creates arrays for constructing y and x DimCoords.
 
@@ -182,7 +182,7 @@ def _default_grid(ypoints, xpoints, spatial_grid):
         domain_corner = [-100000, -400000]
         grid_spacing = np.around(1000000.0 / ypoints)
 
-        y_array, x_array = _create_y_x_arrays(
+        y_array, x_array = _create_yx_arrays(
             ypoints, xpoints, domain_corner, grid_spacing
         )
     return y_array, x_array
@@ -330,7 +330,7 @@ def set_up_variable_cube(
     # construct spatial dimension coordimates
     ypoints = data.shape[-2]
     xpoints = data.shape[-1]
-    y_coord, x_coord = construct_xy_coords(
+    y_coord, x_coord = construct_yx_coords(
         ypoints,
         xpoints,
         spatial_grid,

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -64,8 +64,8 @@ def construct_xy_coords(
             Specifier to produce either a "latlon" or "equalarea" grid
         grid_spacing (Optional[int or float]):
             Grid resolution (degrees for latlon or metres for equalarea).
-        domain_corner (Optional[List[int] or List[float]]):
-            Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea). If not
+        domain_corner (Optional[Tuple[int, int] or Tuple[float, float]]):
+            Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea). If not
             provided, a grid is created centred around (0,0).
 
     Returns:
@@ -112,8 +112,8 @@ def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
             Number of grid points required along the y-axis
         xpoints (int):
             Number of grid points required along the x-axis
-        domain_corner (List[int] or List[float]):
-            Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea)
+        domain_corner (Tuple[int, int] or Tuple[float, float]):
+            Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea)
         grid_spacing (int or float):
             Grid resolution (degrees for latlon or metres for equalarea)
 
@@ -142,14 +142,13 @@ def _set_domain_corner(ypoints, xpoints, grid_spacing):
             Grid resolution (degrees for latlon or metres for equalarea).
 
     Returns:
-        List[int] or List[float]:
-            [y,x] values of the bottom left corner of the domain
+        Tuple[int, int] or Tuple[float, float]:
+            (y,x) values of the bottom left corner of the domain
     """
     y_start = 0 - ((ypoints - 1) * grid_spacing) / 2
     x_start = 0 - ((xpoints - 1) * grid_spacing) / 2
-    domain_corner = [y_start, x_start]
 
-    return domain_corner
+    return y_start, x_start
 
 
 def _default_grid(ypoints, xpoints, spatial_grid):
@@ -321,8 +320,8 @@ def set_up_variable_cube(
             'gl_det' or 'gl_ens'.
         grid_spacing (Optional[int or float]):
             Grid resolution (degrees for latlon or metres for equalarea).
-        domain_corner (Optional[List[int] or List[float]]):
-            Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea).
+        domain_corner (Optional[Tuple[int, int] or Tuple[float, float]]):
+            Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea).
 
     Returns:
         iris.cube.Cube:

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -63,9 +63,9 @@ def construct_xy_coords(
         spatial_grid (str):
             Specifier to produce either a "latlon" or "equalarea" grid
         grid_spacing (int or float):
-            Grid resolution (degrees or metres).
+            Grid resolution (degrees for latlon or metres for equalarea).
         domain_corner (list of int or float):
-            Bottom left corner of grid domain [y,x] (degrees or metres). If not
+            Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea). If not
             provided, a grid is created centred around (0,0).
 
     Returns:
@@ -113,9 +113,9 @@ def _create_y_x_arrays(ypoints, xpoints, domain_corner, grid_spacing):
         xpoints (int):
             Number of grid points required along the x-axis
         domain_corner (list of int or float):
-            Bottom left corner of grid domain [y,x] (degrees or metres)
+            Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea)
         grid_spacing (int or float):
-            Grid resolution (degrees or metres)
+            Grid resolution (degrees for latlon or metres for equalarea)
 
     Returns:
         y_array, x_array (tuple):
@@ -139,7 +139,7 @@ def _set_domain_corner(ypoints, xpoints, grid_spacing):
         xpoints (int):
             Number of grid points required along the x-axis
         grid_spacing (int or float):
-            Grid resolution (degrees or metres).
+            Grid resolution (degrees for latlon or metres for equalarea).
 
     Returns:
         domain_corner (list of int or float):
@@ -316,9 +316,9 @@ def set_up_variable_cube(
             Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
             'gl_det' or 'gl_ens'.
         grid_spacing (int or float):
-            Grid resolution (degrees or metres).
+            Grid resolution (degrees for latlon or metres for equalarea).
         domain_corner (list of int or float):
-            Bottom left corner of grid domain [y,x] (degrees or metres).
+            Bottom left corner of grid domain [y,x] (degrees for latlon or metres for equalarea).
     """
     # construct spatial dimension coordimates
     ypoints = data.shape[-2]

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -291,17 +291,7 @@ def set_up_variable_cube(
 
 
 def set_up_percentile_cube(
-    data,
-    percentiles,
-    name="air_temperature",
-    units="K",
-    spatial_grid="latlon",
-    time=datetime(2017, 11, 10, 4, 0),
-    time_bounds=None,
-    frt=datetime(2017, 11, 10, 0, 0),
-    include_scalar_coords=None,
-    attributes=None,
-    standard_grid_metadata=None,
+    data, percentiles, **kwargs,
 ):
     """
     Set up a cube containing percentiles of a variable with:
@@ -317,40 +307,8 @@ def set_up_percentile_cube(
         percentiles (list or numpy.ndarray):
             List of int / float percentile values whose length must match the
             first dimension on the input data cube
-        name (str):
-            Variable standard name
-        units (str):
-            Variable units
-        spatial_grid (str):
-            What type of x/y coordinate values to use.  Default is "latlon",
-            otherwise uses "projection_[x|y]_coordinate".
-        time (datetime.datetime):
-            Single cube validity time
-        time_bounds (Iterable[datetime.datetime]):
-            Lower and upper bound on time point, if required
-        frt (datetime.datetime):
-            Single cube forecast reference time
-        include_scalar_coords (list):
-            List of iris.coords.DimCoord or AuxCoord instances of length 1.
-        attributes (dict):
-            Optional cube attributes.
-        standard_grid_metadata (str):
-            Recognised mosg__model_configuration for which to set up Met
-            Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
-            'gl_det' or 'gl_ens'.
     """
-    cube = set_up_variable_cube(
-        data,
-        name=name,
-        units=units,
-        spatial_grid=spatial_grid,
-        time=time,
-        frt=frt,
-        realizations=percentiles,
-        attributes=attributes,
-        include_scalar_coords=include_scalar_coords,
-        standard_grid_metadata=standard_grid_metadata,
-    )
+    cube = set_up_variable_cube(data, realizations=percentiles, **kwargs,)
     cube.coord("realization").rename("percentile")
     cube.coord("percentile").units = Unit("%")
     return cube
@@ -362,13 +320,7 @@ def set_up_probability_cube(
     variable_name="air_temperature",
     threshold_units="K",
     spp__relative_to_threshold="above",
-    spatial_grid="latlon",
-    time=datetime(2017, 11, 10, 4, 0),
-    time_bounds=None,
-    frt=datetime(2017, 11, 10, 0, 0),
-    include_scalar_coords=None,
-    attributes=None,
-    standard_grid_metadata=None,
+    **kwargs,
 ):
     """
     Set up a cube containing probabilities at thresholds with:
@@ -392,26 +344,9 @@ def set_up_probability_cube(
             applies, eg "air_temperature".  NOT name of probability field.
         threshold_units (str):
             Units of the underlying variable / threshold.
-        spatial_grid (str):
-            What type of x/y coordinate values to use.  Default is "latlon",
-            otherwise uses "projection_[x|y]_coordinate".
         spp__relative_to_threshold (str):
             Value of the attribute "spp__relative_to_threshold" which is
             required for IMPROVER probability cubes.
-        time (datetime.datetime):
-            Single cube validity time
-        time_bounds (tuple or list of datetime.datetime instances):
-            Lower and upper bound on time point, if required
-        frt (datetime.datetime):
-            Single cube forecast reference time
-        include_scalar_coords (list):
-            List of iris.coords.DimCoord or AuxCoord instances of length 1.
-        attributes (dict):
-            Optional cube attributes.
-        standard_grid_metadata (str):
-            Recognised mosg__model_configuration for which to set up Met
-            Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
-            'gl_det' or 'gl_ens'.
     """
     # create a "relative to threshold" attribute
     coord_attributes = {"spp__relative_to_threshold": spp__relative_to_threshold}
@@ -428,17 +363,7 @@ def set_up_probability_cube(
         raise ValueError(msg)
 
     cube = set_up_variable_cube(
-        data,
-        name=name,
-        units="1",
-        spatial_grid=spatial_grid,
-        time=time,
-        frt=frt,
-        time_bounds=time_bounds,
-        realizations=thresholds,
-        attributes=attributes,
-        include_scalar_coords=include_scalar_coords,
-        standard_grid_metadata=standard_grid_metadata,
+        data, name=name, units="1", realizations=thresholds, **kwargs,
     )
     cube.coord("realization").rename(variable_name)
     cube.coord(variable_name).var_name = "threshold"

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -195,7 +195,7 @@ def _create_time_point(time):
 
     Args:
         time (datetime.datetime)
-    
+
     Returns:
         Any:
             Returns coordinate point as datatype specified in TIME_COORDS["time"]

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -111,10 +111,11 @@ def _create_yx_arrays(ypoints, xpoints, domain_corner, grid_spacing):
         Tuple[numpy.ndarray, numpy.ndarray]:
             Tuple containing arrays of y and x coordinate values
     """
-    y_points_array = [domain_corner[0] + i * grid_spacing for i in range(ypoints)]
-    x_points_array = [domain_corner[1] + i * grid_spacing for i in range(xpoints)]
-    y_array = np.array(y_points_array, dtype=np.float32)
-    x_array = np.array(x_points_array, dtype=np.float32)
+    y_stop = domain_corner[0] + (grid_spacing * ypoints)
+    x_stop = domain_corner[1] + (grid_spacing * xpoints)
+
+    y_array = np.arange(domain_corner[0], y_stop, grid_spacing, dtype=np.float32)
+    x_array = np.arange(domain_corner[1], x_stop, grid_spacing, dtype=np.float32)
 
     return y_array, x_array
 

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -65,7 +65,8 @@ def construct_xy_coords(
         grid_spacing (int or float):
             Grid resolution (degrees or metres).
         domain_corner (list of int or float):
-            Bottom left corner of grid domain [y,x] (degrees or metres).
+            Bottom left corner of grid domain [y,x] (degrees or metres). If not
+            provided, a grid is created centred around (0,0).
 
     Returns:
         y_coord, x_coord (tuple):

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -373,6 +373,8 @@ def set_up_percentile_cube(
         percentiles (list or numpy.ndarray):
             List of int / float percentile values whose length must match the
             first dimension on the input data cube
+        **kwargs:
+            Additional keyword arguments passed to 'set_up_variable_cube' function
     """
     cube = set_up_variable_cube(data, realizations=percentiles, **kwargs,)
     cube.coord("realization").rename("percentile")
@@ -413,6 +415,8 @@ def set_up_probability_cube(
         spp__relative_to_threshold (str):
             Value of the attribute "spp__relative_to_threshold" which is
             required for IMPROVER probability cubes.
+        **kwargs:
+            Additional keyword arguments passed to 'set_up_variable_cube' function
     """
     # create a "relative to threshold" attribute
     coord_attributes = {"spp__relative_to_threshold": spp__relative_to_threshold}

--- a/improver_tests/spotdata/spotdata/test_SpotLapseRateAdjust.py
+++ b/improver_tests/spotdata/spotdata/test_SpotLapseRateAdjust.py
@@ -45,7 +45,7 @@ from improver.utilities.temporal import iris_time_to_datetime
 
 from ...set_up_test_cubes import (
     construct_scalar_time_coords,
-    construct_xy_coords,
+    construct_yx_coords,
     set_up_variable_cube,
 )
 
@@ -93,7 +93,7 @@ class Test_SpotLapseRateAdjust(IrisTest):
         diagnostic_cube_hash = create_coordinate_hash(self.lapse_rate_cube)
 
         # Set up neighbour and spot diagnostic cubes
-        y_coord, x_coord = construct_xy_coords(3, 3, "equalarea")
+        y_coord, x_coord = construct_yx_coords(3, 3, "equalarea")
         y_coord = y_coord.points
         x_coord = x_coord.points
 

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -116,7 +116,7 @@ class Test_construct_xy_coords(IrisTest):
         self.assertEqual(len(x_coord.points), 3)
 
     def test_equal_area_grid_spacing(self):
-        """Test latitude and longitude point values created around 0,0 with
+        """Test projection_y_coordinate and projection_x_coordinate point values created around 0,0 with
         provided grid spacing"""
         y_coord, x_coord = construct_xy_coords(3, 3, "equalarea", grid_spacing=1)
         self.assertArrayEqual(x_coord.points, [-1.0, 0.0, 1.0])
@@ -127,7 +127,7 @@ class Test_construct_xy_coords(IrisTest):
         self.assertArrayEqual(y_coord.points, [-1.5, -0.5, 0.5, 1.5])
 
     def test_equal_area_grid_spacing_domain_corner(self):
-        """Test latitude and longitude point values start at domain corner
+        """Test projection_y_coordinate and projection_x_coordinate point values start at domain corner
         with provided grid spacing"""
         y_coord, x_coord = construct_xy_coords(
             3, 3, "equalarea", grid_spacing=2, domain_corner=[15, 12]

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -48,19 +48,19 @@ from improver.utilities.temporal import iris_time_to_datetime
 from .set_up_test_cubes import (
     add_coordinate,
     construct_scalar_time_coords,
-    construct_xy_coords,
+    construct_yx_coords,
     set_up_percentile_cube,
     set_up_probability_cube,
     set_up_variable_cube,
 )
 
 
-class Test_construct_xy_coords(IrisTest):
-    """Test the construct_xy_coords method"""
+class Test_construct_yx_coords(IrisTest):
+    """Test the construct_yx_coords method"""
 
     def test_lat_lon(self):
         """Test coordinates created for a lat-lon grid"""
-        y_coord, x_coord = construct_xy_coords(4, 3, "latlon")
+        y_coord, x_coord = construct_yx_coords(4, 3, "latlon")
         self.assertEqual(y_coord.name(), "latitude")
         self.assertEqual(x_coord.name(), "longitude")
         for crd in [y_coord, x_coord]:
@@ -72,25 +72,25 @@ class Test_construct_xy_coords(IrisTest):
 
     def test_lat_lon_values(self):
         """Test latitude and longitude point values are as expected"""
-        y_coord, x_coord = construct_xy_coords(3, 3, "latlon")
+        y_coord, x_coord = construct_yx_coords(3, 3, "latlon")
         self.assertArrayAlmostEqual(x_coord.points, [-20.0, 0.0, 20.0])
         self.assertArrayAlmostEqual(y_coord.points, [40.0, 60.0, 80.0])
 
     def test_lat_lon_grid_spacing(self):
         """Test latitude and longitude point values created around 0,0 with
         provided grid spacing"""
-        y_coord, x_coord = construct_xy_coords(3, 3, "latlon", grid_spacing=1)
+        y_coord, x_coord = construct_yx_coords(3, 3, "latlon", grid_spacing=1)
         self.assertArrayEqual(x_coord.points, [-1.0, 0.0, 1.0])
         self.assertArrayEqual(y_coord.points, [-1.0, 0.0, 1.0])
 
-        y_coord, x_coord = construct_xy_coords(4, 4, "latlon", grid_spacing=1)
+        y_coord, x_coord = construct_yx_coords(4, 4, "latlon", grid_spacing=1)
         self.assertArrayEqual(x_coord.points, [-1.5, -0.5, 0.5, 1.5])
         self.assertArrayEqual(y_coord.points, [-1.5, -0.5, 0.5, 1.5])
 
     def test_lat_lon_grid_spacing_domain_corner(self):
         """Test latitude and longitude point values start at domain corner
         with provided grid spacing"""
-        y_coord, x_coord = construct_xy_coords(
+        y_coord, x_coord = construct_yx_coords(
             3, 3, "latlon", grid_spacing=2, domain_corner=(15, 12)
         )
         self.assertArrayEqual(x_coord.points, [12.0, 14.0, 16.0])
@@ -101,11 +101,11 @@ class Test_construct_xy_coords(IrisTest):
         not provided"""
         msg = "Grid spacing required to setup grid from domain corner."
         with self.assertRaisesRegex(ValueError, msg):
-            construct_xy_coords(3, 3, "latlon", domain_corner=(0, 0))
+            construct_yx_coords(3, 3, "latlon", domain_corner=(0, 0))
 
     def test_proj_xy(self):
         """Test coordinates created for an equal area grid"""
-        y_coord, x_coord = construct_xy_coords(4, 3, "equalarea")
+        y_coord, x_coord = construct_yx_coords(4, 3, "equalarea")
         self.assertEqual(y_coord.name(), "projection_y_coordinate")
         self.assertEqual(x_coord.name(), "projection_x_coordinate")
         for crd in [y_coord, x_coord]:
@@ -118,18 +118,18 @@ class Test_construct_xy_coords(IrisTest):
     def test_equal_area_grid_spacing(self):
         """Test projection_y_coordinate and projection_x_coordinate point values created around 0,0 with
         provided grid spacing"""
-        y_coord, x_coord = construct_xy_coords(3, 3, "equalarea", grid_spacing=1)
+        y_coord, x_coord = construct_yx_coords(3, 3, "equalarea", grid_spacing=1)
         self.assertArrayEqual(x_coord.points, [-1.0, 0.0, 1.0])
         self.assertArrayEqual(y_coord.points, [-1.0, 0.0, 1.0])
 
-        y_coord, x_coord = construct_xy_coords(4, 4, "equalarea", grid_spacing=1)
+        y_coord, x_coord = construct_yx_coords(4, 4, "equalarea", grid_spacing=1)
         self.assertArrayEqual(x_coord.points, [-1.5, -0.5, 0.5, 1.5])
         self.assertArrayEqual(y_coord.points, [-1.5, -0.5, 0.5, 1.5])
 
     def test_equal_area_grid_spacing_domain_corner(self):
         """Test projection_y_coordinate and projection_x_coordinate point values start at domain corner
         with provided grid spacing"""
-        y_coord, x_coord = construct_xy_coords(
+        y_coord, x_coord = construct_yx_coords(
             3, 3, "equalarea", grid_spacing=2, domain_corner=(15, 12)
         )
         self.assertArrayEqual(x_coord.points, [12.0, 14.0, 16.0])
@@ -140,14 +140,14 @@ class Test_construct_xy_coords(IrisTest):
         not provided"""
         msg = "Grid spacing required to setup grid from domain corner."
         with self.assertRaisesRegex(ValueError, msg):
-            construct_xy_coords(3, 3, "equalarea", domain_corner=(0, 0))
+            construct_yx_coords(3, 3, "equalarea", domain_corner=(0, 0))
 
     def test_unknown_spatial_grid(self):
         """Test error raised if spatial_grid unknown"""
         spatial_grid = "unknown"
         msg = "Grid type {} not recognised".format(spatial_grid)
         with self.assertRaisesRegex(ValueError, msg):
-            construct_xy_coords(3, 3, spatial_grid, domain_corner=(0, 0))
+            construct_yx_coords(3, 3, spatial_grid, domain_corner=(0, 0))
 
 
 class Test_construct_scalar_time_coords(IrisTest):

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -91,7 +91,7 @@ class Test_construct_xy_coords(IrisTest):
         """Test latitude and longitude point values start at domain corner
         with provided grid spacing"""
         y_coord, x_coord = construct_xy_coords(
-            3, 3, "latlon", grid_spacing=2, domain_corner=[12, 15]
+            3, 3, "latlon", grid_spacing=2, domain_corner=[15, 12]
         )
         self.assertArrayEqual(x_coord.points, [12.0, 14.0, 16.0])
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
@@ -130,7 +130,7 @@ class Test_construct_xy_coords(IrisTest):
         """Test latitude and longitude point values start at domain corner
         with provided grid spacing"""
         y_coord, x_coord = construct_xy_coords(
-            3, 3, "equalarea", grid_spacing=2, domain_corner=[12, 15]
+            3, 3, "equalarea", grid_spacing=2, domain_corner=[15, 12]
         )
         self.assertArrayEqual(x_coord.points, [12.0, 14.0, 16.0])
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
@@ -406,7 +406,7 @@ class Test_set_up_variable_cube(IrisTest):
     def test_latlon_domain_corner_grid_spacing(self):
         """Test ability to set up lat-lon grid from domain corner with grid spacing"""
         grid_spacing = 1
-        domain_corner = [-10, -17]
+        domain_corner = [-17, -10]
         result = set_up_variable_cube(
             self.data,
             spatial_grid="latlon",
@@ -425,13 +425,13 @@ class Test_set_up_variable_cube(IrisTest):
         )
         self.assertEqual(lat_spacing, grid_spacing)
         self.assertEqual(lon_spacing, grid_spacing)
-        self.assertEqual(result.coord("latitude").points[0], domain_corner[1])
-        self.assertEqual(result.coord("longitude").points[0], domain_corner[0])
+        self.assertEqual(result.coord("latitude").points[0], domain_corner[0])
+        self.assertEqual(result.coord("longitude").points[0], domain_corner[1])
 
     def test_equalarea_domain_corner_grid_spacing(self):
         """Test ability to set up equalarea grid from domain corner with grid spacing"""
         grid_spacing = 1
-        domain_corner = [300, 1100]
+        domain_corner = [1100, 300]
         result = set_up_variable_cube(
             self.data,
             spatial_grid="equalarea",
@@ -453,15 +453,15 @@ class Test_set_up_variable_cube(IrisTest):
         self.assertEqual(y_spacing, grid_spacing)
         self.assertEqual(x_spacing, grid_spacing)
         self.assertEqual(
-            result.coord("projection_y_coordinate").points[0], domain_corner[1]
+            result.coord("projection_y_coordinate").points[0], domain_corner[0]
         )
         self.assertEqual(
-            result.coord("projection_x_coordinate").points[0], domain_corner[0]
+            result.coord("projection_x_coordinate").points[0], domain_corner[1]
         )
 
     def test_latlon_domain_corner(self):
         """Test error raised if attempt to make latlon grid providing domain corner but not grid spacing"""
-        domain_corner = [-10, -17]
+        domain_corner = [-17, -10]
         with self.assertRaisesRegex(
             ValueError, "Grid spacing required to setup grid from domain corner."
         ):
@@ -471,7 +471,7 @@ class Test_set_up_variable_cube(IrisTest):
 
     def test_equalarea_domain_corner(self):
         """Test error raised if attempt to make equalarea grid providing domain corner but not grid spacing"""
-        domain_corner = [300, 1100]
+        domain_corner = [1100, 300]
         with self.assertRaisesRegex(
             ValueError, "Grid spacing required to setup grid from domain corner."
         ):

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -142,6 +142,13 @@ class Test_construct_xy_coords(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             construct_xy_coords(3, 3, "equalarea", domain_corner=[0, 0])
 
+    def test_unknown_spatial_grid(self):
+        """Test error raised if spatial_grid unknown"""
+        spatial_grid = "unknown"
+        msg = "Grid type {} not recognised".format(spatial_grid)
+        with self.assertRaisesRegex(ValueError, msg):
+            construct_xy_coords(3, 3, spatial_grid, domain_corner=[0, 0])
+
 
 class Test_construct_scalar_time_coords(IrisTest):
     """Test the construct_scalar_time_coords method"""

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -55,7 +55,7 @@ from .set_up_test_cubes import (
 )
 
 
-class test_construct_xy_coords(IrisTest):
+class Test_construct_xy_coords(IrisTest):
     """Test the construct_xy_coords method"""
 
     def test_lat_lon(self):
@@ -143,7 +143,7 @@ class test_construct_xy_coords(IrisTest):
             construct_xy_coords(3, 3, "equalarea", domain_corner=[0, 0])
 
 
-class test_construct_scalar_time_coords(IrisTest):
+class Test_construct_scalar_time_coords(IrisTest):
     """Test the construct_scalar_time_coords method"""
 
     def test_basic(self):
@@ -223,7 +223,7 @@ class test_construct_scalar_time_coords(IrisTest):
             )
 
 
-class test_set_up_variable_cube(IrisTest):
+class Test_set_up_variable_cube(IrisTest):
     """Test the set_up_variable_cube base function"""
 
     def setUp(self):
@@ -480,7 +480,7 @@ class test_set_up_variable_cube(IrisTest):
             )
 
 
-class test_set_up_percentile_cube(IrisTest):
+class Test_set_up_percentile_cube(IrisTest):
     """Test the set_up_percentile_cube function"""
 
     def setUp(self):
@@ -515,7 +515,7 @@ class test_set_up_percentile_cube(IrisTest):
         self.assertEqual(result.attributes["mosg__model_configuration"], "uk_ens")
 
 
-class test_set_up_probability_cube(IrisTest):
+class Test_set_up_probability_cube(IrisTest):
     """Test the set_up_probability_cube function"""
 
     def setUp(self):
@@ -580,7 +580,7 @@ class test_set_up_probability_cube(IrisTest):
         self.assertEqual(result.attributes["mosg__model_configuration"], "uk_ens")
 
 
-class test_add_coordinate(IrisTest):
+class Test_add_coordinate(IrisTest):
     """Test the add_coordinate utility"""
 
     def setUp(self):

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -91,7 +91,7 @@ class Test_construct_xy_coords(IrisTest):
         """Test latitude and longitude point values start at domain corner
         with provided grid spacing"""
         y_coord, x_coord = construct_xy_coords(
-            3, 3, "latlon", grid_spacing=2, domain_corner=[15, 12]
+            3, 3, "latlon", grid_spacing=2, domain_corner=(15, 12)
         )
         self.assertArrayEqual(x_coord.points, [12.0, 14.0, 16.0])
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
@@ -101,7 +101,7 @@ class Test_construct_xy_coords(IrisTest):
         not provided"""
         msg = "Grid spacing required to setup grid from domain corner."
         with self.assertRaisesRegex(ValueError, msg):
-            construct_xy_coords(3, 3, "latlon", domain_corner=[0, 0])
+            construct_xy_coords(3, 3, "latlon", domain_corner=(0, 0))
 
     def test_proj_xy(self):
         """Test coordinates created for an equal area grid"""
@@ -130,7 +130,7 @@ class Test_construct_xy_coords(IrisTest):
         """Test projection_y_coordinate and projection_x_coordinate point values start at domain corner
         with provided grid spacing"""
         y_coord, x_coord = construct_xy_coords(
-            3, 3, "equalarea", grid_spacing=2, domain_corner=[15, 12]
+            3, 3, "equalarea", grid_spacing=2, domain_corner=(15, 12)
         )
         self.assertArrayEqual(x_coord.points, [12.0, 14.0, 16.0])
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
@@ -140,14 +140,14 @@ class Test_construct_xy_coords(IrisTest):
         not provided"""
         msg = "Grid spacing required to setup grid from domain corner."
         with self.assertRaisesRegex(ValueError, msg):
-            construct_xy_coords(3, 3, "equalarea", domain_corner=[0, 0])
+            construct_xy_coords(3, 3, "equalarea", domain_corner=(0, 0))
 
     def test_unknown_spatial_grid(self):
         """Test error raised if spatial_grid unknown"""
         spatial_grid = "unknown"
         msg = "Grid type {} not recognised".format(spatial_grid)
         with self.assertRaisesRegex(ValueError, msg):
-            construct_xy_coords(3, 3, spatial_grid, domain_corner=[0, 0])
+            construct_xy_coords(3, 3, spatial_grid, domain_corner=(0, 0))
 
 
 class Test_construct_scalar_time_coords(IrisTest):
@@ -413,7 +413,7 @@ class Test_set_up_variable_cube(IrisTest):
     def test_latlon_domain_corner_grid_spacing(self):
         """Test ability to set up lat-lon grid from domain corner with grid spacing"""
         grid_spacing = 1
-        domain_corner = [-17, -10]
+        domain_corner = (-17, -10)
         result = set_up_variable_cube(
             self.data,
             spatial_grid="latlon",
@@ -438,7 +438,7 @@ class Test_set_up_variable_cube(IrisTest):
     def test_equalarea_domain_corner_grid_spacing(self):
         """Test ability to set up equalarea grid from domain corner with grid spacing"""
         grid_spacing = 1
-        domain_corner = [1100, 300]
+        domain_corner = (1100, 300)
         result = set_up_variable_cube(
             self.data,
             spatial_grid="equalarea",
@@ -468,7 +468,7 @@ class Test_set_up_variable_cube(IrisTest):
 
     def test_latlon_domain_corner(self):
         """Test error raised if attempt to make latlon grid providing domain corner but not grid spacing"""
-        domain_corner = [-17, -10]
+        domain_corner = (-17, -10)
         with self.assertRaisesRegex(
             ValueError, "Grid spacing required to setup grid from domain corner."
         ):
@@ -478,7 +478,7 @@ class Test_set_up_variable_cube(IrisTest):
 
     def test_equalarea_domain_corner(self):
         """Test error raised if attempt to make equalarea grid providing domain corner but not grid spacing"""
-        domain_corner = [1100, 300]
+        domain_corner = (1100, 300)
         with self.assertRaisesRegex(
             ValueError, "Grid spacing required to setup grid from domain corner."
         ):


### PR DESCRIPTION
Addresses #1273 / IMPRO-1760

Description

- Use kwargs for functions that use `set_up_variable_cube()` and removed duplicate docstrings
- Add `grid_spacing` and `domain_corner` args to `set_up_variable_cube()` and `construct_xy_coords()`
- Use `grid_spacing` and `domain_corner` to set up grid, using previous values if neither provided and around 0,0 if only `grid_spacing` provided
- Raise error if `domain_corner` provided but no `grid_spacing`
- Add `_create_y_x_arrays()` for to use by `construct_xy_coords()` to create x and y numpy.ndarray

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
