### PR TITLE
Support deterministic field texture input and blending of field texture output

### DIFF
--- a/improver/cli/field_texture.py
+++ b/improver/cli/field_texture.py
@@ -41,6 +41,7 @@ def process(
     nbhood_radius: float = 10000.0,
     textural_threshold: float = 0.05,
     diagnostic_threshold: float = 0.8125,
+    model_id_attr: str = None,
 ):
 
     """Calculates field texture for a given neighbourhood radius.
@@ -75,6 +76,10 @@ def process(
             cube. Default value set to 0.8125 corresponding to 6 oktas, assuming
             cloud area fraction cube.
 
+        model_id_attr (str):
+            Name of the attribute used to identify the source model for
+            blending.
+
     Returns:
         iris.cube.Cube:
             A field texture cube containing values between 0 and 1, where 0
@@ -86,6 +91,9 @@ def process(
     from improver.field_texture import FieldTexture
 
     field_texture = FieldTexture(
-        nbhood_radius, textural_threshold, diagnostic_threshold
+        nbhood_radius,
+        textural_threshold,
+        diagnostic_threshold,
+        model_id_attr=model_id_attr,
     )(cube)
     return field_texture

--- a/improver/field_texture.py
+++ b/improver/field_texture.py
@@ -263,6 +263,7 @@ class FieldTexture(BasePlugin):
         ratios = ratios.merge_cube()
         thresholded = BasicThreshold(self.diagnostic_threshold).process(ratios)
 
+        # Squeeze scalar threshold coordinate.
         try:
             field_texture = iris.util.squeeze(collapse_realizations(thresholded))
         except CoordinateNotFoundError:

--- a/improver/field_texture.py
+++ b/improver/field_texture.py
@@ -202,8 +202,10 @@ class FieldTexture(BasePlugin):
 
         Returns:
             iris.cube.Cube:
-                A cube containing the mean of the thresholded ratios to give
-                the field texture.
+                A cube containing either the mean across realization of the
+                thresholded ratios to give the field texture, if a realization
+                coordinate is present, or the thresholded ratios directly, if
+                no realization coordinate is present.
         """
 
         values = np.unique(input_cube.data)
@@ -247,6 +249,11 @@ class FieldTexture(BasePlugin):
 
         ratios = ratios.merge_cube()
         thresholded = BasicThreshold(self.diagnostic_threshold).process(ratios)
-        field_texture = iris.util.squeeze(collapse_realizations(thresholded))
+
+        try:
+            field_texture = iris.util.squeeze(collapse_realizations(thresholded))
+        except CoordinateNotFoundError:
+            field_texture = iris.util.squeeze(thresholded)
+
         field_texture.data = np.float32(field_texture.data)
         return field_texture

--- a/improver/field_texture.py
+++ b/improver/field_texture.py
@@ -61,7 +61,13 @@ class FieldTexture(BasePlugin):
        (texture values close to zero).
     """
 
-    def __init__(self, nbhood_radius, textural_threshold, diagnostic_threshold):
+    def __init__(
+        self,
+        nbhood_radius,
+        textural_threshold,
+        diagnostic_threshold,
+        model_id_attr=None,
+    ):
         """
 
         Args:
@@ -81,10 +87,15 @@ class FieldTexture(BasePlugin):
                 A user defined threshold value related either to cloud or precipitation,
                 used to extract the corresponding dimensional cube with assumed units of 1.
 
