### PR TITLE
Update to constant observation frequency assumption

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -34,6 +34,7 @@ import warnings
 
 import iris
 import numpy as np
+import operator
 import scipy
 
 from improver import BasePlugin, PostProcessingPlugin
@@ -750,11 +751,11 @@ class ManipulateReliabilityTable(BasePlugin):
     @staticmethod
     def _assume_constant_observation_frequency(observation_count, forecast_count):
         """
-        Iterate through the observation frequency from the lowest probability
-        bin to the highest probability bin. Compare each pair of bins and, if
-        a pair is non-monotonic, replace the value of the upper bin with the
-        value of the lower bin. Then calculate the new observation count
-        required to give a monotonic observation frequency.
+        Iterate through the observation frequency from the bin with the highest
+        sample count to the bin with the lowest sample count. Compare each
+        pair of bins and, if a pair is non-monotonic, replace the value of the
+        upper bin with the value of the lower bin. Then calculate the new
+        observation count required to give a monotonic observation frequency.
 
         Args:
             observation_count (numpy.ndarray):
@@ -768,10 +769,25 @@ class ManipulateReliabilityTable(BasePlugin):
 
         """
         observation_frequency = np.array(observation_count / forecast_count)
-        for index, lower_bin in enumerate(observation_frequency[:-1]):
-            (diff,) = np.diff([lower_bin, observation_frequency[index + 1]])
-            if diff < 0:
-                observation_frequency[index + 1] = lower_bin
+
+        iterator = observation_frequency
+        operation = operator.lt
+        # Top down if forecast count is lower for lowest probability bin,
+        # than for highest probability bin.
+        if forecast_count[0] < forecast_count[-1]:
+            # Reverse array to iterate from top to bottom.
+            iterator = observation_frequency[::-1]
+            operation = operator.gt
+
+        for index, lower_bin in enumerate(iterator[:-1]):
+            (diff,) = np.diff([lower_bin, iterator[index + 1]])
+            if operation(diff, 0):
+                iterator[index + 1] = lower_bin
+
+        observation_frequency = iterator
+        if forecast_count[0] < forecast_count[-1]:
+            observation_frequency = iterator[::-1]
+
         observation_count = observation_frequency * forecast_count
         return observation_count
 

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -751,11 +751,15 @@ class ManipulateReliabilityTable(BasePlugin):
     @staticmethod
     def _assume_constant_observation_frequency(observation_count, forecast_count):
         """
-        Iterate through the observation frequency from the bin with the highest
-        sample count to the bin with the lowest sample count. Compare each
-        pair of bins and, if a pair is non-monotonic, replace the value of the
-        upper bin with the value of the lower bin. Then calculate the new
-        observation count required to give a monotonic observation frequency.
+        Decide which end bin (highest probability bin or lowest probability
+        bin) has the highest sample count. Iterate through the observation
+        frequency from the end bin with the highest sample count to the end bin
+        with the lowest sample count. Whilst iterating, compare each pair of
+        bins and, if a pair is non-monotonic, replace the value of the bin
+        closer to the lowest sample count end bin with the value of the
+        bin that is closer to the higher sample count end bin. Then calculate
+        the new observation count required to give a monotonic observation
+        frequency.
 
         Args:
             observation_count (numpy.ndarray):

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -790,6 +790,7 @@ class ManipulateReliabilityTable(BasePlugin):
 
         observation_frequency = iterator
         if forecast_count[0] < forecast_count[-1]:
+            # Re-reverse array from bottom to top to ensure original ordering.
             observation_frequency = iterator[::-1]
 
         observation_count = observation_frequency * forecast_count

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -30,11 +30,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Reliability calibration plugins."""
 
+import operator
 import warnings
 
 import iris
 import numpy as np
-import operator
 import scipy
 
 from improver import BasePlugin, PostProcessingPlugin

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -464,7 +464,8 @@ class Test__assume_constant_observation_frequency(Test_setup):
         )
         assert_array_equal(result.data, expected_result)
 
