### PR TITLE
Finish integer seconds

### DIFF
--- a/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
+++ b/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
@@ -80,7 +80,7 @@ def make_ancil_cube(data, name, unit, shape=None):
 def _add_model_levels(flat_cube, data):
     """Add a model level coordinate to a point cube and insert 1D height data"""
     cube = add_coordinate(flat_cube, np.arange(len(data)), "model_level_number", 1)
-    cube.data = np.array(data).reshape(len(data), 1, 1)
+    cube.data = np.array(data).reshape((len(data), 1, 1))
     return cube
 
 

--- a/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
+++ b/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
@@ -153,20 +153,22 @@ class TestMultiPoint:
         if modelorog is None:
             modelorog = np.full(shape, 230.0, dtype=np.float32)
         self.w_cube = None
-        self.aos_cube = make_ancil_cube(AoS, None, 1, shape=shape)
+        self.aos_cube = make_ancil_cube(AoS, "silhouette_roughness", 1, shape=shape)
         self.s_cube = make_ancil_cube(
-            Sigma, "standard_deviation_of_orography_height", "m", shape=shape
+            Sigma, "standard_deviation_of_height_in_grid_cell", "m", shape=shape
         )
         if z_0 is None:
             self.z0_cube = None
         elif isinstance(z_0, float):
             z_0 = np.full(shape, z_0, dtype=np.float32)
-            self.z0_cube = make_ancil_cube(z_0, None, "m")
+            self.z0_cube = make_ancil_cube(z_0, "vegetative_roughness_length", "m")
         elif isinstance(z_0, list):
-            self.z0_cube = make_ancil_cube(np.array(z_0), None, "m", shape=shape)
-        self.poro_cube = make_ancil_cube(pporog, "orography_height", "m", shape=shape)
+            self.z0_cube = make_ancil_cube(
+                np.array(z_0), "vegetative_roughness_length", "m", shape=shape
+            )
+        self.poro_cube = make_ancil_cube(pporog, "surface_altitude", "m", shape=shape)
         self.moro_cube = make_ancil_cube(
-            modelorog, "orography_height", "m", shape=shape
+            modelorog, "surface_altitude", "m", shape=shape
         )
 
     def run_hc_rc(self, wind, dtime=1, height=None, aslist=False):
@@ -273,17 +275,19 @@ class TestSinglePoint:
 
         """
         self.w_cube = None
-        self.aos_cube = make_ancil_cube(AoS, None, 1, shape=(1, 1))
+        self.aos_cube = make_ancil_cube(AoS, "silhouette_roughness", 1, shape=(1, 1))
         self.s_cube = make_ancil_cube(
-            Sigma, "standard_deviation_of_orography_height", "m", shape=(1, 1)
+            Sigma, "standard_deviation_of_height_in_grid_cell", "m", shape=(1, 1)
         )
         if z_0 is None:
             self.z0_cube = None
         else:
-            self.z0_cube = make_ancil_cube(z_0, None, "m", shape=(1, 1))
-        self.poro_cube = make_ancil_cube(pporog, "orography_height", "m", shape=(1, 1))
+            self.z0_cube = make_ancil_cube(
+                z_0, "vegetative_roughness_length", "m", shape=(1, 1)
+            )
+        self.poro_cube = make_ancil_cube(pporog, "surface_altitude", "m", shape=(1, 1))
         self.moro_cube = make_ancil_cube(
-            modelorog, "orography_height", "m", shape=(1, 1)
+            modelorog, "surface_altitude", "m", shape=(1, 1)
         )
         if heightlevels is not None:
             self.hl_cube = make_point_height_ancil_cube(heightlevels)
@@ -693,7 +697,9 @@ class Test2D(IrisTest):
         z0_data = np.array(
             [landpointtests_rc.z0_cube.data, landpointtests_rc.z0_cube.data]
         )
-        landpointtests_rc.z0_cube = make_ancil_cube(z0_data, None, "m", shape=(1, 2))
+        landpointtests_rc.z0_cube = make_ancil_cube(
+            z0_data, "vegetative_roughness_length", "m", shape=(1, 2)
+        )
         msg = "ancillary grids are not consistent"
         with self.assertRaisesRegex(ValueError, msg):
             _ = landpointtests_rc.run_hc_rc(self.uin)
@@ -710,7 +716,7 @@ class Test2D(IrisTest):
             [landpointtests_rc.moro_cube.data, landpointtests_rc.moro_cube.data]
         )
         landpointtests_rc.moro_cube = make_ancil_cube(
-            moro_data, "orography_height", "m", shape=(1, 2)
+            moro_data, "surface_altitude", "m", shape=(1, 2)
         )
         msg = "ancillary grids are not consistent"
         with self.assertRaisesRegex(ValueError, msg):

--- a/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
+++ b/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
@@ -90,7 +90,7 @@ def _make_ukvx_grid():
     return cube
 
 
-def make_point_cube(data_point, name, unit):
+def make_point_ancil_cube(data_point, name, unit):
     """Create a cube containing a single point ancillary value"""
     cube = set_up_variable_cube(
         np.array([[data_point]], dtype=np.float32),
@@ -100,6 +100,8 @@ def make_point_cube(data_point, name, unit):
         domain_corner=(-1036000, -1158000),
     )
     # add bounds for a 2 km grid square
+    # Test1D::section0g fails without this test - bounds appear to be used to
+    # calculate grid length which affects the outputs of this code
     for axis in ['x', 'y']:
         point = cube.coord(axis=axis).points[0]
         cube.coord(axis=axis).bounds = [point-1000., point+1000.]
@@ -357,14 +359,16 @@ class TestSinglePoint:
 
         """
         self.w_cube = None