+            model_id_attr (str):
+                Name of the attribute used to identify the source model for
+                blending.
+
         """
         self.nbhood_radius = nbhood_radius
         self.textural_threshold = textural_threshold
         self.diagnostic_threshold = diagnostic_threshold
+        self.model_id_attr = model_id_attr
         self.cube_name = None
 
     def _calculate_ratio(self, cube, radius):
@@ -159,7 +170,9 @@ class FieldTexture(BasePlugin):
             "texture_of_{}".format(self.cube_name),
             1,
             cube,
-            mandatory_attributes=generate_mandatory_attributes([cube]),
+            mandatory_attributes=generate_mandatory_attributes(
+                [cube], model_id_attr=self.model_id_attr
+            ),
             data=ratio,
         )
         return ratio

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -122,7 +122,7 @@ aa3e49a252d9b3222ec71459fe981791d7f631b1aa83dcee9c95bc1f1b82cecc  ./feels_like_t
 09149c4ff592e9337e7ee8819d084b890438e050f7140701939d0524cae1b1b3  ./feels_like_temp/ukvx/20181121T1200Z-PT0012H00M-wind_speed_at_10m.nc
 986df18975a55a8e00589fb45c36c375c459940504580bb4fa1c62a03082ba07  ./feels_like_temp/ukvx/kgo.nc
 4d18db23620186e1a020121bd1348cf59331ebc8472a864711d5484c31cf6dbb  ./field-texture/args/input.nc
-b445760175b914f5c857388dcce66bee324aee40b5933388ce72864efe54f5f8  ./field-texture/args/kgo.nc
+724698a223741d238c39ab28c965d536e79eb45efb65a3bb91dcdbaab501f10a  ./field-texture/args/kgo.nc
 4d18db23620186e1a020121bd1348cf59331ebc8472a864711d5484c31cf6dbb  ./field-texture/basic/input.nc
 175698d69391fb02afaf8dc560ceb15a310056e7739b7204b008ef1ff9a495e5  ./field-texture/basic/kgo.nc
 a67f7c879abc799c207d6ba124d245ca1f1939ba4703aa5bdf0c74131aee3a30  ./fill-radar-holes/basic/201811271330_remasked_rainrate_composite.nc

--- a/improver_tests/acceptance/test_field_texture.py
+++ b/improver_tests/acceptance/test_field_texture.py
@@ -69,6 +69,7 @@ def test_args(tmp_path):
         "--nbhood-radius=5000.0",
         "--textural-threshold=0.05",
         "--diagnostic-threshold=0.6145",
+        "--model-id-attr=mosg__model_configuration",
         "--output",
         output_path,
     ]

--- a/improver_tests/test_field_texture.py
+++ b/improver_tests/test_field_texture.py
@@ -309,12 +309,12 @@ def test_metadata_attributes_with_model_id_attr(multi_cloud_cube):
         "mosg__model_configuration": "uk_ens",
     }
 
-    PLUGIN = FieldTexture(
+    plugin = FieldTexture(
         nbhood_radius=NB_RADIUS,
         textural_threshold=TEXT_THRESH,
         diagnostic_threshold=DIAG_THRESH,
         model_id_attr="mosg__model_configuration",
     )
 
-    result = PLUGIN.process(multi_cloud_cube)
+    result = plugin.process(multi_cloud_cube)
     assert result.attributes == expected_attributes

--- a/improver_tests/test_field_texture.py
+++ b/improver_tests/test_field_texture.py
@@ -72,6 +72,24 @@ def thresholded_cloud_fixture():
     return next(multi_realization_cube.slices_over("realization"))
 
 
+@pytest.fixture(name="no_realization_cloud_cube")
+def no_realization_cloud_fixture():
+    """No realization, multiple threshold cloud data cube."""
+    cloud_area_fraction = np.zeros((3, 10, 10), dtype=np.float32)
+    cloud_area_fraction[:, 1:4, 1:4] = 1.0
+    thresholds = [0.265, 0.415, 0.8125]
+    multi_realization_cube = cloud_probability_cube(cloud_area_fraction, thresholds)
+    no_realization_cube = next(multi_realization_cube.slices_over("realization"))
+    no_realization_cube.remove_coord("realization")
+    no_realization_cube.attributes.update(
+        {
+            "title": "UKV Forecast on 2 km Standard Grid",
+            "mosg__model_configuration": "uk_det",
+        }
+    )
+    return no_realization_cube
+
+
 @pytest.fixture(name="no_cloud_cube")
 def no_cloud_fixture():
     """Multi-realization cloud data cube with no cloud present."""
@@ -158,6 +176,19 @@ def test_process_single_threshold(multi_cloud_cube):
     expected_data = np.where(single_thresh_cloud_cube.data[0] == 0.0, 1.0, 0.0)
 
     result = PLUGIN.process(single_thresh_cloud_cube)
+    np.testing.assert_almost_equal(result.data, expected_data, decimal=4)
+
+
+def test_process_no_realization(no_realization_cloud_cube):
+    """Test the process function when the input cube does not contain a
+       realization coordinate."""
+
+    cube = no_realization_cloud_cube.extract(
+        iris.Constraint(cloud_area_fraction=DIAG_THRESH)
+    )
+    expected_data = np.where(cube.data == 0.0, 1.0, 0.0)
+
+    result = PLUGIN.process(no_realization_cloud_cube)
     np.testing.assert_almost_equal(result.data, expected_data, decimal=4)
 
 

--- a/improver_tests/test_field_texture.py
+++ b/improver_tests/test_field_texture.py
@@ -296,3 +296,25 @@ def test_metadata_attributes(multi_cloud_cube):
 
     result = PLUGIN.process(multi_cloud_cube)
     assert result.attributes == expected_attributes
+
+
+def test_metadata_attributes_with_model_id_attr(multi_cloud_cube):
+    """Test that the metadata attributes in the output cube follows expected
+    conventions when the model_id_attr argument is specified."""
+
+    expected_attributes = {
+        "source": "Unified Model",
+        "institution": "Met Office",
+        "title": "MOGREPS-UK Forecast on 2 km Standard Grid",
+        "mosg__model_configuration": "uk_ens",
+    }
+
+    PLUGIN = FieldTexture(
+        nbhood_radius=NB_RADIUS,
+        textural_threshold=TEXT_THRESH,
+        diagnostic_threshold=DIAG_THRESH,
+        model_id_attr="mosg__model_configuration",
+    )
+
+    result = PLUGIN.process(multi_cloud_cube)
+    assert result.attributes == expected_attributes


### PR DESCRIPTION
This PR:
1. Amends the field texture plugin to support deterministic field texture input i.e. an input without a realization coordinate.
2. Adds support for blending field texture by adding the specification of a `model-id-attr` argument, similar to e.g. the [uv-index](https://github.com/metoppv/improver/blob/master/improver/cli/uv_index.py) or [feels-like-temp](https://github.com/metoppv/improver/blob/master/improver/cli/feels_like_temp.py) CLIs. The `model_id_attr` attribute is then available to enable model blending.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

