### PR TITLE
Add one more acceptance test for new regridding

### DIFF
--- a/improver_tests/acceptance/test_regrid.py
+++ b/improver_tests/acceptance/test_regrid.py
@@ -45,7 +45,7 @@ run_cli = acc.run_cli(CLI)
 
 def test_regrid_basic(tmp_path):
     """Test basic regridding"""
-    # KGO for this test is the same as test_regrid_check_landmask below
+    # KGO for this test (deafult: bilinear) is the same as test_regrid_bilinear_2
     kgo_dir = acc.kgo_root() / "regrid"
     kgo_path = kgo_dir / "basic/kgo.nc"
     input_path = kgo_dir / "global_cutout.nc"
@@ -56,15 +56,15 @@ def test_regrid_basic(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
-def test_regrid_bilinear(tmp_path):
+def test_regrid_bilinear_2(tmp_path):
     """Test bilinear-2 regridding"""
-    # KGO for this test is the same as test_regrid_check_landmask below
+    # KGO for this test is the same as test_regrid_basic
+    # bilinear-2 regridding produces the same result as Iris/bilinear regridding
     kgo_dir = acc.kgo_root() / "regrid"
     kgo_path = kgo_dir / "basic/kgo.nc"
     input_path = kgo_dir / "global_cutout.nc"
     target_path = kgo_dir / "ukvx_grid.nc"
     output_path = tmp_path / "output.nc"
-    # args = [input_path, target_path, "--output", output_path]
     args = [
         input_path,
         target_path,
@@ -148,7 +148,6 @@ def test_regrid_nearest_landmask(tmp_path):
 @pytest.mark.slow
 def test_regrid_check_landmask(tmp_path):
     """Test land sea mask output matches other test"""
-    # KGO for this test is the same as test_basic above
     kgo_dir = acc.kgo_root() / "regrid"
     kgo_path = kgo_dir / "nearest/kgo.nc"
     input_path = kgo_dir / "global_cutout.nc"

--- a/improver_tests/acceptance/test_regrid.py
+++ b/improver_tests/acceptance/test_regrid.py
@@ -56,6 +56,27 @@ def test_regrid_basic(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
+def test_regrid_bilinear(tmp_path):
+    """Test bilinear-2 regridding"""
+    # KGO for this test is the same as test_regrid_check_landmask below
+    kgo_dir = acc.kgo_root() / "regrid"
+    kgo_path = kgo_dir / "basic/kgo.nc"
+    input_path = kgo_dir / "global_cutout.nc"
+    target_path = kgo_dir / "ukvx_grid.nc"
+    output_path = tmp_path / "output.nc"
+    # args = [input_path, target_path, "--output", output_path]
+    args = [
+        input_path,
+        target_path,
+        "--output",
+        output_path,
+        "--regrid-mode",
+        "bilinear-2",
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
 def test_regrid_nearest(tmp_path):
     """Test nearest neighbour regridding"""
     kgo_dir = acc.kgo_root() / "regrid"
@@ -227,7 +248,7 @@ def test_regrid_nearest_2_multi_realization(tmp_path):
 
 
 def test_regrid_bilinear_2_multi_realization(tmp_path):
-    """Test bilinear-2 neighbour regridding"""
+    """Test bilinear-2 regridding"""
     kgo_dir = acc.kgo_root() / "regrid"
     kgo_path = kgo_dir / "bilinear_2/kgo_multi_realization.nc"
     input_path = kgo_dir / "landmask/global_cutout_multi_realization.nc"

--- a/improver_tests/acceptance/test_regrid.py
+++ b/improver_tests/acceptance/test_regrid.py
@@ -45,7 +45,7 @@ run_cli = acc.run_cli(CLI)
 
 def test_regrid_basic(tmp_path):
     """Test basic regridding"""
-    # KGO for this test (deafult: bilinear) is the same as test_regrid_bilinear_2
+    # KGO for this test (default: bilinear) is the same as test_regrid_bilinear_2
     kgo_dir = acc.kgo_root() / "regrid"
     kgo_path = kgo_dir / "basic/kgo.nc"
     input_path = kgo_dir / "global_cutout.nc"


### PR DESCRIPTION
Addresses #1464 

Description:   

Add one more acceptance test for bilinear without land-sea mask awareness , as suggested by Fiona.
The new bilinear-2 regridding option should produce the same result as the original bilinear regridding option.
Therefore, this added test shares the existing kgo.nc with  the original bilinear regridding test, and no new acceptance data file is required.

It addressed the last item in https://github.com/metoppv/improver/issues/1464. 

Testing:
 - [Y] Ran tests and they passed OK
 - [ Y] Added new tests for the new feature(s)
