### PR TITLE
Collection of minor bug fixes

### DIFF
--- a/improver_tests/acceptance/test_map_to_timezones.py
+++ b/improver_tests/acceptance/test_map_to_timezones.py
@@ -34,7 +34,7 @@ import pytest
 
 from . import acceptance as acc
 
-pytestmark = [pytest.mark.acc]
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
 
 CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)

--- a/improver_tests/acceptance/test_nowcast_accumulate.py
+++ b/improver_tests/acceptance/test_nowcast_accumulate.py
@@ -43,6 +43,7 @@ run_cli = acc.run_cli(CLI)
 @pytest.mark.slow
 def test_optical_flow_inputs(tmp_path):
     """Test creating a nowcast accumulation using optical flow inputs"""
+    pytest.importorskip("pysteps")
     kgo_dir = acc.kgo_root() / "nowcast-accumulate/basic"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "201811031600_radar_rainrate_composite_UK_regridded.nc"
@@ -67,6 +68,7 @@ def test_optical_flow_inputs(tmp_path):
 @pytest.mark.slow
 def test_wind_inputs(tmp_path):
     """Test creating a nowcast accumulation using wind component inputs"""
+    pytest.importorskip("pysteps")
     kgo_dir = acc.kgo_root() / "nowcast-accumulate/basic"
     kgo_path = kgo_dir / "kgo.nc"
     input_path = kgo_dir / "201811031600_radar_rainrate_composite_UK_regridded.nc"

--- a/improver_tests/acceptance/test_nowcast_extrapolate.py
+++ b/improver_tests/acceptance/test_nowcast_extrapolate.py
@@ -46,6 +46,7 @@ OE = "orographic_enhancement_standard_resolution"
 
 def test_optical_flow_inputs(tmp_path):
     """Test extrapolation nowcast using optical flow inputs"""
+    pytest.importorskip("pysteps")
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
     kgo_path = kgo_dir / "kgo.nc"
     input_dir = acc.kgo_root() / "nowcast-extrapolate"
@@ -70,6 +71,7 @@ def test_optical_flow_inputs(tmp_path):
 
 def test_wind_inputs(tmp_path):
     """Test extrapolation nowcast using wind component inputs"""
+    pytest.importorskip("pysteps")
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/extrapolate"
     kgo_path = kgo_dir / "kgo.nc"
     input_dir = acc.kgo_root() / "nowcast-extrapolate"
@@ -94,6 +96,7 @@ def test_wind_inputs(tmp_path):
 
 def test_metadata(tmp_path):
     """Test basic extrapolation nowcast with json metadata"""
+    pytest.importorskip("pysteps")
     kgo_dir = acc.kgo_root() / "nowcast-extrapolate/metadata"
     kgo_path = kgo_dir / "kgo_with_metadata.nc"
     input_dir = acc.kgo_root() / "nowcast-extrapolate"

--- a/improver_tests/acceptance/test_nowcast_optical_flow_from_winds.py
+++ b/improver_tests/acceptance/test_nowcast_optical_flow_from_winds.py
@@ -43,6 +43,7 @@ RADAR_EXT = "u1096_ng_radar_precip_ratecomposite_2km"
 
 def test_basic(tmp_path):
     """Test optical flow calculation by perturbing model winds"""
