### PR TITLE
Handle masked truth within reliability calibration

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -373,9 +373,7 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
             # being masked within the resulting reliability table.
             mask = threshold_reliability.mask & table.mask
             threshold_reliability = np.ma.array(
-                threshold_reliability.data + table.data,
-                mask=mask,
-                dtype=np.float32,
+                threshold_reliability.data + table.data, mask=mask, dtype=np.float32,
             )
         else:
             np.add(
@@ -455,7 +453,8 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
 
             for forecast, truth in time_slices:
                 threshold_reliability = self._add_reliability_tables(
-                    forecast, truth, threshold_reliability)
+                    forecast, truth, threshold_reliability
+                )
 
             reliability_entry = reliability_cube.copy(data=threshold_reliability)
             reliability_entry.replace_coord(forecast_slice.coord(threshold_coord))

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -409,7 +409,12 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         Slice data over threshold and time coordinates to construct reliability
         tables. These are summed over time to give a single table for each
         threshold, constructed from all the provided historic forecasts and
-        truths.
+        truths. If a masked truth is provided, a masked reliability table is
+        returned. If the mask within the truth varies at different timesteps,
+        any point that is unmasked for at least one timestep will have
+        unmasked values within the reliability table. Therefore historic
+        forecast points will only be used if they have a corresponding valid
+        truth point for each timestep.
 
         .. See the documentation for an example of the resulting reliability
            table cube.

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -296,14 +296,14 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         a reliability table using the provided truth.
 
         Args:
-            forecast (numpy.ndarray):
+            forecast (numpy.ndarray or numpy.ma.MaskedArray):
                 An array containing data over an xy slice for a single validity
                 time and threshold.
             truth (numpy.ndarray or numpy.ma.MaskedArray):
                 An array containing a thresholded gridded truth at an
                 equivalent validity time to the forecast array.
         Returns:
-            numpy.ndarray or numpy.ma.MaskedArray:
+            numpy.ma.MaskedArray:
                 An array containing reliability table data for a single time
                 and threshold. The leading dimension corresponds to the rows
                 of a calibration table, the second dimension to the number of
@@ -359,6 +359,7 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         """
         forecast = np.ma.masked_where(np.ma.getmask(truth), forecast)
         table = self._populate_reliability_bins(forecast, truth)
+        # Zero data underneath mask to support bitwise addition of masks.
         table.data[table.mask] = 0
         return table
 
@@ -385,7 +386,7 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
                 dimensions of the forecast and truth cubes (which are
                 equivalent).
         """
-        if np.ma.isMaskedArray(truth.data):
+        if np.ma.is_masked(truth.data):
             table = self._populate_masked_reliability_bins(forecast.data, truth.data)
             # Bitwise addition of masks. This ensures that only points that are
             # masked in both the existing and new reliability tables are kept
@@ -455,7 +456,7 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         )
 
         populate_bins_func = self._populate_reliability_bins
-        if np.ma.isMaskedArray(truths.data):
+        if np.ma.is_masked(truths.data):
             populate_bins_func = self._populate_masked_reliability_bins
 
         reliability_tables = iris.cube.CubeList()

--- a/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
@@ -68,12 +68,16 @@ class Test_Aggregation(Test_Setup):
         self.masked_reliability_cube = self.reliability_cube.copy()
         masked_array = np.zeros(self.reliability_cube.shape, dtype=bool)
         masked_array[:, :, 0, :2] = True
-        self.masked_reliability_cube.data = np.ma.array(self.reliability_cube.data, mask=masked_array)
+        self.masked_reliability_cube.data = np.ma.array(
+            self.reliability_cube.data, mask=masked_array
+        )
 
         self.masked_different_frt = self.different_frt.copy()
         masked_array = np.zeros(self.different_frt.shape, dtype=bool)
         masked_array[:, :, :2, 0] = True
-        self.masked_different_frt.data = np.ma.array(self.different_frt.data, mask=masked_array)
+        self.masked_different_frt.data = np.ma.array(
+            self.different_frt.data, mask=masked_array
+        )
 
         self.overlapping_frt = self.reliability_cube.copy()
         new_frt = self.overlapping_frt.coord("forecast_reference_time")

--- a/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
@@ -60,7 +60,6 @@ class Test_Aggregation(Test_Setup):
         )
         self.reliability_cube = reliability_cube_format.copy(data=self.expected_table)
         self.different_frt = self.reliability_cube.copy()
-
         new_frt = self.different_frt.coord("forecast_reference_time")
         new_frt.points = new_frt.points + 48 * 3600
         new_frt.bounds = new_frt.bounds + 48 * 3600

