### PR TITLE
1273 Modify set_up_test_cubes to provide additional functionality for metdata cube generation CLI.

### DIFF
--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -275,7 +275,7 @@ def _construct_dimension_coords(
         coord_length = data_shape[0]
 
         realization_coord = _create_dimension_coord(
-            realizations, data, coord_length, coord_name, units=coord_units
+            realizations, data_shape, coord_length, coord_name, units=coord_units
         )
         dim_coords.append((realization_coord, 0))
 

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -218,15 +218,15 @@ def construct_scalar_time_coords(time, time_bounds, frt):
     return coord_dims
 
 
-def _create_dimension_coord(coord_array, data_shape, data_length, coord_name, **kwargs):
+def _create_dimension_coord(coord_array, data_length, coord_name, **kwargs):
     """
     Creates dimension coordinate from coord_array if not None, otherwise creating an array of integers with an interval of 1
     """
     if coord_array is not None:
         if len(coord_array) != data_length:
             raise ValueError(
-                "Cannot generate {} {}s from data of shape "
-                "{}".format(len(coord_array), coord_name, data_shape)
+                "Cannot generate {} {}s from data of length "
+                "{}".format(len(coord_array), coord_name, data_length)
             )
 
         coord_array = np.array(coord_array)
@@ -238,7 +238,7 @@ def _create_dimension_coord(coord_array, data_shape, data_length, coord_name, **
         coord_array = np.arange(data_length).astype(np.int32)
 
     if coord_name in iris.std_names.STD_NAMES:
-        dim_coord = DimCoord(coord_array, coord_name, **kwargs)
+        dim_coord = DimCoord(coord_array, standard_name=coord_name, **kwargs)
     else:
         dim_coord = DimCoord(coord_array, long_name=coord_name, **kwargs)
 
@@ -275,7 +275,7 @@ def _construct_dimension_coords(
         coord_length = data_shape[0]
 
         realization_coord = _create_dimension_coord(
-            realizations, data_shape, coord_length, coord_name, units=coord_units
+            realizations, coord_length, coord_name, units=coord_units
         )
         dim_coords.append((realization_coord, 0))
 
@@ -294,7 +294,6 @@ def _construct_dimension_coords(
 
         height_coord = _create_dimension_coord(
             height_levels,
-            data_shape,
             coord_length,
             coord_name,
             units=coord_units,

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -225,7 +225,7 @@ def _create_dimension_coord(coord_array, data_length, coord_name, **kwargs):
     if coord_array is not None:
         if len(coord_array) != data_length:
             raise ValueError(
-                "Cannot generate {} {}s from data of length "
+                "Cannot generate {} {}s with data of length "
                 "{}".format(len(coord_array), coord_name, data_length)
             )
 

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -48,6 +48,12 @@ from improver.metadata.constants.mo_attributes import MOSG_GRID_DEFINITION
 from improver.metadata.constants.time_types import TIME_COORDS
 from improver.metadata.forecast_times import forecast_period_coord
 
+DIM_COORD_ATTRIBUTES = {
+    "realization": {"units": "1"},
+    "height": {"units": "m", "attributes": {"positive": "up"}},
+    "pressure": {"units": "Pa", "attributes": {"positive": "down"}},
+}
+
 
 def construct_yx_coords(
     ypoints, xpoints, spatial_grid, grid_spacing=None, domain_corner=None
@@ -258,21 +264,24 @@ def _get_dimension_coords(
     if height_levels is None and ndims == 4:
         raise ValueError("Height levels must be provided if data has 4 dimensions.")
     if ndims == 4 or (height_levels is None and ndims == 3):
+        coord_name = "realization"
+        coord_units = DIM_COORD_ATTRIBUTES[coord_name]["units"]
         realization_coord = _create_dimension_coord(
-            realizations, data, 0, "realization", "1"
+            realizations, data, 0, coord_name, coord_units
         )
         dim_coords.append((realization_coord, 0))
     if height_levels is not None and ndims in (3, 4):
         i = len(dim_coords)
-        coord_name = "height"
-        coord_units = "m"
-        attributes = {"positive": "up"}
         if pressure:
             coord_name = "pressure"
-            coord_units = "Pa"
-            attributes["positive"] = "down"
+        else:
+            coord_name = "height"
+
+        coord_units = DIM_COORD_ATTRIBUTES[coord_name]["units"]
+        coord_attributes = DIM_COORD_ATTRIBUTES[coord_name]["attributes"]
+
         height_coord = _create_dimension_coord(
-            height_levels, data, i, coord_name, coord_units, attributes=attributes
+            height_levels, data, i, coord_name, coord_units, attributes=coord_attributes
         )
         dim_coords.append((height_coord, i))
     dim_coords.append((y_coord, len(dim_coords)))

--- a/improver_tests/calibration/ensemble_calibration/helper_functions.py
+++ b/improver_tests/calibration/ensemble_calibration/helper_functions.py
@@ -116,8 +116,6 @@ class SetupCubes(IrisTest):
             frt=frt_dt,
             attributes=MANDATORY_ATTRIBUTE_DEFAULTS,
         )
-        for axis in ["x", "y"]:
-            self.current_temperature_forecast_cube.coord(axis=axis).guess_bounds()
 
         # Create historic forecasts and truth
         self.historic_forecasts = _create_historic_forecasts(
@@ -140,8 +138,6 @@ class SetupCubes(IrisTest):
             realizations=[0, 1, 2],
             attributes=MANDATORY_ATTRIBUTE_DEFAULTS,
         )
-        for axis in ["x", "y"]:
-            self.current_wind_speed_forecast_cube.coord(axis=axis).guess_bounds()
 
         self.historic_wind_speed_forecast_cube = _create_historic_forecasts(
             base_data,

--- a/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
@@ -81,7 +81,10 @@ def build_coefficients_cubelist(template, coeff_values, predictor="mean"):
         aux_coords_and_dims.append((template.coord(coord).copy(), None))
 
     for coord in [template.coord(axis="x"), template.coord(axis="y")]:
-        bounds = [min(coord.points), max(coord.points)]
+        coord_diffs = np.diff(coord.points)
+        min_bound = min(coord.points) - (coord_diffs[0] / 2)
+        max_bound = max(coord.points) + (coord_diffs[-1] / 2)
+        bounds = [min_bound, max_bound]
         point = np.median(bounds)
         new_coord = coord.copy(points=[point], bounds=[bounds])
         aux_coords_and_dims.append((new_coord, None))

--- a/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
+++ b/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
@@ -148,16 +148,12 @@ class SetupCoefficientsCubes(SetupCubes, SetupExpectedCoefficients):
             units="K",
             attributes=MANDATORY_ATTRIBUTE_DEFAULTS,
         )
-        for axis in ["x", "y"]:
-            self.expected_loc_param_mean_cube.coord(axis=axis).guess_bounds()
         self.expected_scale_param_mean_cube = set_up_variable_cube(
             self.expected_scale_param_mean,
             name="scale_parameter",
             units="Kelvin^2",
             attributes=MANDATORY_ATTRIBUTE_DEFAULTS,
         )
-        for axis in ["x", "y"]:
-            self.expected_scale_param_mean_cube.coord(axis=axis).guess_bounds()
 
 
 class Test__init__(IrisTest):

--- a/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -298,7 +298,6 @@ class Test_create_coefficients_cubelist(SetupExpectedCoefficients):
         self.expected_x_coord_points = np.median(
             self.historic_forecast.coord(axis="x").points
         )
-        self.historic_forecast.coord(axis="x").guess_bounds()
         self.expected_x_coord_bounds = np.array(
             [
                 [
@@ -310,7 +309,6 @@ class Test_create_coefficients_cubelist(SetupExpectedCoefficients):
         self.expected_y_coord_points = np.median(
             self.historic_forecast.coord(axis="y").points
         )
-        self.historic_forecast.coord(axis="y").guess_bounds()
         self.expected_y_coord_bounds = np.array(
             [
                 [

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -282,7 +282,7 @@ class Test_generate_hash(unittest.TestCase):
         cube = set_up_variable_cube(np.ones((3, 3)).astype(np.float32))
         hash_input = cube.coord("latitude")
         result = generate_hash(hash_input)
-        expected = "68fa646ab98ab7a994e07cc1e4e42f080f6d3b9b8b70166cd0be176290391b15"
+        expected = "ee6a057f5eeef0e94a853cfa98f3c22b121dda31ada3378ce9466e48d06f9887"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -360,9 +360,16 @@ class Test_set_up_variable_cube(IrisTest):
     def test_error_unmatched_realizations(self):
         """Test error is raised if the realizations provided do not match the
         data dimensions"""
-        msg = "Cannot generate 4 realizations"
+        msg = "Cannot generate 4 realizations from data of length 3"
         with self.assertRaisesRegex(ValueError, msg):
             _ = set_up_variable_cube(self.data_3d, realizations=np.arange(4))
+
+    def test_error_unmatched_height_levels(self):
+        """Test error is raised if the heights provided do not match the
+        data dimensions"""
+        msg = "Cannot generate 4 heights from data of length 3"
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_variable_cube(self.data_3d, height_levels=np.arange(4))
 
     def test_realizations_from_data_height_levels(self):
         """ Tests realizations from data and height coordinates added """

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -360,16 +360,28 @@ class Test_set_up_variable_cube(IrisTest):
     def test_error_unmatched_realizations(self):
         """Test error is raised if the realizations provided do not match the
         data dimensions"""
-        msg = "Cannot generate 4 realizations from data of length 3"
+        realizations_len = 4
+        data_len = len(self.data_3d[0])
+        msg = "Cannot generate {} realizations with data of length {}".format(
+            realizations_len, data_len
+        )
         with self.assertRaisesRegex(ValueError, msg):
-            _ = set_up_variable_cube(self.data_3d, realizations=np.arange(4))
+            _ = set_up_variable_cube(
+                self.data_3d, realizations=np.arange(realizations_len)
+            )
 
     def test_error_unmatched_height_levels(self):
         """Test error is raised if the heights provided do not match the
         data dimensions"""
-        msg = "Cannot generate 4 heights from data of length 3"
+        height_levels_len = 4
+        data_len = len(self.data_3d[0])
+        msg = "Cannot generate {} heights with data of length {}".format(
+            height_levels_len, data_len
+        )
         with self.assertRaisesRegex(ValueError, msg):
-            _ = set_up_variable_cube(self.data_3d, height_levels=np.arange(4))
+            _ = set_up_variable_cube(
+                self.data_3d, height_levels=np.arange(height_levels_len)
+            )
 
     def test_realizations_from_data_height_levels(self):
         """ Tests realizations from data and height coordinates added """

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -312,6 +312,37 @@ class Test_set_up_variable_cube(IrisTest):
         self.assertEqual(result.coord("forecast_period").points[0], 10800)
         self.assertFalse(result.coords("time", dim_coords=True))
 
+    def test_height_levels(self):
+        """Test height coordinate is added"""
+        height_levels = [1.5, 3.0, 4.5]
+        expected_units = "m"
+        expected_attributes = {"positive": "up"}
+        result = set_up_variable_cube(self.data_3d, height_levels=height_levels)
+        self.assertArrayAlmostEqual(result.data, self.data_3d)
+        self.assertEqual(result.coord_dims("height"), (0,))
+        self.assertArrayEqual(result.coord("height").points, np.array(height_levels))
+        self.assertEqual(result.coord("height").units, expected_units)
+        self.assertEqual(result.coord("height").attributes, expected_attributes)
+        self.assertEqual(result.coord_dims("latitude"), (1,))
+        self.assertEqual(result.coord_dims("longitude"), (2,))
+
+    def test_pressure_levels(self):
+        """Test pressure coordinate is added"""
+        height_levels = [90000, 70000, 3000]
+        expected_units = "Pa"
+        pressure = True
+        expected_attributes = {"positive": "down"}
+        result = set_up_variable_cube(
+            self.data_3d, height_levels=height_levels, pressure=pressure
+        )
+        self.assertArrayAlmostEqual(result.data, self.data_3d)
+        self.assertEqual(result.coord_dims("pressure"), (0,))
+        self.assertArrayEqual(result.coord("pressure").points, np.array(height_levels))
+        self.assertEqual(result.coord("pressure").units, expected_units)
+        self.assertEqual(result.coord("pressure").attributes, expected_attributes)
+        self.assertEqual(result.coord_dims("latitude"), (1,))
+        self.assertEqual(result.coord_dims("longitude"), (2,))
+
     def test_realizations_from_data(self):
         """Test realization coordinate is added for 3D data"""
         result = set_up_variable_cube(self.data_3d)
@@ -333,12 +364,60 @@ class Test_set_up_variable_cube(IrisTest):
         with self.assertRaisesRegex(ValueError, msg):
             _ = set_up_variable_cube(self.data_3d, realizations=np.arange(4))
 
-    def test_error_too_many_dimensions(self):
-        """Test error is raised if input cube has more than 3 dimensions"""
+    def test_realizations_from_data_height_levels(self):
+        """ Tests realizations from data and height coordinates added """
+        height_levels = [1.5, 3.0, 4.5]
         data_4d = np.array([self.data_3d, self.data_3d])
-        msg = "Expected 2 or 3 dimensions on input data: got 4"
+        result = set_up_variable_cube(data_4d, height_levels=height_levels)
+        self.assertArrayAlmostEqual(result.data, data_4d)
+        self.assertEqual(result.coord_dims("realization"), (0,))
+        self.assertArrayEqual(result.coord("realization").points, np.array([0, 1]))
+        self.assertEqual(result.coord_dims("height"), (1,))
+        self.assertArrayEqual(result.coord("height").points, np.array(height_levels))
+        self.assertEqual(result.coord_dims("latitude"), (2,))
+        self.assertEqual(result.coord_dims("longitude"), (3,))
+
+    def test_realizations_height_levels(self):
+        """ Tests realizations and height coordinates added """
+        realizations = [0, 3]
+        height_levels = [1.5, 3.0, 4.5]
+        data_4d = np.array([self.data_3d, self.data_3d])
+        result = set_up_variable_cube(
+            data_4d, realizations=realizations, height_levels=height_levels
+        )
+        self.assertArrayAlmostEqual(result.data, data_4d)
+        self.assertEqual(result.coord_dims("realization"), (0,))
+        self.assertArrayEqual(
+            result.coord("realization").points, np.array(realizations)
+        )
+        self.assertEqual(result.coord_dims("height"), (1,))
+        self.assertArrayEqual(result.coord("height").points, np.array(height_levels))
+        self.assertEqual(result.coord_dims("latitude"), (2,))
+        self.assertEqual(result.coord_dims("longitude"), (3,))
+
+    def test_error_no_height_levels_4d_data(self):
+        """ Tests error is raised if 4d data provided but not height_levels """
+        data_4d = np.array([self.data_3d, self.data_3d])
+        msg = "Height levels must be provided if data has 4 dimensions."
         with self.assertRaisesRegex(ValueError, msg):
             _ = set_up_variable_cube(data_4d)
+
+    def test_error_too_many_dimensions(self):
+        """Test error is raised if input cube has more than 4 dimensions"""
+        data_5d = np.array([[self.data_3d, self.data_3d], [self.data_3d, self.data_3d]])
+        msg = "Expected 2 to 4 dimensions on input data: got 5"
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_variable_cube(data_5d)
+
+    def test_error_not_enough_dimensions(self):
+        """Test error is raised if input cube 3 dimensions and both realizations and height_levels provided"""
+        realizations = [0, 3, 4]
+        height_levels = [1.5, 3.0, 4.5]
+        msg = "Input data must have 4 dimensions to add both realization and height coordinates: got 3"
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_variable_cube(
+                self.data_3d, realizations=realizations, height_levels=height_levels
+            )
 
     def test_standard_grid_metadata_uk(self):
         """Test standard grid metadata is added if specified"""

--- a/improver_tests/utilities/test_cube_extraction.py
+++ b/improver_tests/utilities/test_cube_extraction.py
@@ -87,9 +87,9 @@ def set_up_precip_probability_cube():
         variable_name="precipitation_rate",
         threshold_units="m s-1",
         spatial_grid="equalarea",
+        grid_spacing=1,
+        domain_corner=(0, 0),
     )
-    cube.coord(axis="x").points = np.arange(3, dtype=np.float32)
-    cube.coord(axis="y").points = np.arange(3, dtype=np.float32)
 
     return cube
 

--- a/improver_tests/utilities/test_load.py
+++ b/improver_tests/utilities/test_load.py
@@ -143,7 +143,7 @@ class Test_load_cube(IrisTest):
         realization_points = np.array([0])
         longitude_points = np.array([0])
         constr1 = iris.Constraint(realization=0)
-        constr2 = iris.Constraint(longitude=lambda cell: -0.1 < cell < 0.1)
+        constr2 = iris.Constraint(longitude=lambda cell: -5.1 < cell < 5.1)
         constr = constr1 & constr2
         result = load_cube(self.filepath, constraints=constr)
         self.assertArrayAlmostEqual(

--- a/improver_tests/utilities/test_load.py
+++ b/improver_tests/utilities/test_load.py
@@ -143,7 +143,7 @@ class Test_load_cube(IrisTest):
         realization_points = np.array([0])
         longitude_points = np.array([0])
         constr1 = iris.Constraint(realization=0)
-        constr2 = iris.Constraint(longitude=lambda cell: -5.1 < cell < 5.1)
+        constr2 = iris.Constraint(longitude=lambda cell: cell.contains_point(0))
         constr = constr1 & constr2
         result = load_cube(self.filepath, constraints=constr)
         self.assertArrayAlmostEqual(


### PR DESCRIPTION
Addresses #1273 

- Add ability to add height/pressure level as a dimension coordinate.
- Add tests to test new dimension.
- Add bounds to y and x coordinates using guess_bounds().
- Modify tests that failed as a result of adding bounds.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