-        self.aos_cube = make_point_cube(AoS, None, 1)
-        self.s_cube = make_point_cube(Sigma, None, "m")
+        self.aos_cube = make_point_ancil_cube(AoS, None, 1)
+        self.s_cube = make_point_ancil_cube(
+            Sigma, "standard_deviation_of_orography_height", "m"
+        )
         if z_0 is None:
             self.z0_cube = None
         else:
-            self.z0_cube = make_point_cube(z_0, None, "m")
-        self.poro_cube = make_point_cube(pporog, "orography_height", "m")
-        self.moro_cube = make_point_cube(modelorog, "orography_height", "m")
+            self.z0_cube = make_point_ancil_cube(z_0, None, "m")
+        self.poro_cube = make_point_ancil_cube(pporog, "orography_height", "m")
+        self.moro_cube = make_point_ancil_cube(modelorog, "orography_height", "m")
         if heightlevels is not None:
             self.hl_cube = set_up_cube(num_height_levels=len(heightlevels), data=heightlevels)
         else:
@@ -431,10 +435,6 @@ class Test1D(IrisTest):
         """Test AoS is RMDI, point should not do anything, uin = uout."""
         landpointtests_hc_rc = TestSinglePoint(
             AoS=RMDI,
-            Sigma=20.0,
-            z_0=0.2,
-            pporog=250.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -444,10 +444,6 @@ class Test1D(IrisTest):
         """Test AoS is np.nan, point should not do anything, uin = uout."""
         landpointtests_hc_rc = TestSinglePoint(
             AoS=np.nan,
-            Sigma=20.0,
-            z_0=0.2,
-            pporog=250.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -456,11 +452,7 @@ class Test1D(IrisTest):
     def test_section0c(self):
         """Test Sigma is RMDI, point should not do anything, uin = uout."""
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
             Sigma=RMDI,
-            z_0=0.2,
-            pporog=250.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -469,11 +461,7 @@ class Test1D(IrisTest):
     def test_section0d(self):
         """Test Sigma is np.nan, point should not do anything, uin = uout."""
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
             Sigma=np.nan,
-            z_0=0.2,
-            pporog=250.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -486,11 +474,8 @@ class Test1D(IrisTest):
 
         """
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
             z_0=RMDI,
             pporog=230.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -503,11 +488,8 @@ class Test1D(IrisTest):
 
         """
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
             z_0=np.nan,
             pporog=230.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -520,11 +502,7 @@ class Test1D(IrisTest):
 
         """
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
             z_0=RMDI,
-            pporog=250.0,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -540,11 +518,7 @@ class Test1D(IrisTest):
 
         """
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
-            z_0=0.2,
             pporog=RMDI,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -563,11 +537,7 @@ class Test1D(IrisTest):
 
         """
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
-            z_0=0.2,
             pporog=np.nan,
-            modelorog=230.0,
             heightlevels=self.hls,
         )
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
@@ -586,10 +556,6 @@ class Test1D(IrisTest):
 
         """
         landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
-            z_0=0.2,
-            pporog=250.0,
             modelorog=RMDI,
             heightlevels=self.hls,
         )
@@ -607,9 +573,7 @@ class Test1D(IrisTest):
 
         """
         hls = [0.2, 3, 13, RMDI, 133, 333, 1133]
-        landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2, Sigma=20.0, z_0=0.2, pporog=250, modelorog=230, heightlevels=hls
-        )
+        landpointtests_hc_rc = TestSinglePoint(heightlevels=hls)
         with self.assertRaises(ValueError):
             _ = landpointtests_hc_rc.run_hc_rc(self.uin)
 
@@ -621,9 +585,7 @@ class Test1D(IrisTest):
 
         """
         hls = [0.2, 3, 13, np.nan, 133, 333, 1133]
-        landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2, Sigma=20.0, z_0=0.2, pporog=250, modelorog=230, heightlevels=hls
-        )
+        landpointtests_hc_rc = TestSinglePoint(heightlevels=hls)
         with self.assertRaises(ValueError):
             _ = landpointtests_hc_rc.run_hc_rc(self.uin)
 
