### PR TITLE
IMPRO-1778: Plugin for timezone mask creation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,4 +25,4 @@ dependencies:
     - od
     - sigtools>=2.0
     - clize
-    - timezonefinder=4.2.0
+    - timezonefinder==4.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -25,3 +25,4 @@ dependencies:
     - od
     - sigtools>=2.0
     - clize
+    - timezonefinder=4.2.0

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -266,6 +266,8 @@ class GenerateTimezoneMask(BasePlugin):
                 UTC_offset=lambda cell: group[0] <= cell <= group[-1]
             )
             subset = timezone_mask.extract(constraint)
+            if not subset:
+                continue
             subset = subset.merge_cube()
             if subset.coord("UTC_offset").shape[0] > 1:
                 offset_max = subset.coord("UTC_offset").points.max()
@@ -285,8 +287,8 @@ class GenerateTimezoneMask(BasePlugin):
             cube (iris.cube.Cube):
                 A cube with the desired grid. If no 'time' is specified in
                 the plugin configuration the time on this cube will be used
-                for determining the UTC offsets (this is only relevant if
-                daylights savings times are being included).
+                for determining the validity time of the calculated UTC offsets
+                (this is only relevant if daylights savings times are being included).
         Returns:
             iris.cube.Cube:
                 A timezone mask cube.

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -159,7 +159,7 @@ class GenerateTimezoneMask(BasePlugin):
                 to the product of the grid's y-x dimension lengths.
         """
         grid_offsets = []
-        for ii, (latitude, longitude) in enumerate(coordinate_pairs.T):
+        for latitude, longitude in coordinate_pairs.T:
             point_tz = self._get_timezone(latitude, longitude)
 
             if point_tz is None:

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2020 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module for generating timezone masks."""
+
+import iris
+import json
+import numpy as np
+
+from datetime import datetime
+from pytz import timezone
+from timezonefinder import TimezoneFinder
+from iris.exceptions import CoordinateNotFoundError
+
+from improver.metadata.utilities import (
+    create_new_diagnostic_cube,
+    generate_mandatory_attributes,
+)
+from improver.utilities.spatial import lat_lon_determine, transform_grid_to_lat_lon
+
+from improver import BasePlugin
+
+
+class GenerateTimezoneMask(BasePlugin):
+
+    """
+
+    """
+
+    def __init__(self, ignore_dst=True, time=None, groupings=None):
+
+        self.tf = TimezoneFinder()
+        self.time = time
+        self.ignore_dst = ignore_dst
+        self.groupings = groupings
+
+    def _set_time(self, cube):
+        if self.time:
+            self.time = datetime.strptime(self.time, "%Y%m%dT%H%MZ")
+        else:
+            try:
+                self.time = cube.coord("time").cell(0).point
+            except CoordinateNotFoundError:
+                msg = (
+                    "The input cube does not contain a 'time' coordinate. "
+                    "As such a time must be provided by the user."
+                )
+                raise ValueError(msg)
+
+    def get_timezone(self, latitude, longitude):
+        """
+        Args:
+            latitude, longitude (float):
+                The latitude and longitude for which a timezone should be identified.
+        Returns:
+            int:
+                The UTC offset in integer hours of the latitude and longitude provided.
+                This offset is not date dependent, i.e. it ignores daylights savings.
+        """
+        point_tz = self.tf.certain_timezone_at(lng=longitude, lat=latitude)
+        return point_tz
+
+    def calculate_offset(self, point_tz):
+        """
+        calculates the offset in seconds for a given timezone, either with or
+        without consideration of daylights savings.
+        """
+        target = timezone(point_tz)
+        offset = target.utcoffset(self.time)
+
+        dst = 0
+        if self.ignore_dst:
+            dst = target.dst(self.time)
+            # The timezone for Ireland does not capture DST:
+            # https://github.com/regebro/tzlocal/issues/80
+            if point_tz == "Europe/Dublin":
+                dst = timezone("Europe/London").dst(self.time)
+
+        return int((offset - dst).total_seconds())
+
+    def calculate_tz_offsets(self, coordinate_pairs):
+
+        grid_offsets = []
+        for ii, (latitude, longitude) in enumerate(coordinate_pairs.T):
+            point_tz = self.get_timezone(latitude, longitude)
+
+            if point_tz is None:
+                grid_offsets.append(3600 * longitude / 15)
+            else:
+                grid_offsets.append(self.calculate_offset(point_tz))
+
+        return np.array(grid_offsets)
+
+    @staticmethod
+    def get_coordinate_pairs(cube):
+
+        if lat_lon_determine(cube) is not None:
+            yy, xx = transform_grid_to_lat_lon(cube)
+        else:
+            latitudes = cube.coord("latitude").points
+            longitudes = cube.coord("longitude").points
+
+            # timezone finder works using -180 to 180 longitudes.
+            if (longitudes > 180).any():
+                longitudes[longitudes > 180] -= 360
+                if (longitudes > 180 or longitudes < -180).any():
+                    raise ValueError("Nope")
+            yy, xx = np.meshgrid(latitudes, longitudes)
+
+        return np.array([yy.flatten(), xx.flatten()])
+
+    def group_timezones(self, timezone_mask):
+
+        grouped_timezone_masks = iris.cube.CubeList()
+        for group in self.groupings.values():
+            constraint = iris.Constraint(
+                UTC_offset=lambda cell: group[0] <= cell <= group[-1]
+            )
+            subset = timezone_mask.extract(constraint)
+            subset = subset.merge_cube()
+            grouped_timezone_masks.append(
+                subset.collapsed("UTC_offset", iris.analysis.MIN)
+            )
+        return grouped_timezone_masks
+
+    def process(self, cube):
+        """
+        Args:
+            cube (iris.cube.Cube):
+                A cube with the desired grid.
+        Returns:
+            iris.cube.Cube:
+                A timezone mask cube.
+        """
+        self._set_time(cube)
+        coordinate_pairs = self.get_coordinate_pairs(cube)
+        grid_offsets = self.calculate_tz_offsets(coordinate_pairs)
+
+        # Model data is hourly, so we need offsets at hourly fidelity
+        grid_offsets = np.around(grid_offsets / 3600).astype(np.int32)
+
+        # Reshape the flattened array back into the original cube shape.
+        grid_offsets = grid_offsets.reshape(cube.shape, order="F")
+
+        min_offset = grid_offsets.min()
+        max_offset = grid_offsets.max()
+
+        attributes = generate_mandatory_attributes([cube])
+        template_cube = create_new_diagnostic_cube("timezone_mask", 1, cube, attributes)
+
+        # Create a cube containing the timezone UTC offset information.
+        timezone_mask = iris.cube.CubeList()
+        for offset in range(min_offset, max_offset + 1):
+            zone = (grid_offsets != offset).astype(np.int32)
+            coord = iris.coords.DimCoord([offset], long_name="UTC_offset")
+            tz_slice = template_cube.copy(data=zone)
+            tz_slice.add_aux_coord(coord)
+            timezone_mask.append(tz_slice)
+
+        if self.groupings:
+            timezone_mask = self.group_timezones(timezone_mask)
+
+        timezone_mask = timezone_mask.merge_cube()
+        return timezone_mask

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -93,7 +93,7 @@ class GenerateTimezoneMask(BasePlugin):
 
         Args:
             cube (iris.cube.Cube):
