### PR TITLE
Refactor CubeCombiner

### DIFF
--- a/improver/cli/combine.py
+++ b/improver/cli/combine.py
@@ -71,19 +71,23 @@ def process(
         result (iris.cube.Cube):
             Returns a cube with the combined data.
     """
-    from improver.cube_combiner import CubeCombiner
+    from improver.cube_combiner import CubeCombiner, CubeMultiplier
     from iris.cube import CubeList
 
     if not cubes:
         raise TypeError("A cube is needed to be combined.")
     if new_name is None:
         new_name = cubes[0].name()
-    broadcast_to_coords = ["threshold"] if broadcast_to_threshold else None
-    result = CubeCombiner(operation, warnings_on=check_metadata)(
-        CubeList(cubes),
-        new_name,
-        broadcast_to_coords=broadcast_to_coords,
-        use_midpoint=use_midpoint,
-    )
+
+    if operation == "*" or operation == "multiply":
+        broadcast_to_coords = ["threshold"] if broadcast_to_threshold else None
+        result = CubeMultiplier()(
+            CubeList(cubes), new_name, broadcast_to_coords=broadcast_to_coords
+        )
+
+    else:
+        result = CubeCombiner(operation)(
+            CubeList(cubes), new_name, use_midpoint=use_midpoint,
+        )
 
     return result

--- a/improver/cli/combine.py
+++ b/improver/cli/combine.py
@@ -80,9 +80,8 @@ def process(
         new_name = cubes[0].name()
 
     if operation == "*" or operation == "multiply":
-        broadcast_to_coords = ["threshold"] if broadcast_to_threshold else None
         result = CubeMultiplier()(
-            CubeList(cubes), new_name, broadcast_to_coords=broadcast_to_coords
+            CubeList(cubes), new_name, broadcast_to_threshold=broadcast_to_threshold,
         )
 
     else:

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -83,14 +83,15 @@ class CubeCombiner(BasePlugin):
     @staticmethod
     def _check_dimensions_match(cube_list, comparators=[eq]):
         """
-        Check all coordinate dimensions on the input cubes are equal or broadcastable
+        Check all coordinate dimensions on the input cubes match according to
+        the comparators specified.
 
         Args:
-            cube_list (iris.cube.CubeList or list):
+            cube_list (list of iris.cube.Cube):
                 List of cubes to compare
             comparators (list of callable):
-                Comparison operators, at least one of which must return "True" for each
-                coordinate in order for the match to be valid
+                Comparison operators, at least one of which must return "True"
+                for each coordinate in order for the match to be valid
         Raises:
             ValueError: If dimension coordinates do not match
         """
@@ -116,7 +117,7 @@ class CubeCombiner(BasePlugin):
         that are present on all input cubes, but have different values.
 
         Args:
-            cube_list (iris.cube.CubeList or list):
+            cube_list (list of iris.cube.Cube):
                 List of cubes to that will be combined
 
         Returns:
@@ -147,7 +148,7 @@ class CubeCombiner(BasePlugin):
         Perform cumulative operation to combine cube data
 
         Args:
-            cube_list (iris.cube.CubeList or list)
+            cube_list (list of iris.cube.Cube)
 
         Returns:
             iris.cube.Cube
@@ -176,7 +177,7 @@ class CubeCombiner(BasePlugin):
         cube metadata.
 
         Args:
-            cube_list (iris.cube.CubeList or list):
+            cube_list (list of iris.cube.Cube):
                 List of cubes to combine.
             new_diagnostic_name (str):
                 New name for the combined diagnostic.
@@ -231,7 +232,7 @@ class CubeMultiplier(CubeCombiner):
         match the dimensions, in order, of the first cube in the list
 
         Args:
-            cube_list (iris.cube.CubeList or list of iris.cube.Cube)
+            cube_list (list of iris.cube.Cube)
 
         Returns:
             iris.cube.CubeList

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -174,10 +174,7 @@ class CubeCombiner(BasePlugin):
         return result
 
     def process(
-        self,
-        cube_list,
-        new_diagnostic_name,
-        use_midpoint=False,
+        self, cube_list, new_diagnostic_name, use_midpoint=False,
     ):
         """
         Combine data and metadata from a list of input cubes into a single
@@ -286,10 +283,7 @@ class CubeMultiplier(CubeCombiner):
         return cube_list
 
     def process(
-        self,
-        cube_list,
-        new_diagnostic_name,
-        broadcast_to_coords=None,
+        self, cube_list, new_diagnostic_name, broadcast_to_coords=None,
     ):
         """
         Combine data and metadata from a list of input cubes into a single

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -153,7 +153,7 @@ class CubeCombiner(BasePlugin):
             iris.cube.Cube
 
         Raises:
-            ValueError: if the operation results in an escalated datatype
+            TypeError: if the operation results in an escalated datatype
         """
         result = cube_list[0].copy()
         for cube in cube_list[1:]:
@@ -191,7 +191,6 @@ class CubeCombiner(BasePlugin):
 
         Raises:
             ValueError: If the cube_list contains only one cube.
-            TypeError: If combining data results in float64 data.
         """
         if len(cube_list) < 2:
             msg = "Expecting 2 or more cubes in cube_list"
@@ -232,12 +231,18 @@ class CubeMultiplier(CubeCombiner):
         match the dimensions, in order, of the first cube in the list
 
         Args:
-            cube_list: (iris.cube.CubeList)
+            cube_list (iris.cube.CubeList or list of iris.cube.Cube)
 
         Returns:
             iris.cube.CubeList
                 Updated version of cube_list
 
+        Raises:
+            CoordinateNotFoundError: if there is no threshold coordinate on the
+                first cube in the list
+            TypeError: if there is a scalar threshold coordinate on any of the
+                later cubes, which would indicate that the cube is only valid for
+                a single threshold and should not be broadcast to all thresholds.
         """
         target_cube = cube_list[0]
         try:
@@ -261,9 +266,6 @@ class CubeMultiplier(CubeCombiner):
                 )
             else:
                 if found_coord not in cube.dim_coords:
