### PR TITLE
Weather symbols vicinity inputs

### DIFF
--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -511,12 +511,13 @@ def set_up_probability_cube(
     cube = set_up_variable_cube(
         data, name=name, units="1", realizations=thresholds, **kwargs,
     )
-    cube.coord("realization").rename(variable_name)
-    cube.coord(variable_name).var_name = "threshold"
-    cube.coord(variable_name).attributes.update(coord_attributes)
-    cube.coord(variable_name).units = Unit(threshold_units)
+    threshold_name = variable_name.replace("_in_vicinity", "")
+    cube.coord("realization").rename(threshold_name)
+    cube.coord(threshold_name).var_name = "threshold"
+    cube.coord(threshold_name).attributes.update(coord_attributes)
+    cube.coord(threshold_name).units = Unit(threshold_units)
     if len(thresholds) == 1:
-        cube = next(cube.slices_over(variable_name))
+        cube = next(cube.slices_over(threshold_name))
     return cube
 
 

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -129,9 +129,6 @@ class WeatherSymbols(BasePlugin):
         # flag to indicate whether to expect "threshold" as a coordinate name
         # (defaults to False, checked on reading input cubes)
         self.coord_named_threshold = False
-        # dictionary to contain names of threshold coordinates that do not
-        # match expected convention
-        self.threshold_coord_names = {}
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
@@ -194,14 +191,6 @@ class WeatherSymbols(BasePlugin):
                 # cube, and that the thresholding is relative to it correctly.
                 threshold = threshold.points.item()
                 threshold_name = find_threshold_coordinate(matched_cube[0]).name()
-
-                # Check cube and threshold coordinate names match according to
-                # expected convention.  If not, add to exception dictionary.
-                if (
-                    get_threshold_coord_name_from_probability_name(diagnostic)
-                    != threshold_name
-                ):
-                    self.threshold_coord_names[diagnostic] = threshold_name
 
                 # Set flag to check for old threshold coordinate names
                 if threshold_name == "threshold" and not self.coord_named_threshold:
@@ -488,8 +477,6 @@ class WeatherSymbols(BasePlugin):
         for diagnostic, threshold in zip(diagnostics, thresholds):
             if coord_named_threshold:
                 threshold_coord_name = "threshold"
-            elif diagnostic in self.threshold_coord_names:
-                threshold_coord_name = self.threshold_coord_names[diagnostic]
             else:
                 threshold_coord_name = get_threshold_coord_name_from_probability_name(
                     diagnostic

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -709,6 +709,20 @@ class Test_set_up_probability_cube(IrisTest):
         dim_coords = get_dim_coord_names(result)
         self.assertNotIn("air_temperature", dim_coords)
 
+    def test_vicinity_cube(self):
+        """Test an in-vicinity cube gets the correct name and threshold coordinate"""
+        result = set_up_probability_cube(
+            self.data,
+            self.thresholds,
+            variable_name="air_temperature_in_vicinity",
+        )
+        thresh_coord = find_threshold_coordinate(result)
+        self.assertEqual(
+            result.name(), "probability_of_air_temperature_in_vicinity_above_threshold"
+        )
+        self.assertEqual(thresh_coord.name(), "air_temperature")
+        self.assertEqual(thresh_coord.var_name, "threshold")
+
 
 class Test_add_coordinate(IrisTest):
     """Test the add_coordinate utility"""

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -712,9 +712,7 @@ class Test_set_up_probability_cube(IrisTest):
     def test_vicinity_cube(self):
         """Test an in-vicinity cube gets the correct name and threshold coordinate"""
         result = set_up_probability_cube(
-            self.data,
-            self.thresholds,
-            variable_name="air_temperature_in_vicinity",
+            self.data, self.thresholds, variable_name="air_temperature_in_vicinity",
         )
         thresh_coord = find_threshold_coordinate(result)
         self.assertEqual(


### PR DESCRIPTION
Weather symbols tidy up PR #1421 has some things in it that ought to break the tests, but don't.  This PR fixes the underlying issues, namely:

- Temporary clause in weather symbols code that allows for non-conformant metadata.  Now that we have a finalised metadata standard this should not be necessary.
- Error setting up "in vicinity" probability metadata in unit test setup functions

The blending suite has been run and confirmed that weather symbols are correctly produced from individual model suites at version 0.16.0.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
