### PR TITLE
IMPRO-1801: Added the forecast period bounds to emos coefficients cubes

### DIFF
--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -624,12 +624,15 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
             historic_forecasts.coord("forecast_reference_time")
         )
 
-        # Create forecast period coordinate.
-        (fp_point,) = historic_forecasts.coord("forecast_period").points
-        fp_bounds = historic_forecasts.coord("forecast_period").bounds
-        fp_coord = historic_forecasts.coord("forecast_period").copy(
-            points=fp_point, bounds=fp_bounds
-        )
+        # Copy the forecast period coordinate.
+        fp_coord = historic_forecasts.coord("forecast_period").copy()
+
+        if fp_coord.shape[0] != 1:
+            msg = (
+                "The forecast period must be the same for all historic forecasts. "
+                "Forecast periods found: {}".format(fp_coord.points)
+            )
+            raise ValueError(msg)
 
         return [(frt_coord, None), (fp_coord, None)]
 

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -624,8 +624,7 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
             historic_forecasts.coord("forecast_reference_time")
         )
 
-        # Copy the forecast period coordinate.
-        fp_coord = historic_forecasts.coord("forecast_period").copy()
+        fp_coord = historic_forecasts.coord("forecast_period")
 
         if fp_coord.shape[0] != 1:
             msg = (

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -625,8 +625,11 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
         )
 
         # Create forecast period coordinate.
-        fp_point = np.unique(historic_forecasts.coord("forecast_period").points)
-        fp_coord = historic_forecasts.coord("forecast_period").copy(fp_point)
+        (fp_point,) = historic_forecasts.coord("forecast_period").points
+        fp_bounds = historic_forecasts.coord("forecast_period").bounds
+        fp_coord = historic_forecasts.coord("forecast_period").copy(
+            points=fp_point, bounds=fp_bounds
+        )
 
         return [(frt_coord, None), (fp_coord, None)]
 

--- a/improver/calibration/utilities.py
+++ b/improver/calibration/utilities.py
@@ -277,10 +277,9 @@ def merge_land_and_sea(calibrated_land_only, uncalibrated):
 def forecast_coords_match(first_cube, second_cube):
     """
     Determine if two cubes have equivalent forecast_periods and that the hours
-    of the forecast_reference_time coordinates match. Only the points of the
-    forecast period and forecast reference time coordinate are checked. This is
-    to ensure that a calibration / coefficient cube matches the forecast cube,
-    as appropriate.
+    of the forecast_reference_time coordinates match. Only the point of the
+    forecast reference time coordinate is checked to ensure that a calibration
+    / coefficient cube matches the forecast cube, as appropriate.
 
     Args:
         first_cube (iris.cube.Cube):

--- a/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -390,7 +390,7 @@ class Test_create_coefficients_cubelist(SetupExpectedCoefficients):
         self.historic_forecast.remove_coord("forecast_period")
         self.historic_forecast.add_aux_coord(fp_coord, 0)
 
-        msg = "too many values to unpack"
+        msg = "The forecast period must be the same"
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin.create_coefficients_cubelist(
                 self.optimised_coeffs, self.historic_forecast

--- a/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -364,8 +364,7 @@ class Test_create_coefficients_cubelist(SetupExpectedCoefficients):
         fp_bounds = [10800, 14400]
 
         self.historic_forecast.coord("forecast_period").bounds = fp_bounds
-        expected_fp = self.expected_fp
-        expected_fp.bounds = fp_bounds
+        self.expected_fp.bounds = fp_bounds
 
         result = self.plugin.create_coefficients_cubelist(
             self.optimised_coeffs, self.historic_forecast
@@ -376,7 +375,7 @@ class Test_create_coefficients_cubelist(SetupExpectedCoefficients):
                 cube.coord("forecast_reference_time").cell(0).point, self.expected_frt,
             )
             self.assertEqual(
-                cube.coord("forecast_period"), expected_fp,
+                cube.coord("forecast_period"), self.expected_fp,
             )
 
     @ManageWarnings(ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)


### PR DESCRIPTION
This PR adds the forecast period bounds to the emos coefficient cubes coordinates. This is required as the entire coordinate is checked when applying the coefficients, so without these bounds an exception is raised when calibrating period diagnostics.

An alternative approach would be to only check the coordinate point and ignore the bounds, but the chosen approach has the benefit of ensuring that we cannot apply the coefficients for an instantaneous temperature to a period temperature minimum/maximum.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)