-                The cube from which the validity time should be taken is one
+                The cube from which the validity time should be taken if one
                 has not been explicitly provided by the user.
         """
         if self.time:
@@ -122,8 +122,8 @@ class GenerateTimezoneMask(BasePlugin):
         Returns:
             numpy.array:
                 A numpy array containing all the pairs of coordinates that describe
-                the y-x points in the grid. This array is 2-dimensional, being
-                2 by the product of the grid's y-x dimension lengths.
+                the y-x points in the grid. This array is 2-dimensional, with
+                shape (2,  (len(y-points) * len(x-points))).
         """
         if lat_lon_determine(cube) is not None:
             yy, xx = transform_grid_to_lat_lon(cube)
@@ -274,13 +274,8 @@ class GenerateTimezoneMask(BasePlugin):
         grouped_timezone_masks = iris.cube.CubeList()
         for offset, group in self.groupings.items():
 
-            if not group[0] <= offset <= group[-1]:
-                msg = (
-                    "Defined UTC offset point for timezone group does not "
-                    "fall within the timezone group bounds. Point: {}"
-                    ", Bounds: {}".format(offset, group)
-                )
-                raise ValueError(msg)
+            # If offset key comes from a json file it will be a string
+            offset = int(offset)
 
             constraint = iris.Constraint(
                 UTC_offset=lambda cell: group[0] <= cell <= group[-1]

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -273,6 +273,9 @@ class GenerateTimezoneMask(BasePlugin):
                 offset_max = subset.coord("UTC_offset").points.max()
                 subset = collapsed(subset, "UTC_offset", iris.analysis.MIN)
                 subset.coord("UTC_offset").points = [offset_max]
+            else:
+                point, = subset.coord('UTC_offset').points
+                subset.coord('UTC_offset').bounds = [point, point]
             grouped_timezone_masks.append(subset)
         return grouped_timezone_masks
 

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -73,7 +73,7 @@ class GenerateTimezoneMask(BasePlugin):
                 A dictionary specifying how timezones should be grouped if so
                 desired. This dictionary takes the form::
 
-                    {0: [-12, -5], 1:[-4, 4], 2: [5, 12]}
+                    {-9: [-12, -5], 0:[-4, 4], 9: [5, 12]}
 
                 The numbers in the lists denote the inclusive limits of the
                 groups. This is of use if data is not available at hourly
@@ -259,7 +259,7 @@ class GenerateTimezoneMask(BasePlugin):
         The grouped UTC_offset cubes are collapsed together over the UTC_offset
         coordinate using iris.analysis.MIN. This means all the unmasked (0)
         points in each cube are preserved as the dimension is collapsed,
-        enlarging the unmasked region to include all unmaksed points from all
+        enlarging the unmasked region to include all unmasked points from all
         the cubes.
 
         Args:
@@ -273,6 +273,15 @@ class GenerateTimezoneMask(BasePlugin):
         """
         grouped_timezone_masks = iris.cube.CubeList()
         for offset, group in self.groupings.items():
+
+            if not group[0] <= offset <= group[-1]:
+                msg = (
+                    "Defined UTC offset point for timezone group does not "
+                    "fall within the timezone group bounds. Point: {}"
+                    ", Bounds: {}".format(offset, group)
+                )
+                raise ValueError(msg)
+
             constraint = iris.Constraint(
                 UTC_offset=lambda cell: group[0] <= cell <= group[-1]
             )

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -33,9 +33,10 @@
 import pytest
 from datetime import datetime
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from iris.cube import Cube
+import iris
+from iris.cube import Cube, CubeList
 
 from improver.generate_ancillaries.generate_timezone_mask import GenerateTimezoneMask
 from ..set_up_test_cubes import set_up_variable_cube
@@ -45,9 +46,19 @@ from ..set_up_test_cubes import set_up_variable_cube
 def global_grid() -> Cube:
     """Global grid template"""
 
+    attributes = {
+        "title": "MOGREPS-G Model Forecast on Global 20 km Standard Grid",
+        "source": "Met Office Unified Model",
+        "institution": "Met Office",
+    }
+
     data = np.zeros((19, 37), dtype=np.float32)
     cube = set_up_variable_cube(
-        data, name="template", grid_spacing=10, domain_corner=(-90, -180)
+        data,
+        name="template",
+        grid_spacing=10,
+        domain_corner=(-90, -180),
+        attributes=attributes,
     )
     return cube
 
@@ -56,6 +67,12 @@ def global_grid() -> Cube:
 def uk_grid() -> Cube:
     """UK grid template"""
 
+    attributes = {
+        "title": "MOGREPS-UK Model Forecast on UK 2 km Standard Grid",
+        "source": "Met Office Unified Model",
+        "institution": "Met Office",
+    }
+
     data = np.zeros((21, 22), dtype=np.float32)
     cube = set_up_variable_cube(
         data,
@@ -63,8 +80,28 @@ def uk_grid() -> Cube:
         spatial_grid="equalarea",
         grid_spacing=96900.0,
         domain_corner=(-1036000.0, -1158000.0),
+        attributes=attributes,
     )
     return cube
+
+
+@pytest.fixture
+def timezone_mask() -> CubeList:
+    """A timezone mask cubelist"""
+
+    data = np.zeros((19, 37), dtype=np.float32)
+    cube = set_up_variable_cube(
+        data, name="template", grid_spacing=10, domain_corner=(-90, -180)
+    )
+
+    cubelist = CubeList()
+    for offset in range(0, 4):
+        mask = cube.copy()
+        utc_offset_coord = iris.coords.AuxCoord([offset], long_name="UTC_offset")
+        mask.add_aux_coord(utc_offset_coord)
+        mask = iris.util.new_axis(mask, "UTC_offset")
+        cubelist.append(mask)
+    return cubelist
 
 
 def test__set_time(uk_grid):
@@ -78,7 +115,7 @@ def test__set_time(uk_grid):
 
     # Set by the user provided argument
     expected = datetime(2020, 7, 16, 15)
-    plugin = GenerateTimezoneMask(time="20200716T1500Z")
+    plugin = GenerateTimezoneMask(time="20200716T1500")
     plugin(uk_grid)
     assert plugin.time == expected
 
@@ -90,19 +127,133 @@ def test__get_coordinate_pairs(request, grid_fixture):
     grid and for an equal areas grid that must be transformed."""
 
     sample_points = [0, 10, -1]
-    expected = {
+    expected_data = {
         "global_grid": [[-90.0, -180.0], [-90.0, -80.0], [90.0, 180.0]],
         "uk_grid": [[44.517, -17.117], [45.548, -4.913], [62.026, 14.410]],
     }
 
     grid = request.getfixturevalue(grid_fixture)
     result = GenerateTimezoneMask()._get_coordinate_pairs(grid)
+
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (2, np.product(grid.shape))
     for i, ii in enumerate(sample_points):
-        assert_array_almost_equal(result[:, ii], expected[grid_fixture][i], decimal=3)
+        assert_array_almost_equal(
+            result[:, ii], expected_data[grid_fixture][i], decimal=3
+        )
 
 
-# _calculate_tz_offsets
-# _get_timezone
-# _calculate_offset
-# _group_timezones
-# process
+def test__get_coordinate_pairs_exception(global_grid):
+    """Test that an exception is raised if longitudes are found outside the
+    range -180 to 180."""
+    global_grid.coord("longitude").points = global_grid.coord("longitude").points + 360
+
+    with pytest.raises(ValueError, match=r"TimezoneFinder requires .*"):
+        GenerateTimezoneMask()._get_coordinate_pairs(global_grid)
+
+
+def test__calculate_tz_offsets():
+    """
+
+    These test also cover the functionality of _calculate_offset.
+    """
+    pytest.importorskip("timezonefinder")
+
+    # New York, London, and Melbourne
+    coordinate_pairs = np.array([[41, 51.5, -37.9], [-74, 0, 145]])
+
+    # Test ignoring daylights savings, so the result should be consistent
+    # regardless of the date.
+    expected = [-5 * 3600, 0, 10 * 3600]
+
+    # Northern hemisphere winter
+    time = datetime(2020, 1, 1, 12)
+    plugin = GenerateTimezoneMask(time=time)
+    result = plugin._calculate_tz_offsets(coordinate_pairs)
+    assert_array_equal(result, expected)
+
+    # Check return type information as well
+    assert result.ndim == 1
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.int32
+
+    # Southern hemisphere winter
+    time = datetime(2020, 7, 1, 12)
+    plugin = GenerateTimezoneMask(time=time)
+    result = plugin._calculate_tz_offsets(coordinate_pairs)
+    assert_array_equal(result, expected)
+
+    # Test including daylights savings, so the result should change as the
+    # date is changed.
+
+    # Northern hemisphere winter
+    expected = [-5 * 3600, 0, 11 * 3600]
+    time = datetime(2020, 1, 1, 12)
+    plugin = GenerateTimezoneMask(ignore_dst=False, time=time)
+    result = plugin._calculate_tz_offsets(coordinate_pairs)
+    assert_array_equal(result, expected)
+
+    # Southern hemisphere winter
+    expected = [-4 * 3600, 1 * 3600, 10 * 3600]
+    time = datetime(2020, 7, 1, 12)
+    plugin = GenerateTimezoneMask(ignore_dst=False, time=time)
+    result = plugin._calculate_tz_offsets(coordinate_pairs)
+    assert_array_equal(result, expected)
+
+
+def test__group_timezones(timezone_mask):
+    """
+    Group the 4 UTC offset masks into groups.
+    """
+    # Split the 4 offsets first in equal sized groups, then test unequally
+    # sized groups
+    groupings = [{0: [0, 1], 1: [2, 3]}, {0: [0, 2], 1: [3]}]
+
+    for groups in groupings:
+        plugin = GenerateTimezoneMask(groupings=groups)
+        result = plugin._group_timezones(timezone_mask)
+
+        assert len(result) == len(groups)
+        for group, cube in zip(groups.values(), result):
+            assert cube.coord("UTC_offset").points[0] == group[-1]
+            # A single UTC_offset point has no bounds, hence this try-except
+            try:
+                assert_array_equal(cube.coord("UTC_offset").bounds[0], group)
+            except TypeError:
+                pass
+
+
+@pytest.mark.parametrize("grid_fixture", ["global_grid", "uk_grid"])
+def test_process(request, grid_fixture):
+    """Test that the process method returns cubes that take the expected form.
+    Note that the time set by the user is effectively local time at every
+    grid point, but the cube stores the time information in UTC.
+
+    For UK users this means that despite the time test below setting a time of
+    1500, as it falls within British summer time (BST), the cube time is shown
+    as 1400.
+
+    EEEEEEEKKKKKKKK timezone hell. I need the test to work regardless of the
+    local timezone. Come back to this with a clearer mind.
+
+    """
+
+    expected = {
+        "global_grid": {"shape": (27, 19, 37), "min": -12, "max": 14},
+        "uk_grid": {"shape": (4, 21, 22), "min": -2, "max": 1},
+    }
+    expected_times = [1510286400, 1594908000]
+    times = [None, "20200716T1500"]
+
+    grid = request.getfixturevalue(grid_fixture)
+
+    for time, expected_time in zip(times, expected_times):
+        result = GenerateTimezoneMask(time=time)(grid)
+
+        print(result)
+        assert result.name() == "timezone_mask"
+        assert result.units == 1
+        assert result.coord('time').points[0] == expected_time
+        assert result.shape == expected[grid_fixture]["shape"]
+        assert result.coord("UTC_offset").points.min() == expected[grid_fixture]["min"]
+        assert result.coord("UTC_offset").points.max() == expected[grid_fixture]["max"]

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -40,8 +40,7 @@ from iris.cube import Cube, CubeList
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from improver.generate_ancillaries.generate_timezone_mask import GenerateTimezoneMask
-
-from ..set_up_test_cubes import set_up_variable_cube
+from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
 
 GLOBAL_ATTRIBUTES = {
     "title": "MOGREPS-G Model Forecast on Global 20 km Standard Grid",

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -260,13 +260,28 @@ def test__group_timezones(timezone_mask):
         result = plugin._group_timezones(timezone_mask)
 
         assert len(result) == len(groups)
-        for group, cube in zip(groups.values(), result):
+        for group, cube in zip(list(groups.values()), result):
             assert cube.coord("UTC_offset").points[0] == group[-1]
             # A single UTC_offset point has no bounds, hence this try-except
             try:
                 assert_array_equal(cube.coord("UTC_offset").bounds[0], group)
             except TypeError:
                 pass
+
+
+def test__group_timezones_empty_group(timezone_mask):
+    """Test the grouping of different UTC offsets into larger groups in a case
+    for which a specified group contains no data."""
+
+    groups = {0: [0, 1], 1: [2, 3], 2: [4, 10]}
+
+    plugin = GenerateTimezoneMask(groupings=groups)
+    result = plugin._group_timezones(timezone_mask)
+
+    assert len(result) == 2
+    for group, cube in zip(list(groups.values())[:-1], result):
+        assert cube.coord("UTC_offset").points[0] == group[-1]
+        assert_array_equal(cube.coord("UTC_offset").bounds[0], group)
 
 
 @pytest.mark.parametrize("grid_fixture", ["global_grid", "uk_grid"])

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -262,11 +262,12 @@ def test__group_timezones(timezone_mask):
         assert len(result) == len(groups)
         for group, cube in zip(list(groups.values()), result):
             assert cube.coord("UTC_offset").points[0] == group[-1]
-            # A single UTC_offset point has no bounds, hence this try-except
-            try:
+            assert cube.coord("UTC_offset").bounds is not None
+            if len(group) > 1:
                 assert_array_equal(cube.coord("UTC_offset").bounds[0], group)
-            except TypeError:
-                pass
+            else:
+                assert cube.coord("UTC_offset").bounds[0][0] == group[0]
+                assert cube.coord("UTC_offset").bounds[0][-1] == group[0]
 
 
 def test__group_timezones_empty_group(timezone_mask):

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2020 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the GenerateTimezoneMask plugin."""
+
+import pytest
+from datetime import datetime
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+from iris.cube import Cube
+
+from improver.generate_ancillaries.generate_timezone_mask import GenerateTimezoneMask
+from ..set_up_test_cubes import set_up_variable_cube
+
+
+@pytest.fixture
+def global_grid() -> Cube:
+    """Global grid template"""
+
+    data = np.zeros((19, 37), dtype=np.float32)
+    cube = set_up_variable_cube(
+        data, name="template", grid_spacing=10, domain_corner=(-90, -180)
+    )
+    return cube
+
+
+@pytest.fixture
+def uk_grid() -> Cube:
+    """UK grid template"""
+
+    data = np.zeros((21, 22), dtype=np.float32)
+    cube = set_up_variable_cube(
+        data,
+        name="template",
+        spatial_grid="equalarea",
+        grid_spacing=96900.0,
+        domain_corner=(-1036000.0, -1158000.0),
+    )
+    return cube
+
+
+def test__set_time(uk_grid):
+    """Test time is set correctly from either the cube or user."""
+
+    # Set by the cube time coordinate
+    expected = datetime(2017, 11, 10, 4)
+    plugin = GenerateTimezoneMask()
+    plugin(uk_grid)
+    assert plugin.time == expected
+
+    # Set by the user provided argument
+    expected = datetime(2020, 7, 16, 15)
+    plugin = GenerateTimezoneMask(time="20200716T1500Z")
+    plugin(uk_grid)
+    assert plugin.time == expected
+
+
+@pytest.mark.parametrize("grid_fixture", ["global_grid", "uk_grid"])
+def test__get_coordinate_pairs(request, grid_fixture):
+    """Test that a selection of elements are as expected in what is returned
+    by the _get_coordinate_pairs function. Tests are for both a native lat-long
+    grid and for an equal areas grid that must be transformed."""
+
+    sample_points = [0, 10, -1]
+    expected = {
+        "global_grid": [[-90.0, -180.0], [-90.0, -80.0], [90.0, 180.0]],
+        "uk_grid": [[44.517, -17.117], [45.548, -4.913], [62.026, 14.410]],
+    }
+
+    grid = request.getfixturevalue(grid_fixture)
+    result = GenerateTimezoneMask()._get_coordinate_pairs(grid)
+    for i, ii in enumerate(sample_points):
+        assert_array_almost_equal(result[:, ii], expected[grid_fixture][i], decimal=3)
+
+
+# _calculate_tz_offsets
+# _get_timezone
+# _calculate_offset
+# _group_timezones
+# process

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -282,17 +282,6 @@ def test__group_timezones_empty_group(timezone_mask):
         assert_array_equal(cube.coord("UTC_offset").bounds[0], group)
 
 
-def test__group_timezones_exception(timezone_mask):
-    """Test that an exception is raised if the key defining the timezone group
-    UTC_offset point is not within the bounds that the group defines."""
-
-    groups = {-3: [-6, -1], 9: [0, 6]}
-
-    plugin = GenerateTimezoneMask(groupings=groups)
-    with pytest.raises(ValueError, match=r"Defined UTC offset point for .*"):
-        plugin._group_timezones(timezone_mask)
-
-
 @pytest.fixture(name="process_expected")
 def process_expected_fixture() -> callable:
     """Returns expected results for parameterized process tests."""


### PR DESCRIPTION
This PR includes a new plugin for creating masks of timezone information to be used as ancillaries.
Note that it uses a package not currently in the stack. See the ticket for information.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)