### PR TITLE
Updates code to prevent combine outputting float64 data

### DIFF
--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -36,6 +36,7 @@ from iris.cube import CubeList
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
+from improver.metadata.constants import FLOAT_DTYPE, FLOAT_TYPES
 from improver.metadata.probabilistic import (
     extract_diagnostic_name,
     find_threshold_coordinate,
@@ -276,6 +277,12 @@ class CubeCombiner(BasePlugin):
         # normalise mean (for which self.operator is np.add)
         if self.operation == "mean":
             result.data = result.data / len(cube_list)
+
+        # Check resulting dtype and modify if necessary
+        types_to_fix = FLOAT_TYPES.copy()
+        types_to_fix.remove(FLOAT_DTYPE)
+        if result.dtype in types_to_fix:
+            result.data = result.data.astype(FLOAT_DTYPE)
 
         # where the operation is "multiply", retain all coordinate metadata
         # from the first cube in the list; otherwise expand coordinate bounds

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -185,6 +185,20 @@ class Test_process(CombinerTest):
         self.assertEqual(result.name(), "new_cube_name")
         self.assertArrayAlmostEqual(result.data, expected_data)
 
+    def test_mixed_dtypes(self):
+        """Test that the plugin calculates the sum correctly and doesn't mangle dtypes."""
+        plugin = CubeCombiner("add")
+        cubelist = iris.cube.CubeList(
+            [self.cube1, self.cube2.copy(np.ones_like(self.cube2.data, dtype=np.int32))]
+        )
+        result = plugin.process(cubelist, "new_cube_name")
+        expected_data = np.full((1, 2, 2), 1.5, dtype=np.float32)
+        self.assertEqual(result.name(), "new_cube_name")
+        self.assertArrayAlmostEqual(result.data, expected_data)
+        self.assertTrue(cubelist[0].dtype == np.float32)
+        self.assertTrue(cubelist[1].dtype == np.int32)
+        self.assertTrue(result.dtype == np.float32)
+
     def test_bounds_expansion(self):
         """Test that the plugin calculates the sum of the input cubes
         correctly and expands the time coordinate bounds on the


### PR DESCRIPTION
Updates code to prevent combine outputting float64 data which can happen if inputs are of mixed type. Specifically, multiplying float32 by int32 results in float64.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
