### PR TITLE
Vicinity names

### DIFF
--- a/improver/between_thresholds.py
+++ b/improver/between_thresholds.py
@@ -37,7 +37,6 @@ from iris.exceptions import CoordinateNotFoundError
 
 from improver import PostProcessingPlugin
 from improver.metadata.probabilistic import (
-    extract_diagnostic_name,
     find_threshold_coordinate,
     probability_is_above_or_below,
 )
@@ -185,11 +184,12 @@ class OccurrenceBetweenThresholds(PostProcessingPlugin):
             original_units (str):
                 Required threshold-type coordinate units
         """
-        output_cube.rename(
-            "probability_of_{}_between_thresholds".format(
-                extract_diagnostic_name(self.cube.name(), check_vicinity=True)
-            )
+        new_name = self.cube.name().replace(
+            "{}_threshold".format(probability_is_above_or_below(self.cube)),
+            "between_thresholds",
         )
+        output_cube.rename(new_name)
+
         new_thresh_coord = output_cube.coord(self.thresh_coord.name())
         new_thresh_coord.convert_units(original_units)
         new_thresh_coord.attributes["spp__relative_to_threshold"] = "between_thresholds"

--- a/improver/between_thresholds.py
+++ b/improver/between_thresholds.py
@@ -187,7 +187,7 @@ class OccurrenceBetweenThresholds(PostProcessingPlugin):
         """
         output_cube.rename(
             "probability_of_{}_between_thresholds".format(
-                extract_diagnostic_name(self.cube.name())
+                extract_diagnostic_name(self.cube.name(), check_vicinity=True)
             )
         )
         new_thresh_coord = output_cube.coord(self.thresh_coord.name())

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -32,7 +32,9 @@
 
 from collections import OrderedDict
 
-from improver.metadata.probabilistic import extract_diagnostic_name
+from improver.metadata.probabilistic import (
+    get_diagnostic_cube_name_from_probability_name,
+)
 from improver.utilities.cube_manipulation import MergeCubes
 
 
@@ -70,7 +72,7 @@ def split_forecasts_and_truth(cubes, truth_attribute):
     grouped_cubes = {}
     for cube in cubes:
         try:
-            cube_name = extract_diagnostic_name(cube.name(), check_vicinity=True)
+            cube_name = get_diagnostic_cube_name_from_probability_name(cube.name())
         except ValueError:
             cube_name = cube.name()
         grouped_cubes.setdefault(cube_name, []).append(cube)

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -70,7 +70,7 @@ def split_forecasts_and_truth(cubes, truth_attribute):
     grouped_cubes = {}
     for cube in cubes:
         try:
-            cube_name = extract_diagnostic_name(cube.name())
+            cube_name = extract_diagnostic_name(cube.name(), check_vicinity=True)
         except ValueError:
             cube_name = cube.name()
         grouped_cubes.setdefault(cube_name, []).append(cube)

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -331,14 +331,9 @@ class CubeMultiplier(CubeCombiner):
                 probabilistic_name
             )
 
-            new_threshold_name = (
-                new_diagnostic_name[:-12]
-                if "vicinity" in new_diagnostic_name
-                else new_diagnostic_name
-            )
-
             # Rename the threshold coordinate to match the name of the diagnostic
             # that results from the combine operation.
+            new_threshold_name = new_diagnostic_name.replace("_in_vicinity", "")
             result.coord(var_name="threshold").rename(new_threshold_name)
             result.coord(new_threshold_name).var_name = "threshold"
 

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -325,12 +325,15 @@ class CubeMultiplier(CubeCombiner):
 
         if broadcast_to_threshold:
             probabilistic_name = cube_list[0].name()
-            diagnostic_name = extract_diagnostic_name(probabilistic_name)
+            threshold_coord_name = extract_diagnostic_name(probabilistic_name)
+            diagnostic_name = extract_diagnostic_name(
+                probabilistic_name, check_vicinity=True
+            )
 
             # Rename the threshold coordinate to match the name of the diagnostic
             # that results from the combine operation.
