### PR TITLE
Update cell methods for probability data

### DIFF
--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -53,6 +53,7 @@ from improver.metadata.probabilistic import (
     extract_diagnostic_name,
     find_percentile_coordinate,
     find_threshold_coordinate,
+    format_cell_methods_for_diagnostic,
     probability_is_above_or_below,
 )
 from improver.utilities.cube_checker import (
@@ -658,6 +659,11 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
                 )
             )
         forecast_at_percentiles = cubelist.merge_cube()
+
+        # Update cell methods on final cube
+        if forecast_at_percentiles.cell_methods:
+            format_cell_methods_for_diagnostic(forecast_at_percentiles)
+
         return forecast_at_percentiles
 
 

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -244,8 +244,8 @@ def format_cell_methods_for_probability(cube, threshold_name):
 
 
 def format_cell_methods_for_diagnostic(cube):
-    """Remove reference to threshold-type coordinate from cell methods on a
-    probability cube.  Modifies cube in place.
+    """Remove reference to threshold-type coordinate from cell method comments that
+    were previously on a probability cube.  Modifies cube in place.
 
     Args:
         cube (iris.cube.Cube):

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -218,3 +218,48 @@ def find_percentile_coordinate(cube):
         raise ValueError(msg)
 
     return perc_coord
+
+
+def format_cell_methods_as_attribute(cell_methods):
+    """Convert cell methods from an input cube into a string attribute
+    for the threshold coordinate
+
+    Args:
+        cell_methods (iterable):
+            Iterable of iris.coords.CellMethod from input cube
+
+    Returns:
+        str:
+            Concatenated string containing information from all cell methods.
+            The IMPROVER standard requires only method and coordinate names,
+            so intervals are not preserved.
+    """
+    method_string = ""
+    for method in cell_methods:
+        coords = ""
+        for coord in method.coord_names:
+            coords += f"{coord}, "
+        formatted_method = f"{method.method}: {coords[:-2]}"
+        method_string += f"{formatted_method}; "
+    if method_string:
+        method_string = method_string[:-2]
+    return method_string
+
+
+def format_attribute_as_cell_methods(attribute):
+    """Convert a "cell_method" attribute back into a list of iris.coords.CellMethod
+    instances for application to cube data.
+
+    Args:
+        str:
+            Cell method attribute from a threshold-type coordinate
+
+    Returns:
+        list of iris.coord.CellMethod
+    """
+    method_strings = attribute.split("; ")
+    cell_methods = []
+    for ms in method_strings:
+        method, coords = ms.split(": ")
+        cell_methods.append(iris.coords.CellMethod(method, coords=coords.split(", ")))
+    return cell_methods

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -254,7 +254,9 @@ def format_cell_methods_for_diagnostic(cube):
     cell_methods = []
     for cell_method in cube.cell_methods:
         new_cell_method = iris.coords.CellMethod(
-            cell_method.method, coords=cell_method.coord_names,
+            cell_method.method,
+            coords=cell_method.coord_names,
+            intervals=cell_method.intervals,
         )
         cell_methods.append(new_cell_method)
     cube.cell_methods = cell_methods

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -282,8 +282,9 @@ class BasicThreshold(PostProcessingPlugin):
             format_cell_methods_for_probability(cube, self.threshold_coord_name)
 
         cube.rename(
-            "probability_of_{}_{}_threshold".format(
-                self.threshold_coord_name, probability_is_above_or_below(cube)
+            "probability_of_{parameter}_{relative_to}_threshold".format(
+                parameter=self.threshold_coord_name,
+                relative_to=probability_is_above_or_below(cube),
             )
         )
         cube.units = Unit(1)

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -40,7 +40,7 @@ from cf_units import Unit
 from improver import PostProcessingPlugin
 from improver.metadata.constants import FLOAT_DTYPE
 from improver.metadata.probabilistic import (
-    format_cell_methods_as_attribute,
+    format_cell_methods_for_probability,
     probability_is_above_or_below,
 )
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
@@ -282,11 +282,7 @@ class BasicThreshold(PostProcessingPlugin):
             {"spp__relative_to_threshold": self.comparison_operator["spp_string"]}
         )
         if cube.cell_methods:
