### PR TITLE
Flake8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
     - uses: codecov/codecov-action@v1
-  Codestyle-and-Pylint:
+  Codestyle-and-flake8:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -94,11 +94,6 @@ jobs:
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
         flake8 improver improver_tests || true
-    - name: pylint
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate improver_${{ matrix.env }}
-        pylint -j 0 -E --rcfile=etc/pylintrc improver improver_tests
   Safety-Bandit:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,11 @@ jobs:
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
         black --check .
+    - name: flake8
+      run: |
+        source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda activate improver_${{ matrix.env }}
+        flake8 improver improver_tests
     - name: pylint
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,10 +88,12 @@ jobs:
         conda activate improver_${{ matrix.env }}
         black --check .
     - name: flake8
+      # flake8 is run but failures are ignored
+      # Remove `|| true` to cause failure to fail CI job
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate improver_${{ matrix.env }}
-        flake8 improver improver_tests
+        flake8 improver improver_tests || true
     - name: pylint
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -66,15 +66,8 @@ function improver_test_isort {
     echo_ok "isort"
 }
 
-function improver_test_pylint {
-    # Pylint score generation.
-    ${PYLINT:-pylint} --rcfile=etc/pylintrc $FILES_TO_TEST
-}
-
-function improver_test_pylintE {
-    # Pylint obvious-errors-only testing.
-    ${PYLINT:-pylint} -E --rcfile=etc/pylintrc $FILES_TO_TEST
-    echo_ok "pylint -E"
+function improver_test_flake8 {
+    ${FLAKE8:-flake8} $FILES_TO_TEST
 }
 
 function improver_test_doc {
@@ -108,7 +101,6 @@ function improver_test_recreate_checksums {
     echo_ok "Checksums recreated"
 }
 
-
 function improver_test_cli {
     # CLI testing.
 
@@ -137,7 +129,7 @@ function print_usage {
     cat <<'__USAGE__'
 improver tests [OPTIONS] [SUBTEST...] [SUBCLI...]
 
-Run black, isort, pylint, documentation, unit and CLI acceptance tests.
+Run black, isort, flake8, documentation, unit and CLI acceptance tests.
 
 Optional arguments:
     --debug         Run in verbose mode (may take longer for CLI)
@@ -145,13 +137,11 @@ Optional arguments:
 
 Arguments:
     SUBTEST         Name(s) of a subtest to run without running the rest.
-                    Valid names are: black, isort, pylint, pylintE,
-                    doc, unit, cli, and recreate_checksums. The default tests
-                    are black, isort, pylintE, doc, unit,
-                    and cli.
-                    Using recreate_checksums will regenerate the
-                    test data checksum file which is used as part of the cli
-                    tests.
+                    Valid names are: black, isort, flake8, doc, unit, cli,
+                    and recreate_checksums. The default tests are black,
+                    isort, flake8, doc, unit, and cli.  Using
+                    recreate_checksums will regenerate the test data
+                    checksum file which is used as part of the cli tests.
 __USAGE__
 }
 
@@ -192,7 +182,7 @@ for arg in "$@"; do
         print_usage
         exit 0
         ;;
-        black|isort|pylint|pylintE|doc|unit|cli|recreate_checksums)
+        black|isort|flake8|doc|unit|cli|recreate_checksums)
         SUBTESTS="$SUBTESTS $arg"
         ;;
         $cli_tasks)
@@ -210,7 +200,7 @@ if [[ -n "$SUBTESTS" ]]; then
     TESTS="$SUBTESTS"
 else
     # Default tests.
-    TESTS="isort black pylintE doc unit cli"
+    TESTS="isort black flake8 doc unit cli"
 fi
 
 # If cli sub test is not specified by user, do all cli tests.

--- a/envs/environment_py36_iris22.yml
+++ b/envs/environment_py36_iris22.yml
@@ -17,7 +17,6 @@ dependencies:
   - pytest
   - pytest-cov
   - codacy-coverage
-  - pylint=2.4.4
   - astroid=2.3.3
   - filelock
   - mock

--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -36,7 +36,6 @@ dependencies:
   - isort=5.*
   - mock
   - mypy
-  - pylint
   - pytest
   - pytest-cov
   - safety

--- a/envs/environment_py37_iris24.yml
+++ b/envs/environment_py37_iris24.yml
@@ -32,6 +32,7 @@ dependencies:
   - black=19.10b0
   - codacy-coverage
   - filelock
+  - flake8
   - isort=5.*
   - mock
   - mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,11 @@ full =
     statsmodels
     timezonefinder
 
+[flake8]
+max-line-length = 88
+select = C,E,F,W
+extend-ignore = E203,W503
+
 [mypy]
 ignore_missing_imports = True
 exclude = cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ dev =
     isort == 5.*
     mock
     mypy
-    pylint
     pytest
     pytest-cov
     safety

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ full =
     timezonefinder
 
 [flake8]
-max-line-length = 88
+max-line-length = 100
 select = C,E,F,W
 extend-ignore = E203,W503
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ full =
 [flake8]
 max-line-length = 100
 select = C,E,F,W
-extend-ignore = E203,W503
+extend-ignore = E203,E731,W503
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
Addresses #1462 

This small PR adds [flake8](https://flake8.pycqa.org/) linting to GitHub Actions. This adds flake8 as a "development dependency" to the Python 3.7 conda environment file. I have also added a config block for flake8 in setup.cfg to make it compatible with black, see [here](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8).

Currently the action is failing to pass. There are a few changes required, some of which may require some discussion of the approach required. E.g. stylistic things such as "E731 do not assign a lambda expression, ...".

Testing:
 - [x] Ran tests and they passed OK
