### PR TITLE
Fixing attrs version in environments

### DIFF
--- a/envs/environment_py36_iris22.yml
+++ b/envs/environment_py36_iris22.yml
@@ -14,6 +14,7 @@ dependencies:
   - cftime=1.0.1
   - python-stratify=0.1
   - sphinx=3.4.3
+  - attrs=19.1.0
   - pytest
   - pytest-cov
   - codacy-coverage

--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - python=3.7
   # Required
+  - attrs=19.1.0
   - cartopy
   - cftime=1.0.1
   - cf_units


### PR DESCRIPTION
The version of attrs built with these environments varies depending upon the dependency solver. Clize uses attr functionality that was deprecated beyond version 19.1.0, so that version is hardcoded by this PR. This issue manifests in problems building documentation for the CLIs; I am not aware of any functional issues when using the CLIs.

Once clize loses this dependency this strict version setting should be removed.

Addresses #1449 

Testing:
 - [x] Ran tests and they passed OK