### PR TITLE
Impro 1770

### DIFF
--- a/improver/grids.py
+++ b/improver/grids.py
@@ -54,11 +54,13 @@ GRID_COORD_ATTRIBUTES = {
         "yname": "latitude",
         "units": "degrees",
         "coord_system": GLOBAL_GRID_CCRS,
+        "default_grid_spacing": 10,
     },
     "equalarea": {
         "xname": "projection_x_coordinate",
         "yname": "projection_y_coordinate",
         "units": "metres",
         "coord_system": STANDARD_GRID_CCRS,
+        "default_grid_spacing": 2000,
     },
 }

--- a/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
+++ b/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
@@ -69,7 +69,7 @@ def set_up_masked_cubes():
     # 5x5 matrix results in grid spacing of 200 km
     base_data = np.ones((5, 5), dtype=np.float32)
 
-    # Calculate grid spacing that tests were written for
+    # Calculate grid spacing
     grid_spacing = np.around(1000000.0 / 5)
 
     # set up a UKV cube with some rain

--- a/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
+++ b/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
@@ -69,6 +69,9 @@ def set_up_masked_cubes():
     # 5x5 matrix results in grid spacing of 200 km
     base_data = np.ones((5, 5), dtype=np.float32)
 
+    # Calculate grid spacing that tests were written for
+    grid_spacing = np.around(1000000.0 / 5)
+
     # set up a UKV cube with some rain
     rain_data = np.array([0.9 * base_data, 0.5 * base_data, 0 * base_data])
     ukv_cube = set_up_probability_cube(
@@ -80,6 +83,7 @@ def set_up_masked_cubes():
         frt=cycletime,
         spatial_grid="equalarea",
         standard_grid_metadata="uk_det",
+        grid_spacing=grid_spacing,
     )
 
     # set up a masked nowcast cube with more rain
@@ -95,6 +99,7 @@ def set_up_masked_cubes():
         frt=cycletime,
         spatial_grid="equalarea",
         attributes={"mosg__model_configuration": "nc_det"},
+        grid_spacing=grid_spacing,
     )
 
     return iris.cube.CubeList([ukv_cube, nowcast_cube])

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -283,7 +283,7 @@ class Test_generate_hash(unittest.TestCase):
         cube = set_up_variable_cube(np.ones((3, 3)).astype(np.float32))
         hash_input = cube.coord("latitude")
         result = generate_hash(hash_input)
-        expected = "69d1ae620d150ea3945bb8a69b0a2662787a42a2ef63bc64b565a4cbf5ad3a4f"
+        expected = "68fa646ab98ab7a994e07cc1e4e42f080f6d3b9b8b70166cd0be176290391b15"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 
@@ -317,7 +317,7 @@ class Test_create_coordinate_hash(unittest.TestCase):
 
         hash_input = set_up_variable_cube(np.zeros((3, 3)).astype(np.float32))
         result = create_coordinate_hash(hash_input)
-        expected = "9fe703e6a4783faa1b719a1fab3e3228a07d6a84356f92ffe2e6f2bc8c610d05"
+        expected = "54812a6fed0f92fe75d180d63a6bd6c916407ea1e7e5fd32a5f20f86ea997fac"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -283,7 +283,7 @@ class Test_generate_hash(unittest.TestCase):
         cube = set_up_variable_cube(np.ones((3, 3)).astype(np.float32))
         hash_input = cube.coord("latitude")
         result = generate_hash(hash_input)
-        expected = "62267c5827656790244ef2f26b708a1be5dcb491e4ae36b9db9b47c2aaaadf7e"
+        expected = "69d1ae620d150ea3945bb8a69b0a2662787a42a2ef63bc64b565a4cbf5ad3a4f"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 
@@ -317,7 +317,7 @@ class Test_create_coordinate_hash(unittest.TestCase):
 
         hash_input = set_up_variable_cube(np.zeros((3, 3)).astype(np.float32))
         result = create_coordinate_hash(hash_input)
-        expected = "b26ca16d28f6e06ea4573fd745f55750c6dd93a06891f1b4ff0c6cd50585ac08"
+        expected = "9fe703e6a4783faa1b719a1fab3e3228a07d6a84356f92ffe2e6f2bc8c610d05"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 

--- a/improver_tests/nbhood/circular_kernel/test_check_radius_against_distance.py
+++ b/improver_tests/nbhood/circular_kernel/test_check_radius_against_distance.py
@@ -59,7 +59,7 @@ class Test_check_radius_against_distance(IrisTest):
     def test_passes(self):
         """Test no exception raised when the distance is smaller than the
         corner-to-corner distance of the domain."""
-        distance = 6100
+        distance = 4000
         check_radius_against_distance(self.cube, distance)
 
 

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -46,6 +46,16 @@ from ...set_up_test_cubes import set_up_variable_cube
 from ..nbhood.test_BaseNeighbourhoodProcessing import set_up_cube
 
 
+def _mean_points(points):
+    """Create an array of the mean of adjacent points in original array"""
+    mean_points = []
+    for i in range(0, len(points) - 1):
+        point = (points[i] + points[i + 1]) / 2
+        mean_points.append(point)
+
+    return np.array(mean_points, dtype=np.float32)
+
+
 class Test__repr__(IrisTest):
 
     """Test the repr method."""
@@ -64,15 +74,6 @@ class Test__repr__(IrisTest):
 class Test_RecursiveFilter(IrisTest):
 
     """Test class for the RecursiveFilter tests, setting up cubes."""
