### PR TITLE
Upgrades isort version from 4.3.21 to 5.7.0

### DIFF
--- a/envs/environment_py36_iris22.yml
+++ b/envs/environment_py36_iris22.yml
@@ -22,7 +22,7 @@ dependencies:
   - filelock
   - mock
   - pysteps
-  - isort=4.3.21
+  - isort=5.7.0
   - black=19.10b0
   - bandit
   - safety

--- a/improver/cli/combine.py
+++ b/improver/cli/combine.py
@@ -71,10 +71,9 @@ def process(
         result (iris.cube.Cube):
             Returns a cube with the combined data.
     """
-    from improver.cube_combiner import CubeCombiner, CubeMultiplier
     from iris.cube import CubeList
 
-    from improver.cube_combiner import CubeCombiner
+    from improver.cube_combiner import CubeCombiner, CubeMultiplier
 
     if not cubes:
         raise TypeError("A cube is needed to be combined.")

--- a/improver/cli/map_to_timezones.py
+++ b/improver/cli/map_to_timezones.py
@@ -61,6 +61,7 @@ def process(
             Processed cube.
     """
     from datetime import datetime
+
     from improver.utilities.temporal import TimezoneExtraction
 
     local_datetime = datetime.strptime(local_time, "%Y%m%dT%H%M")

--- a/improver/cli/shower_condition.py
+++ b/improver/cli/shower_condition.py
@@ -52,6 +52,7 @@ def process(*cubes: cli.inputcube):
 
     """
     from iris.cube import CubeList
+
     from improver.precipitation_type.shower_condition import ShowerCondition
 
     return ShowerCondition()(CubeList(cubes))

--- a/improver/cli/snow_fraction.py
+++ b/improver/cli/snow_fraction.py
@@ -55,7 +55,8 @@ def process(*cubes: cli.inputcube, model_id_attr: str = None):
             A single cube containing the snow-fraction data.
 
     """
-    from improver.precipitation_type.snow_fraction import SnowFraction
     from iris.cube import CubeList
+
+    from improver.precipitation_type.snow_fraction import SnowFraction
 
     return SnowFraction(model_id_attr=model_id_attr)(CubeList(cubes))

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ dev =
     bandit
     black == 19.10b0
     filelock
-    isort == 4.3.21
+    isort == 5.7.0
     mock
     pylint
     pytest


### PR DESCRIPTION
Upgrades isort version to https://github.com/PyCQA/isort/releases/tag/5.7.0 in line with Met Office support.

Testing:
 - [x] Ran tests and they passed OK
