### PR TITLE
Pylint fixes following stack change

### DIFF
--- a/improver/cli/wind_downscaling.py
+++ b/improver/cli/wind_downscaling.py
@@ -128,10 +128,7 @@ def process(
             height_levels_cube=None,
         )(wind_speed_slice)
         wind_speed_list.append(result)
-    # TODO: Remove temporary fix for chunking problems when merging cubes
-    max_npoints = max([np.prod(cube.data.shape) for cube in wind_speed_list])
-    while iris._lazy_data._MAX_CHUNK_SIZE < max_npoints:
-        iris._lazy_data._MAX_CHUNK_SIZE *= 2
+
     wind_speed = wind_speed_list.merge_cube()
     non_dim_coords = [x.name() for x in wind_speed.coords(dim_coords=False)]
     if "realization" in non_dim_coords:

--- a/improver_tests/spotdata/spotdata/test_SpotLapseRateAdjust.py
+++ b/improver_tests/spotdata/spotdata/test_SpotLapseRateAdjust.py
@@ -106,6 +106,7 @@ class Test_SpotLapseRateAdjust(IrisTest):
             ]
         )
         altitudes = np.array([3, 4, 0])
+        # pylint: disable=unsubscriptable-object
         latitudes = np.array([y_coord[0], y_coord[1], y_coord[2]])
         longitudes = np.array([x_coord[0], x_coord[1], x_coord[2]])
         wmo_ids = np.arange(3)

--- a/improver_tests/spotdata/spotdata/test_build_spotdata_cube.py
+++ b/improver_tests/spotdata/spotdata/test_build_spotdata_cube.py
@@ -204,6 +204,7 @@ class Test_build_spotdata_cube(IrisTest):
             neighbour_methods=self.neighbour_methods,
         )
 
+        # pylint: disable=unsubscriptable-object
         self.assertEqual(result.coord("time").points[0], time_coord.points[0])
         self.assertEqual(
             result.coord("forecast_reference_time").points[0], frt_coord.points[0]

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -199,6 +199,7 @@ class Test_construct_scalar_time_coords(IrisTest):
         self.assertEqual(
             iris_time_to_datetime(time_coord)[0], datetime(2017, 12, 1, 14, 0)
         )
+        # pylint: disable=unsubscriptable-object
         self.assertEqual(time_coord.bounds[0][0], time_coord.points[0] - 3600)
         self.assertEqual(time_coord.bounds[0][1], time_coord.points[0])
 
@@ -214,6 +215,7 @@ class Test_construct_scalar_time_coords(IrisTest):
         self.assertEqual(
             iris_time_to_datetime(time_coord)[0], datetime(2017, 12, 1, 14, 0)
         )
+        # pylint: disable=unsubscriptable-object
         self.assertEqual(time_coord.bounds[0][0], time_coord.points[0] - 3600)
         self.assertEqual(time_coord.bounds[0][1], time_coord.points[0])
 


### PR DESCRIPTION
Adds pylint subscription exemptions where required. These can probably be removed when we have a newer pylint version; recorded in stack upgrade sticky ticket.

I have also removed a chunking fix from the wind downscaling CLI. This relies upon an iris variable that no longer exists in the newer version of iris. The reason for this fix is well documented in #669 which also states that the fix can be removed when dask is upgraded beyond version 0.19.3 ([comment](https://github.com/metoppv/improver/issues/669#issuecomment-435075462)). The os43-2 stack and the other stacks we commonly use (default-current, experimental-current) all now include dask v1.0.0.

Testing:
 - [x] Ran tests and they passed OK