-                    # We don't expect the coord to already exist in a scalar form as
-                    # this would indicate that the broadcast-from cube is only valid
-                    # for a single threshold and therefore should be rejected.
                     msg = "Cannot broadcast to coord threshold as it already exists as an AuxCoord"
                     raise TypeError(msg)
             new_list.append(cube)

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -77,7 +77,8 @@ class CubeCombiner(BasePlugin):
         except KeyError:
             msg = "Unknown operation {}".format(operation)
             raise ValueError(msg)
-        self.operation = operation
+
+        self.normalise = operation == "mean"
 
     @staticmethod
     def _check_dimensions_match(cube_list, comparators=[eq]):
@@ -158,10 +159,10 @@ class CubeCombiner(BasePlugin):
         for cube in cube_list[1:]:
             result.data = self.operator(result.data, cube.data)
 
-        if self.operation == "mean":
+        if self.normalise:
             result.data = result.data / len(cube_list)
 
-        enforce_dtype(self.operation, cube_list, result)
+        enforce_dtype(str(self.operator), cube_list, result)
 
         return result
 
@@ -223,7 +224,7 @@ class CubeMultiplier(CubeCombiner):
     def __init__(self):
         """Create a CubeMultiplier plugin"""
         self.operator = np.multiply
-        self.operation = "multiply"
+        self.normalise = False
 
     def _setup_coords_for_broadcast(self, cube_list):
         """

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -80,23 +80,7 @@ class CubeCombiner(BasePlugin):
         self.operation = operation
 
     @staticmethod
-    def _dimensions_match(cube_list):
-        """Returns True if dimensions match on all input cubes, False otherwise
-
-        Args:
-            cube_list (iris.cube.CubeList or list):
-                List of cubes to compare
-        """
-        ref_coords = cube_list[0].coords(dim_coords=True)
-        for cube in cube_list[1:]:
-            coords = cube.coords(dim_coords=True)
-            compare = [eq(a, b) for a, b in zip(coords, ref_coords)]
-            if not np.all(compare):
-                return False
-
-        return True
-
-    def _check_dimensions_match(self, cube_list, comparators=[eq]):
+    def _check_dimensions_match(cube_list, comparators=[eq]):
         """
         Check all coordinate dimensions on the input cubes are equal or broadcastable
 

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -283,34 +283,20 @@ class CubeMultiplier(CubeCombiner):
         return cube_list
 
     def process(
-        self, cube_list, new_diagnostic_name, broadcast_to_coords=None,
+        self, cube_list, new_diagnostic_name, broadcast_to_threshold=False,
     ):
         """
-        Combine data and metadata from a list of input cubes into a single
-        cube, using the specified operation to combine the cube data.  The
-        first cube in the input list provides the template for the combined
-        cube metadata.
-
-        NOTE the behaviour for the "multiply" operation is different from
-        other types of cube combination.  The only valid use case for
-        "multiply" is to apply a factor that conditions an input probability
-        field - that is, to apply Bayes Theorem.  The input probability is
-        therefore used as the source of ALL input metadata, and should always
-        be the first cube in the input list.  The factor(s) by which this is
-        multiplied are not compared for any mis-match in scalar coordinates,
-        neither do they to contribute to expanded bounds.
-
-        TODO the "multiply" case should be factored out into a separate plugin
-        given its substantial differences from other combine use cases.
+        Multiply data from a list of input cubes into a single cube.  The first
+        cube in the input list provides the combined cube metadata.
 
         Args:
             cube_list (iris.cube.CubeList or list):
                 List of cubes to combine.
             new_diagnostic_name (str):
                 New name for the combined diagnostic.
-            broadcast_to_coords (list):
-                Specifies a list of coord names that exist only on the first cube that
-                the other cube(s) need(s) broadcasting to prior to the combine.
+            broadcast_to_threshold (bool):
+                True if the first cube has a threshold coordinate to which the
+                following cube(s) need(s) to be broadcast prior to combining data.
 
         Returns:
             iris.cube.Cube:
@@ -324,8 +310,8 @@ class CubeMultiplier(CubeCombiner):
             msg = "Expecting 2 or more cubes in cube_list"
             raise ValueError(msg)
 
-        self.broadcast_coords = broadcast_to_coords
-        if self.broadcast_coords:
+        self.broadcast_coords = ["threshold"] if broadcast_to_threshold else None
+        if self.broadcast_coords is not None:
             cube_list = self._setup_coords_for_broadcast(cube_list)
         self._check_dimensions_match(cube_list)
 

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -88,7 +88,7 @@ class CubeCombiner(BasePlugin):
             cube_list (iris.cube.CubeList or list):
                 List of cubes to compare
             comparators (list of callable):
-                Comparison operators, one of which must return "True" for each
+                Comparison operators, at least one of which must return "True" for each
                 coordinate in order for the match to be valid
         Raises:
             ValueError: If dimension coordinates do not match
@@ -96,14 +96,10 @@ class CubeCombiner(BasePlugin):
         ref_coords = cube_list[0].coords(dim_coords=True)
         for cube in cube_list[1:]:
             coords = cube.coords(dim_coords=True)
-            compare = []
-            for a, b in zip(coords, ref_coords):
-                comp = False
-                for operator in comparators:
-                    if operator(a, b):
-                        comp = True
-                compare.append(comp)
-
+            compare = [
+                np.any([comp(a, b) for comp in comparators])
+                for a, b in zip(coords, ref_coords)
+            ]
             if not np.all(compare):
                 msg = (
                     "Cannot combine cubes with different dimensions:\n"

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -55,7 +55,7 @@ class Test__init__(IrisTest):
     def test_basic(self):
         """Test that the __init__ sets things up correctly"""
         plugin = CubeCombiner("+")
-        self.assertEqual(plugin.operation, "+")
+        self.assertEqual(plugin.operator, np.add)
 
     def test_raise_error_wrong_operation(self):
         """Test __init__ raises a ValueError for invalid operation"""
@@ -194,10 +194,7 @@ class Test_process(CombinerTest):
         cubelist = iris.cube.CubeList(
             [self.cube1, self.cube2.copy(np.ones_like(self.cube2.data, dtype=np.int32))]
         )
-        msg = (
-            r"Operation add on types \{dtype\(\'.*\'\)\} results in "
-            r"float64 data which cannot be safely coerced to float32"
-        )
+        msg = "Operation .* results in float64 data"
         with self.assertRaisesRegex(TypeError, msg):
             plugin.process(cubelist, "new_cube_name")
 

--- a/improver_tests/cube_combiner/test_CubeMultiplier.py
+++ b/improver_tests/cube_combiner/test_CubeMultiplier.py
@@ -118,6 +118,15 @@ class Test_process(CombinerTest):
         self.assertArrayAlmostEqual(result.data, np.full((2, 3, 3), 0.3))
         self.assertArrayEqual(result.coord("time"), precip_accum.coord("time"))
 
+    def test_exception_for_single_entry_cubelist(self):
+        """Test that the plugin raises an exception if a cubelist containing
+        only one cube is passed in."""
+        plugin = CubeMultiplier()
+        msg = "Expecting 2 or more cubes in cube_list"
+        cubelist = iris.cube.CubeList([self.cube1])
+        with self.assertRaisesRegex(ValueError, msg):
+            plugin.process(cubelist, "new_cube_name")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/improver_tests/cube_combiner/test_CubeMultiplier.py
+++ b/improver_tests/cube_combiner/test_CubeMultiplier.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2020 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the cube_combiner.CubeMultiplier plugin."""
+import unittest
+from copy import deepcopy
+from datetime import datetime
+
+import iris
+import numpy as np
+from iris.cube import Cube
+from iris.exceptions import CoordinateNotFoundError
+
+from improver.cube_combiner import CubeMultiplier
+from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
+from improver_tests.cube_combiner.test_CubeCombiner import CombinerTest
+
+
+class Test_process(CombinerTest):
+    """Test process method of CubeMultiplier"""
+
+    def test_broadcast_coord(self):
+        """Test that plugin broadcasts to a coord and doesn't change the inputs.
+        Using the broadcast_to_coords argument including a value of "threshold"
+        will result in the returned cube maintaining the probabilistic elements
+        of the name of the first input cube."""
+        cube = self.cube4[:, 0, ...].copy()
+        cube.data = np.ones_like(cube.data)
+        cube.remove_coord("lwe_thickness_of_precipitation_amount")
+        cubelist = iris.cube.CubeList([self.cube4.copy(), cube])
+        input_copy = deepcopy(cubelist)
+        result = CubeMultiplier()(
+            cubelist, "new_cube_name", broadcast_to_coords=["threshold"]
+        )
+        self.assertIsInstance(result, Cube)
+        self.assertEqual(result.name(), "probability_of_new_cube_name_above_threshold")
+        self.assertEqual(result.coord(var_name="threshold").name(), "new_cube_name")
+        self.assertArrayAlmostEqual(result.data, self.cube4.data)
+        self.assertCubeListEqual(input_copy, cubelist)
+
+    def test_error_broadcast_coord_wrong_order(self):
+        """Test that plugin throws an error if the broadcast coord is not on the first cube"""
+        cube = self.cube4[:, 0, ...].copy()
+        cube.data = np.ones_like(cube.data)
+        cube.remove_coord("lwe_thickness_of_precipitation_amount")
+        cubelist = iris.cube.CubeList([cube, self.cube4.copy()])
+        msg = (
+            "Cannot find coord threshold in "
+            "<iris 'Cube' of probability_of_lwe_thickness_of_precipitation_amount_above_threshold / \(1\) "
+            "\(realization: 3; latitude: 2; longitude: 2\)> to broadcast to"
+        )
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
+            CubeMultiplier()(
+                cubelist, "new_cube_name", broadcast_to_coords=["threshold"]
+            )
+
+    def test_error_broadcast_coord_not_found(self):
+        """Test that plugin throws an error if the broadcast coord is not present anywhere"""
+        cube = self.cube4[:, 0, ...].copy()
+        cube.data = np.ones_like(cube.data)
+        cubelist = iris.cube.CubeList([self.cube4.copy(), cube])
+        msg = (
+            "Cannot find coord kittens in "
+            "<iris 'Cube' of probability_of_lwe_thickness_of_precipitation_amount_above_threshold / \(1\) "
+            "\(realization: 3; lwe_thickness_of_precipitation_amount: 2; latitude: 2; longitude: 2\)> "
+            "to broadcast to."
+        )
+        with self.assertRaisesRegex(CoordinateNotFoundError, msg):
+            CubeMultiplier()(cubelist, "new_cube_name", broadcast_to_coords=["kittens"])
+
+    def test_error_broadcast_coord_is_auxcoord(self):
+        """Test that plugin throws an error if the broadcast coord already exists"""
+        cube = self.cube4[:, 0, ...].copy()
+        cube.data = np.ones_like(cube.data)
+        cubelist = iris.cube.CubeList([self.cube4.copy(), cube])
+        msg = "Cannot broadcast to coord threshold as it already exists as an AuxCoord"
+        with self.assertRaisesRegex(TypeError, msg):
+            CubeMultiplier()(
+                cubelist, "new_cube_name", broadcast_to_coords=["threshold"]
+            )
+
+    def test_multiply_preserves_bounds(self):
+        """Test specific case for precipitation type, where multiplying a
+        precipitation accumulation by a point-time probability of snow retains
+        the bounds on the original accumulation."""
+        validity_time = datetime(2015, 11, 19, 0)
+        time_bounds = [datetime(2015, 11, 18, 23), datetime(2015, 11, 19, 0)]
+        forecast_reference_time = datetime(2015, 11, 18, 22)
+        precip_accum = set_up_variable_cube(
+            np.full((2, 3, 3), 1.5, dtype=np.float32),
+            name="lwe_thickness_of_precipitation_amount",
+            units="mm",
+            time=validity_time,
+            time_bounds=time_bounds,
+            frt=forecast_reference_time,
+        )
+        snow_prob = set_up_variable_cube(
+            np.full(precip_accum.shape, 0.2, dtype=np.float32),
+            name="probability_of_snow",
+            units="1",
+            time=validity_time,
+            frt=forecast_reference_time,
+        )
+        result = CubeMultiplier()(
+            [precip_accum, snow_prob], "lwe_thickness_of_snowfall_amount"
+        )
+        self.assertArrayAlmostEqual(result.data, np.full((2, 3, 3), 0.3))
+        self.assertArrayEqual(result.coord("time"), precip_accum.coord("time"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Single responsibility principle.  Splits `CubeCombiner` into two plugins: a "parent" plugin to apply linear operators, and a `CubeMultiplier` plugin to do the additional work of broadcasting to threshold coordinates in the "multiply" case.

Unit tests have not been changed or extended - existing tests have been copied for `CubeMultiplier` with updated calls.  This, and the passing of the "combine" CLI tests, show that functionality is unchanged with this refactor.

Testing:
 - [x] Ran tests and they passed OK
