### PR TITLE
Add security checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,3 +57,25 @@ jobs:
       run:  black --check .
     - name: pylint
       run: pylint -j 0 -E --rcfile=etc/pylintrc improver improver_tests
+  Safety-Bandit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      id: cache
+      with:
+        path: /usr/share/miniconda/envs/improver
+        key: ${{ runner.os }}-conda-improver-${{ hashFiles('**/environment.yml') }}
+        restore-keys: ${{ runner.OS }}-conda-improver-
+    - name: conda env update
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda env update -q --file environment.yml --name improver
+        conda list --export
+    - name: conda activate
+      run:  echo "/usr/share/miniconda/envs/improver/bin" >>$GITHUB_PATH
+    - name: safety
+      run:  safety check || true
+    - name: bandit
+      run:  bandit -r improver || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ below:
 * Simon Jackson (Met Office, UK)
 * Caroline Jones (Met Office, UK)
 * Bruno P. Kinoshita (NIWA, NZ)
+* Daniel Mentiplay (Bureau of Meteorology, Australia)
 * Stephen Moseley (Met Office, UK)
 * Meabh NicGuidhir (Met Office, UK)
 * Tim Pillinger (Met Office, UK)

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,8 @@ dependencies:
   - pysteps
   - isort=4.3.21
   - black=19.10b0
+  - bandit
+  - safety
   - pip
   - pip:
     - od


### PR DESCRIPTION
Addresses #1382 

Run bandit and safety as part of CI. Bandit finds common security issues in Python code. Safety checks installed dependencies for know security vulnerabilities. 

If bandit/safety find any issues the tests will _not_ fail. However, the output is written to the log (in GitHub Actions) for inspection.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

CLA
 - [x] If a new developer, signed up to CLA
