### PR TITLE
IMPRO-1890: Fix issue with parallel acceptance tests caused by modification of default attributes

### DIFF
--- a/improver/utilities/ancillary_creation.py
+++ b/improver/utilities/ancillary_creation.py
@@ -229,7 +229,7 @@ class OrographicSmoothingCoefficients(BasePlugin):
             cube_name,
             "1",
             template,
-            MANDATORY_ATTRIBUTE_DEFAULTS,
+            MANDATORY_ATTRIBUTE_DEFAULTS.copy(),
             optional_attributes=attributes,
             data=data,
         )


### PR DESCRIPTION
Modification of mandatory attributes in place seems to affect multiple tests.

This PR modifies the code to use a copy of the mandatory attributes rather than the original when creating a new smoothing coefficients cube. When running the parallel pytest acceptance tests it is found that modifying this default dictionary effects 
multiple tests.

I have no idea why the default dictionary being overwritten in one acceptance test affects the others, but it does.

Testing:
 - [x] Ran tests and they passed OK