+    pytest.importorskip("pysteps")
     kgo_dir = acc.kgo_root() / "nowcast-optical-flow-from-winds"
     kgo_path = kgo_dir / "kgo_15min.nc"
     input_paths = [
@@ -59,6 +60,7 @@ def test_basic(tmp_path):
 
 
 def test_longer_interval(tmp_path):
+    pytest.importorskip("pysteps")
     """Test optical flow calculation by perturbing model winds over a 30 minute
     time interval"""
     kgo_dir = acc.kgo_root() / "nowcast-optical-flow-from-winds"

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -131,7 +131,7 @@ class Test__extract_matching_reliability_table(Test_ReliabilityCalibrate):
         result = self.plugin._extract_matching_reliability_table(
             self.forecast[0], self.reliability_cube
         )
-        self.assertEqual(result.xml, self.reliability_cube[0].xml)
+        self.assertEqual(result.xml(), self.reliability_cube[0].xml())
 
     def test_matching_coords_cubelist(self):
         """Test that no exception is raised in the case that the forecast
@@ -141,7 +141,7 @@ class Test__extract_matching_reliability_table(Test_ReliabilityCalibrate):
         result = self.plugin._extract_matching_reliability_table(
             self.forecast[0], self.reliability_cubelist
         )
-        self.assertEqual(result.xml, self.reliability_cubelist[0].xml)
+        self.assertEqual(result.xml(), self.reliability_cubelist[0].xml())
 
     def test_unmatching_coords(self):
         """Test that an exception is raised in the case that the forecast

--- a/improver_tests/nowcasting/pysteps_advection/test_PystepsExtrapolate.py
+++ b/improver_tests/nowcasting/pysteps_advection/test_PystepsExtrapolate.py
@@ -248,7 +248,7 @@ class Test_process(IrisTest):
                 # the final step (i==8) has no data (as initialised); the
                 # original rain field has been advected out of the domain
                 pass
-            self.assertTrue(np.allclose(cube.data.data, expected_data, equal_nan=True))
+            np.testing.assert_allclose(cube.data.data, expected_data, equal_nan=True)
 
     def test_values_noninteger_step(self):
         """Test values for an advection speed of 0.6 grid squares per time
@@ -270,15 +270,9 @@ class Test_process(IrisTest):
         self.vcube.data = 0.6 * self.vcube.data
         result = self.plugin(self.rain_cube, self.ucube, self.vcube, self.orogenh_cube)
 
-        self.assertTrue(
-            np.allclose(result[1].data.data, expected_data_1, equal_nan=True)
-        )
-        self.assertTrue(
-            np.allclose(result[2].data.data, expected_data_2, equal_nan=True)
-        )
-        self.assertTrue(
-            np.allclose(result[3].data.data, expected_data_3, equal_nan=True)
-        )
+        np.testing.assert_allclose(result[1].data.data, expected_data_1, equal_nan=True)
+        np.testing.assert_allclose(result[2].data.data, expected_data_2, equal_nan=True)
+        np.testing.assert_allclose(result[3].data.data, expected_data_3, equal_nan=True)
 
     def test_error_non_rate_cube(self):
         """Test plugin rejects cube of non-rate data"""

--- a/improver_tests/orographic_enhancement/test_OrographicEnhancement.py
+++ b/improver_tests/orographic_enhancement/test_OrographicEnhancement.py
@@ -610,7 +610,7 @@ class Test__get_point_distances(IrisTest):
         expected_data = np.array([slice_0, slice_1, slice_2, slice_3, slice_4])
 
         distance = self.plugin._get_point_distances(self.wind_speed, self.max_sin_cos)
-        self.assertTrue(np.allclose(distance, expected_data, equal_nan=True))
+        np.testing.assert_allclose(distance, expected_data, equal_nan=True)
 
 
 class Test__locate_source_points(IrisTest):

--- a/improver_tests/precipitation_type/snow_fraction/test_SnowFraction.py
+++ b/improver_tests/precipitation_type/snow_fraction/test_SnowFraction.py
@@ -109,7 +109,7 @@ def test_basic(cube_name, mask_what, model_id_attr):
     assert str(result.units) == "1"
     assert result.name() == "snow_fraction"
     assert result.attributes == expected_attributes
-    assert np.allclose(result.data, EXPECTED_DATA)
+    np.testing.assert_allclose(result.data, EXPECTED_DATA)
 
 
 def test_acclen_mismatch_error():
@@ -186,7 +186,7 @@ def test_coercing_units():
     rain.convert_units("mm h-1")
     result = SnowFraction()(iris.cube.CubeList([rain, snow]))
     assert str(result.units) == "1"
-    assert np.allclose(result.data, EXPECTED_DATA)
+    np.testing.assert_allclose(result.data, EXPECTED_DATA)
     assert rain.units == "mm h-1"
     assert snow.units == "m s-1"
 


### PR DESCRIPTION
A collection of fixes to a few issues:
- Acceptance tests for the map-to-timezones CLI were not being skipped when the acceptance test KGOs were not present
- Unit tests using pysteps were being skipped if pysteps was not available, but acceptance tests using pysteps were attempting to run
- Some tests used the [iris.cube.xml](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html#iris.cube.Cube.xml) method to compare cubes, but didn't actually call the method. This caused the test to compare two references to the method/function, rather than XML representations of the cube.
- Numpy allclose was being used inside other test assertions. This produced a true/false output on failure, rather than a useful explanation of the differences between the arrays.

Testing:
 - [x] Ran tests and they passed OK