### PR TITLE
Widen scipy requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     clize
     numpy
     sigtools
-    scipy == 1.3.3
+    scipy >= 1.3.0, < 1.4.0
     scitools-iris >= 2.2
     sphinx
     stratify


### PR DESCRIPTION
Due to unavailability of scipy 1.3.3 for Windows on conda-forge (https://anaconda.org/conda-forge/scipy/files?version=1.3.3), widen scipy version requirement. See https://github.com/conda-forge/staged-recipes/pull/13867 for details of Windows build.

Have tested that the acceptance tests pass for 1.3.0, 1.3.1, 1.3.2 and 1.3.3

cc @tjtg 

Testing:
 - [N/A] Ran tests and they passed OK
 - [N/A] Added new tests for the new feature(s)

CLA
 - [N/A] If a new developer, signed up to CLA
