### PR TITLE
Pin scipy to 1.3.3 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - python=3.6
   - iris=2.2
+  - scipy=1.3.3
   - numpy=1.15.4
   - cftime=1.0.1
   - python-stratify=0.1


### PR DESCRIPTION
Relates to #1397

Looking at the functions of the failing tests and the location of the failing points suggests that scipy.interpolate.griddata is the cause.

Downgrading scipy to 1.3.3 results in the acceptance tests passing.
Downgrading scipy to 1.4.1 results in 5 (of the original 8) tests failing:
```
FAILED improver_tests/acceptance/test_interpolate_using_difference.py::test_filling_without_limit
FAILED improver_tests/acceptance/test_interpolate_using_difference.py::test_filling_with_maximum_limit
FAILED improver_tests/acceptance/test_phase_change_level.py::test_phase_change[snow-sleet-snow_sleet-T
rue]
FAILED improver_tests/acceptance/test_interpolate_using_difference.py::test_filling_with_minimum_limit
FAILED improver_tests/acceptance/test_phase_change_level.py::test_phase_change[sleet-rain-sleet_rain-T
rue]
```

cc @tjtg 