### PR TITLE
Update add-path in Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         conda env update -q --file environment.yml --name improver
         conda list --export
     - name: conda activate
-      run:  echo "::add-path::/usr/share/miniconda/envs/improver/bin"
+      run:  echo "/usr/share/miniconda/envs/improver/bin" >>$GITHUB_PATH
     - name: sphinx-build
       run: make -C doc html SPHINXOPTS="-W --keep-going"
     - name: pytest unit-tests & cov-report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         conda env update -q --file environment.yml --name improver
         conda list --export
     - name: conda activate
-      run:  echo "::add-path::/usr/share/miniconda/envs/improver/bin"
+      run:  echo "/usr/share/miniconda/envs/improver/bin" >>$GITHUB_PATH
     - name: isort
       run:  isort --check-only --recursive .
     - name: black


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ and https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