-            result.coord(var_name="threshold").rename(new_diagnostic_name)
-            result.coord(new_diagnostic_name).var_name = "threshold"
+            result.coord(var_name="threshold").rename(threshold_coord_name)
+            result.coord(threshold_coord_name).var_name = "threshold"
 
             new_diagnostic_name = probabilistic_name.replace(
                 diagnostic_name, new_diagnostic_name

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -297,7 +297,9 @@ class CubeMultiplier(CubeCombiner):
             cube_list (iris.cube.CubeList or list):
                 List of cubes to combine.
             new_diagnostic_name (str):
-                New name for the combined diagnostic.
+                New name for the combined diagnostic.  This should be the diagnostic
+                name, eg rainfall_rate or rainfall_rate_in_vicinity, rather than the
+                name of the probabilistic output cube.
             broadcast_to_threshold (bool):
                 True if the first cube has a threshold coordinate to which the
                 following cube(s) need(s) to be broadcast prior to combining data.
@@ -325,15 +327,20 @@ class CubeMultiplier(CubeCombiner):
 
         if broadcast_to_threshold:
             probabilistic_name = cube_list[0].name()
-            threshold_coord_name = extract_diagnostic_name(probabilistic_name)
             diagnostic_name = extract_diagnostic_name(
                 probabilistic_name, check_vicinity=True
             )
 
+            new_threshold_name = (
+                new_diagnostic_name[:-12]
+                if "vicinity" in new_diagnostic_name
+                else new_diagnostic_name
+            )
+
             # Rename the threshold coordinate to match the name of the diagnostic
             # that results from the combine operation.
-            result.coord(var_name="threshold").rename(threshold_coord_name)
-            result.coord(threshold_coord_name).var_name = "threshold"
+            result.coord(var_name="threshold").rename(new_threshold_name)
+            result.coord(new_threshold_name).var_name = "threshold"
 
             new_diagnostic_name = probabilistic_name.replace(
                 diagnostic_name, new_diagnostic_name

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -40,8 +40,8 @@ from iris.exceptions import CoordinateNotFoundError
 from improver import BasePlugin
 from improver.metadata.check_datatypes import enforce_dtype
 from improver.metadata.probabilistic import (
-    extract_diagnostic_name,
     find_threshold_coordinate,
+    get_diagnostic_cube_name_from_probability_name,
 )
 from improver.utilities.cube_manipulation import (
     enforce_coordinate_ordering,
@@ -327,8 +327,8 @@ class CubeMultiplier(CubeCombiner):
 
         if broadcast_to_threshold:
             probabilistic_name = cube_list[0].name()
-            diagnostic_name = extract_diagnostic_name(
-                probabilistic_name, check_vicinity=True
+            diagnostic_name = get_diagnostic_cube_name_from_probability_name(
+                probabilistic_name
             )
 
             new_threshold_name = (

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -561,7 +561,9 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
         )
 
         template_cube = next(forecast_probabilities.slices_over(threshold_coord.name()))
-        template_cube.rename(extract_diagnostic_name(template_cube.name(), check_vicinity=True))
+        template_cube.rename(
+            extract_diagnostic_name(template_cube.name(), check_vicinity=True)
+        )
         template_cube.remove_coord(threshold_coord.name())
 
         percentile_cube = create_cube_with_percentiles(

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -561,7 +561,7 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
         )
 
         template_cube = next(forecast_probabilities.slices_over(threshold_coord.name()))
-        template_cube.rename(extract_diagnostic_name(template_cube.name()))
+        template_cube.rename(extract_diagnostic_name(template_cube.name(), check_vicinity=True))
         template_cube.remove_coord(threshold_coord.name())
 
         percentile_cube = create_cube_with_percentiles(

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -50,10 +50,11 @@ from improver.ensemble_copula_coupling.utilities import (
     restore_non_percentile_dimensions,
 )
 from improver.metadata.probabilistic import (
-    extract_diagnostic_name,
     find_percentile_coordinate,
     find_threshold_coordinate,
     format_cell_methods_for_diagnostic,
+    get_diagnostic_cube_name_from_probability_name,
+    get_threshold_coord_name_from_probability_name,
     probability_is_above_or_below,
 )
 from improver.utilities.cube_checker import (
@@ -562,7 +563,7 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
 
         template_cube = next(forecast_probabilities.slices_over(threshold_coord.name()))
         template_cube.rename(
-            extract_diagnostic_name(template_cube.name(), check_vicinity=True)
+            get_diagnostic_cube_name_from_probability_name(template_cube.name())
         )
         template_cube.remove_coord(threshold_coord.name())
 
@@ -628,7 +629,9 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
             )
 
         threshold_coord = find_threshold_coordinate(forecast_probabilities)
-        phenom_name = extract_diagnostic_name(forecast_probabilities.name())
+        phenom_name = get_threshold_coord_name_from_probability_name(
+            forecast_probabilities.name()
+        )
 
         if no_of_percentiles is None:
             no_of_percentiles = len(

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -76,7 +76,7 @@ def in_vicinity_name_format(cube_name):
     return new_cube_name
 
 
-def extract_diagnostic_name(cube_name):
+def extract_diagnostic_name(cube_name, check_vicinity=False):
     """
     Extract the standard or long name X of the diagnostic from a probability
     cube name of the form 'probability_of_X_above/below_threshold',
@@ -86,6 +86,12 @@ def extract_diagnostic_name(cube_name):
     Args:
         cube_name (str):
             The probability cube name
+        check_vicinity (bool):
+            If False the function will return X as described above, which matches
+            the name of the threshold-type coordinate on the cube.  If True, the
+            cube name is checked to see whether it is a vicinity diagnostic, and
+            if so the function returns "X_in_vicinity".  This is the name of the
+            equivalent diagnostic in percentile or realization space.
 
     Returns:
         str:
@@ -101,6 +107,10 @@ def extract_diagnostic_name(cube_name):
         raise ValueError(
             "Input {} is not a valid probability cube name".format(cube_name)
         )
+
+    if check_vicinity and "_in_vicinity" in cube_name:
+        diagnostic_name += "_in_vicinity"
+
     return diagnostic_name
 
 

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -76,7 +76,20 @@ def in_vicinity_name_format(cube_name):
     return new_cube_name
 
 
-def extract_diagnostic_name(cube_name, check_vicinity=False):
+def get_threshold_coord_name_from_probability_name(cube_name):
+    """Get the name of the threshold coordinate from the name of the probability
+    cube.  This can be used to set or modify a threshold coordinate name after
+    renaming or conversion from probabilities to percentiles / realizations."""
+    return _extract_diagnostic_name(cube_name)
+
+
+def get_diagnostic_cube_name_from_probability_name(cube_name):
+    """Get the name of the original diagnostic cube, including vicinity, from
+    the name of the probability cube."""
+    return _extract_diagnostic_name(cube_name, check_vicinity=True)
+
+
+def _extract_diagnostic_name(cube_name, check_vicinity=False):
     """
     Extract the standard or long name X of the diagnostic from a probability
     cube name of the form 'probability_of_X_above/below_threshold',

--- a/improver/precipitation_type/shower_condition.py
+++ b/improver/precipitation_type/shower_condition.py
@@ -36,8 +36,8 @@ import numpy as np
 from improver import BasePlugin
 from improver.metadata.constants import FLOAT_DTYPE
 from improver.metadata.probabilistic import (
-    extract_diagnostic_name,
     find_threshold_coordinate,
+    get_diagnostic_cube_name_from_probability_name,
     probability_is_above_or_below,
 )
 from improver.metadata.utilities import (
@@ -88,7 +88,7 @@ class ShowerCondition(BasePlugin):
         """Calculate deterministic "precipitation is showery" field"""
         showery_points = np.ones(shape, dtype=FLOAT_DTYPE)
         for cube in self.cubes:
-            name = extract_diagnostic_name(cube.name())
+            name = get_diagnostic_cube_name_from_probability_name(cube.name())
             slice_constraint = iris.Constraint(
                 coord_values={
                     name: lambda cell: np.isclose(

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -38,8 +38,8 @@ import numpy as np
 
 from improver import BasePlugin
 from improver.metadata.probabilistic import (
-    extract_diagnostic_name,
     find_threshold_coordinate,
+    get_threshold_coord_name_from_probability_name,
     probability_is_above_or_below,
 )
 from improver.metadata.utilities import (
@@ -197,7 +197,10 @@ class WeatherSymbols(BasePlugin):
 
                 # Check cube and threshold coordinate names match according to
                 # expected convention.  If not, add to exception dictionary.
-                if extract_diagnostic_name(diagnostic) != threshold_name:
+                if (
+                    get_threshold_coord_name_from_probability_name(diagnostic)
+                    != threshold_name
+                ):
                     self.threshold_coord_names[diagnostic] = threshold_name
 
                 # Set flag to check for old threshold coordinate names
@@ -488,7 +491,9 @@ class WeatherSymbols(BasePlugin):
             elif diagnostic in self.threshold_coord_names:
                 threshold_coord_name = self.threshold_coord_names[diagnostic]
             else:
-                threshold_coord_name = extract_diagnostic_name(diagnostic)
+                threshold_coord_name = get_threshold_coord_name_from_probability_name(
+                    diagnostic
+                )
             threshold_val = threshold.points.item()
             constraints.append(
                 _constraint_string(diagnostic, threshold_coord_name, threshold_val)

--- a/improver_tests/calibration/ensemble_calibration/helper_functions.py
+++ b/improver_tests/calibration/ensemble_calibration/helper_functions.py
@@ -42,7 +42,6 @@ from iris.cube import Cube
 from iris.tests import IrisTest
 
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
-from improver.metadata.probabilistic import extract_diagnostic_name
 from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.warnings_handler import ManageWarnings
 

--- a/improver_tests/cube_combiner/test_CubeMultiplier.py
+++ b/improver_tests/cube_combiner/test_CubeMultiplier.py
@@ -65,6 +65,23 @@ class Test_process(CombinerTest):
         self.assertArrayAlmostEqual(result.data, self.cube4.data)
         self.assertCubeListEqual(input_copy, cubelist)
 
+    def test_vicinity_names(self):
+        """Test plugin names the cube and threshold coordinate correctly for a
+        vicinity diagnostic"""
+        input = "lwe_thickness_of_precipitation_amount_in_vicinity"
+        output = "thickness_of_rainfall_amount_in_vicinity"
+        self.cube4.rename(f"probability_of_{input}_above_threshold")
+        cube = self.cube4[:, 0, ...].copy()
+        cube.data = np.ones_like(cube.data)
+        cube.remove_coord("lwe_thickness_of_precipitation_amount")
+        cubelist = iris.cube.CubeList([self.cube4.copy(), cube])
+        input_copy = deepcopy(cubelist)
+        result = CubeMultiplier()(cubelist, output, broadcast_to_threshold=True)
+        self.assertEqual(result.name(), f"probability_of_{output}_above_threshold")
+        self.assertEqual(
+            result.coord(var_name="threshold").name(), "thickness_of_rainfall_amount"
+        )
+
     def test_error_broadcast_coord_not_found(self):
         """Test that plugin throws an error if asked to broadcast to a threshold coord
         that is not present on the first cube"""

--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -596,6 +596,12 @@ class Test_process(IrisTest):
         self.assertEqual(result.units, expected_units)
         self.assertEqual(result.cell_methods[0], expected_cell_method)
 
+    def test_vicinity_metadata(self):
+        """Test vicinity cube name is correctly regenerated after processing"""
+        self.cube.rename("probability_of_air_temperature_in_vicinity_above_threshold")
+        result = Plugin().process(self.cube)
+        self.assertEqual(result.name(), "air_temperature_in_vicinity")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -230,8 +230,7 @@ class Test_get_diagnostic_cube_name_from_probability_name(unittest.TestCase):
     """Test utility to derive diagnostic cube name from probability cube name"""
 
     def test_basic(self):
-        """Test correct name is returned from a standard probability if the
-        "check_vicinity" argument is set"""
+        """Test correct name is returned from a point probability field"""
         diagnostic = "air_temperature"
         result = get_diagnostic_cube_name_from_probability_name(
             f"probability_of_{diagnostic}_above_threshold"
@@ -239,8 +238,8 @@ class Test_get_diagnostic_cube_name_from_probability_name(unittest.TestCase):
         self.assertEqual(result, diagnostic)
 
     def test_in_vicinity(self):
-        """Test the full vicinity name is returned if the "check_vicinity"
-        argument is set"""
+        """Test the full vicinity name is returned from a vicinity probability
+        field"""
         diagnostic = "precipitation_rate"
         result = get_diagnostic_cube_name_from_probability_name(
             f"probability_of_{diagnostic}_in_vicinity_above_threshold"

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -215,7 +215,26 @@ class Test_extract_diagnostic_name(unittest.TestCase):
         cannot be removed with "rstrip"."""
         diagnostic = "cloud_height"
         result = extract_diagnostic_name(
-            "probability_of_{}_in_vicinity_above_threshold".format(diagnostic)
+            f"probability_of_{diagnostic}_in_vicinity_above_threshold"
+        )
+        self.assertEqual(result, diagnostic)
+
+    def test_in_vicinity_check_vicinity(self):
+        """Test the full vicinity name is returned if the "check_vicinity"
+        argument is set"""
+        diagnostic = "precipitation_rate"
+        result = extract_diagnostic_name(
+            f"probability_of_{diagnostic}_in_vicinity_above_threshold",
+            check_vicinity=True,
+        )
+        self.assertEqual(result, f"{diagnostic}_in_vicinity")      
+
+    def test_check_vicinity_noop(self):
+        """Test correct name is returned from a standard probability if the
+        "check_vicinity" argument is set"""
+        diagnostic = "air_temperature"
+        result = extract_diagnostic_name(
+            f"probability_of_{diagnostic}_above_threshold", check_vicinity=True
         )
         self.assertEqual(result, diagnostic)
 

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -40,10 +40,10 @@ from iris.tests import IrisTest
 from improver.metadata.probabilistic import (
     find_percentile_coordinate,
     find_threshold_coordinate,
-    get_diagnostic_cube_name_from_probability_name,
-    get_threshold_coord_name_from_probability_name,
     format_cell_methods_for_diagnostic,
     format_cell_methods_for_probability,
+    get_diagnostic_cube_name_from_probability_name,
+    get_threshold_coord_name_from_probability_name,
     in_vicinity_name_format,
     is_probability,
     probability_is_above_or_below,

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -187,7 +187,7 @@ class Test_in_vicinity_name_format(unittest.TestCase):
 class Test_get_threshold_coord_name_from_probability_name(unittest.TestCase):
     """Test utility to derive threshold coordinate name from probability cube name"""
 
-    def test_basic(self):
+    def test_above_threshold(self):
         """Test correct name is returned from a standard (above threshold)
         probability field"""
         result = get_threshold_coord_name_from_probability_name(

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -227,7 +227,7 @@ class Test_extract_diagnostic_name(unittest.TestCase):
             f"probability_of_{diagnostic}_in_vicinity_above_threshold",
             check_vicinity=True,
         )
-        self.assertEqual(result, f"{diagnostic}_in_vicinity")      
+        self.assertEqual(result, f"{diagnostic}_in_vicinity")
 
     def test_check_vicinity_noop(self):
         """Test correct name is returned from a standard probability if the

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -38,9 +38,10 @@ from iris.exceptions import CoordinateNotFoundError
 from iris.tests import IrisTest
 
 from improver.metadata.probabilistic import (
-    extract_diagnostic_name,
     find_percentile_coordinate,
     find_threshold_coordinate,
+    get_diagnostic_cube_name_from_probability_name,
+    get_threshold_coord_name_from_probability_name,
     format_cell_methods_for_diagnostic,
     format_cell_methods_for_probability,
     in_vicinity_name_format,
@@ -183,20 +184,20 @@ class Test_in_vicinity_name_format(unittest.TestCase):
         self.assertEqual(result, "probability_of_X_in_vicinity")
 
 
-class Test_extract_diagnostic_name(unittest.TestCase):
-    """Test utility to extract diagnostic name from probability cube name"""
+class Test_get_threshold_coord_name_from_probability_name(unittest.TestCase):
+    """Test utility to derive threshold coordinate name from probability cube name"""
 
     def test_basic(self):
         """Test correct name is returned from a standard (above threshold)
         probability field"""
-        result = extract_diagnostic_name(
+        result = get_threshold_coord_name_from_probability_name(
             "probability_of_air_temperature_above_threshold"
         )
         self.assertEqual(result, "air_temperature")
 
     def test_below_threshold(self):
         """Test correct name is returned from a probability below threshold"""
-        result = extract_diagnostic_name(
+        result = get_threshold_coord_name_from_probability_name(
             "probability_of_air_temperature_below_threshold"
         )
         self.assertEqual(result, "air_temperature")
@@ -204,7 +205,7 @@ class Test_extract_diagnostic_name(unittest.TestCase):
     def test_between_thresholds(self):
         """Test correct name is returned from a probability between thresholds
         """
-        result = extract_diagnostic_name(
+        result = get_threshold_coord_name_from_probability_name(
             "probability_of_visibility_in_air_between_thresholds"
         )
         self.assertEqual(result, "visibility_in_air")
@@ -214,34 +215,42 @@ class Test_extract_diagnostic_name(unittest.TestCase):
         Name "cloud_height" is used in this test to illustrate why suffix
         cannot be removed with "rstrip"."""
         diagnostic = "cloud_height"
-        result = extract_diagnostic_name(
+        result = get_threshold_coord_name_from_probability_name(
             f"probability_of_{diagnostic}_in_vicinity_above_threshold"
-        )
-        self.assertEqual(result, diagnostic)
-
-    def test_in_vicinity_check_vicinity(self):
-        """Test the full vicinity name is returned if the "check_vicinity"
-        argument is set"""
-        diagnostic = "precipitation_rate"
-        result = extract_diagnostic_name(
-            f"probability_of_{diagnostic}_in_vicinity_above_threshold",
-            check_vicinity=True,
-        )
-        self.assertEqual(result, f"{diagnostic}_in_vicinity")
-
-    def test_check_vicinity_noop(self):
-        """Test correct name is returned from a standard probability if the
-        "check_vicinity" argument is set"""
-        diagnostic = "air_temperature"
-        result = extract_diagnostic_name(
-            f"probability_of_{diagnostic}_above_threshold", check_vicinity=True
         )
         self.assertEqual(result, diagnostic)
 
     def test_error_not_probability(self):
         """Test exception if input is not a probability cube name"""
         with self.assertRaises(ValueError):
-            extract_diagnostic_name("lwe_precipitation_rate")
+            get_threshold_coord_name_from_probability_name("lwe_precipitation_rate")
+
+
+class Test_get_diagnostic_cube_name_from_probability_name(unittest.TestCase):
+    """Test utility to derive diagnostic cube name from probability cube name"""
+
+    def test_basic(self):
+        """Test correct name is returned from a standard probability if the
+        "check_vicinity" argument is set"""
+        diagnostic = "air_temperature"
+        result = get_diagnostic_cube_name_from_probability_name(
+            f"probability_of_{diagnostic}_above_threshold"
+        )
+        self.assertEqual(result, diagnostic)
+
+    def test_in_vicinity(self):
+        """Test the full vicinity name is returned if the "check_vicinity"
+        argument is set"""
+        diagnostic = "precipitation_rate"
+        result = get_diagnostic_cube_name_from_probability_name(
+            f"probability_of_{diagnostic}_in_vicinity_above_threshold"
+        )
+        self.assertEqual(result, f"{diagnostic}_in_vicinity")
+
+    def test_error_not_probability(self):
+        """Test exception if input is not a probability cube name"""
+        with self.assertRaises(ValueError):
+            get_diagnostic_cube_name_from_probability_name("lwe_precipitation_rate")
 
 
 class Test_is_probability(IrisTest):


### PR DESCRIPTION
Cube names were not being regenerated correctly for "in vicinity" diagnostics through ECC.  Traced issue to utility being inappropriately used.  Wrapped utility for different purposes and renamed wrapper functions to specify clearly the intended usage.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

