### PR TITLE
Minor edit to checking of overlapping forecast reference time bounds

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -518,11 +518,12 @@ class AggregateReliabilityCalibrationTables(BasePlugin):
         Raises:
             ValueError: If the bounds overlap.
         """
-        bounds = []
+        lower_bounds = []
+        upper_bounds = []
         for cube in cubes:
-            bounds.extend(cube.coord("forecast_reference_time").bounds)
-        bounds = np.concatenate(bounds)
-        if not all(x < y for x, y in zip(bounds, bounds[1:])):
+            lower_bounds.append(cube.coord("forecast_reference_time").bounds[0][0])
+            upper_bounds.append(cube.coord("forecast_reference_time").bounds[0][1])
+        if not all(x < y for x, y in zip(upper_bounds, lower_bounds[1:])):
             raise ValueError(
                 "Reliability calibration tables have overlapping "
                 "forecast reference time bounds, indicating that "

--- a/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
@@ -115,9 +115,10 @@ class Test__check_frt_coord(Test_Aggregation):
     def test_matching_bounds(self):
         """Test that no exception is raised in the input cubes if a cube
         contains matching bounds."""
-        reliability_cube = self.reliability_cube.copy()
-        lower_bound = reliability_cube.coord("forecast_reference_time").bounds[0][0]
-        reliability_cube.coord("forecast_reference_time").bounds = [
+        lower_bound = self.reliability_cube.coord("forecast_reference_time").bounds[0][
+            0
+        ]
+        self.reliability_cube.coord("forecast_reference_time").bounds = [
             [lower_bound, lower_bound]
         ]
         plugin = Plugin()

--- a/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
@@ -112,6 +112,17 @@ class Test__check_frt_coord(Test_Aggregation):
         plugin = Plugin()
         plugin._check_frt_coord([self.reliability_cube, self.different_frt])
 
+    def test_matching_bounds(self):
+        """Test that no exception is raised in the input cubes if a cube
+        contains matching bounds."""
+        reliability_cube = self.reliability_cube.copy()
+        lower_bound = reliability_cube.coord("forecast_reference_time").bounds[0][0]
+        reliability_cube.coord("forecast_reference_time").bounds = [
+            [lower_bound, lower_bound]
+        ]
+        plugin = Plugin()
+        plugin._check_frt_coord([self.reliability_cube, self.different_frt])
+
     def test_invalid_bounds(self):
         """Test that an exception is raised if the input cubes have forecast
         reference time bounds that overlap."""


### PR DESCRIPTION
Description
This PR makes a minor edit to the reliability calibration error handling to support aggregation when the reliability table has been constructed using a single forecast and truth pair.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

