### PR TITLE
Modify import and test skipping for timezonefinder module

### DIFF
--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -30,6 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for generating timezone masks."""
 
+import imp
 from datetime import datetime
 
 import iris
@@ -79,7 +80,12 @@ class GenerateTimezoneMask(BasePlugin):
                 groups. This is of use if data is not available at hourly
                 intervals.
         """
-        from timezonefinder import TimezoneFinder
+        try:
+            imp.find_module("timezonefinder")
+        except ImportError as err:
+            raise err
+        else:
+            from timezonefinder import TimezoneFinder
 
         self.tf = TimezoneFinder()
         self.time = time

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for generating timezone masks."""
 
-import imp
+import importlib
 from datetime import datetime
 
 import iris
@@ -81,7 +81,7 @@ class GenerateTimezoneMask(BasePlugin):
                 intervals.
         """
         try:
-            imp.find_module("timezonefinder")
+            importlib.util.find_spec("timezonefinder")
         except ImportError as err:
             raise err
         else:

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -42,6 +42,9 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from improver.generate_ancillaries.generate_timezone_mask import GenerateTimezoneMask
 from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
 
+pytest.importorskip("timezonefinder")
+pytest.importorskip("numba")
+
 GLOBAL_ATTRIBUTES = {
     "title": "MOGREPS-G Model Forecast on Global 20 km Standard Grid",
     "source": "Met Office Unified Model",
@@ -157,6 +160,7 @@ def test__get_coordinate_pairs(request, grid_fixture):
 def test__get_coordinate_pairs_exception(global_grid):
     """Test that an exception is raised if longitudes are found outside the
     range -180 to 180."""
+
     global_grid.coord("longitude").points = global_grid.coord("longitude").points + 360
 
     with pytest.raises(ValueError, match=r"TimezoneFinder requires .*"):
@@ -170,8 +174,6 @@ def test__calculate_tz_offsets():
 
     These test also cover the functionality of _calculate_offset.
     """
-    pytest.importorskip("timezonefinder")
-    pytest.importorskip("numba")
 
     # New York, London, and Melbourne
     coordinate_pairs = np.array([[41, -74], [51.5, 0], [-37.9, 145]])
@@ -341,9 +343,6 @@ def test_process(request, grid_fixture, time, process_expected):
     The output data is primarily checked in the acceptance tests as a reasonably
     large number of data points are required to reliably check it. Here we check
     only a small sample."""
-
-    pytest.importorskip("timezonefinder")
-    pytest.importorskip("numba")
 
     expected, expected_time, index = process_expected(time, grid_fixture)
     grid = request.getfixturevalue(grid_fixture)


### PR DESCRIPTION
The timezonefinder module is imported in the init of the GenerateTimezoneMask plugin. This is instantiated for all the unit and acceptance test, so they must all be skipped if the module is not available. Pylint further checks that imports are available, so to work around this a check has been added to the import that satisfies pylint in the absence of the module.

Testing:
 - [x] Ran tests and they passed OK