### PR TITLE
Reduces code complexity in one part of weather_symbols.py.

### DIFF
--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -66,7 +66,6 @@ def _define_invertible_conditions():
     invertible_conditions = {
         ">=": "<",
         ">": "<=",
-        "==": "==",
         "OR": "AND",
         "": "",
     }

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -60,6 +60,27 @@ from improver.wxcode.wxcode_decision_tree_global import (
 )
 
 
+def _define_invertible_conditions():
+    """Returns a dictionary of boolean comparator strings where the value is the
+    logical inverse of the key."""
+    invertible_conditions = {
+        ">=": "<",
+        ">": "<=",
+        "==": "==",
+        "OR": "AND",
+        "": "",
+    }
+    # Add reverse {value: key} entries to invertible_conditions
+    reverse_inversions = {}
+    for k, v in invertible_conditions.items():
+        reverse_inversions[v] = k
+    invertible_conditions.update(reverse_inversions)
+    return invertible_conditions
+
+
+INVERTIBLE_CONDITIONS = _define_invertible_conditions()
+
+
 class WeatherSymbols(BasePlugin):
     """
     Definition and implementation of a weather symbol decision tree. This
@@ -230,19 +251,8 @@ class WeatherSymbols(BasePlugin):
     @staticmethod
     def _invert_comparator(comparator):
         """Inverts a single comparator string."""
-        condition_inversions = {
-            ">=": "<",
-            ">": "<=",
-            "==": "==",
-            "OR": "AND",
-            "": "",
-        }
-        reverse_inversions = {}
-        for k, v in condition_inversions.items():
-            reverse_inversions[v] = k
-        condition_inversions.update(reverse_inversions)
         try:
-            return condition_inversions[comparator]
+            return INVERTIBLE_CONDITIONS[comparator]
         except KeyError:
             raise KeyError(f"Unexpected condition {comparator}, cannot invert it.")
 

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -228,12 +228,30 @@ class WeatherSymbols(BasePlugin):
         return optional_node_data_missing
 
     @staticmethod
-    def invert_condition(test_conditions):
+    def _invert_comparator(comparator):
+        """Inverts a single comparator string."""
+        condition_inversions = {
+            ">=": "<",
+            ">": "<=",
+            "==": "==",
+            "OR": "AND",
+            "": "",
+        }
+        reverse_inversions = {}
+        for k, v in condition_inversions.items():
+            reverse_inversions[v] = k
+        condition_inversions.update(reverse_inversions)
+        try:
+            return condition_inversions[comparator]
+        except KeyError:
+            raise KeyError(f"Unexpected condition {comparator}, cannot invert it.")
+
+    def invert_condition(self, condition):
         """
         Invert a comparison condition to select the negative case.
 
         Args:
-            test_conditions (dict):
+            condition (dict):
                 A single query from the decision tree.
         Returns:
             (tuple): tuple containing:
@@ -242,23 +260,10 @@ class WeatherSymbols(BasePlugin):
                 **inverted_combination** (str):
                     A string representing the inverted combination
         """
-        threshold = test_conditions["threshold_condition"]
-        inverted_threshold = threshold
-        if threshold == ">=":
-            inverted_threshold = "<"
-        elif threshold == "<=":
-            inverted_threshold = ">"
-        elif threshold == "<":
-            inverted_threshold = ">="
-        elif threshold == ">":
-            inverted_threshold = "<="
-        combination = test_conditions["condition_combination"]
-        inverted_combination = combination
-        if combination == "OR":
-            inverted_combination = "AND"
-        elif combination == "AND":
-            inverted_combination = "OR"
-
+        inverted_threshold = self._invert_comparator(condition["threshold_condition"])
+        inverted_combination = self._invert_comparator(
+            condition["condition_combination"]
+        )
         return inverted_threshold, inverted_combination
 
     @staticmethod

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -257,7 +257,8 @@ class WeatherSymbols(BasePlugin):
 
     def invert_condition(self, condition):
         """
-        Invert a comparison condition to select the negative case.
+        Invert a comparison condition to allow positive identification of conditions
+        satisfying the negative ('fail') case.
 
         Args:
             condition (dict):

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -363,8 +363,8 @@ class Test_invert_condition(IrisTest):
         """Test invert_condition inverts thresholds correctly."""
         plugin = WeatherSymbols()
         node = {"threshold_condition": ">=", "condition_combination": ""}
-        possible_inputs = [">=", "<=", "<", ">"]
-        inverse_outputs = ["<", ">", ">=", "<="]
+        possible_inputs = [">=", "<=", "<", ">", "=="]
+        inverse_outputs = ["<", ">", ">=", "<=", "=="]
         for i, val in enumerate(possible_inputs):
             node["threshold_condition"] = val
             result = plugin.invert_condition(node)
@@ -380,6 +380,17 @@ class Test_invert_condition(IrisTest):
             node["condition_combination"] = val
             result = plugin.invert_condition(node)
             self.assertEqual(result[1], inverse_outputs[i])
+
+    def test_error(self):
+        """Test that the _invert_comparator method raises an error when the condition
+        cannot be inverted."""
+        plugin = WeatherSymbols()
+        possible_inputs = ["!=", "NOT", "XOR"]
+        for val in possible_inputs:
+            with self.assertRaisesRegex(
+                KeyError, f"Unexpected condition {val}, cannot invert it."
+            ):
+                plugin._invert_comparator(val)
 
 
 class Test_construct_condition(IrisTest):

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -385,7 +385,7 @@ class Test_invert_condition(IrisTest):
         """Test that the _invert_comparator method raises an error when the condition
         cannot be inverted."""
         plugin = WeatherSymbols()
-        possible_inputs = ["!=", "NOT", "XOR"]
+        possible_inputs = ["==", "!=", "NOT", "XOR"]
         for val in possible_inputs:
             with self.assertRaisesRegex(
                 KeyError, f"Unexpected condition {val}, cannot invert it."

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -363,8 +363,8 @@ class Test_invert_condition(IrisTest):
         """Test invert_condition inverts thresholds correctly."""
         plugin = WeatherSymbols()
         node = {"threshold_condition": ">=", "condition_combination": ""}
-        possible_inputs = [">=", "<=", "<", ">", "=="]
-        inverse_outputs = ["<", ">", ">=", "<=", "=="]
+        possible_inputs = [">=", "<=", "<", ">"]
+        inverse_outputs = ["<", ">", ">=", "<="]
         for i, val in enumerate(possible_inputs):
             node["threshold_condition"] = val
             result = plugin.invert_condition(node)


### PR DESCRIPTION
In an attempt to apply some Python training, I've refactored the "invert_condition" function in WeatherSymbols to remove an if..elif..elif..elif block. The code will no longer allow unrecognised comparators rather than returning them unchanged.

Testing:
 - [x] Ran tests and they passed OK