@@ -635,14 +597,7 @@ class Test1D(IrisTest):
 
         """
         uin = [20.0, 20.0, 20.0, RMDI, RMDI, 20.0, 0.0]
-        landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
-            z_0=0.2,
-            pporog=250,
-            modelorog=230,
-            heightlevels=self.hls,
-        )
+        landpointtests_hc_rc = TestSinglePoint(heightlevels=self.hls)
         with self.assertRaises(ValueError):
             _ = landpointtests_hc_rc.run_hc_rc(uin)
 
@@ -654,14 +609,7 @@ class Test1D(IrisTest):
 
         """
         uin = [20.0, 20.0, 20.0, np.nan, 20.0, 20.0, 20.0]
-        landpointtests_hc_rc = TestSinglePoint(
-            AoS=0.2,
-            Sigma=20.0,
-            z_0=0.2,
-            pporog=250,
-            modelorog=230,
-            heightlevels=self.hls,
-        )
+        landpointtests_hc_rc = TestSinglePoint(heightlevels=self.hls)
         with self.assertRaises(ValueError):
             _ = landpointtests_hc_rc.run_hc_rc(uin)
 
@@ -673,7 +621,7 @@ class Test1D(IrisTest):
         uin = uout
 
         """
-        landpointtests_hc = TestSinglePoint(z_0=None, pporog=250.0, modelorog=250.0)
+        landpointtests_hc = TestSinglePoint(z_0=None, modelorog=250.0)
         land_hc_rc = landpointtests_hc.run_hc_rc(self.uin)
         self.assertArrayEqual(landpointtests_hc.w_cube, land_hc_rc)
 
@@ -685,7 +633,7 @@ class Test1D(IrisTest):
         uin <= uout, at least one height has uin < uout.
 
         """
