### PR TITLE
IMPRO-1815 sleetacc and rainacc bounds for ECC

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -48,41 +48,48 @@ Bounds = namedtuple("bounds", "value units")
 # Calibrated ensemble reliability whilst preserving spatial structure.
 # Tellus Series A, Dynamic Meteorology and Oceanography, 66, 22662.
 
+# Grouped by parameter, then sorted alphabetically.
 BOUNDS_FOR_ECDF = {
-    "air_temperature": (Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")),
-    "feels_like_temperature": (
-        Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")
-    ),
-    "wind_speed": Bounds((0, 50), "m s^-1"),
-    "wind_speed_of_gust": Bounds((0, 200), "m s^-1"),
-    "air_pressure_at_sea_level": Bounds((86000, 108000), "Pa"),
-    "cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_2p5_oktas": Bounds(
-        (-300, 20000), "m"
-    ),
+    # Cloud
     "cloud_area_fraction": Bounds((0, 1.0), "1"),
     "cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl": Bounds(
         (0, 1.0), "1"
     ),
+    "cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_2p5_oktas": Bounds(
+        (-300, 20000), "m"
+    ),
     "low_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
-    "lwe_precipitation_rate": Bounds((0, 128.0), "mm h-1"),
-    "lwe_precipitation_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
-    "rainfall_rate": Bounds((0, 128.0), "mm h-1"),
-    "rainfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
-    "relative_humidity": Bounds((0, 1.2), "1"),
+    # Precipitation amount
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.5), "m"),
-    "thickness_of_rainfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_snowfall_amount": Bounds((0, 0.5), "m"),
+    "thickness_of_rainfall_amount": Bounds((0, 0.5), "m"),
+    "air_pressure_at_sea_level": Bounds((86000, 108000), "Pa"),
+    # Precipitation rate
+    "lwe_precipitation_rate": Bounds((0, 128.0), "mm h-1"),
+    "lwe_precipitation_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
     "lwe_sleetfall_rate": Bounds((0, 128.0), "mm h-1"),
     "lwe_snowfall_rate": Bounds((0, 128.0), "mm h-1"),
     "lwe_snowfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
-    "visibility_in_air": Bounds((0, 100000), "m"),
-    "temperature_at_screen_level_nighttime_min": Bounds(
-        (-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin"
+    "rainfall_rate": Bounds((0, 128.0), "mm h-1"),
+    "rainfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
+    # Temperature
+    "air_temperature": (Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")),
+    "feels_like_temperature": (
+        Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")
     ),
     "temperature_at_screen_level_daytime_max": (
         Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")
     ),
+    "temperature_at_screen_level_nighttime_min": Bounds(
+        (-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin"
+    ),
+    # Wind
+    "wind_speed": Bounds((0, 50), "m s^-1"),
+    "wind_speed_of_gust": Bounds((0, 200), "m s^-1"),
+    # Others
+    "relative_humidity": Bounds((0, 1.2), "1"),
+    "visibility_in_air": Bounds((0, 100000), "m"),
     "ultraviolet_index": Bounds((0, 25.0), "1"),
 }

--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -71,6 +71,7 @@ BOUNDS_FOR_ECDF = {
     "relative_humidity": Bounds((0, 1.2), "1"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.5), "m"),
+    "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_snowfall_amount": Bounds((0, 0.5), "m"),
     "lwe_sleetfall_rate": Bounds((0, 128.0), "mm h-1"),
     "lwe_snowfall_rate": Bounds((0, 128.0), "mm h-1"),

--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -65,7 +65,6 @@ BOUNDS_FOR_ECDF = {
     "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_snowfall_amount": Bounds((0, 0.5), "m"),
     "thickness_of_rainfall_amount": Bounds((0, 0.5), "m"),
-    "air_pressure_at_sea_level": Bounds((86000, 108000), "Pa"),
     # Precipitation rate
     "lwe_precipitation_rate": Bounds((0, 128.0), "mm h-1"),
     "lwe_precipitation_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
@@ -89,6 +88,7 @@ BOUNDS_FOR_ECDF = {
     "wind_speed": Bounds((0, 50), "m s^-1"),
     "wind_speed_of_gust": Bounds((0, 200), "m s^-1"),
     # Others
+    "air_pressure_at_sea_level": Bounds((86000, 108000), "Pa"),
     "relative_humidity": Bounds((0, 1.2), "1"),
     "visibility_in_air": Bounds((0, 100000), "m"),
     "ultraviolet_index": Bounds((0, 25.0), "1"),

--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -71,6 +71,7 @@ BOUNDS_FOR_ECDF = {
     "relative_humidity": Bounds((0, 1.2), "1"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.5), "m"),
+    "thickness_of_rainfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_snowfall_amount": Bounds((0, 0.5), "m"),
     "lwe_sleetfall_rate": Bounds((0, 128.0), "mm h-1"),


### PR DESCRIPTION
Adds bounds for data named `lwe_thickness_of_sleetfall_amount` and `thickness_of_rainfall_amount` (identical to values for snow) so that engl sleet chain can extract a 50th percentile.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s) - nothing to add.