-
-    def _mean_points(self, points):
-        """Create an array of the mean of adjacent points in original array"""
-        mean_points = []
-        for i in range(0, len(points) - 1):
-            point = (points[i] + points[i + 1]) / 2
-            mean_points.append(point)
-
-        return np.array(mean_points, dtype=np.float32)
 
     def setUp(self):
         """Create test cubes."""
@@ -100,7 +101,7 @@ class Test_RecursiveFilter(IrisTest):
         self.smoothing_coefficients_cube_x = set_up_variable_cube(
             np.full((5, 4), 0.5, dtype=np.float32), name="smoothing_coefficient_x"
         )
-        mean_x_points = self._mean_points(
+        mean_x_points = _mean_points(
             self.smoothing_coefficients_cube_x.coord(axis="y").points
         )
         self.smoothing_coefficients_cube_x.coord(axis="x").points = mean_x_points
@@ -109,7 +110,7 @@ class Test_RecursiveFilter(IrisTest):
         self.smoothing_coefficients_cube_y = set_up_variable_cube(
             np.full((4, 5), 0.5, dtype=np.float32), name="smoothing_coefficient_y"
         )
-        mean_y_points = self._mean_points(
+        mean_y_points = _mean_points(
             self.smoothing_coefficients_cube_y.coord(axis="x").points
         )
         self.smoothing_coefficients_cube_y.coord(axis="y").points = mean_y_points

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -65,6 +65,15 @@ class Test_RecursiveFilter(IrisTest):
 
     """Test class for the RecursiveFilter tests, setting up cubes."""
 
+    def _mean_points(self, points):
+        """Create an array of the mean of adjacent points in original array"""
+        mean_points = []
+        for i in range(0, len(points) - 1):
+            point = (points[i] + points[i + 1]) / 2
+            mean_points.append(point)
+
+        return np.array(mean_points, dtype=np.float32)
+
     def setUp(self):
         """Create test cubes."""
 
@@ -87,18 +96,21 @@ class Test_RecursiveFilter(IrisTest):
             data, name="precipitation_amount", units="kg m^-2 s^-1"
         )
 
-        mean_x_points = np.array([-15.0, -5.0, 5.0, 15.0], dtype=np.float32)
-        mean_y_points = np.array([45.0, 55.0, 65.0, 75.0], dtype=np.float32)
-
         # Generate x smoothing_coefficients_cube with correct dimensions 5 x 4
         self.smoothing_coefficients_cube_x = set_up_variable_cube(
             np.full((5, 4), 0.5, dtype=np.float32), name="smoothing_coefficient_x"
+        )
+        mean_x_points = self._mean_points(
+            self.smoothing_coefficients_cube_x.coord(axis="y").points
         )
         self.smoothing_coefficients_cube_x.coord(axis="x").points = mean_x_points
 
         # Generate y smoothing_coefficients_cube with correct dimensions 5 x 4
         self.smoothing_coefficients_cube_y = set_up_variable_cube(
             np.full((4, 5), 0.5, dtype=np.float32), name="smoothing_coefficient_y"
+        )
+        mean_y_points = self._mean_points(
+            self.smoothing_coefficients_cube_y.coord(axis="x").points
         )
         self.smoothing_coefficients_cube_y.coord(axis="y").points = mean_y_points
 

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -48,12 +48,7 @@ from ..nbhood.test_BaseNeighbourhoodProcessing import set_up_cube
 
 def _mean_points(points):
     """Create an array of the mean of adjacent points in original array"""
-    mean_points = []
-    for i in range(0, len(points) - 1):
-        point = (points[i] + points[i + 1]) / 2
-        mean_points.append(point)
-
-    return np.array(mean_points, dtype=np.float32)
+    return np.array((points[:-1] + points[1:]) / 2, dtype=np.float32)
 
 
 class Test__repr__(IrisTest):

--- a/improver_tests/psychrometric_calculations/precip_phase_probability/test_PrecipPhaseProbability.py
+++ b/improver_tests/psychrometric_calculations/precip_phase_probability/test_PrecipPhaseProbability.py
@@ -69,8 +69,8 @@ class Test_process(IrisTest):
         middle realization gives both not-snow and not-rain because both the
         20th percentile is <= zero and the 80th percentile is >= zero."""
 
-        # cubes for testing have a grid-length of 333333m.
-        self.plugin = PrecipPhaseProbability(radius=350000.0)
+        # cubes for testing have a grid-length of 2000m.
+        self.plugin = PrecipPhaseProbability(radius=2100.0)
         self.mandatory_attributes = {
             "title": "mandatory title",
             "source": "mandatory_source",

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -112,11 +112,11 @@ def _create_yx_arrays(ypoints, xpoints, domain_corner, grid_spacing):
         Tuple[numpy.ndarray, numpy.ndarray]:
             Tuple containing arrays of y and x coordinate values
     """
-    y_stop = domain_corner[0] + (grid_spacing * ypoints)
-    x_stop = domain_corner[1] + (grid_spacing * xpoints)
+    y_stop = domain_corner[0] + (grid_spacing * (ypoints - 1))
+    x_stop = domain_corner[1] + (grid_spacing * (xpoints - 1))
 
-    y_array = np.arange(domain_corner[0], y_stop, grid_spacing, dtype=np.float32)
-    x_array = np.arange(domain_corner[1], x_stop, grid_spacing, dtype=np.float32)
+    y_array = np.linspace(domain_corner[0], y_stop, ypoints, dtype=np.float32)
+    x_array = np.linspace(domain_corner[1], x_stop, xpoints, dtype=np.float32)
 
     return y_array, x_array
 

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -41,7 +41,6 @@ import numpy as np
 from cf_units import Unit, date2num
 from iris.coords import DimCoord
 from iris.exceptions import CoordinateNotFoundError
-from sigtools.wrappers import decorator
 
 from improver.grids import GRID_COORD_ATTRIBUTES
 from improver.metadata.check_datatypes import check_mandatory_standards

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -63,7 +63,8 @@ def construct_yx_coords(
         spatial_grid (str):
             Specifier to produce either a "latlon" or "equalarea" grid
         grid_spacing (Optional[float]):
-            Grid resolution (degrees for latlon or metres for equalarea).
+            Grid resolution (degrees for latlon or metres for equalarea). If not provided, defaults to 10 degrees
+            for "latlon" grid or 2000 metres for "equalarea" grid
         domain_corner (Optional[Tuple[float, float]]):
             Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea). If not
             provided, a grid is created centred around (0,0).
@@ -76,10 +77,7 @@ def construct_yx_coords(
         raise ValueError("Grid type {} not recognised".format(spatial_grid))
 
     if grid_spacing is None:
-        if spatial_grid == "latlon":
-            grid_spacing = 10
-        elif spatial_grid == "equalarea":
-            grid_spacing = 2000
+        grid_spacing = GRID_COORD_ATTRIBUTES[spatial_grid]["default_grid_spacing"]
 
     if domain_corner is None:
         domain_corner = _set_domain_corner(ypoints, xpoints, grid_spacing)

--- a/improver_tests/set_up_test_cubes.py
+++ b/improver_tests/set_up_test_cubes.py
@@ -76,13 +76,10 @@ def construct_yx_coords(
         raise ValueError("Grid type {} not recognised".format(spatial_grid))
 
     if grid_spacing is None:
-        if domain_corner is None:
-            if spatial_grid == "equalarea":
-                grid_spacing = 2000
-            elif spatial_grid == "latlon":
-                grid_spacing = 2
-        else:
-            raise ValueError("Grid spacing required to setup grid from domain corner.")
+        if spatial_grid == "latlon":
+            grid_spacing = 10
+        elif spatial_grid == "equalarea":
+            grid_spacing = 2000
 
     if domain_corner is None:
         domain_corner = _set_domain_corner(ypoints, xpoints, grid_spacing)

--- a/improver_tests/standardise/test_RegridLandSea.py
+++ b/improver_tests/standardise/test_RegridLandSea.py
@@ -115,12 +115,12 @@ class Test_process(IrisTest):
     def test_access_regrid_with_landmask(self):
         """Test the AdjustLandSeaPoints module is correctly called when using
         landmask arguments. Diagnosed by identifiable error."""
-        msg = "Distance of 10000m gives zero cell extent"
+        msg = "Distance of 1000m gives zero cell extent"
         with self.assertRaisesRegex(ValueError, msg):
             RegridLandSea(
                 regrid_mode="nearest-with-mask",
                 landmask=self.landmask,
-                landmask_vicinity=10000,
+                landmask_vicinity=1000,
             )(self.cube, self.target_grid)
 
     @ManageWarnings(ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)

--- a/improver_tests/standardise/test_RegridLandSea.py
+++ b/improver_tests/standardise/test_RegridLandSea.py
@@ -70,13 +70,15 @@ class Test_process(IrisTest):
 
     def setUp(self):
         """Set up input cubes and landmask"""
-        # Domain corner of UK domain using 15.9,-2.5 as centre (as equalarea grid is configured)
+        # Set domain_corner to define a lat/lon grid which overlaps and completely covers the UK standard grid,
+        # using 15.9,-2.5 as centre (as equalarea grid is configured)
         domain_corner = (54.9 - 15, -2.5 - 15)
         self.cube = set_up_variable_cube(
             282 * np.ones((15, 15), dtype=np.float32),
             spatial_grid="latlon",
             standard_grid_metadata="gl_det",
             domain_corner=domain_corner,
+            grid_spacing=2,
         )
 
         # set up dummy landmask on source grid

--- a/improver_tests/standardise/test_RegridLandSea.py
+++ b/improver_tests/standardise/test_RegridLandSea.py
@@ -70,10 +70,13 @@ class Test_process(IrisTest):
 
     def setUp(self):
         """Set up input cubes and landmask"""
+        # Domain corner of UK domain using 15.9,-2.5 as centre (as equalarea grid is configured)
+        domain_corner = (54.9 - 15, -2.5 - 15)
         self.cube = set_up_variable_cube(
             282 * np.ones((15, 15), dtype=np.float32),
             spatial_grid="latlon",
             standard_grid_metadata="gl_det",
+            domain_corner=domain_corner,
         )
 
         # set up dummy landmask on source grid

--- a/improver_tests/standardise/test_RegridLandSea.py
+++ b/improver_tests/standardise/test_RegridLandSea.py
@@ -71,7 +71,7 @@ class Test_process(IrisTest):
     def setUp(self):
         """Set up input cubes and landmask"""
         # Set domain_corner to define a lat/lon grid which overlaps and completely covers the UK standard grid,
-        # using 15.9,-2.5 as centre (as equalarea grid is configured)
+        # using 54.9,-2.5 as centre (as equalarea grid is configured)
         domain_corner = (54.9 - 15, -2.5 - 15)
         self.cube = set_up_variable_cube(
             282 * np.ones((15, 15), dtype=np.float32),

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -101,6 +101,7 @@ class Test_construct_yx_coords(IrisTest):
         not provided"""
         y_coord, x_coord = construct_yx_coords(3, 3, "latlon", domain_corner=(0, 0))
         self.assertArrayEqual(x_coord.points, [0.0, 10.0, 20.0])
+        self.assertArrayEqual(y_coord.points, [0.0, 10.0, 20.0])
 
     def test_proj_xy(self):
         """Test coordinates created for an equal area grid"""

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -73,8 +73,8 @@ class Test_construct_yx_coords(IrisTest):
     def test_lat_lon_values(self):
         """Test latitude and longitude point values are as expected"""
         y_coord, x_coord = construct_yx_coords(3, 3, "latlon")
-        self.assertArrayAlmostEqual(x_coord.points, [-20.0, 0.0, 20.0])
-        self.assertArrayAlmostEqual(y_coord.points, [40.0, 60.0, 80.0])
+        self.assertArrayAlmostEqual(x_coord.points, [-2.0, 0.0, 2.0])
+        self.assertArrayAlmostEqual(y_coord.points, [-2.0, 0.0, 2.0])
 
     def test_lat_lon_grid_spacing(self):
         """Test latitude and longitude point values created around 0,0 with

--- a/improver_tests/test_set_up_test_cubes.py
+++ b/improver_tests/test_set_up_test_cubes.py
@@ -73,8 +73,8 @@ class Test_construct_yx_coords(IrisTest):
     def test_lat_lon_values(self):
         """Test latitude and longitude point values are as expected"""
         y_coord, x_coord = construct_yx_coords(3, 3, "latlon")
-        self.assertArrayAlmostEqual(x_coord.points, [-2.0, 0.0, 2.0])
-        self.assertArrayAlmostEqual(y_coord.points, [-2.0, 0.0, 2.0])
+        self.assertArrayAlmostEqual(x_coord.points, [-10.0, 0.0, 10.0])
+        self.assertArrayAlmostEqual(y_coord.points, [-10.0, 0.0, 10.0])
 
     def test_lat_lon_grid_spacing(self):
         """Test latitude and longitude point values created around 0,0 with
@@ -97,11 +97,10 @@ class Test_construct_yx_coords(IrisTest):
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
 
     def test_lat_lon_domain_corner(self):
-        """Test error raised if domain corner provided and grid spacing
+        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
         not provided"""
-        msg = "Grid spacing required to setup grid from domain corner."
-        with self.assertRaisesRegex(ValueError, msg):
-            construct_yx_coords(3, 3, "latlon", domain_corner=(0, 0))
+        y_coord, x_coord = construct_yx_coords(3, 3, "latlon", domain_corner=(0, 0))
+        self.assertArrayEqual(x_coord.points, [0.0, 10.0, 20.0])
 
     def test_proj_xy(self):
         """Test coordinates created for an equal area grid"""
@@ -136,11 +135,11 @@ class Test_construct_yx_coords(IrisTest):
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
 
     def test_equal_area_domain_corner(self):
-        """Test error raised if domain corner provided and grid spacing
+        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
         not provided"""
-        msg = "Grid spacing required to setup grid from domain corner."
-        with self.assertRaisesRegex(ValueError, msg):
-            construct_yx_coords(3, 3, "equalarea", domain_corner=(0, 0))
+        y_coord, x_coord = construct_yx_coords(3, 3, "equalarea", domain_corner=(0, 0))
+        self.assertArrayEqual(x_coord.points, [0.0, 2000.0, 4000.0])
+        self.assertArrayEqual(y_coord.points, [0.0, 2000.0, 4000.0])
 
     def test_unknown_spatial_grid(self):
         """Test error raised if spatial_grid unknown"""
@@ -467,24 +466,31 @@ class Test_set_up_variable_cube(IrisTest):
         )
 
     def test_latlon_domain_corner(self):
-        """Test error raised if attempt to make latlon grid providing domain corner but not grid spacing"""
+        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
+        not provided"""
         domain_corner = (-17, -10)
-        with self.assertRaisesRegex(
-            ValueError, "Grid spacing required to setup grid from domain corner."
-        ):
-            set_up_variable_cube(
-                self.data, spatial_grid="latlon", domain_corner=domain_corner
-            )
+        result = set_up_variable_cube(
+            self.data, spatial_grid="latlon", domain_corner=domain_corner
+        )
+        self.assertArrayEqual(result.coord("latitude").points, [-17.0, -7.0, 3.0])
+        self.assertArrayEqual(
+            result.coord("longitude").points, [-10.0, 0.0, 10.0, 20.0]
+        )
 
     def test_equalarea_domain_corner(self):
-        """Test error raised if attempt to make equalarea grid providing domain corner but not grid spacing"""
+        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
+        not provided"""
         domain_corner = (1100, 300)
-        with self.assertRaisesRegex(
-            ValueError, "Grid spacing required to setup grid from domain corner."
-        ):
-            set_up_variable_cube(
-                self.data, spatial_grid="equalarea", domain_corner=domain_corner
-            )
+        result = set_up_variable_cube(
+            self.data, spatial_grid="equalarea", domain_corner=domain_corner
+        )
+        self.assertArrayEqual(
+            result.coord("projection_y_coordinate").points, [1100.0, 3100.0, 5100.0]
+        )
+        self.assertArrayEqual(
+            result.coord("projection_x_coordinate").points,
+            [300.0, 2300.0, 4300.0, 6300.0],
+        )
 
 
 class Test_set_up_percentile_cube(IrisTest):

--- a/improver_tests/utilities/test_TemporalInterpolation.py
+++ b/improver_tests/utilities/test_TemporalInterpolation.py
@@ -44,7 +44,7 @@ from ..set_up_test_cubes import add_coordinate, set_up_variable_cube
 
 
 def _grid_params(spatial_grid, npoints):
-    # Domain corner and grid spacing that tests were written for
+    # Set domain corner and grid spacing
     domain_corner = None
     grid_spacing = None
     if spatial_grid == "latlon":

--- a/improver_tests/utilities/test_TemporalInterpolation.py
+++ b/improver_tests/utilities/test_TemporalInterpolation.py
@@ -188,8 +188,19 @@ class Test_enforce_time_coords_dtype(IrisTest):
         time_mid = datetime.datetime(2017, 11, 1, 6)
         time_end = datetime.datetime(2017, 11, 1, 9)
         self.npoints = 10
+
+        # Domain corner and grid spacing that tests were written for
+        domain_corner = (-100000, -400000)
+        grid_spacing = np.around(1000000.0 / self.npoints)
+
         data_time_0 = np.ones((self.npoints, self.npoints), dtype=np.float32)
-        cube_time_0 = set_up_variable_cube(data_time_0, time=time_start, frt=time_start)
+        cube_time_0 = set_up_variable_cube(
+            data_time_0,
+            time=time_start,
+            frt=time_start,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
+        )
         cube_times = add_coordinate(
             cube_time_0.copy(),
             [time_start, time_mid, time_end],
@@ -319,13 +330,31 @@ class Test_calc_lats_lons(IrisTest):
         time_mid = datetime.datetime(2017, 11, 1, 6)
         time_end = datetime.datetime(2017, 11, 1, 9)
         self.npoints = 3
+
+        # Domain corner and grid spacing that tests were written for
+        equalarea_domain_corner = (-100000, -400000)
+        equalarea_grid_spacing = np.around(1000000.0 / self.npoints)
+        latlon_domain_corner = (40, -20)
+        latlon_grid_spacing = 40 / (self.npoints - 1)
+
         data_time_0 = np.ones((self.npoints, self.npoints), dtype=np.float32)
-        cube_time_0 = set_up_variable_cube(data_time_0, time=time_start, frt=time_start)
+        cube_time_0 = set_up_variable_cube(
+            data_time_0,
+            time=time_start,
+            frt=time_start,
+            domain_corner=latlon_domain_corner,
+            grid_spacing=latlon_grid_spacing,
+        )
         self.cube = add_coordinate(
             cube_time_0, [time_start, time_mid, time_end], "time", is_datetime=True
         )
         cube_time_0_equalarea = set_up_variable_cube(
-            data_time_0, time=time_start, frt=time_start, spatial_grid="equalarea"
+            data_time_0,
+            time=time_start,
+            frt=time_start,
+            spatial_grid="equalarea",
+            domain_corner=equalarea_domain_corner,
+            grid_spacing=equalarea_grid_spacing,
         )
         self.cube_equalarea = add_coordinate(
             cube_time_0_equalarea,
@@ -403,35 +432,63 @@ class Test_solar_interpolation(IrisTest):
             ]
         )
 
+        # Domain corner and grid spacing that tests were written for
+        domain_corner = (40, -20)
+        grid_spacing = 40 / (self.npoints - 1)
+
         data_time_0 = np.zeros((self.npoints, self.npoints), dtype=np.float32)
         data_time_1 = np.ones((self.npoints, self.npoints), dtype=np.float32)
         data_time_mid = np.ones((self.npoints, self.npoints), dtype=np.float32)
         cube_time_0 = set_up_variable_cube(
-            data_time_0, time=self.time_0, frt=self.time_0
+            data_time_0,
+            time=self.time_0,
+            frt=self.time_0,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         cube_time_1 = set_up_variable_cube(
-            data_time_1, time=self.time_1, frt=self.time_0
+            data_time_1,
+            time=self.time_1,
+            frt=self.time_0,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         cubes = iris.cube.CubeList([cube_time_0, cube_time_1])
         self.cube = cubes.merge_cube()
         interp_cube = set_up_variable_cube(
-            data_time_mid, time=self.time_mid, frt=self.time_0
+            data_time_mid,
+            time=self.time_mid,
+            frt=self.time_0,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         self.interpolated_cube = iris.util.new_axis(interp_cube, "time")
         data_time_0_ens = np.zeros((3, self.npoints, self.npoints), dtype=np.float32)
         data_time_1_ens = np.ones((3, self.npoints, self.npoints), dtype=np.float32)
         data_time_mid_ens = np.ones((3, self.npoints, self.npoints), dtype=np.float32)
         cube_time_0_ens = set_up_variable_cube(
-            data_time_0_ens, time=self.time_0, frt=self.time_0, realizations=[0, 1, 2]
+            data_time_0_ens,
+            time=self.time_0,
+            frt=self.time_0,
+            realizations=[0, 1, 2],
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         cube_time_1_ens = set_up_variable_cube(
-            data_time_1_ens, time=self.time_1, frt=self.time_0, realizations=[0, 1, 2]
+            data_time_1_ens,
+            time=self.time_1,
+            frt=self.time_0,
+            realizations=[0, 1, 2],
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         interp_cube_ens = set_up_variable_cube(
             data_time_mid_ens,
             time=self.time_mid,
             frt=self.time_0,
             realizations=[0, 1, 2],
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         self.interpolated_cube_ens = iris.util.new_axis(interp_cube_ens, "time")
         cubes_ens = iris.cube.CubeList([cube_time_0_ens, cube_time_1_ens])
@@ -500,10 +557,18 @@ class Test_daynight_interpolation(IrisTest):
             ]
         )
 
+        # Domain corner and grid spacing that tests were written for
+        domain_corner = (40, -20)
+        grid_spacing = 40 / (self.npoints - 1)
+
         data_time_mid = np.ones((self.npoints, self.npoints), dtype=np.float32) * 4
 
         interp_cube = set_up_variable_cube(
-            data_time_mid, time=self.time_mid, frt=self.time_0
+            data_time_mid,
+            time=self.time_mid,
+            frt=self.time_0,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         self.interpolated_cube = iris.util.new_axis(interp_cube, "time")
 
@@ -515,6 +580,8 @@ class Test_daynight_interpolation(IrisTest):
             time=self.time_mid,
             frt=self.time_0,
             realizations=[0, 1, 2],
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         self.interpolated_cube_ens = iris.util.new_axis(interp_cube_ens, "time")
 
@@ -573,13 +640,26 @@ class Test_process(IrisTest):
         self.time_extra = datetime.datetime(2017, 11, 1, 6)
         self.time_1 = datetime.datetime(2017, 11, 1, 9)
         self.npoints = 10
+
+        # Domain corner and grid spacing that tests were written for
+        domain_corner = (40, -20)
+        grid_spacing = 40 / (self.npoints - 1)
+
         data_time_0 = np.ones((self.npoints, self.npoints), dtype=np.float32)
         data_time_1 = np.ones((self.npoints, self.npoints), dtype=np.float32) * 7
         self.cube_time_0 = set_up_variable_cube(
-            data_time_0, time=self.time_0, frt=self.time_0
+            data_time_0,
+            time=self.time_0,
+            frt=self.time_0,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
         self.cube_time_1 = set_up_variable_cube(
-            data_time_1, time=self.time_1, frt=self.time_0
+            data_time_1,
+            time=self.time_1,
+            frt=self.time_0,
+            domain_corner=domain_corner,
+            grid_spacing=grid_spacing,
         )
 
     def test_return_type(self):

--- a/improver_tests/utilities/test_TemporalInterpolation.py
+++ b/improver_tests/utilities/test_TemporalInterpolation.py
@@ -43,6 +43,19 @@ from improver.utilities.temporal_interpolation import TemporalInterpolation
 from ..set_up_test_cubes import add_coordinate, set_up_variable_cube
 
 
+def _grid_params(spatial_grid, npoints):
+    # Domain corner and grid spacing that tests were written for
+    domain_corner = None
+    grid_spacing = None
+    if spatial_grid == "latlon":
+        domain_corner = (40, -20)
+        grid_spacing = 40 / (npoints - 1)
+    elif spatial_grid == "equalarea":
+        domain_corner = (-100000, -400000)
+        grid_spacing = np.around(1000000.0 / npoints)
+    return domain_corner, grid_spacing
+
+
 class Test__init__(IrisTest):
 
     """Test the __init__ method."""
@@ -189,9 +202,7 @@ class Test_enforce_time_coords_dtype(IrisTest):
         time_end = datetime.datetime(2017, 11, 1, 9)
         self.npoints = 10
 
-        # Domain corner and grid spacing that tests were written for
-        domain_corner = (-100000, -400000)
-        grid_spacing = np.around(1000000.0 / self.npoints)
+        domain_corner, grid_spacing = _grid_params("latlon", self.npoints)
 
         data_time_0 = np.ones((self.npoints, self.npoints), dtype=np.float32)
         cube_time_0 = set_up_variable_cube(
@@ -331,11 +342,10 @@ class Test_calc_lats_lons(IrisTest):
         time_end = datetime.datetime(2017, 11, 1, 9)
         self.npoints = 3
 
-        # Domain corner and grid spacing that tests were written for
-        equalarea_domain_corner = (-100000, -400000)
-        equalarea_grid_spacing = np.around(1000000.0 / self.npoints)
-        latlon_domain_corner = (40, -20)
-        latlon_grid_spacing = 40 / (self.npoints - 1)
+        equalarea_domain_corner, equalarea_grid_spacing = _grid_params(
+            "equalarea", self.npoints
+        )
+        latlon_domain_corner, latlon_grid_spacing = _grid_params("latlon", self.npoints)
 
         data_time_0 = np.ones((self.npoints, self.npoints), dtype=np.float32)
         cube_time_0 = set_up_variable_cube(
@@ -432,9 +442,7 @@ class Test_solar_interpolation(IrisTest):
             ]
         )
 
-        # Domain corner and grid spacing that tests were written for
-        domain_corner = (40, -20)
-        grid_spacing = 40 / (self.npoints - 1)
+        domain_corner, grid_spacing = _grid_params("latlon", self.npoints)
 
         data_time_0 = np.zeros((self.npoints, self.npoints), dtype=np.float32)
         data_time_1 = np.ones((self.npoints, self.npoints), dtype=np.float32)
@@ -557,9 +565,7 @@ class Test_daynight_interpolation(IrisTest):
             ]
         )
 
-        # Domain corner and grid spacing that tests were written for
-        domain_corner = (40, -20)
-        grid_spacing = 40 / (self.npoints - 1)
+        domain_corner, grid_spacing = _grid_params("latlon", self.npoints)
 
         data_time_mid = np.ones((self.npoints, self.npoints), dtype=np.float32) * 4
 
@@ -641,9 +647,7 @@ class Test_process(IrisTest):
         self.time_1 = datetime.datetime(2017, 11, 1, 9)
         self.npoints = 10
 
-        # Domain corner and grid spacing that tests were written for
-        domain_corner = (40, -20)
-        grid_spacing = 40 / (self.npoints - 1)
+        domain_corner, grid_spacing = _grid_params("latlon", self.npoints)
 
         data_time_0 = np.ones((self.npoints, self.npoints), dtype=np.float32)
         data_time_1 = np.ones((self.npoints, self.npoints), dtype=np.float32) * 7

--- a/improver_tests/utilities/test_pad_spatial.py
+++ b/improver_tests/utilities/test_pad_spatial.py
@@ -151,11 +151,11 @@ class Test_create_cube_with_halo(IrisTest):
             attributes=attrs,
         )
         self.grid_spacing = np.diff(self.cube.coord(axis="x").points)[0]
+        self.halo_size_m = 2000.0
 
     def test_basic(self):
         """Test function returns a cube with expected metadata"""
-        halo_size_m = 2000.0
-        result = create_cube_with_halo(self.cube, halo_size_m)
+        result = create_cube_with_halo(self.cube, self.halo_size_m)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "grid_with_halo")
         self.assertFalse(result.attributes)
@@ -163,8 +163,6 @@ class Test_create_cube_with_halo(IrisTest):
     def test_values(self):
         """Test coordinate values with standard halo radius (rounds down to 1
         grid cell)"""
-        halo_size_m = 2000.0
-
         x_min = self.cube.coord(axis="x").points[0] - self.grid_spacing
         x_max = self.cube.coord(axis="x").points[-1] + self.grid_spacing
         expected_x_points = np.arange(x_min, x_max + 1, self.grid_spacing)
@@ -172,7 +170,7 @@ class Test_create_cube_with_halo(IrisTest):
         y_max = self.cube.coord(axis="y").points[-1] + self.grid_spacing
         expected_y_points = np.arange(y_min, y_max + 1, self.grid_spacing)
 
-        result = create_cube_with_halo(self.cube, halo_size_m)
+        result = create_cube_with_halo(self.cube, self.halo_size_m)
         self.assertSequenceEqual(result.data.shape, (13, 13))
         self.assertArrayAlmostEqual(result.coord(axis="x").points, expected_x_points)
         self.assertArrayAlmostEqual(result.coord(axis="y").points, expected_y_points)
@@ -493,11 +491,11 @@ class Test_remove_cube_halo(IrisTest):
             attributes=self.attrs,
         )
         self.grid_spacing = np.diff(self.cube.coord(axis="x").points)[0]
+        self.halo_size_m = 2000.0
 
     def test_basic(self):
         """Test function returns a cube with expected attributes and shape"""
-        halo_size_m = 2000.0
-        result = remove_cube_halo(self.cube, halo_size_m)
+        result = remove_cube_halo(self.cube, self.halo_size_m)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.attributes["history"], self.attrs["history"])
         self.assertEqual(result.attributes["title"], self.attrs["title"])
@@ -506,10 +504,9 @@ class Test_remove_cube_halo(IrisTest):
 
     def test_values(self):
         """Test function returns a cube with expected shape and data"""
-        halo_size_m = 2000.0
         self.cube_1d.data[0, 2, :] = np.arange(0, 11)
         self.cube_1d.data[0, :, 2] = np.arange(0, 11)
-        result = remove_cube_halo(self.cube_1d, halo_size_m)
+        result = remove_cube_halo(self.cube_1d, self.halo_size_m)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertSequenceEqual(result.data.shape, (1, 9, 9))
         self.assertArrayEqual(result.data[0, 1, :], np.arange(1, 10))

--- a/improver_tests/utilities/test_pad_spatial.py
+++ b/improver_tests/utilities/test_pad_spatial.py
@@ -154,7 +154,7 @@ class Test_create_cube_with_halo(IrisTest):
 
     def test_basic(self):
         """Test function returns a cube with expected metadata"""
-        halo_size_km = 162.0
+        halo_size_km = 2.0
         result = create_cube_with_halo(self.cube, 1000.0 * halo_size_km)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "grid_with_halo")
@@ -163,7 +163,7 @@ class Test_create_cube_with_halo(IrisTest):
     def test_values(self):
         """Test coordinate values with standard halo radius (rounds down to 1
         grid cell)"""
-        halo_size_km = 162.0
+        halo_size_km = 2.0
 
         x_min = self.cube.coord(axis="x").points[0] - self.grid_spacing
         x_max = self.cube.coord(axis="x").points[-1] + self.grid_spacing
@@ -496,7 +496,7 @@ class Test_remove_cube_halo(IrisTest):
 
     def test_basic(self):
         """Test function returns a cube with expected attributes and shape"""
-        halo_size_km = 162.0
+        halo_size_km = 2.0
         result = remove_cube_halo(self.cube, 1000.0 * halo_size_km)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.attributes["history"], self.attrs["history"])
@@ -506,7 +506,7 @@ class Test_remove_cube_halo(IrisTest):
 
     def test_values(self):
         """Test function returns a cube with expected shape and data"""
-        halo_size_km = 162.0
+        halo_size_km = 2.0
         self.cube_1d.data[0, 2, :] = np.arange(0, 11)
         self.cube_1d.data[0, :, 2] = np.arange(0, 11)
         result = remove_cube_halo(self.cube_1d, 1000.0 * halo_size_km)

--- a/improver_tests/utilities/test_pad_spatial.py
+++ b/improver_tests/utilities/test_pad_spatial.py
@@ -154,8 +154,8 @@ class Test_create_cube_with_halo(IrisTest):
 
     def test_basic(self):
         """Test function returns a cube with expected metadata"""
-        halo_size_km = 2.0
-        result = create_cube_with_halo(self.cube, 1000.0 * halo_size_km)
+        halo_size_m = 2000.0
+        result = create_cube_with_halo(self.cube, halo_size_m)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "grid_with_halo")
         self.assertFalse(result.attributes)
@@ -163,7 +163,7 @@ class Test_create_cube_with_halo(IrisTest):
     def test_values(self):
         """Test coordinate values with standard halo radius (rounds down to 1
         grid cell)"""
-        halo_size_km = 2.0
+        halo_size_m = 2000.0
 
         x_min = self.cube.coord(axis="x").points[0] - self.grid_spacing
         x_max = self.cube.coord(axis="x").points[-1] + self.grid_spacing
@@ -172,7 +172,7 @@ class Test_create_cube_with_halo(IrisTest):
         y_max = self.cube.coord(axis="y").points[-1] + self.grid_spacing
         expected_y_points = np.arange(y_min, y_max + 1, self.grid_spacing)
 
-        result = create_cube_with_halo(self.cube, 1000.0 * halo_size_km)
+        result = create_cube_with_halo(self.cube, halo_size_m)
         self.assertSequenceEqual(result.data.shape, (13, 13))
         self.assertArrayAlmostEqual(result.coord(axis="x").points, expected_x_points)
         self.assertArrayAlmostEqual(result.coord(axis="y").points, expected_y_points)
@@ -496,8 +496,8 @@ class Test_remove_cube_halo(IrisTest):
 
     def test_basic(self):
         """Test function returns a cube with expected attributes and shape"""
-        halo_size_km = 2.0
-        result = remove_cube_halo(self.cube, 1000.0 * halo_size_km)
+        halo_size_m = 2000.0
+        result = remove_cube_halo(self.cube, halo_size_m)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.attributes["history"], self.attrs["history"])
         self.assertEqual(result.attributes["title"], self.attrs["title"])
@@ -506,10 +506,10 @@ class Test_remove_cube_halo(IrisTest):
 
     def test_values(self):
         """Test function returns a cube with expected shape and data"""
-        halo_size_km = 2.0
+        halo_size_m = 2000.0
         self.cube_1d.data[0, 2, :] = np.arange(0, 11)
         self.cube_1d.data[0, :, 2] = np.arange(0, 11)
-        result = remove_cube_halo(self.cube_1d, 1000.0 * halo_size_km)
+        result = remove_cube_halo(self.cube_1d, halo_size_m)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertSequenceEqual(result.data.shape, (1, 9, 9))
         self.assertArrayEqual(result.data[0, 1, :], np.arange(1, 10))

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -175,7 +175,7 @@ class Test_calculate_grid_spacing(IrisTest):
         self.cube = set_up_variable_cube(
             np.ones((5, 5), dtype=np.float32), spatial_grid="equalarea"
         )
-        self.spacing = 200000.0
+        self.spacing = 2000.0
         self.unit = "metres"
         self.lat_lon_cube = set_up_variable_cube(np.ones((5, 5), dtype=np.float32))
 
@@ -202,7 +202,7 @@ class Test_calculate_grid_spacing(IrisTest):
     def test_lat_lon_equal_spacing(self):
         """Test outputs with lat-lon grid in degrees"""
         result = calculate_grid_spacing(self.lat_lon_cube, "degrees")
-        self.assertAlmostEqual(result, 10.0)
+        self.assertAlmostEqual(result, 2.0)
 
     def test_incorrect_units(self):
         """Test ValueError for incorrect units"""

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -202,7 +202,7 @@ class Test_calculate_grid_spacing(IrisTest):
     def test_lat_lon_equal_spacing(self):
         """Test outputs with lat-lon grid in degrees"""
         result = calculate_grid_spacing(self.lat_lon_cube, "degrees")
-        self.assertAlmostEqual(result, 2.0)
+        self.assertAlmostEqual(result, 10.0)
 
     def test_incorrect_units(self):
         """Test ValueError for incorrect units"""


### PR DESCRIPTION
Addresses #1273 / [IMPRO-1770](https://exxconfigmgmt:6391/browse/IMPRO-1770)

Description

Added new default `grid_spacing` values to `construct_yx_coords()` then modified unit tests that relied on the previous test grid setup to either use the new values or set up a grid using the `domain_corner` and `grid_spacing` arguments. Hard coded default grid setup removed from set_up_test_cubes.py.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