-            threshold_cell_methods = format_cell_methods_as_attribute(cube.cell_methods)
-            threshold_coord.attributes.update(
-                {CELL_METHODS_ATTRIBUTE: threshold_cell_methods}
-            )
-            cube.cell_methods = ()
+            format_cell_methods_for_probability(cube, self.threshold_coord_name)
 
         cube.rename(
             "probability_of_{}_{}_threshold".format(

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -279,9 +279,7 @@ class BasicThreshold(PostProcessingPlugin):
             {"spp__relative_to_threshold": self.comparison_operator["spp_string"]}
         )
         if cube.cell_methods:
-            threshold_cell_methods = format_cell_methods_as_attribute(
-                cube.cell_methods
-            )
+            threshold_cell_methods = format_cell_methods_as_attribute(cube.cell_methods)
             threshold_coord.attributes.update({"cell_methods": threshold_cell_methods})
             cube.cell_methods = ()
 

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -46,6 +46,9 @@ from improver.metadata.probabilistic import (
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 from improver.utilities.rescale import rescale
 
+# define a name for the "cell_methods" attribute
+CELL_METHODS_ATTRIBUTE = "original_cell_methods"
+
 
 class BasicThreshold(PostProcessingPlugin):
 
@@ -280,7 +283,9 @@ class BasicThreshold(PostProcessingPlugin):
         )
         if cube.cell_methods:
             threshold_cell_methods = format_cell_methods_as_attribute(cube.cell_methods)
-            threshold_coord.attributes.update({"cell_methods": threshold_cell_methods})
+            threshold_coord.attributes.update(
+                {CELL_METHODS_ATTRIBUTE: threshold_cell_methods}
+            )
             cube.cell_methods = ()
 
         cube.rename(

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -46,9 +46,6 @@ from improver.metadata.probabilistic import (
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 from improver.utilities.rescale import rescale
 
-# define a name for the "cell_methods" attribute
-CELL_METHODS_ATTRIBUTE = "original_cell_methods"
-
 
 class BasicThreshold(PostProcessingPlugin):
 

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -41,6 +41,8 @@ from improver.metadata.probabilistic import (
     extract_diagnostic_name,
     find_percentile_coordinate,
     find_threshold_coordinate,
+    format_attribute_as_cell_methods,
+    format_cell_methods_as_attribute,
     in_vicinity_name_format,
     is_probability,
     probability_is_above_or_below,
@@ -341,6 +343,44 @@ class Test_find_percentile_coordinate(IrisTest):
         cube.add_aux_coord(new_perc_coord)
         with self.assertRaisesRegex(ValueError, msg):
             find_percentile_coordinate(cube)
+
+
+class Test_format_cell_methods_as_attribute(unittest.TestCase):
+    """Test conversion of cell methods into attribute string"""
+
+    def test_one_method(self):
+        """Test one method returns the expected string"""
+        input = iris.coords.CellMethod("max", coords="time", intervals="1 hour")
+        result = format_cell_methods_as_attribute([input])
+        self.assertEqual(result, "max: time")
+
+    def test_multiple_methods(self):
+        """Test a list of methods returns the expected string"""
+        input1 = iris.coords.CellMethod("max", coords="time")
+        input2 = iris.coords.CellMethod("min", coords="latitude")
+        result = format_cell_methods_as_attribute([input1, input2])
+        self.assertEqual(result, "max: time; min: latitude")
+
+    def test_multiple_coords(self):
+        """Test multiple coords are formatted correctly"""
+        input1 = iris.coords.CellMethod("max", coords="time")
+        input2 = iris.coords.CellMethod("min", coords=("latitude", "longitude"))
+        result = format_cell_methods_as_attribute([input1, input2])
+        self.assertEqual(result, "max: time; min: latitude, longitude")
+
+
+class Test_format_attribute_as_cell_methods(unittest.TestCase):
+    """Test reconversion of attribute string into cell methods"""
+
+    def test_multiple_methods(self):
+        """Test the output list of cell methods is as expected"""
+        input = "max: time; min: latitude, longitude"
+        result = format_attribute_as_cell_methods(input)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], iris.coords.CellMethod("max", coords="time"))
+        self.assertEqual(
+            result[1], iris.coords.CellMethod("min", coords=("latitude", "longitude"))
+        )
 
 
 if __name__ == "__main__":

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -42,7 +42,6 @@ from improver.synthetic_data.set_up_test_cubes import (
     add_coordinate,
     set_up_variable_cube,
 )
-from improver.threshold import CELL_METHODS_ATTRIBUTE
 from improver.threshold import BasicThreshold as Threshold
 
 

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -64,9 +64,6 @@ class Test__add_threshold_coord(IrisTest):
         )
         threshold_coord = self.cube.coord("air_temperature")
         self.assertEqual(threshold_coord.var_name, "threshold")
-        self.assertEqual(
-            threshold_coord.attributes, {"spp__relative_to_threshold": "greater_than"}
-        )
         self.assertAlmostEqual(threshold_coord.points[0], 1)
         self.assertEqual(threshold_coord.units, self.cube.units)
 
@@ -477,6 +474,7 @@ class Test_process(IrisTest):
     def test_each_threshold_func(self):
         """Test user supplied func is applied on each threshold cube."""
         # Need to copy the cube as we're adjusting the data.
+        # TODO need to use different function since we rename the cube after this operation
         plugin = Threshold(
             2.0, each_threshold_func=lambda cube: cube.rename("new_name") or cube
         )

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -474,12 +474,13 @@ class Test_process(IrisTest):
     def test_each_threshold_func(self):
         """Test user supplied func is applied on each threshold cube."""
         # Need to copy the cube as we're adjusting the data.
-        # TODO need to use different function since we rename the cube after this operation
+        new_attr = {"new_attribute": "narwhal"}
         plugin = Threshold(
-            2.0, each_threshold_func=lambda cube: cube.rename("new_name") or cube
+            2.0,
+            each_threshold_func=lambda cube: cube.attributes.update(new_attr) or cube,
         )
         result = plugin(self.cube)
-        self.assertTrue("new_name" in result.name())
+        self.assertTrue("new_attribute" in result.attributes)
 
 
 class Test__init__(IrisTest):

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -34,7 +34,7 @@
 import unittest
 
 import numpy as np
-from iris.coords import DimCoord
+from iris.coords import CellMethod, DimCoord
 from iris.cube import Cube
 from iris.tests import IrisTest
 
@@ -42,6 +42,7 @@ from improver.synthetic_data.set_up_test_cubes import (
     add_coordinate,
     set_up_variable_cube,
 )
+from improver.threshold import CELL_METHODS_ATTRIBUTE
 from improver.threshold import BasicThreshold as Threshold
 
 
@@ -481,6 +482,18 @@ class Test_process(IrisTest):
         )
         result = plugin(self.cube)
         self.assertTrue("new_attribute" in result.attributes)
