### PR TITLE
Mutation testing 1

### DIFF
--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -477,14 +477,15 @@ class Test_check_weights(Test_weighted_blend):
         """Test that if a weights cube is provided which is zero or properly
         normalised,  i.e. the weights sum to one over the blending
         dimension, no exception is raised."""
-        weights = [
-            [[0, 0.3], [0.2, 0.4]],
-            [[0, 0.3], [0.2, 0.4]],
-            [[0, 0.4], [0.6, 0.2]],
-        ]
+        weights = np.array(
+            [[[0, 0.3], [0.2, 0.4]], [[0, 0.3], [0.2, 0.4]], [[0, 0.4], [0.6, 0.2]]]
+        )
         coord = "forecast_reference_time"
         plugin = WeightedBlendAcrossWholeDimension(coord)
-        plugin.check_weights(weights, 0)
+        try:
+            plugin.check_weights(weights, 0)
+        except ValueError:
+            self.fail("Error testing check_weights")
 
     def test_weights_do_not_sum_to_1_error(self):
         """Test that if a weights cube is provided which is not properly
@@ -519,7 +520,7 @@ class Test_percentile_weighted_mean(Test_weighted_blend):
     @ManageWarnings(ignored_messages=[COORD_COLLAPSE_WARNING])
     def test_with_weights_perc_as_float64(self):
         """Test function when a data cube and a weights cube are provided. But with
-        a percentile cood that is float64"""
+        a percentile coord that is float64"""
 
         perc_cube = percentile_cube()
         coord = "forecast_reference_time"

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -517,9 +517,9 @@ class Test_percentile_weighted_mean(Test_weighted_blend):
         self.assertArrayAlmostEqual(result.data, BLENDED_PERCENTILE_DATA)
 
     @ManageWarnings(ignored_messages=[COORD_COLLAPSE_WARNING])
-    def test_with_weights__perc_as_float64(self):
+    def test_with_weights_perc_as_float64(self):
         """Test function when a data cube and a weights cube are provided. But with
-        a cood that is float64"""
+        a percentile cood that is float64"""
 
         perc_cube = percentile_cube()
         coord = "forecast_reference_time"
@@ -623,20 +623,6 @@ class Test_weighted_mean(Test_weighted_blend):
         coord = "forecast_reference_time"
         plugin = WeightedBlendAcrossWholeDimension(coord)
         result = plugin.weighted_mean(self.cube, self.weights1d)
-        expected = np.full((2, 2), 1.5)
-
-        self.assertIsInstance(result, iris.cube.Cube)
-        self.assertArrayAlmostEqual(result.data, expected)
-
-    @ManageWarnings(ignored_messages=[COORD_COLLAPSE_WARNING])
-    def test_with_weights_boundry(self):
-        """Test function when a data cube and a weights cube are provided."""
-
-        coord = "forecast_reference_time"
-        plugin = WeightedBlendAcrossWholeDimension(coord)
-        cube = self.cube
-        weights = self.weights1d
-        result = plugin.weighted_mean(cube, weights)
         expected = np.full((2, 2), 1.5)
 
         self.assertIsInstance(result, iris.cube.Cube)

--- a/improver_tests/test_PostProcessingPlugin.py
+++ b/improver_tests/test_PostProcessingPlugin.py
@@ -35,6 +35,7 @@ import unittest
 import numpy as np
 
 from improver import PostProcessingPlugin
+from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
 
 from .set_up_test_cubes import set_up_variable_cube
 
@@ -68,6 +69,13 @@ class Test_process(unittest.TestCase):
     def test_title_preserved(self):
         """Test title is preserved if it contains 'Post-Processed'"""
         expected_title = "IMPROVER Post-Processed Multi-Model Blend"
+        self.cube.attributes["title"] = expected_title
+        result = self.plugin(self.cube)
+        self.assertEqual(result.attributes["title"], expected_title)
+
+    def test_title_mandatory_attribute_default(self):
+        """Test title is preserved if it is the same as mandatory_attribute['title']"""
+        expected_title = MANDATORY_ATTRIBUTE_DEFAULTS["title"]
         self.cube.attributes["title"] = expected_title
         result = self.plugin(self.cube)
         self.assertEqual(result.attributes["title"], expected_title)


### PR DESCRIPTION
Addresses #911 Part 1.

Improved testing for WeightedBlendAcrossWholeDimension
This includes:
- better boundry checking
- following the clean path of the code

This PR right now does not question if the functions should be changed, but that can be open for discussion.


### improver_tests/test_PostProcessingPlugin.py
#### `test_title_mandatory_attribute_default`
Better testing of the if statement 
`improver/__init__.py`
```python
        if (
            "title" in cube.attributes.keys()
            and cube.attributes["title"] != default_title
            and "Post-Processed" not in cube.attributes["title"]
        ):
```


### improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
#### Line 207 `test_basic`

Tests that the function returns normally when the percentile coord has enough points to blend.

#### Line 249 `test_basic`

Tests that the function doesn't throw an error when the validity times are the same but `self.timeblending` is `False`

#### Line 255 `test_unmatched_validity_time_exception`

reduced cube length down to 2 for better boundry checking.

#### Line 368 `test_incompatible_weights_and_data_cubes_shape`

Tests the path of invalid shape.

#### Line 476 `test_weights_sum_to_1_but_with_a_zero_weight`

Tests when a weight is zero

#### Line 519 `test_with_weights__perc_as_float64`

Tests that a coord is converted back to float32

#### Line 710 `test_perc`

Tests with a percentile cube


Testing:
 - [x] Ran tests and they passed OK
