### PR TITLE
IMPRO-1865: Modify recursive filter plugin to receive coefficients as cubelist

### DIFF
--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -76,8 +76,4 @@ def process(
     from improver.nbhood.recursive_filter import RecursiveFilter
 
     plugin = RecursiveFilter(iterations=iterations, re_mask=remask)
-    return plugin(
-        cube,
-        smoothing_coefficients=smoothing_coefficients,
-        mask_cube=mask,
-    )
+    return plugin(cube, smoothing_coefficients=smoothing_coefficients, mask_cube=mask,)

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -33,16 +33,12 @@
 
 from improver import cli
 
-input_smoothing_coefficients = cli.create_constrained_inputcubelist_converter(
-    "smoothing_coefficient_x", "smoothing_coefficient_y",
-)
-
 
 @cli.clizefy
 @cli.with_output
 def process(
     cube: cli.inputcube,
-    smoothing_coefficients: input_smoothing_coefficients,
+    smoothing_coefficients: cli.inputcubelist,
     mask: cli.inputcube = None,
     *,
     iterations: int = 1,
@@ -79,14 +75,9 @@ def process(
     """
     from improver.nbhood.recursive_filter import RecursiveFilter
 
-    (
-        smoothing_coefficients_x_cube,
-        smoothing_coefficients_y_cube,
-    ) = smoothing_coefficients
     plugin = RecursiveFilter(iterations=iterations, re_mask=remask)
     return plugin(
         cube,
-        smoothing_coefficients_x=smoothing_coefficients_x_cube,
-        smoothing_coefficients_y=smoothing_coefficients_y_cube,
+        smoothing_coefficients=smoothing_coefficients,
         mask_cube=mask,
     )

--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -88,6 +88,7 @@ class RecursiveFilter(PostProcessingPlugin):
         self.iterations = iterations
         self.edge_width = edge_width
         self.re_mask = re_mask
+        self.smoothing_coefficient_name_format = "smoothing_coefficient_{}"
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -284,8 +285,7 @@ class RecursiveFilter(PostProcessingPlugin):
             cube.data = output
         return cube
 
-    @staticmethod
-    def _validate_smoothing_coefficients(cube, smoothing_coefficients_cube):
+    def _validate_smoothing_coefficients(self, cube, smoothing_coefficients):
         """Validate the smoothing coefficients cubes.
 
         Args:
@@ -293,9 +293,10 @@ class RecursiveFilter(PostProcessingPlugin):
                 2D cube containing the input data to which the recursive
                 filter will be applied.
 
-            smoothing_coefficients_cube (iris.cube.Cube):
-                Cube containing array of smoothing_coefficient values that will
-                be used when applying the recursive filter in a specific
+            smoothing_coefficients_cube (iris.cube.CubeList):
+                A cubelist containing two cubes of smoothing_coefficient values,
+                one corresponding to smoothing in the x-direction, and the other
+                to smoothing in the y-direction.
 
         Raises:
             ValueError: Smoothing coefficient cubes are not named correctly.
@@ -304,51 +305,59 @@ class RecursiveFilter(PostProcessingPlugin):
             ValueError: The coordinate to be smoothed within the
                 smoothing coefficient cube does not have the expected points.
         """
-        if smoothing_coefficients_cube.name() == "smoothing_coefficient_x":
-            smoothing_axis = "x"
-            non_smoothing_axis = "y"
-        elif smoothing_coefficients_cube.name() == "smoothing_coefficient_y":
-            smoothing_axis = "y"
-            non_smoothing_axis = "x"
-        else:
-            msg = (
-                "The smoothing coefficients cube must be named either "
-                "smoothing_coefficient_x or smoothing_coefficient_y. "
-                "The smoothing coefficients are named: "
-                f"{smoothing_coefficients_cube.name()}"
-            )
-            raise ValueError(msg)
+        # Ensure cubes are in x, y order.
+        smoothing_coefficients.sort(key=lambda cell: cell.name())
+        axes = ["x", "y"]
 
-        smoothing_coord = smoothing_coefficients_cube.coord(axis=smoothing_axis)
-        non_smoothing_coord = smoothing_coefficients_cube.coord(axis=non_smoothing_axis)
+        for axis, smoothing_coefficient in zip(axes, smoothing_coefficients):
 
-        mean_points = (
-            cube.coord(axis=smoothing_axis).points[1:]
-            + cube.coord(axis=smoothing_axis).points[:-1]
-        ) / 2
+            # Check the smoothing coefficient cube name is as expected
+            expected_name = self.smoothing_coefficient_name_format.format(axis)
+            if smoothing_coefficient.name() != expected_name:
+                msg = (
+                    "The smoothing coefficient cube name {} does not match the "
+                    "expected name {}".format(
+                        smoothing_coefficient.name(), expected_name
+                    )
+                )
+                raise ValueError(msg)
 
-        if len(smoothing_coord.points) != len(mean_points) or not np.allclose(
-            smoothing_coord.points, mean_points
-        ):
-            msg = (
-                f"The points of the {smoothing_axis} spatial dimension of the "
-                "smoothing coefficients must be equal to the mean of each pair "
-                f"of points along the {smoothing_axis} dimension of the input "
-                "cube."
-            )
-            raise ValueError(msg)
+            # Check the smoothing coefficients do not exceed an empirically determined
+            # maximum value; larger values damage conservation significantly.
+            if (smoothing_coefficient.data > 0.5).any():
+                raise ValueError(
+                    "All smoothing_coefficient values must be less than 0.5. "
+                    "A large smoothing_coefficient value leads to poor "
+                    "conservation of probabilities"
+                )
 
-        if len(non_smoothing_coord.points) != len(
-            cube.coord(axis=non_smoothing_axis).points
-        ) or not np.allclose(
-            non_smoothing_coord.points, cube.coord(axis=non_smoothing_axis).points
-        ):
-            msg = (
-                f"The points of the {non_smoothing_axis} spatial dimension of "
-                "the smoothing coefficients must be equal to the points along "
-                f"the {non_smoothing_axis} dimension of the input cube."
-            )
-            raise ValueError(msg)
+            for test_axis in axes:
+                coefficient_crd = smoothing_coefficient.coord(axis=test_axis)
+                if test_axis == axis:
+                    expected_points = (
+                        cube.coord(axis=test_axis).points[1:]
+                        + cube.coord(axis=test_axis).points[:-1]
+                    ) / 2
+                else:
+                    expected_points = cube.coord(axis=test_axis).points
+
+                if len(coefficient_crd.points) != len(
+                    expected_points
+                ) or not np.allclose(coefficient_crd.points, expected_points):
+                    msg = (
+                        f"The smoothing coefficients {test_axis} dimension does not "
+                        "have the expected length or values compared with the cube "
+                        "to which smoothing is being applied.\n\nSmoothing "
+                        "coefficient cubes must have coordinates that are:\n"
+                        "- one element shorter along the dimension being smoothed "
+                        f"({axis}) than in the target cube, with points in that "
+                        "dimension equal to the mean of each pair of points along "
+                        "the dimension in the target cube\n- equal to the points "
+                        "in the target cube along the dimension not being smoothed"
+                    )
+                    raise ValueError(msg)
+
+        return smoothing_coefficients
 
     def _set_smoothing_coefficients(self, smoothing_coefficients_cube):
         """
@@ -374,7 +383,7 @@ class RecursiveFilter(PostProcessingPlugin):
         return smoothing_coefficients_cube
 
     def process(
-        self, cube, smoothing_coefficients_x, smoothing_coefficients_y, mask_cube=None,
+        self, cube, smoothing_coefficients, mask_cube=None,
     ):
         """
         Set up the smoothing_coefficient parameters and run the recursive
@@ -409,12 +418,10 @@ class RecursiveFilter(PostProcessingPlugin):
             cube (iris.cube.Cube):
                 Cube containing the input data to which the recursive filter
                 will be applied.
-            smoothing_coefficients_x (iris.cube.Cube):
-                Cube containing array of smoothing_coefficient values that will
-                be used when applying the recursive filter along the x-axis.
-            smoothing_coefficients_y (iris.cube.Cube):
-                Cube containing array of smoothing_coefficient values that will
-                be used when applying the recursive filter along the y-axis.
+            smoothing_coefficients (iris.cube.CubeList):
+                A cubelist containing two cubes of smoothing_coefficient values,
+                one corresponding to smoothing in the x-direction, and the other
+                to smoothing in the y-direction.
             mask_cube (iris.cube.Cube or None):
                 Cube containing an external mask to apply to the cube before
                 applying the recursive filter.
@@ -427,22 +434,19 @@ class RecursiveFilter(PostProcessingPlugin):
         Raises:
             ValueError: If any smoothing_coefficient cube value is over 0.5
         """
-        for smoothing_coefficient in (
+        cube_format = next(cube.slices([cube.coord(axis="y"), cube.coord(axis="x")]))
+
+        (
             smoothing_coefficients_x,
             smoothing_coefficients_y,
-        ):
-            if (smoothing_coefficient.data > 0.5).any():
-                raise ValueError(
-                    "All smoothing_coefficient values must be less than 0.5. "
-                    "A large smoothing_coefficient value leads to poor "
-                    "conservation of probabilities"
-                )
-        cube_format = next(cube.slices([cube.coord(axis="y"), cube.coord(axis="x")]))
-        self._validate_smoothing_coefficients(cube_format, smoothing_coefficients_x)
+        ) = self._validate_smoothing_coefficients(cube_format, smoothing_coefficients)
+
+        print(cube)
+        print(smoothing_coefficients_x)
+
         smoothing_coefficients_x = self._set_smoothing_coefficients(
             smoothing_coefficients_x
         )
-        self._validate_smoothing_coefficients(cube_format, smoothing_coefficients_y)
         smoothing_coefficients_y = self._set_smoothing_coefficients(
             smoothing_coefficients_y
         )

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -350,6 +350,20 @@ class Test__validate_and_pad_coefficients(Test_RecursiveFilter):
                 self.cube, self.smoothing_coefficients_wrong_points
             )
 
+    def test_smoothing_coefficients_exceed_max(self):
+        """Test that an error is raised if any smoothing coefficient value
+        exceeds the allowed maximum of 0.5."""
+        self.smoothing_coefficients[0].data += 1.
+        msg = (
+                "All smoothing_coefficient values must be less than 0.5. "
+                "A large smoothing_coefficient value leads to poor "
+                "conservation of probabilities"
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            RecursiveFilter(edge_width=1)._validate_and_pad_coefficients(
+                self.cube, self.smoothing_coefficients
+            )
+
     def test_padding_default(self):
         """Test that the returned smoothing_coefficients array is padded as
         expected with the default edge_width."""

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -294,12 +294,6 @@ class Test__validate_and_pad_coefficients(Test_RecursiveFilter):
 
     """Test the _validate_and_pad_coefficients method"""
 
-    def test_smoothing_coefficients_cube(self):
-        """Test that correctly shaped smoothing_coefficients validate."""
-        _ = RecursiveFilter(edge_width=1)._validate_and_pad_coefficients(
-            self.cube, self.smoothing_coefficients
-        )
-
     def test_return_order(self):
         """Test that the coefficients cubes are returned in x, y order."""
         x, y = RecursiveFilter()._validate_and_pad_coefficients(
@@ -366,20 +360,32 @@ class Test__validate_and_pad_coefficients(Test_RecursiveFilter):
 
     def test_padding_default(self):
         """Test that the returned smoothing_coefficients array is padded as
-        expected with the default edge_width."""
-        expected_shape = (65, 64)
-        expected_result = np.full(expected_shape, 0.5)
-        result, _ = RecursiveFilter()._validate_and_pad_coefficients(
+        expected with the default edge_width.
+
+        Using default edge_width of 15 cells, which is doubled and applied to both
+        sides of the array, so array should be padded with 15 * 4 extra rows/columns.
+        """
+        expected_shape_x = (65, 64)
+        expected_shape_y = (64, 65)
+        expected_result_x = np.full(expected_shape_x, 0.5)
+        expected_result_y = np.full(expected_shape_y, 0.5)
+        result_x, result_y = RecursiveFilter()._validate_and_pad_coefficients(
             self.cube, self.smoothing_coefficients
         )
-        self.assertIsInstance(result.data, np.ndarray)
-        self.assertArrayEqual(result.data, expected_result)
-        # Check shape: Array should be padded with 15 * 4 extra rows/columns
-        self.assertEqual(result.shape, expected_shape)
+        self.assertIsInstance(result_x.data, np.ndarray)
+        self.assertIsInstance(result_y.data, np.ndarray)
+        self.assertArrayEqual(result_x.data, expected_result_x)
+        self.assertArrayEqual(result_y.data, expected_result_y)
+        self.assertEqual(result_x.shape, expected_shape_x)
+        self.assertEqual(result_y.shape, expected_shape_y)
 
     def test_padding_set_edge_width(self):
         """Test that the returned smoothing_coefficients arrays are padded as
-        expected with a set edge_width."""
+        expected with a set edge_width.
+
+        Using an edge_width of 1 cell, which is doubled and applied to both
+        sides of the array, so array should be padded with 1 * 4 extra rows/columns.
+        """
         expected_shape_x = (9, 8)
         expected_shape_y = (8, 9)
         expected_result_x = np.full(expected_shape_x, 0.5)
@@ -389,14 +395,17 @@ class Test__validate_and_pad_coefficients(Test_RecursiveFilter):
         )._validate_and_pad_coefficients(self.cube, self.smoothing_coefficients)
         self.assertArrayEqual(result_x.data, expected_result_x)
         self.assertArrayEqual(result_y.data, expected_result_y)
-        # Check shape: Array should be padded with 1 * 4 extra rows/columns
         self.assertEqual(result_x.shape, expected_shape_x)
         self.assertEqual(result_y.shape, expected_shape_y)
 
     def test_padding_non_constant_values(self):
         """Test that the returned smoothing_coefficients array contains the
         expected values when padded symmetrically with non-constant smoothing
-        coefficients."""
+        coefficients.
+
+        Using an edge_width of 1 cell, which is doubled and applied to both
+        sides of the array, so array should be padded with 1 * 4 extra rows/columns.
+        """
         expected_shape = (9, 8)
         expected_result = np.full(expected_shape, 0.5)
         expected_result[1:3, 1:3] = 0.25
@@ -405,7 +414,6 @@ class Test__validate_and_pad_coefficients(Test_RecursiveFilter):
             self.cube, self.smoothing_coefficients
         )
         self.assertArrayEqual(result.data, expected_result)
-        # Check shape: Array should be padded with 1 * 4 extra rows/columns
         self.assertEqual(result.shape, expected_shape)
 
 

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -353,11 +353,11 @@ class Test__validate_and_pad_coefficients(Test_RecursiveFilter):
     def test_smoothing_coefficients_exceed_max(self):
         """Test that an error is raised if any smoothing coefficient value
         exceeds the allowed maximum of 0.5."""
-        self.smoothing_coefficients[0].data += 1.
+        self.smoothing_coefficients[0].data += 1.0
         msg = (
-                "All smoothing_coefficient values must be less than 0.5. "
-                "A large smoothing_coefficient value leads to poor "
-                "conservation of probabilities"
+            "All smoothing_coefficient values must be less than 0.5. "
+            "A large smoothing_coefficient value leads to poor "
+            "conservation of probabilities"
         )
         with self.assertRaisesRegex(ValueError, msg):
             RecursiveFilter(edge_width=1)._validate_and_pad_coefficients(


### PR DESCRIPTION
This PR modifies the recursive filter plugin and CLI to alter the way the coefficients cubes are passed in. The CLI is modified to simply accept a list without any checks. The plugin is modified to order the cubes such that the x and y coefficient cubes can be identified.

Additional changes:
- Remove the _set_smoothing_coefficients method as it didn't do a great deal. Move the padding into the _validate_and_pad_coefficients method so that it can be done within a loop.
- Modify various of the tests in _validate_and_pad_coefficients to make use of the loop.
- Added an additional test to show the symmetrical padding is working as expected (though this is tested in the padding code as well) and one to show return order is correct regardless of input order.
- Modified tests to work with new structure.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)