--- a/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
@@ -60,9 +60,20 @@ class Test_Aggregation(Test_Setup):
         )
         self.reliability_cube = reliability_cube_format.copy(data=self.expected_table)
         self.different_frt = self.reliability_cube.copy()
+
         new_frt = self.different_frt.coord("forecast_reference_time")
         new_frt.points = new_frt.points + 48 * 3600
         new_frt.bounds = new_frt.bounds + 48 * 3600
+
+        self.masked_reliability_cube = self.reliability_cube.copy()
+        masked_array = np.zeros(self.reliability_cube.shape, dtype=bool)
+        masked_array[:, :, 0, :2] = True
+        self.masked_reliability_cube.data = np.ma.array(self.reliability_cube.data, mask=masked_array)
+
+        self.masked_different_frt = self.different_frt.copy()
+        masked_array = np.zeros(self.different_frt.shape, dtype=bool)
+        masked_array[:, :, :2, 0] = True
+        self.masked_different_frt.data = np.ma.array(self.different_frt.data, mask=masked_array)
 
         self.overlapping_frt = self.reliability_cube.copy()
         new_frt = self.overlapping_frt.coord("forecast_reference_time")
@@ -180,6 +191,38 @@ class Test_process(Test_Aggregation):
             coordinates=["latitude", "longitude"],
         )
         assert_array_equal(result.data, self.lat_lon_collapse * 2)
+        self.assertEqual(result.coord(frt).points, expected_points)
+        assert_array_equal(result.coord(frt).bounds, expected_bounds)
+
+    def test_aggregating_over_masked_cubes_and_coordinates(self):
+        """Test of aggregating over coordinates and cubes in a single call
+        using a masked reliability table. In this instance the latitude and
+        longitude coordinates are collapsed and the values from two input cube
+        combined."""
+
+        frt = "forecast_reference_time"
+        expected_points = self.masked_different_frt.coord(frt).points
+        expected_bounds = [
+            [
+                self.masked_reliability_cube.coord(frt).bounds[0][0],
+                self.masked_different_frt.coord(frt).bounds[-1][1],
+            ]
+        ]
+        expected_result = np.array(
+            [
+                [0.0, 0.0, 2.0, 4.0, 2.0],
+                [0.0, 0.625, 2.625, 3.25, 2.0],
+                [0.0, 3.0, 5.0, 4.0, 2.0],
+            ]
+        )
+
+        plugin = Plugin()
+        result = plugin.process(
+            [self.masked_reliability_cube, self.masked_different_frt],
+            coordinates=["latitude", "longitude"],
+        )
+        self.assertIsInstance(result.data, np.ma.MaskedArray)
+        assert_array_equal(result.data, expected_result)
         self.assertEqual(result.coord(frt).points, expected_points)
         assert_array_equal(result.coord(frt).bounds, expected_bounds)
 

--- a/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
@@ -524,7 +524,9 @@ class Test_process(Test_Setup):
             ],
             dtype=np.float32,
         )
-        expected = np.sum([self.expected_table_for_mask, expected_table_for_second_mask], axis=0)
+        expected = np.sum(
+            [self.expected_table_for_mask, expected_table_for_second_mask], axis=0
+        )
         expected_mask = np.zeros(expected.shape, dtype=bool)
         expected_mask[:, :, 0, 0] = True
         result = Plugin(

--- a/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
@@ -447,7 +447,7 @@ class Test__populate_masked_reliability_bins(Test_Setup):
         )._populate_masked_reliability_bins(forecast_slice.data, truth_slice.data)
 
         self.assertSequenceEqual(result.shape, self.expected_table_shape)
-        self.assertIsInstance(result, np.ma.MaskedArray)
+        self.assertTrue(np.ma.is_masked(result))
         assert_array_equal(result.data, self.expected_table_for_mask)
         expected_mask = np.zeros(self.expected_table_for_mask.shape, dtype=bool)
         expected_mask[:, :, 0, :2] = True

--- a/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
@@ -92,6 +92,33 @@ class Test_Setup(unittest.TestCase):
             frt=datetime(2017, 11, 11, 4, 0),
         )
         self.truths = MergeCubes()([self.truth_1, self.truth_2])
