### PR TITLE
Fix metadata interpreter acceptance tests skipping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
-        pytest -m "not acc" --cov=improver --cov-report xml:coverage.xml
+        pytest --cov=improver --cov-report xml:coverage.xml
     - name: codacy-coverage
       if: env.CODACY_PROJECT_TOKEN
       run: |

--- a/improver_tests/acceptance/test_interpret_metadata.py
+++ b/improver_tests/acceptance/test_interpret_metadata.py
@@ -37,7 +37,7 @@ from clize.errors import UnknownOption
 
 from . import acceptance as acc
 
-pytestmark = [pytest.mark.acc]
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
 CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 


### PR DESCRIPTION
Fix acceptance tests for the metadata interpreter missing the `skip_if_kgo_missing` check. This causes the acceptance tests to fail rather than be skipped when running without KGO data available (eg. `IMPROVER_ACC_TEST_DIR` environment variable not set).

Change the github actions configuration to remove the marker specification - this was causing the acceptance tests to be ignored during pytest test discovery rather than the tests skipping being checked on Github actions. This change will cause the other issue to be picked up as part of Github actions.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)