### PR TITLE
Construct reliability calibration mem reduction

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -399,10 +399,17 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
                 truth_slice.slices_over(time_coord),
             )
             forecast, truth = next(time_slices)
-            threshold_reliability = self._populate_reliability_bins(forecast.data, truth.data)
+            threshold_reliability = self._populate_reliability_bins(
+                forecast.data, truth.data
+            )
 
             for forecast, truth in time_slices:
-                np.add(threshold_reliability, self._populate_reliability_bins(forecast.data, truth.data), out=threshold_reliability, dtype=np.float32)
+                np.add(
+                    threshold_reliability,
+                    self._populate_reliability_bins(forecast.data, truth.data),
+                    out=threshold_reliability,
+                    dtype=np.float32,
+                )
 
             reliability_entry = reliability_cube.copy(data=threshold_reliability)
             reliability_entry.replace_coord(forecast_slice.coord(threshold_coord))

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -394,28 +394,21 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         )
         for forecast_slice, truth_slice in threshold_slices:
 
-            threshold_reliability = []
             time_slices = zip(
                 forecast_slice.slices_over(time_coord),
                 truth_slice.slices_over(time_coord),
             )
+            forecast, truth = next(time_slices)
+            threshold_reliability = self._populate_reliability_bins(forecast.data, truth.data)
+
             for forecast, truth in time_slices:
+                np.add(threshold_reliability, self._populate_reliability_bins(forecast.data, truth.data), out=threshold_reliability, dtype=np.float32)
 
-                reliability_table = self._populate_reliability_bins(
-                    forecast.data, truth.data
-                )
-
-                threshold_reliability.append(reliability_table)
-
-            # Stack and sum reliability tables for all times
-            table_values = np.stack(threshold_reliability)
-            table_values = np.sum(table_values, axis=0, dtype=np.float32)
-
-            reliability_entry = reliability_cube.copy(data=table_values)
+            reliability_entry = reliability_cube.copy(data=threshold_reliability)
             reliability_entry.replace_coord(forecast_slice.coord(threshold_coord))
             reliability_tables.append(reliability_entry)
 
-        return MergeCubes()(reliability_tables)
+        return MergeCubes()(reliability_tables, copy=False)
 
 
 class AggregateReliabilityCalibrationTables(BasePlugin):

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -211,7 +211,11 @@ class MergeCubes(BasePlugin):
                 raise ValueError(msg)
 
     def process(
-        self, cubes_in, check_time_bounds_ranges=False, slice_over_realization=False, copy=True,
+        self,
+        cubes_in,
+        check_time_bounds_ranges=False,
+        slice_over_realization=False,
+        copy=True,
     ):
         """
         Function to merge cubes, accounting for differences in attributes,

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -261,11 +261,11 @@ class MergeCubes(BasePlugin):
             return cubes_in[0]
 
         if copy:
+            # create copies of input cubes so as not to modify in place
             cube_return = lambda cube: cube.copy()
         else:
             cube_return = lambda cube: cube
 
-        # create copies of input cubes so as not to modify in place
         cubelist = iris.cube.CubeList([])
         for cube in cubes_in:
             if slice_over_realization:

--- a/improver_tests/utilities/cube_manipulation/test_MergeCubes.py
+++ b/improver_tests/utilities/cube_manipulation/test_MergeCubes.py
@@ -302,6 +302,17 @@ class Test_process(IrisTest):
         self.assertIn("realization", result_coords)
         self.assertSequenceEqual(result_dims, expected_dims)
 
+    def test_copy(self):
+        """Tests the use of copy avoids altering an object in place."""
+        self.cube_ukv.var_name = "VAR1"
+        cubes = iris.cube.CubeList([self.cube_ukv, self.cube_ukv_t1])
+        cube_orig = cubes[0].copy()
+        self.plugin.process(cubes)
+        self.assertTrue(cubes[0] == cube_orig)
+
+        self.plugin.process(cubes, copy=False)
+        self.assertFalse(cubes[0] == cube_orig)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Lowers the memory cost of construct reliability calibration table from ~3.6 GB to ~2.1 GB. Increases the time from 264.074s to 266.197s.

Description

Testing:
 - [x] Ran tests and they passed OK