+
+        # print("truth_data.shape = ", truth_data.shape)
+        masked_array = np.zeros(truth_data.shape, dtype=bool)
+        masked_array[:, 0, :2] = True
+        masked_truth_data_1 = np.ma.array(truth_data, mask=masked_array)
+        masked_array = np.zeros(truth_data.shape, dtype=bool)
+        masked_array[:, :2, 0] = True
+        masked_truth_data_2 = np.ma.array(truth_data, mask=masked_array)
+
+        # print("truth_data_1 = ", truth_data_1)
+        # print("truth_data_2 = ", truth_data)
+        # print("masked_truth_data_1 = ", masked_truth_data_1)
+        # print("masked_truth_data_2 = ", masked_truth_data_2)
+        # import sys
+        # sys.exit(1)
+        self.masked_truth_1 = set_up_probability_cube(
+            masked_truth_data_1, thresholds, frt=datetime(2017, 11, 10, 4, 0)
+        )
+        self.masked_truth_2 = set_up_probability_cube(
+            masked_truth_data_2,
+            thresholds,
+            time=datetime(2017, 11, 11, 4, 0),
+            frt=datetime(2017, 11, 11, 4, 0),
+        )
+        # print("masked_truth_1 = ", self.masked_truth_1)
+        self.masked_truths = MergeCubes()([self.masked_truth_1, self.masked_truth_2])
+        # print("self.masked_truths = ", self.masked_truths.data)
         self.expected_threshold_coord = self.forecasts.coord(var_name="threshold")
         self.expected_table_shape = (3, 5, 3, 3)
         self.expected_attributes = {
@@ -121,6 +148,32 @@ class Test_Setup(unittest.TestCase):
                 [
                     [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                     [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        self.expected_table_for_mask = np.array(
+            [
+                [
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                ],
+                [
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.25], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.375, 0.5, 0.625], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.75, 0.875, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                ],
+                [
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                     [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0]],
                     [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
                     [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
@@ -387,6 +440,23 @@ class Test__populate_reliability_bins(Test_Setup):
         self.assertSequenceEqual(result.shape, self.expected_table_shape)
         assert_array_equal(result, self.expected_table)
 
+    def test_table_values_masked_truth(self):
+        """Test the reliability table returned has the expected values when a
+        masked truth is input."""
+
+        forecast_slice = next(self.forecast_1.slices_over("air_temperature"))
+        truth_slice = next(self.masked_truth_1.slices_over("air_temperature"))
+        result = Plugin(
+            single_value_lower_limit=True, single_value_upper_limit=True
+        )._populate_reliability_bins(forecast_slice.data, truth_slice.data)
+
+        self.assertSequenceEqual(result.shape, self.expected_table_shape)
+        self.assertIsInstance(result.data, np.ma.MaskedArray)
+        assert_array_equal(result.data, self.expected_table_for_mask)
+        expected_mask = np.zeros(self.expected_table_for_mask.shape, dtype=bool)
+        expected_mask[:, :, 0, :2] = True
+        assert_array_equal(result.mask, expected_mask)
+
 
 class Test_process(Test_Setup):
 
@@ -415,6 +485,56 @@ class Test_process(Test_Setup):
         ).process(self.forecasts, self.truths)
 
         assert_array_equal(result[0].data, expected)
+
+    def test_table_values_masked_truth(self):
+        """Test, similar to test_table_values, using masked arrays. The
+        mask is different for different timesteps, reflecting the potential
+        for masked areas in e.g. a radar truth to differ between timesteps.
+        At timestep 1, two grid points are masked. At timestep 2, two
+        grid points are also masked with one masked grid point in common
+        between timesteps. As a result, only one grid point is masked (
+        within the upper left corner) within the resulting reliability table."""
+
+        # Expected values shown explicitly of comparison with self.expected_table.
+        # Example differences arising from masking are that the 0.125 value
+        # would have been 0.250 without the masking.
+        expected_table_for_second_mask = np.array(
+            [
+                [
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                ],
+                [
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.125, 0.25], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.5, 0.625], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.75, 0.875, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                ],
+                [
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 1.0, 1.0], [0.0, 0.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        expected = np.sum([self.expected_table_for_mask, expected_table_for_second_mask], axis=0)
+        expected_mask = np.zeros(expected.shape, dtype=bool)
+        expected_mask[:, :, 0, 0] = True
+        result = Plugin(
+            single_value_lower_limit=True, single_value_upper_limit=True
+        ).process(self.forecasts, self.masked_truths)
+        self.assertIsInstance(result.data, np.ma.MaskedArray)
+        assert_array_equal(result[0].data.data, expected)
+        assert_array_equal(result[0].data.mask, expected_mask)
+        # Different thresholds must have the same mask.
+        assert_array_equal(result[0].data.mask, result[1].data.mask)
 
     def test_mismatching_threshold_coordinates(self):
         """Test that an exception is raised if the forecast and truth cubes


### PR DESCRIPTION
Description
This PR primarily updates the `ConstructReliabilityCalibrationTable`s plugin to support a masked truth. This affects the populating of the reliability table and adding the reliability tables for each timestep. The addition of the reliability tables with masked data is designed, so that only points that are always masked will be masked in the resulting reliability table. This avoids temporary outages, as might occur within, for example, a radar field, where a point might otherwise always be masked, if it is masked within one timestep within the training dataset.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