-    def test_non_monotonic_lower_forecast_count_on_left(self):
+    @staticmethod
+    def test_non_monotonic_lower_forecast_count_on_left():
         """Test enforcement of monotonicity for observation frequency."""
         obs_count = np.array([0, 750, 500, 1000, 750], dtype=np.float32)
         forecast_count = np.array([500, 1000, 1000, 1000, 1000], dtype=np.float32)
@@ -474,7 +475,8 @@ class Test__assume_constant_observation_frequency(Test_setup):
         )
         assert_array_equal(result.data, expected_result)
 
-    def test_non_monotonic_higher_forecast_count_on_left(self):
+    @staticmethod
+    def test_non_monotonic_higher_forecast_count_on_left():
         """Test enforcement of monotonicity for observation frequency."""
         obs_count = np.array([0, 750, 500, 1000, 75], dtype=np.float32)
         forecast_count = np.array([1000, 1000, 1000, 1000, 100], dtype=np.float32)

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -455,12 +455,32 @@ class Test__assume_constant_observation_frequency(Test_setup):
         )
         assert_array_equal(result.data, self.obs_count)
 
-    def test_non_monotonic(self):
+    def test_non_monotonic_equal_forecast_count(self):
         """Test enforcement of monotonicity for observation frequency."""
         obs_count = np.array([0, 750, 500, 1000, 750], dtype=np.float32)
         expected_result = np.array([0, 750, 750, 1000, 1000], dtype=np.float32)
         result = Plugin()._assume_constant_observation_frequency(
             obs_count, self.forecast_count
+        )
+        assert_array_equal(result.data, expected_result)
+
+    def test_non_monotonic_lower_forecast_count_on_left(self):
+        """Test enforcement of monotonicity for observation frequency."""
+        obs_count = np.array([0, 750, 500, 1000, 750], dtype=np.float32)
+        forecast_count = np.array([500, 1000, 1000, 1000, 1000], dtype=np.float32)
+        expected_result = np.array([0, 500, 500, 750, 750], dtype=np.float32)
+        result = Plugin()._assume_constant_observation_frequency(
+            obs_count, forecast_count
+        )
+        assert_array_equal(result.data, expected_result)
+
+    def test_non_monotonic_higher_forecast_count_on_left(self):
+        """Test enforcement of monotonicity for observation frequency."""
+        obs_count = np.array([0, 750, 500, 1000, 75], dtype=np.float32)
+        forecast_count = np.array([1000, 1000, 1000, 1000, 100], dtype=np.float32)
+        expected_result = np.array([0, 750, 750, 1000, 100], dtype=np.float32)
+        result = Plugin()._assume_constant_observation_frequency(
+            obs_count, forecast_count
         )
         assert_array_equal(result.data, expected_result)
 
@@ -603,7 +623,7 @@ class Test_process(Test_setup):
         """Test expected values are returned where the upper observation
         count bins are non-monotonic."""
         expected_data = np.array(
-            [[0, 1000, 1000, 2000], [0, 250, 500, 1750], [1000, 1000, 1000, 2000]]
+            [[0, 375, 375, 750], [0, 250, 500, 1750], [1000, 1000, 1000, 2000]]
         )
         expected_bin_coord_points = np.array([0.1, 0.3, 0.5, 0.8], dtype=np.float32)
 


### PR DESCRIPTION
Description
Alter the behaviour of the `assume_constant_observation_frequency` method within the ManipulateReliabilityTables plugin to work from the bin with the highest sample count to the bin with the lowest sample count, rather than the previous logic to always work from the lowest probability bin to the highest probability bin. This helps because usually the probability bins with lowest sample counts are more likely to show non-monotonic behaviour, so any anomalous behaviour of low sample count bins, either for the low or high probability bins, can be removed, in order to guarantee a monotonic observation frequency. A monotonic observation frequency is desirable to avoid odd spatial behaviour when calibrating.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