+
+    def test_cell_method_transfer(self):
+        """Test plugin correctly translates cell method onto threshold coordinate"""
+        self.cube.add_cell_method(CellMethod("max", coords="time"))
+        expected_threshold_attrs = {
+            "spp__relative_to_threshold": "greater_than",
+            CELL_METHODS_ATTRIBUTE: "max: time",
+        }
+        plugin = Threshold(2.0, comparison_operator=">")
+        result = plugin(self.cube)
+        threshold_attrs = result.coord("precipitation_amount").attributes
+        self.assertDictEqual(threshold_attrs, expected_threshold_attrs)
 
 
 class Test__init__(IrisTest):

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -483,17 +483,15 @@ class Test_process(IrisTest):
         result = plugin(self.cube)
         self.assertTrue("new_attribute" in result.attributes)
 
-    def test_cell_method_transfer(self):
-        """Test plugin correctly translates cell method onto threshold coordinate"""
+    def test_cell_method_updates(self):
+        """Test plugin adds correct information to cell methods"""
         self.cube.add_cell_method(CellMethod("max", coords="time"))
-        expected_threshold_attrs = {
-            "spp__relative_to_threshold": "greater_than",
-            CELL_METHODS_ATTRIBUTE: "max: time",
-        }
         plugin = Threshold(2.0, comparison_operator=">")
         result = plugin(self.cube)
-        threshold_attrs = result.coord("precipitation_amount").attributes
-        self.assertDictEqual(threshold_attrs, expected_threshold_attrs)
+        (cell_method,) = result.cell_methods
+        self.assertEqual(cell_method.method, "max")
+        self.assertEqual(cell_method.coord_names, ("time",))
+        self.assertEqual(cell_method.comments, ("of precipitation_amount",))
 
 
 class Test__init__(IrisTest):


### PR DESCRIPTION
Final part of metadata standard.

Cell methods on an initial dataset (eg maximum temperature in period) don't apply directly to the thresholded probabilities (it is not a maximum probability in time, but a probability of maximum in time.  The cell method can't be transferred to the relevant coordinate (https://github.com/SciTools/iris/issues/3946). This PR updates the cell method to clarify that it refers to the threshold-type coordinate, rather than the probability data and reverses this in the ECC to-percentiles plugin.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
