### PR TITLE
Update intersphinx mapping for Iris

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -394,7 +394,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "https://docs.python.org/": None,
-    "https://scitools.org.uk/iris/docs/latest/": None,
+    "https://scitools-iris.readthedocs.io/en/latest/": None,
     "https://scitools.org.uk/cartopy/docs/latest/": None,
     "https://scitools.org.uk/cf-units/docs/latest/": None,
     "https://docs.scipy.org/doc/numpy/": None,


### PR DESCRIPTION
Description
Update intersphinx mapping for Iris due to an update to the url of the latest Iris build. The latest version of Iris is now documented at https://scitools-iris.readthedocs.io/en/latest/.  The previous url (https://scitools.org.uk/iris/docs/latest/) now automatically redirects to the latest webpage, however, this redirection doesn't work for fetching the intersphinx inventory that sphinx requires.

Currently affecting: #1322, #1317  

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

