### PR TITLE
Use setuptools_scm to automatically obtain version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
-        isort --check-only --recursive .
+        isort --check-only --recursive --verbose .
     - name: black
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
-        isort --check-only --recursive --verbose .
+        isort --check-only --recursive .
     - name: black
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'

--- a/improver/__init__.py
+++ b/improver/__init__.py
@@ -30,6 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing plugin base class."""
 from abc import ABC, abstractmethod
+
 from pkg_resources import DistributionNotFound, get_distribution
 
 try:

--- a/improver/__init__.py
+++ b/improver/__init__.py
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing plugin base class."""
 from abc import ABC, abstractmethod
-from pkg_resources import get_distribution, DistributionNotFound
+from pkg_resources import DistributionNotFound, get_distribution
 
 try:
     __version__ = get_distribution("improver").version

--- a/improver/__init__.py
+++ b/improver/__init__.py
@@ -30,8 +30,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing plugin base class."""
 from abc import ABC, abstractmethod
+from pkg_resources import get_distribution, DistributionNotFound
 
-__version__ = "0.14.1"
+try:
+    __version__ = get_distribution("improver").version
+except DistributionNotFound:
+    # package is not installed
+    pass
 
 
 class BasePlugin(ABC):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = improver
-version = attr: improver.__version__
 author = UK Met Office
 author_email = ben.fitzpatrick@metoffice.gov.uk
 license = BSD
@@ -16,7 +15,9 @@ classifiers =
 [options]
 python_requires = >= 3.6
 packages = find:
-setup_requires = setuptools >= 38.3.0
+setup_requires =
+    setuptools >= 38.3.0
+    setuptools_scm
 install_requires =
     cftime == 1.0.1
     clize

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,6 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup()
+    setup(
+        use_scm_version={'version_scheme': 'post-release'},
+    )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(
-        use_scm_version={'version_scheme': 'post-release'},
-    )
+    setup(use_scm_version={"version_scheme": "post-release"},)


### PR DESCRIPTION
Use `setuptools_scm` to automatically get version from git tags (as suggested by/discussed with Tom & Tomek).

Description

Testing:
 - [N/A] Ran tests and they passed OK
 - [N/A] Added new tests for the new feature(s)

CLA
 - [N/A] If a new developer, signed up to CLA
