### PR TITLE
Added a cache version number, to reset cache as needed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/cache@v1
       id: cache
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
       with:
         path: /usr/share/miniconda/envs/improver
-        key: ${{ runner.os }}-conda-improver-${{ hashFiles('**/environment.yml') }}
+        key: ${{ runner.os }}-conda-improver-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/environment.yml') }}
         restore-keys: ${{ runner.OS }}-conda-improver-
     - name: conda env update
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/cache@v1
       id: cache
       env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        # Increase this value to reset cache
         CACHE_NUMBER: 0
       with:
         path: /usr/share/miniconda/envs/improver


### PR DESCRIPTION
Added an option to reset the cache to combat caching an outdated library in conda.

We came across an issue with the forks using a different version of sphinx to master, this was down to master using a cached conda build. Github caches expire automatically after 7 days of not writing to them, but do not provide an explicit way to empty a cache, so by providing a `cache_number` we can reset the cache as required if this problem should ever arise again in the future.