### PR TITLE
Reduced conda environment installation time on GH actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         env: [py36_iris22, py37_iris24]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: cache
       env:
         # Increase this value to reset cache
@@ -57,7 +57,7 @@ jobs:
         env: [py36_iris22]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: cache
       env:
         # Increase this value to reset cache
@@ -100,7 +100,7 @@ jobs:
         env: [py36_iris22, py37_iris24]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: cache
       env:
         # Increase this value to reset cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda env update -q --file envs/environment_${{ matrix.env }}.yml --name improver_${{ matrix.env }}
+        conda install -c conda-forge mamba
+        mamba env update -q --file envs/environment_${{ matrix.env }}.yml --name improver_${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -68,7 +69,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda env update -q --file envs/environment_${{ matrix.env }}.yml --name improver_${{ matrix.env }}
+        conda install -c conda-forge mamba
+        mamba env update -q --file envs/environment_${{ matrix.env }}.yml --name improver_${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -110,7 +112,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda env update -q --file envs/environment_${{ matrix.env }}.yml --name improver_${{ matrix.env }}
+        conda install -c conda-forge mamba
+        mamba env update -q --file envs/environment_${{ matrix.env }}.yml --name improver_${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'


### PR DESCRIPTION
Slow conda environment creation has been noticed recently, such as in [PR #1411 review comment](https://github.com/metoppv/improver/pull/1411#pullrequestreview-586505977) and [PR #1424 actions logs](https://github.com/metoppv/improver/pull/1424/checks#step:4:7). The py36 environment in particular takes a long time for conda to do its dependency solving.
Github actions cache minimises the time required once the cache is warm, but initial runs with a cold cache are very slow.

The main change here is to use the [mamba](https://github.com/mamba-org/mamba#mamba) package to do the dependency solving. Mamba is much faster due to using an external C++ solver (same library as the RPM package manager). Install times are reduced from over an hour to around 2 minutes.
The second change is to use actions/cache version 2, which saves cache files using zstd instead of gzip. Zstd compression is generally both smaller and faster to run than gzip, which should result in faster running with a warm cache.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)