### PR TITLE
Demotion of datatypes in "collapsed" wrapper

### DIFF
--- a/improver/blending/spatial_weights.py
+++ b/improver/blending/spatial_weights.py
@@ -37,7 +37,6 @@ import numpy as np
 from scipy.ndimage.morphology import distance_transform_edt
 
 from improver import BasePlugin
-from improver.utilities.cube_manipulation import collapsed
 from improver.utilities.rescale import rescale
 
 

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -521,7 +521,9 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
                     raise ValueError(message.format(dim_coord))
             try:
                 weights_array = iris.util.broadcast_to_shape(
-                    np.array(weights.data, dtype=FLOAT_DTYPE), cube.shape, tuple(dim_map)
+                    np.array(weights.data, dtype=FLOAT_DTYPE),
+                    cube.shape,
+                    tuple(dim_map),
                 )
             except ValueError:
                 msg = (

--- a/improver/field_texture.py
+++ b/improver/field_texture.py
@@ -269,5 +269,4 @@ class FieldTexture(BasePlugin):
         except CoordinateNotFoundError:
             field_texture = iris.util.squeeze(thresholded)
 
-        field_texture.data = np.float32(field_texture.data)
         return field_texture

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -38,6 +38,7 @@ from iris.coords import AuxCoord, DimCoord
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
+from improver.metadata.constants import FLOAT_DTYPE, FLOAT_TYPES
 from improver.metadata.probabilistic import find_threshold_coordinate
 from improver.utilities.cube_checker import check_cube_coordinates
 
@@ -60,6 +61,8 @@ def collapsed(cube, *args, **kwargs):
     original_methods = cube.cell_methods
     new_cube = cube.collapsed(*args, **kwargs)
     new_cube.cell_methods = original_methods
+    if new_cube.dtype in FLOAT_TYPES:
+        new_cube.data = new_cube.data.astype(FLOAT_DTYPE)
     return new_cube
 
 

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -72,12 +72,12 @@ def collapsed(cube, *args, **kwargs):
     collapse_coords = find_dimension_coordinate_mismatch(cube, new_cube)
     for coord in collapse_coords:
         if new_cube.coord(coord).points.dtype in FLOAT_TYPES:
-            new_cube.coord(coord).points = (
-                new_cube.coord(coord).points.astype(FLOAT_DTYPE)
+            new_cube.coord(coord).points = new_cube.coord(coord).points.astype(
+                FLOAT_DTYPE
             )
             if new_cube.coord(coord).bounds is not None:
-                new_cube.coord(coord).bounds = (
-                    new_cube.coord(coord).bounds.astype(FLOAT_DTYPE)
+                new_cube.coord(coord).bounds = new_cube.coord(coord).bounds.astype(
+                    FLOAT_DTYPE
                 )
 
     return new_cube

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -40,10 +40,7 @@ from iris.exceptions import CoordinateNotFoundError
 from improver import BasePlugin
 from improver.metadata.constants import FLOAT_DTYPE, FLOAT_TYPES
 from improver.metadata.probabilistic import find_threshold_coordinate
-from improver.utilities.cube_checker import (
-    check_cube_coordinates,
-    find_dimension_coordinate_mismatch,
-)
+from improver.utilities.cube_checker import check_cube_coordinates
 
 
 def collapsed(cube, *args, **kwargs):
@@ -69,8 +66,8 @@ def collapsed(cube, *args, **kwargs):
     if new_cube.dtype in FLOAT_TYPES:
         new_cube.data = new_cube.data.astype(FLOAT_DTYPE)
 
-    collapse_coords = find_dimension_coordinate_mismatch(cube, new_cube)
-    for coord in collapse_coords:
+    collapsed_coords = args[0] if isinstance(args[0], list) else [args[0]]
+    for coord in collapsed_coords:
         if new_cube.coord(coord).points.dtype in FLOAT_TYPES:
             new_cube.coord(coord).points = new_cube.coord(coord).points.astype(
                 FLOAT_DTYPE

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -40,7 +40,10 @@ from iris.exceptions import CoordinateNotFoundError
 from improver import BasePlugin
 from improver.metadata.constants import FLOAT_DTYPE, FLOAT_TYPES
 from improver.metadata.probabilistic import find_threshold_coordinate
-from improver.utilities.cube_checker import check_cube_coordinates
+from improver.utilities.cube_checker import (
+    check_cube_coordinates,
+    find_dimension_coordinate_mismatch,
+)
 
 
 def collapsed(cube, *args, **kwargs):
@@ -61,8 +64,22 @@ def collapsed(cube, *args, **kwargs):
     original_methods = cube.cell_methods
     new_cube = cube.collapsed(*args, **kwargs)
     new_cube.cell_methods = original_methods
+
+    # demote escalated datatypes as required
     if new_cube.dtype in FLOAT_TYPES:
         new_cube.data = new_cube.data.astype(FLOAT_DTYPE)
+
+    collapse_coords = find_dimension_coordinate_mismatch(cube, new_cube)
+    for coord in collapse_coords:
+        if new_cube.coord(coord).points.dtype in FLOAT_TYPES:
+            new_cube.coord(coord).points = (
+                new_cube.coord(coord).points.astype(FLOAT_DTYPE)
+            )
+            if new_cube.coord(coord).bounds is not None:
+                new_cube.coord(coord).bounds = (
+                    new_cube.coord(coord).bounds.astype(FLOAT_DTYPE)
+                )
+
     return new_cube
 
 
@@ -615,8 +632,8 @@ def expand_bounds(result_cube, cubelist, coord_names, use_midpoint=False):
             new_top_bound = np.max(bounds)
         result_coord = result_cube.coord(coord)
         result_coord.bounds = np.array([[new_low_bound, new_top_bound]])
-        if result_coord.bounds.dtype == np.float64:
-            result_coord.bounds = result_coord.bounds.astype(np.float32)
+        if result_coord.bounds.dtype in FLOAT_TYPES:
+            result_coord.bounds = result_coord.bounds.astype(FLOAT_DTYPE)
 
         if use_midpoint:
             if "seconds" in str(result_coord.units):
@@ -635,7 +652,7 @@ def expand_bounds(result_cube, cubelist, coord_names, use_midpoint=False):
         else:
             result_coord.points = [new_top_bound]
 
-        if result_coord.points.dtype == np.float64:
-            result_coord.points = result_coord.points.astype(np.float32)
+        if result_coord.points.dtype in FLOAT_TYPES:
+            result_coord.points = result_coord.points.astype(FLOAT_DTYPE)
 
     return result_cube

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -530,7 +530,7 @@ class Test_percentile_weighted_mean(Test_weighted_blend):
         result = plugin.percentile_weighted_mean(perc_cube, self.weights1d, perc_coord)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAlmostEqual(result.data, BLENDED_PERCENTILE_DATA)
-        self.assertEqual(result.coord("percentile").points.dtype, np.float32)
+        self.assertEqual(result.coord("percentile").points.dtype, np.float64)
 
     @ManageWarnings(ignored_messages=[COORD_COLLAPSE_WARNING])
     def test_with_spatially_varying_weights(self):

--- a/improver_tests/utilities/cube_manipulation/test_collapsed.py
+++ b/improver_tests/utilities/cube_manipulation/test_collapsed.py
@@ -76,6 +76,22 @@ class Test_collapsed(unittest.TestCase):
             ).all()
         )
 
+    def test_two_coords(self):
+        """Test behaviour collapsing over 2 coordinates, including not escalating
+        precision when collapsing a float coordinate (latitude)"""
+        result = collapsed(self.cube, ["realization", "latitude"], iris.analysis.MEAN)
+        self.assertTrue(
+            (
+                result.data
+                == self.cube.collapsed(
+                    ["realization", "latitude"], iris.analysis.MEAN
+                ).data
+            ).all()
+        )
+        self.assertEqual(
+            result.coord("latitude").dtype, self.cube.coord("latitude").dtype
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/improver_tests/utilities/cube_manipulation/test_collapsed.py
+++ b/improver_tests/utilities/cube_manipulation/test_collapsed.py
@@ -49,17 +49,15 @@ class Test_collapsed(unittest.TestCase):
         """Use temperature cube to test with."""
         data = 281 * np.ones((3, 3, 3), dtype=np.float32)
         self.cube = set_up_variable_cube(data, realizations=[0, 1, 2])
+        self.expected_data = self.cube.collapsed(
+            ["realization"], iris.analysis.MEAN
+        ).data
 
     def test_single_method(self):
         """Test that a collapsed cube is returned with no cell method added"""
         result = collapsed(self.cube, "realization", iris.analysis.MEAN)
         self.assertTupleEqual(result.cell_methods, ())
-        self.assertTrue(
-            (
-                result.data
-                == self.cube.collapsed("realization", iris.analysis.MEAN).data
-            ).all()
-        )
+        self.assertTrue((result.data == self.expected_data).all())
 
     def test_two_methods(self):
         """Test that a cube keeps its original cell method but another
@@ -70,24 +68,16 @@ class Test_collapsed(unittest.TestCase):
         cube.add_cell_method(method)
         result = collapsed(cube, "realization", iris.analysis.MEAN)
         self.assertTupleEqual(result.cell_methods, (method,))
-        self.assertTrue(
-            (
-                result.data == cube.collapsed("realization", iris.analysis.MEAN).data
-            ).all()
-        )
+        self.assertTrue((result.data == self.expected_data).all())
 
     def test_two_coords(self):
         """Test behaviour collapsing over 2 coordinates, including not escalating
         precision when collapsing a float coordinate (latitude)"""
+        expected_data = self.cube.collapsed(
+            ["realization", "latitude"], iris.analysis.MEAN
+        ).data
         result = collapsed(self.cube, ["realization", "latitude"], iris.analysis.MEAN)
-        self.assertTrue(
-            (
-                result.data
-                == self.cube.collapsed(
-                    ["realization", "latitude"], iris.analysis.MEAN
-                ).data
-            ).all()
-        )
+        self.assertTrue((result.data == expected_data).all())
         self.assertEqual(
             result.coord("latitude").dtype, self.cube.coord("latitude").dtype
         )


### PR DESCRIPTION
Cube collapsed wrapper demotes data and coordinate types that have been escalated to float 64.

There is a change to the output of a weighted blending unit test.  The plugin should not have been changing the datatype of a coordinate irrelevant to the blending functionality.  The new implementation only de-escalates types that were escalated by the iris `collapsed` call, and does not "correct" non-standard types on the input cube.

Testing:
 - [x] Ran tests and they passed OK