-        landpointtests_hc = TestSinglePoint(z_0=None, pporog=250.0, modelorog=230.0)
+        landpointtests_hc = TestSinglePoint(z_0=None)
         land_hc_rc = landpointtests_hc.run_hc_rc(self.uin)
         self.assertTrue(
             (land_hc_rc.data >= landpointtests_hc.w_cube.data).all()
@@ -700,7 +648,7 @@ class Test1D(IrisTest):
         uin >= uout, at least one height has uin > uout, uout[0] = 0.
 
         """
-        landpointtests_rc = TestSinglePoint(z_0=0.2, pporog=250.0, modelorog=250.0)
+        landpointtests_rc = TestSinglePoint(modelorog=250.0)
         land_hc_rc = landpointtests_rc.run_hc_rc(self.uin)
         self.assertTrue(
             (land_hc_rc.data <= landpointtests_rc.w_cube.data).all()
@@ -719,7 +667,7 @@ class Test1D(IrisTest):
         Must be 0.
 
         """
-        landpointtests_hc_rc = TestSinglePoint(z_0=0.2, pporog=230.0, modelorog=250.0)
+        landpointtests_hc_rc = TestSinglePoint(pporog=230.0, modelorog=250.0)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
         self.assertTrue(
             (land_hc_rc.data <= landpointtests_hc_rc.w_cube.data).all()
@@ -736,7 +684,7 @@ class Test1D(IrisTest):
         uin = uout.
 
         """
-        landpointtests_hc_rc = TestSinglePoint(z_0=0.2, AoS=0.0)
+        landpointtests_hc_rc = TestSinglePoint(AoS=0.0)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
         self.assertArrayEqual(landpointtests_hc_rc.w_cube, land_hc_rc)
 
@@ -748,7 +696,7 @@ class Test1D(IrisTest):
         uin = uout.
 
         """
-        landpointtests_hc_rc = TestSinglePoint(z_0=0.2, Sigma=0.0)
+        landpointtests_hc_rc = TestSinglePoint(Sigma=0.0)
         land_hc_rc = landpointtests_hc_rc.run_hc_rc(self.uin)
         self.assertArrayEqual(landpointtests_hc_rc.w_cube, land_hc_rc)
 
@@ -782,7 +730,7 @@ class Test2D(IrisTest):
         hlvs = 10
         uin = np.ones(hlvs) * 20
         heights = ((np.arange(hlvs) + 1) ** 2.0) * 12.0
-        multip_hc_rc = TestMultiPoint(3)
+        multip_hc_rc = TestMultiPoint()
         land_hc_rc = multip_hc_rc.run_hc_rc(uin, dtime=1, height=heights)
         hidx = land_hc_rc.shape.index(hlvs)
         for field in land_hc_rc.slices_over(hidx):
@@ -853,7 +801,7 @@ class Test2D(IrisTest):
         hlvs = 10
         uin = (np.ones(hlvs) * 20).astype(np.float32)
         heights = (((np.arange(hlvs) + 1) ** 2.0) * 12.0).astype(np.float32)
-        multip_hc_rc = TestMultiPoint(3)
+        multip_hc_rc = TestMultiPoint()
         land_hc_rc = multip_hc_rc.run_hc_rc(uin, dtime=1, height=heights)
         self.assertEqual(land_hc_rc.dtype, np.float32)
 

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -256,7 +256,7 @@ class Test_update_daynight(IrisTest):
         """Test that the function returns a weather code cube."""
         cube = set_up_wxcube()
         result = update_daynight(cube)
-        self.assertIsInstance(result, Cube)
+        self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "weather_code")
         self.assertEqual(result.units, "1")
         self.assertArrayEqual(result.attributes["weather_code"], self.wxcode)
@@ -348,7 +348,7 @@ class Test_update_daynight(IrisTest):
         """Test that the function returns a weather code lat lon cube.."""
         cube = set_up_wxcube_lat_lon()
         result = update_daynight(cube)
-        self.assertIsInstance(result, Cube)
+        self.assertIsInstance(result, iris.cube.Cube)
         self.assertEqual(result.name(), "weather_code")
         self.assertEqual(result.units, "1")
         self.assertArrayEqual(result.attributes["weather_code"], self.wxcode)

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -169,14 +169,11 @@ def set_up_wxcube(time_points=None):
     return iris.util.squeeze(cube)
 
 
-def set_up_wxcube_lat_lon(time_points=None):
+def set_up_wxcube_lat_lon():
 
     """
-    Set up a lat-lon wxcube
-
-    Args:
-        time_points (numpy.ndarray):
-            Array of time points
+    Set up a lat-lon wxcube for a particular time and location, to include
+    the terminator and test the "update_daynight" functionality
 
     Returns:
         iris.cube.Cube:
@@ -184,19 +181,18 @@ def set_up_wxcube_lat_lon(time_points=None):
             data shape (time_points, 16, 16)
             grid covering 8W to 7E, 49N to 64N
     """
-    num_grid_points = 16
-    cube = _core_wxcube(time_points, num_grid_points)
-
-    lon_points = np.linspace(-8, 7, num_grid_points)
-    lat_points = np.linspace(49, 64, num_grid_points)
-
-    cube.add_dim_coord(
-        DimCoord(lat_points, "latitude", units="degrees", coord_system=ELLIPSOID), 1
+    cube = set_up_variable_cube(
+        np.ones((16, 16), dtype=np.float32),
+        name="weather_code",
+        units=1,
+        spatial_grid="latlon",
+        domain_corner=(49, -8),
+        grid_spacing=1,
+        time=datetime.datetime(2018, 9, 12, 5, 43),
+        frt=datetime.datetime(2018, 9, 12, 3),
+        attributes=weather_code_attributes()
     )
-    cube.add_dim_coord(
-        DimCoord(lon_points, "longitude", units="degrees", coord_system=ELLIPSOID), 2
-    )
-    return iris.util.squeeze(cube)
+    return cube
 
 
 class Test_wx_dict(IrisTest):

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -39,9 +39,6 @@ from tempfile import mkdtemp
 import iris
 import numpy as np
 import pytest
-from cf_units import Unit, date2num
-from iris.coords import DimCoord
-from iris.cube import Cube
 from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
 
@@ -85,7 +82,7 @@ def set_up_wxcube(time_points=None):
         domain_corner=(0, -30000),
         time=datetime.datetime(2018, 9, 12, 5, 43),
         frt=datetime.datetime(2018, 9, 12, 3),
-        attributes=weather_code_attributes()
+        attributes=weather_code_attributes(),
     )
 
     if time_points is not None:
@@ -115,7 +112,7 @@ def set_up_wxcube_lat_lon():
         grid_spacing=1,
         time=datetime.datetime(2018, 9, 12, 5, 43),
         frt=datetime.datetime(2018, 9, 12, 3),
-        attributes=weather_code_attributes()
+        attributes=weather_code_attributes(),
     )
 
 
