### PR TITLE
Add missing dependencies

### DIFF
--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -6,29 +6,35 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - iris=2.4
-  - numpy
-  - numba
-  - scipy=1.3.3
+  # Required
+  - cartopy
   - cftime=1.0.1
+  - cf_units
+  - clize
+  - dask
+  - iris=2.4
+  - netCDF4
+  - numpy
+  - python-dateutil
   - python-stratify
+  - pytz==2020.5
+  - scipy=1.3.3
+  - sigtools
   - sphinx
+  # Optional
+  - numba
+  - pysteps=1.3.2
+  - statsmodels
+  - timezonefinder
+  # Development
+  - astroid
+  - bandit
+  - black=19.10b0
+  - codacy-coverage
+  - filelock
+  - isort=4.3.21
+  - mock
+  - pylint
   - pytest
   - pytest-cov
-  - codacy-coverage
-  - pylint
-  - astroid
-  - filelock
-  - mock
-  - pysteps=1.3.2
-  - isort=4.3.21
-  - black=19.10b0
-  - bandit
   - safety
-  - pip
-  - pip:
-    - od
-    - sigtools
-    - clize
-    - timezonefinder==4.2.0
-    - pytz==2020.5

--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -17,15 +17,15 @@ dependencies:
   - numpy
   - python-dateutil
   - python-stratify
-  - pytz
-  - scipy=1.3.3
+  - pytz=2020.5
+  - scipy=1.3
   - sigtools
   - sphinx
   # Optional
   - numba
   - pysteps=1.3.2
   - statsmodels
-  - timezonefinder=4.3.1
+  - timezonefinder=4.1.0
   # Development
   - astroid
   - bandit

--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -17,7 +17,7 @@ dependencies:
   - numpy
   - python-dateutil
   - python-stratify
-  - pytz==2020.5
+  - pytz
   - scipy=1.3.3
   - sigtools
   - sphinx

--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -25,7 +25,7 @@ dependencies:
   - numba
   - pysteps=1.3.2
   - statsmodels
-  - timezonefinder
+  - timezonefinder=4.3.1
   # Development
   - astroid
   - bandit

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     netCDF4
     numpy
     python-dateutil
-    pytz == 2020.5
+    pytz
     scipy >= 1.3.0, < 1.4.0
     scitools-iris >= 2.2, < 3.0
     sigtools
@@ -55,4 +55,4 @@ full =
     numba
     pysteps == 1.3.2
     statsmodels
-    timezonefinder == 4.1.0
+    timezonefinder

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     netCDF4
     numpy
     python-dateutil
-    pytz
+    pytz == 2020.5
     scipy >= 1.3.0, < 1.4.0
     scitools-iris >= 2.2, < 3.0
     sigtools
@@ -43,14 +43,16 @@ dev =
     astroid
     bandit
     black == 19.10b0
+    codacy-coverage
     filelock
     isort == 4.3.21
     mock
     pylint
     pytest
+    pytest-cov
     safety
 full =
     numba
-    pysteps
+    pysteps == 1.3.2
     statsmodels
-    timezonefinder
+    timezonefinder == 4.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     python-dateutil
     pytz
     scipy >= 1.3.0, < 1.4.0
-    scitools-iris >= 2.2
+    scitools-iris >= 2.2, < 3.0
     sigtools
     sphinx
     stratify

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,12 +19,18 @@ setup_requires =
     setuptools >= 38.3.0
     setuptools_scm
 install_requires =
+    cartopy
     cftime == 1.0.1
+    cf_units
     clize
+    dask
+    netCDF4
     numpy
-    sigtools
+    python-dateutil
+    pytz
     scipy >= 1.3.0, < 1.4.0
     scitools-iris >= 2.2
+    sigtools
     sphinx
     stratify
 scripts = bin/improver
@@ -44,5 +50,7 @@ dev =
     pytest
     safety
 full =
+    numba
     pysteps
+    statsmodels
     timezonefinder


### PR DESCRIPTION
Addresses #1435 

Add missing dependencies to `setup.cfg`. These are packages that are imported directly in IMPROVER code but were not listed as dependencies.

This PR also updates the Python 3.7 / Iris 2.4 Conda environment file. This includes removing pip and packages installed with pip from PyPI as all packages are now available from conda-forge.

There is also a PR for the conda-forge feedstock adding these changes there too: see https://github.com/conda-forge/improver-feedstock/pull/2

Testing:
 - [x] Ran tests and they passed OK
