### PR TITLE
IMPRO-1815: reject float64 data in combine plugin

### DIFF
--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -258,6 +258,7 @@ class CubeCombiner(BasePlugin):
 
         Raises:
             ValueError: If the cube_list contains only one cube.
+            TypeError: If combining data results in float64 data.
         """
         if len(cube_list) < 2:
             msg = "Expecting 2 or more cubes in cube_list"

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -36,7 +36,6 @@ from iris.cube import CubeList
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
-from improver.metadata.constants import FLOAT_DTYPE, FLOAT_TYPES
 from improver.metadata.probabilistic import (
     extract_diagnostic_name,
     find_threshold_coordinate,
@@ -279,10 +278,12 @@ class CubeCombiner(BasePlugin):
             result.data = result.data / len(cube_list)
 
         # Check resulting dtype and modify if necessary
-        types_to_fix = FLOAT_TYPES.copy()
-        types_to_fix.remove(FLOAT_DTYPE)
-        if result.dtype in types_to_fix:
-            result.data = result.data.astype(FLOAT_DTYPE)
+        if result.dtype == np.float64:
+            unique_cube_types = set([c.dtype for c in cube_list])
+            raise TypeError(
+                f"Operation {self.operation} on types {unique_cube_types} results in "
+                "float64 data which cannot be safely coerced to float32"
+            )
 
         # where the operation is "multiply", retain all coordinate metadata
         # from the first cube in the list; otherwise expand coordinate bounds

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -36,6 +36,7 @@ from iris.cube import CubeList
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
+from improver.metadata.constants import FLOAT_DTYPE, FLOAT_TYPES
 from improver.metadata.probabilistic import (
     extract_diagnostic_name,
     find_threshold_coordinate,
@@ -276,6 +277,12 @@ class CubeCombiner(BasePlugin):
         # normalise mean (for which self.operator is np.add)
         if self.operation == "mean":
             result.data = result.data / len(cube_list)
+
+        # Check resulting dtype and modify if necessary
+        types_to_fix = FLOAT_TYPES.copy()
+        types_to_fix.remove(FLOAT_DTYPE)
+        if result.dtype in types_to_fix:
+            result.data = result.data.astype(FLOAT_DTYPE)
 
         # where the operation is "multiply", retain all coordinate metadata
         # from the first cube in the list; otherwise expand coordinate bounds

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -185,6 +185,20 @@ class Test_process(CombinerTest):
         self.assertEqual(result.name(), "new_cube_name")
         self.assertArrayAlmostEqual(result.data, expected_data)
 
+    def test_mixed_dtypes(self):
+        """Test that the plugin calculates the sum correctly and doesn't mangle dtypes."""
+        plugin = CubeCombiner("add")
+        cubelist = iris.cube.CubeList(
+            [self.cube1, self.cube2.copy(np.ones_like(self.cube2.data, dtype=np.int32))]
+        )
+        result = plugin.process(cubelist, "new_cube_name")
+        expected_data = np.full((1, 2, 2), 1.5, dtype=np.float32)
+        self.assertEqual(result.name(), "new_cube_name")
+        self.assertArrayAlmostEqual(result.data, expected_data)
+        self.assertTrue(cubelist[0].dtype == np.float32)
+        self.assertTrue(cubelist[1].dtype == np.int32)
+        self.assertTrue(result.dtype == np.float32)
+
     def test_bounds_expansion(self):
         """Test that the plugin calculates the sum of the input cubes
         correctly and expands the time coordinate bounds on the

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -206,7 +206,7 @@ class Test_process(CombinerTest):
             [self.cube1, self.cube2.copy(np.ones_like(self.cube2.data, dtype=np.int32))]
         )
         msg = (
-            r"Operation add on types \{dtype\(\'int32\'\), dtype\(\'float32\'\)\} results in "
+            r"Operation add on types \{dtype\(\'.*\'\)\} results in "
             r"float64 data which cannot be safely coerced to float32"
         )
         with self.assertRaisesRegex(TypeError, msg):

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -200,7 +200,7 @@ class Test_process(CombinerTest):
         self.assertTrue(result.dtype == np.float32)
 
     def test_mixed_dtypes_overflow(self):
-        """Test that the plugin dtype combinations that result in float64 data."""
+        """Test the plugin with a dtype combination that results in float64 data."""
         plugin = CubeCombiner("add")
         cubelist = iris.cube.CubeList(
             [self.cube1, self.cube2.copy(np.ones_like(self.cube2.data, dtype=np.int32))]


### PR DESCRIPTION
The CubeCombiner plugin now throws a `TypeError` if the specified combine operation results in float64 data.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
