### PR TITLE
Allow bandit to return failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,4 +129,4 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
-        bandit -r improver || true
+        bandit -r improver


### PR DESCRIPTION
Now that #1386 is resolved, allow bandit to fail if new issues are introduced.