### PR TITLE
IMPRO-1840: Modify recursive filter coefficient generation

### DIFF
--- a/improver/utilities/ancillary_creation.py
+++ b/improver/utilities/ancillary_creation.py
@@ -194,7 +194,7 @@ class OrographicSmoothingCoefficients(BasePlugin):
             numpy.ndarray:
                 An array containing the unscaled smoothing_coefficients.
         """
-        return self.coefficient * gradient_cube.data ** self.power
+        return self.coefficient * np.abs(gradient_cube.data) ** self.power
 
     @staticmethod
     def create_coefficient_cube(data, template, cube_name, attributes):

--- a/improver_tests/utilities/ancillary_creation/test_OrographicSmoothingCoefficients.py
+++ b/improver_tests/utilities/ancillary_creation/test_OrographicSmoothingCoefficients.py
@@ -63,7 +63,7 @@ def orography_fixture() -> Cube:
 def gradient_fixture() -> Cube:
     """Gradient cube with several gradient values."""
 
-    data = np.array([0, 0.5, 1.0, 5.0], dtype=np.float32)
+    data = np.array([0, 0.5, -1.0, 5.0], dtype=np.float32)
     data = np.stack([data] * 2)
     cube = set_up_variable_cube(
         data, name="gradient_of_surface_altitude", units="1", spatial_grid="equalarea"
@@ -156,13 +156,19 @@ def test_unnormalised_smoothing_coefficients(gradient):
 
     # Coefficient = 1, power = 1
     plugin = OrographicSmoothingCoefficients(coefficient=1, power=1)
-    expected = gradient.data.copy()
+    expected = np.abs(gradient.data.copy())
     result = plugin.unnormalised_smoothing_coefficients(gradient)
     assert_array_almost_equal(result, expected)
 
     # Coefficient = 0.5, power = 2
     plugin = OrographicSmoothingCoefficients(coefficient=0.5, power=2)
     expected = np.array([0.0, 0.125, 0.5, 12.5])
+    result = plugin.unnormalised_smoothing_coefficients(gradient)
+    assert_array_almost_equal(result[0, :], expected)
+
+    # Coefficient = 0.5, power = 0.5
+    plugin = OrographicSmoothingCoefficients(coefficient=0.5, power=0.5)
+    expected = np.array([0.0, 0.353553, 0.5, 1.118034])
     result = plugin.unnormalised_smoothing_coefficients(gradient)
     assert_array_almost_equal(result[0, :], expected)
 


### PR DESCRIPTION
This small change ensures we are using the absolute value of the orographic gradient when generating smoothing coefficients. This only impacts coefficients generated using a power that is odd or less than 1. The unit tests have been modified to include a negative gradient to test this change.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)