@@ -261,7 +258,7 @@ class Test_update_daynight(IrisTest):
         result = update_daynight(cube)
         self.assertIsInstance(result, Cube)
         self.assertEqual(result.name(), "weather_code")
-        self.assertEqual(result.units, Unit("1"))
+        self.assertEqual(result.units, "1")
         self.assertArrayEqual(result.attributes["weather_code"], self.wxcode)
         self.assertEqual(result.attributes["weather_code_meaning"], self.wxmeaning)
 
@@ -341,7 +338,7 @@ class Test_update_daynight(IrisTest):
                 datetime.datetime(2018, 9, 12, 6),
                 datetime.datetime(2018, 9, 12, 7),
             ]
-        ) 
+        )
         expected_result = np.ones((3, 16, 16))
         expected_result[0, :, :] = 0
         result = update_daynight(cube)
@@ -353,7 +350,7 @@ class Test_update_daynight(IrisTest):
         result = update_daynight(cube)
         self.assertIsInstance(result, Cube)
         self.assertEqual(result.name(), "weather_code")
-        self.assertEqual(result.units, Unit("1"))
+        self.assertEqual(result.units, "1")
         self.assertArrayEqual(result.attributes["weather_code"], self.wxcode)
         self.assertEqual(result.attributes["weather_code_meaning"], self.wxmeaning)
 

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -82,16 +82,12 @@ def set_up_wxcube(time_points=None, lat_lon=False):
         "frt": datetime.datetime(2018, 9, 12, 3),
         "attributes": weather_code_attributes(),
         "spatial_grid": "equalarea",
-        "domain_corner": (0, -30000)
+        "domain_corner": (0, -30000),
     }
 
     if lat_lon:
         kwargs.update(
-            {
-                "spatial_grid": "latlon",
-                "domain_corner": (49, -8),
-                "grid_spacing": 1,
-            }
+            {"spatial_grid": "latlon", "domain_corner": (49, -8), "grid_spacing": 1,}
         )
 
     cube = set_up_variable_cube(np.ones((16, 16), dtype=np.float32), **kwargs)


### PR DESCRIPTION
Completes work to replace all unit tests using time in "hours" to use integer seconds, via the standard test cube setup functions.

Testing:
 - [x] Ran tests and they passed OK