### PR TITLE
IMPRO-1812: Configurable bin fraction for reliability calibration

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -477,7 +477,7 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
     The method implemented here is described in Flowerdew J. 2014.
     """
 
-    def __init__(self, minimum_forecast_count=200):
+    def __init__(self, minimum_forecast_count=200, minimum_bin_fraction=0.6):
         """
         Initialise class for applying reliability calibration.
 
@@ -488,6 +488,13 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
                 table for a forecast threshold includes any bins with
                 insufficient counts that threshold will be returned unchanged.
                 The default value of 200 is that used in Flowerdew 2014.
+            minimum_bin_fraction (float):
+                The minimum fraction of forecast count bins associated with a
+                probability threshold that must exceed minimum_forecast_count
+                for that threshold to be calibrated.
+        Raises:
+            ValueError: If minimum_forecast_count is less than 1.
+            ValueError: If minimum_bin_fraction is not between 0 and 1.
         References:
             Flowerdew J. 2014. Calibrating ensemble reliability whilst
             preserving spatial structure. Tellus, Ser. A Dyn. Meteorol.
@@ -499,7 +506,14 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
                 "bins in the reliability table are not handled."
             )
 
+        if minimum_bin_fraction < 0 or minimum_bin_fraction > 1:
+            raise ValueError(
+                "The minimum_bin_fraction must be between 0 and 1. Value set "
+                f"as {minimum_bin_fraction}"
+            )
+
         self.minimum_forecast_count = minimum_forecast_count
+        self.minimum_bin_fraction = minimum_bin_fraction
         self.threshold_coord = None
 
     def __repr__(self):
@@ -615,10 +629,11 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
             iris.Constraint(table_row_name="sum_of_forecast_probabilities")
         ).data
 
-        # In some bins have insufficient counts, return None to avoid applying
-        # calibration.
+        # If the fraction of bins with forecast counts exceeding minimum_forecast_count
+        # if less than minimum_bin_fraction, return None to avoid applying calibration
+        # to that probability threshold.
         valid_bins = np.where(forecast_count >= self.minimum_forecast_count)
-        if valid_bins[0].size != forecast_count.size:
+        if valid_bins[0].size < forecast_count.size * self.minimum_bin_fraction:
             return None, None
 
         forecast_probability = np.array(forecast_probability_sum / forecast_count)

--- a/improver/cli/apply_reliability_calibration.py
+++ b/improver/cli/apply_reliability_calibration.py
@@ -41,6 +41,7 @@ def process(
     reliability_table: cli.inputcube = None,
     *,
     minimum_forecast_count=200,
+    minimum_bin_fraction=0.6,
 ):
     """
     Calibrate a probability forecast using the provided reliability calibration
@@ -65,6 +66,10 @@ def process(
             table for a forecast threshold includes any bins with
             insufficient counts that threshold will be returned unchanged.
             The default value of 200 is that used in Flowerdew 2014.
+        minimum_bin_fraction (float):
+            The minimum fraction of forecast count bins associated with a
+            probability threshold that must exceed minimum_forecast_count
+            for that threshold to be calibrated.
     Returns:
         iris.cube.Cube:
             Calibrated forecast.
@@ -74,5 +79,8 @@ def process(
     if reliability_table is None:
         return forecast
 
-    plugin = ApplyReliabilityCalibration(minimum_forecast_count=minimum_forecast_count)
+    plugin = ApplyReliabilityCalibration(
+        minimum_forecast_count=minimum_forecast_count,
+        minimum_bin_fraction=minimum_bin_fraction,
+    )
     return plugin(forecast, reliability_table)

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -134,8 +134,7 @@ class Test__init__(unittest.TestCase):
         """Test an exception is raised if the minimum_bin_fraction value is
         not between 0 and 1 inclusive."""
 
-        msg = ("The minimum_bin_fraction must be between 0 and 1. Value set "
-               f"as 1.5")
+        msg = "The minimum_bin_fraction must be between 0 and 1. Value set as 1.5"
         with self.assertRaisesRegex(ValueError, msg):
             Plugin(minimum_bin_fraction=1.5)
 
@@ -291,9 +290,7 @@ class Test__calculate_reliability_probabilities(Test_ReliabilityCalibrate):
         self.reliability_cube.data[0, 2, -1] = 100
 
         plugin = Plugin(minimum_bin_fraction=0.5)
-        result = plugin._calculate_reliability_probabilities(
-            self.reliability_cube[0]
-        )
+        result = plugin._calculate_reliability_probabilities(self.reliability_cube[0])
         assert_array_equal(result, expected)
 
 

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -283,11 +283,11 @@ class Test__calculate_reliability_probabilities(Test_ReliabilityCalibrate):
         expected values."""
 
         expected = (
-            np.array([0.0, 0.25, 0.5, 0.75, 10.0]),
-            np.array([0.0, 0.0, 0.25, 0.5, 7.5]),
+            np.array([0.0, 0.25, 0.5, 0.75, 1.0]),
+            np.array([0.0, 0.0, 0.25, 0.5, 1.0]),
         )
 
-        self.reliability_cube.data[0, 2, -1] = 100
+        self.reliability_cube.data[0, :, -1] = 100
 
         plugin = Plugin(minimum_bin_fraction=0.5)
         result = plugin._calculate_reliability_probabilities(self.reliability_cube[0])


### PR DESCRIPTION
Adds a user configurable bin fraction to determine whether a threshold can be calibrated. This allows thresholds for which there are incomplete forecast bins (as measured against the minimum_forecast_count) to still be calibrated.

This may need slight modification following work in IMPRO-1810/1811.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)