### PR TITLE
Clean up of FieldTexture tests

### DIFF
--- a/improver/field_texture.py
+++ b/improver/field_texture.py
@@ -168,7 +168,7 @@ class FieldTexture(BasePlugin):
         # Create a new cube to contain the resulting ratio data.
         ratio = create_new_diagnostic_cube(
             "texture_of_{}".format(cube_name),
-            1,
+            "1",
             cube,
             mandatory_attributes=generate_mandatory_attributes(
                 [cube], model_id_attr=self.model_id_attr

--- a/improver/field_texture.py
+++ b/improver/field_texture.py
@@ -96,9 +96,8 @@ class FieldTexture(BasePlugin):
         self.textural_threshold = textural_threshold
         self.diagnostic_threshold = diagnostic_threshold
         self.model_id_attr = model_id_attr
-        self.cube_name = None
 
-    def _calculate_ratio(self, cube, radius):
+    def _calculate_ratio(self, cube, cube_name, radius):
         """
         Calculates the ratio of actual to potential value transitions in a
         neighbourhood about each cell.
@@ -128,6 +127,9 @@ class FieldTexture(BasePlugin):
             cube (iris.cube.Cube):
                 Input data in cube format containing a two-dimensional field
                 of binary data.
+
+            cube_name (str):
+                Name of input data cube, used for determining output texture cube name.
 
             radius (float):
                 Radius for neighbourhood in metres.
@@ -165,7 +167,7 @@ class FieldTexture(BasePlugin):
 
         # Create a new cube to contain the resulting ratio data.
         ratio = create_new_diagnostic_cube(
-            "texture_of_{}".format(self.cube_name),
+            "texture_of_{}".format(cube_name),
             1,
             cube,
             mandatory_attributes=generate_mandatory_attributes(
@@ -225,27 +227,27 @@ class FieldTexture(BasePlugin):
             raise ValueError("Incorrect input. Cube should hold binary data only")
 
         # Create new cube name for _calculate_ratio method.
-        self.cube_name = find_threshold_coordinate(input_cube).name()
+        cube_name = find_threshold_coordinate(input_cube).name()
         # Extract threshold from input data to work with, taking into account floating
         # point comparisons.
         cube = input_cube.extract(
             iris.Constraint(
                 coord_values={
-                    self.cube_name: lambda cell: np.isclose(
+                    cube_name: lambda cell: np.isclose(
                         cell.point, self.diagnostic_threshold
                     )
                 }
             )
         )
         try:
-            cube.remove_coord(self.cube_name)
+            cube.remove_coord(cube_name)
         except AttributeError:
             msg = "Threshold {} is not present on coordinate with values {} {}"
             raise ValueError(
                 msg.format(
                     self.diagnostic_threshold,
-                    input_cube.coord(self.cube_name).points,
-                    input_cube.coord(self.cube_name).units,
+                    input_cube.coord(cube_name).points,
+                    input_cube.coord(cube_name).units,
                 )
             )
         ratios = iris.cube.CubeList()
@@ -256,7 +258,7 @@ class FieldTexture(BasePlugin):
             cslices = [cube]
 
         for cslice in cslices:
-            ratios.append(self._calculate_ratio(cslice, self.nbhood_radius))
+            ratios.append(self._calculate_ratio(cslice, cube_name, self.nbhood_radius))
 
         ratios = ratios.merge_cube()
         thresholded = BasicThreshold(self.diagnostic_threshold).process(ratios)

--- a/improver_tests/test_field_texture.py
+++ b/improver_tests/test_field_texture.py
@@ -170,10 +170,8 @@ def test_process_error(multi_cloud_cube):
 
     non_binary_data = np.where(multi_cloud_cube.data == 0.0, 2.1, 0.0)
     non_binary_cube = multi_cloud_cube.copy(data=non_binary_data)
-
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ValueError, match="binary data"):
         ftex_plugin().process(non_binary_cube)
-    assert str(excinfo.value) == "Incorrect input. Cube should hold binary data only"
 
 
 def test_process_no_cloud(multi_cloud_cube):
@@ -200,7 +198,7 @@ def test_no_threshold_cube(multi_cloud_cube):
     """Test the process function with multi_cloud_cube that has no thresholds"""
 
     multi_cloud_cube.remove_coord("cloud_area_fraction")
-    with pytest.raises(CoordinateNotFoundError, match="No threshold coord found.*"):
+    with pytest.raises(CoordinateNotFoundError, match="threshold coord"):
         ftex_plugin().process(multi_cloud_cube)
 
 
@@ -209,12 +207,13 @@ def test_wrong_threshold(multi_cloud_cube):
         diagnostic_threshold variable does not match threshold available in
         the cube."""
 
+    wrong_threshold = 0.235
     plugin = FieldTexture(
         nbhood_radius=NB_RADIUS,
         textural_threshold=TEXT_THRESH,
-        diagnostic_threshold=0.235,
+        diagnostic_threshold=wrong_threshold,
     )
-    with pytest.raises(ValueError, match="Threshold 0.235 is not present.*"):
+    with pytest.raises(ValueError, match=str(wrong_threshold)):
         plugin.process(multi_cloud_cube)
 
 

--- a/improver_tests/test_field_texture.py
+++ b/improver_tests/test_field_texture.py
@@ -41,9 +41,10 @@ from improver.synthetic_data.set_up_test_cubes import (
     set_up_probability_cube,
 )
 
+THRESHOLDS = [0.265, 0.415, 0.8125]
 NB_RADIUS = 10000
 TEXT_THRESH = 0.4
-DIAG_THRESH = 0.8125
+DIAG_THRESH = THRESHOLDS[2]
 
 
 @pytest.fixture(name="multi_cloud_cube")
@@ -51,8 +52,7 @@ def multi_cloud_fixture():
     """Multi-realization/threshold cloud data cube."""
     cloud_area_fraction = np.zeros((3, 10, 10), dtype=np.float32)
     cloud_area_fraction[:, 1:4, 1:4] = 1.0
-    thresholds = [0.265, 0.415, 0.8125]
-    return cloud_probability_cube(cloud_area_fraction, thresholds)
+    return cloud_probability_cube(cloud_area_fraction, THRESHOLDS)
 
 
 @pytest.fixture(name="thresholded_cloud_cube")
@@ -60,9 +60,8 @@ def thresholded_cloud_fixture():
     """Cloud data for a single realization at the relevant threshold."""
     cloud_area_fraction = np.zeros((1, 10, 10), dtype=np.float32)
     cloud_area_fraction[:, 1:4, 1:4] = 1.0
-    thresholds = [DIAG_THRESH]
     multi_realization_cube = iris.util.squeeze(
-        cloud_probability_cube(cloud_area_fraction, thresholds)
+        cloud_probability_cube(cloud_area_fraction, [DIAG_THRESH])
     )
     return next(multi_realization_cube.slices_over("realization"))
 
@@ -72,8 +71,7 @@ def no_realization_cloud_fixture():
     """No realization, multiple threshold cloud data cube."""
     cloud_area_fraction = np.zeros((3, 10, 10), dtype=np.float32)
     cloud_area_fraction[:, 1:4, 1:4] = 1.0
-    thresholds = [0.265, 0.415, 0.8125]
-    multi_realization_cube = cloud_probability_cube(cloud_area_fraction, thresholds)
+    multi_realization_cube = cloud_probability_cube(cloud_area_fraction, THRESHOLDS)
     no_realization_cube = next(multi_realization_cube.slices_over("realization"))
     no_realization_cube.remove_coord("realization")
     no_realization_cube.attributes.update(
@@ -89,16 +87,14 @@ def no_realization_cloud_fixture():
 def no_cloud_fixture():
     """Multi-realization cloud data cube with no cloud present."""
     cloud_area_fraction = np.zeros((3, 10, 10), dtype=np.float32)
-    thresholds = [0.265, 0.415, 0.8125]
-    return cloud_probability_cube(cloud_area_fraction, thresholds)
+    return cloud_probability_cube(cloud_area_fraction, THRESHOLDS)
 
 
 @pytest.fixture(name="all_cloud_cube")
 def all_cloud_fixture():
     """Multi-realization cloud data cube with all cloud present."""
     cloud_area_fraction = np.ones((3, 10, 10), dtype=np.float32)
-    thresholds = [0.265, 0.415, 0.8125]
-    return cloud_probability_cube(cloud_area_fraction, thresholds)
+    return cloud_probability_cube(cloud_area_fraction, THRESHOLDS)
 
 
 def cloud_probability_cube(cloud_area_fraction, thresholds):

--- a/improver_tests/test_field_texture.py
+++ b/improver_tests/test_field_texture.py
@@ -46,11 +46,20 @@ NB_RADIUS = 10000
 TEXT_THRESH = 0.4
 DIAG_THRESH = THRESHOLDS[2]
 CAF = "cloud_area_fraction"
-CAF_ATTRS = {
+REALIZATION = "realization"
+COMMON_ATTRS = {
     "source": "Unified Model",
     "institution": "Met Office",
+}
+UK_ENS_ATTRS = {
+    **COMMON_ATTRS,
     "title": "MOGREPS-UK Forecast on 2 km Standard Grid",
     "mosg__model_configuration": "uk_ens",
+}
+UK_DET_ATTRS = {
+    **COMMON_ATTRS,
+    "title": "UKV Forecast on 2 km Standard Grid",
+    "mosg__model_configuration": "uk_det",
 }
 
 
@@ -70,20 +79,15 @@ def thresholded_cloud_fixture():
     multi_realization_cube = iris.util.squeeze(
         cloud_probability_cube(cloud_area_fraction, [DIAG_THRESH])
     )
-    return next(multi_realization_cube.slices_over("realization"))
+    return next(multi_realization_cube.slices_over(REALIZATION))
 
 
 @pytest.fixture(name="no_realization_cloud_cube")
 def no_realization_cloud_fixture(multi_cloud_cube):
     """No realization, multiple threshold cloud data cube."""
-    no_realization_cube = next(multi_cloud_cube.slices_over("realization"))
-    no_realization_cube.remove_coord("realization")
-    no_realization_cube.attributes.update(
-        {
-            "title": "UKV Forecast on 2 km Standard Grid",
-            "mosg__model_configuration": "uk_det",
-        }
-    )
+    no_realization_cube = next(multi_cloud_cube.slices_over(REALIZATION))
+    no_realization_cube.remove_coord(REALIZATION)
+    no_realization_cube.attributes.update(UK_DET_ATTRS)
     return no_realization_cube
 
 
@@ -95,9 +99,9 @@ def cloud_probability_cube(cloud_area_fraction, thresholds):
         threshold_units="1",
         thresholds=thresholds,
         spatial_grid="equalarea",
-        attributes=CAF_ATTRS,
+        attributes=UK_ENS_ATTRS,
     )
-    cube = add_coordinate(cube, [0, 1, 2], "realization", dtype=np.int32)
+    cube = add_coordinate(cube, [0, 1, 2], REALIZATION, dtype=np.int32)
     return cube
 
 
@@ -112,30 +116,23 @@ def ftex_plugin():
 
 def test_full_process(multi_cloud_cube):
     """Test the process function with multi realization/threshold input cube."""
-
     cube = multi_cloud_cube.extract(iris.Constraint(cloud_area_fraction=DIAG_THRESH))[0]
     expected_data = np.where(cube.data == 0.0, 1.0, 0.0)
-    expected_dtype = "float32"
-
     result = ftex_plugin().process(multi_cloud_cube)
     np.testing.assert_allclose(result.data, expected_data)
-    assert result.dtype == expected_dtype
+    assert result.dtype == np.float32
 
 
 def test__calculate_ratio(thresholded_cloud_cube):
     """Test the _calculate_ratio function with single realization of the input cube."""
-
     expected_data = np.where(thresholded_cloud_cube.data == 0.0, 1.0, 1.0 / 3.0)
-    result = ftex_plugin()._calculate_ratio(
-        thresholded_cloud_cube, CAF, NB_RADIUS
-    )
+    result = ftex_plugin()._calculate_ratio(thresholded_cloud_cube, CAF, NB_RADIUS)
     np.testing.assert_allclose(result.data, expected_data)
 
 
 def test__calculate_transitions(thresholded_cloud_cube):
     """Test the _calculate_transitions function with a numpy array simulating
        the input cube."""
-
     expected_data = np.zeros((10, 10), dtype=np.float32)
     expected_data[1:4, 1:4] = np.array(
         [[2.0, 1.0, 2.0], [1.0, 0.0, 1.0], [2.0, 1.0, 2.0]]
@@ -147,7 +144,6 @@ def test__calculate_transitions(thresholded_cloud_cube):
 def test_process_single_threshold(multi_cloud_cube):
     """Test the process function with single threshold version of the multi
        realization input cube."""
-
     single_thresh_cloud_cube = multi_cloud_cube.extract(
         iris.Constraint(cloud_area_fraction=DIAG_THRESH)
     )
@@ -159,7 +155,6 @@ def test_process_single_threshold(multi_cloud_cube):
 def test_process_no_realization(no_realization_cloud_cube):
     """Test the process function when the input cube does not contain a
        realization coordinate."""
-
     cube = no_realization_cloud_cube.extract(
         iris.Constraint(cloud_area_fraction=DIAG_THRESH)
     )
@@ -170,7 +165,6 @@ def test_process_no_realization(no_realization_cloud_cube):
 
 def test_process_error(multi_cloud_cube):
     """Test the process function with a non-binary input cube to raise an error."""
-
     non_binary_data = np.where(multi_cloud_cube.data == 0.0, 2.1, 0.0)
     non_binary_cube = multi_cloud_cube.copy(data=non_binary_data)
     with pytest.raises(ValueError, match="binary data"):
@@ -181,7 +175,6 @@ def test_process_error(multi_cloud_cube):
 def test_process_constant_cloud(multi_cloud_cube, cloud_frac, expected):
     """Test the FieldTexture plugin with multi realization input cube that has
        no or all cloud present in the field."""
-
     multi_cloud_cube.data[:] = cloud_frac
     result = ftex_plugin().process(multi_cloud_cube)
     np.testing.assert_allclose(result.data, expected)
@@ -189,7 +182,6 @@ def test_process_constant_cloud(multi_cloud_cube, cloud_frac, expected):
 
 def test_no_threshold_cube(multi_cloud_cube):
     """Test the process function with multi_cloud_cube that has no thresholds"""
-
     multi_cloud_cube.remove_coord(CAF)
     with pytest.raises(CoordinateNotFoundError, match="threshold coord"):
         ftex_plugin().process(multi_cloud_cube)
@@ -199,7 +191,6 @@ def test_wrong_threshold(multi_cloud_cube):
     """Test the process function with multi_cloud_cube where user defined
         diagnostic_threshold variable does not match threshold available in
         the cube."""
-
     wrong_threshold = 0.235
     plugin = FieldTexture(
         nbhood_radius=NB_RADIUS,
@@ -213,7 +204,6 @@ def test_wrong_threshold(multi_cloud_cube):
 def test_metadata_name(multi_cloud_cube):
     """Test that the metadata of the output cube follows expected conventions
        after the plugin is complete and all old coordinates have been removed."""
-
     result = ftex_plugin().process(multi_cloud_cube)
     assert result.name() == f"probability_of_texture_of_{CAF}_above_threshold"
     assert result.units == "1"
@@ -222,7 +212,6 @@ def test_metadata_name(multi_cloud_cube):
 def test_metadata_coords(multi_cloud_cube):
     """Test that the coordinate metadata in the output cube follows expected
         conventions after that plugin has completed."""
-
     result = ftex_plugin().process(multi_cloud_cube)
     expected_scalar_coord = f"texture_of_{CAF}"
 
@@ -232,7 +221,7 @@ def test_metadata_coords(multi_cloud_cube):
     # check coordinates
     assert result_dims == ["projection_y_coordinate", "projection_x_coordinate"]
     assert expected_scalar_coord in result_scalar_coords
-    for coord in [CAF, "realization"]:
+    for coord in [CAF, REALIZATION]:
         assert coord not in [crd.name() for crd in result.coords()]
 
     # check threshold coordinate units
@@ -243,7 +232,7 @@ def test_metadata_coords(multi_cloud_cube):
 def test_metadata_attributes(multi_cloud_cube, model_config):
     """Test that the metadata attributes in the output cube follows expected
         conventions after that plugin has completed."""
-    expected_attributes = CAF_ATTRS.copy()
+    expected_attributes = UK_ENS_ATTRS.copy()
     if model_config:
         fieldtexture_args = {"model_id_attr": "mosg__model_configuration"}
     else:


### PR DESCRIPTION
Follow up from #1310 

Main issues addressed in this PR:
- plugin class instance re-used as a constant between tests (generate fresh plugin instances for each test case)
- duplication in fixtures (moved to other fixture or test function)
- duplication in similar tests (combined using parametrize)
- FieldTexture class used a variable `self.cube_name` only for passing to an internal method (replaced with explicit variable in method call) 

The github diff display struggles with test_field_texture.py. For reviewing, it may be best to look at complete files before/after side by side.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
