### PR TITLE
Adds model-id-attr to convection-ratio CLI

### DIFF
--- a/improver/cli/convection_ratio.py
+++ b/improver/cli/convection_ratio.py
@@ -36,7 +36,7 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(*cubes: cli.inputcube,):
+def process(*cubes: cli.inputcube, model_id_attr: str = None):
     """ Calculate the convection ratio from convective and dynamic (stratiform)
     precipitation rate components.
 
@@ -48,6 +48,9 @@ def process(*cubes: cli.inputcube,):
         cubes (iris.cube.CubeList):
             Cubes of "lwe_convective_precipitation_rate" and "lwe_stratiform_precipitation_rate"
             in units that can be converted to "m s-1"
+        model_id_attr (str):
+            Name of the attribute used to identify the source model for
+            blending.
 
     Returns:
         iris.cube.Cube:
@@ -58,4 +61,4 @@ def process(*cubes: cli.inputcube,):
 
     if len(cubes) != 2:
         raise IOError(f"Expected 2 input cubes, received {len(cubes)}")
-    return ConvectionRatioFromComponents()(cubes)
+    return ConvectionRatioFromComponents()(cubes, model_id_attr=model_id_attr)

--- a/improver/precipitation_type/convection.py
+++ b/improver/precipitation_type/convection.py
@@ -414,7 +414,7 @@ class ConvectionRatioFromComponents(BasePlugin):
             )
         return convective_ratios
 
-    def process(self, cubes):
+    def process(self, cubes, model_id_attr=None):
         """
         Calculate the convective ratio from the convective and dynamic components as:
             convective_ratio = convective / (convective + dynamic)
@@ -426,6 +426,9 @@ class ConvectionRatioFromComponents(BasePlugin):
                 Both the convective and dynamic components as iris.cube.Cube in a list
                 with names 'lwe_convective_precipitation_rate' and
                 'lwe_stratiform_precipitation_rate'
+            model_id_attr (str):
+                Name of the attribute used to identify the source model for
+                blending. This is inherited from the input temperature cube.
 
         Returns:
             iris.cube.Cube:
@@ -434,7 +437,9 @@ class ConvectionRatioFromComponents(BasePlugin):
 
         self._split_input(cubes)
 
-        attributes = generate_mandatory_attributes([self.convective])
+        attributes = generate_mandatory_attributes(
+            [self.convective], model_id_attr=model_id_attr
+        )
         output_cube = create_new_diagnostic_cube(
             "convective_ratio",
             "1",

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -83,7 +83,7 @@ ba16a5cd5174bcddd08cad6509b38e7a221e18073fe09f41400a911937446b20  ./construct-re
 350a568d28eab64886ccaca8f057745c98a3fc91e9861dff3e5da1bba24574c8  ./construct-reliability-tables/basic/kgo_without_single_value_bins.nc
 9480392febfe81b76bf93de6ca2d88e07ad3fccabbca343713ef7ee374a77d47  ./construct-reliability-tables/basic/truth_0.nc
 d15752239edb3fb26904b600f1705ea97ac8c637090033f16ddeb86052eed5b4  ./construct-reliability-tables/basic/truth_1.nc
-3684137053805d7be642b674879876868461a25c46c320e8233c35e7f32e7e33  ./convection-ratio/basic/kgo.nc
+9795b9758a88e2c4d4171c8b08304f7f0711e03acda66a7394333f8b919ccf50  ./convection-ratio/basic/kgo.nc
 74f850942572aa99de807396d48bd80dd96088c638a9d5fa379b95f7c5ad8614  ./convection-ratio/basic/lwe_convective_precipitation_rate.nc
 b946c7687cb9ed02a12a934429a31306004ad45214cf4b451468b077018c0911  ./convection-ratio/basic/lwe_stratiform_precipitation_rate.nc
 5e403ecf836c3f36abd10414821bda43159db968ce4a850e435040ac92692ae2  ./create-grid-with-halo/basic/kgo.nc

--- a/improver_tests/acceptance/test_convection_ratio.py
+++ b/improver_tests/acceptance/test_convection_ratio.py
@@ -50,7 +50,13 @@ def test_basic(tmp_path):
     kgo_path = kgo_dir / "kgo.nc"
     param_paths = [kgo_dir / f"{p}.nc" for p in ALL_PARAMS]
     output_path = tmp_path / "output.nc"
-    args = [*param_paths, "--output", output_path]
+    args = [
+        *param_paths,
+        "--output",
+        output_path,
+        "--model-id-attr",
+        "mosg__model_configuration",
+    ]
     run_cli(args)
     acc.compare(output_path, kgo_path)
 


### PR DESCRIPTION
- This is passed to the plugin
- This triggers copying the named attribute from the input cube to the output cube
- Acceptance test updated to use this new argument
- Acceptance test data KGO updated

Allows the output to be consumed by the weighted-blending CLI.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
