### PR TITLE
compare_coords function modified to accept ignored_coords list

### DIFF
--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -400,13 +400,16 @@ def compare_attributes(
     return unmatching_attributes
 
 
-def compare_coords(cubes: CubeList) -> List[Dict]:
+def compare_coords(cubes: CubeList, ignored_coords: List = []) -> List[Dict]:
     """
     Function to compare the coordinates of the cubes
 
     Args:
         cubes:
             List of cubes to compare (must be more than 1)
+        ignored_coords:
+            List of coordinate names that identify coordinates to exclude from
+            the comparison.
 
     Returns:
         List of dictionaries of unmatching coordinates
@@ -437,7 +440,7 @@ def compare_coords(cubes: CubeList) -> List[Dict]:
         for i, cube in enumerate(cubes):
             unmatching_coords.append({})
             for coord in cube.coords():
-                if coord not in common_coords:
+                if coord not in common_coords and coord.name() not in ignored_coords:
                     dim_coords = cube.dim_coords
                     if coord in dim_coords:
                         dim_val = dim_coords.index(coord)

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -400,7 +400,9 @@ def compare_attributes(
     return unmatching_attributes
 
 
-def compare_coords(cubes: CubeList, ignored_coords: List = []) -> List[Dict]:
+def compare_coords(
+    cubes: CubeList, ignored_coords: Optional[List[str]] = None
+) -> List[Dict]:
     """
     Function to compare the coordinates of the cubes
 
@@ -420,6 +422,9 @@ def compare_coords(cubes: CubeList, ignored_coords: List = []) -> List[Dict]:
     Warns:
         Warning: If only a single cube is supplied
     """
+    if ignored_coords is None:
+        ignored_coords = []
+
     unmatching_coords = []
     if len(cubes) == 1:
         msg = "Only a single cube so no differences will be found "

--- a/improver/wind_calculations/wind_components.py
+++ b/improver/wind_calculations/wind_components.py
@@ -206,7 +206,10 @@ class ResolveWindComponents(BasePlugin):
             raise ValueError("{} {}".format(wind_dir.name(), msg))
 
         # check input cube coordinates match
-        unmatched_coords = compare_coords([wind_speed, wind_dir])
+        ignored_coords = ["wind_from_direction status_flag", "wind_speed status_flag"]
+        unmatched_coords = compare_coords(
+            [wind_speed, wind_dir], ignored_coords=ignored_coords
+        )
         if unmatched_coords != [{}, {}]:
             msg = "Wind speed and direction cubes have unmatched coordinates"
             raise ValueError("{} {}".format(msg, unmatched_coords))

--- a/improver_tests/utilities/cube_manipulation/test_compare_coords.py
+++ b/improver_tests/utilities/cube_manipulation/test_compare_coords.py
@@ -64,6 +64,7 @@ class Test_compare_coords(unittest.TestCase):
         cubelist = iris.cube.CubeList([cube1, cube2])
         result = compare_coords(cubelist)
         self.assertIsInstance(result, list)
+        self.assertEqual(result, [{}, {}])
 
     @ManageWarnings(record=True)
     def test_catch_warning(self, warning_list=None):
@@ -136,6 +137,19 @@ class Test_compare_coords(unittest.TestCase):
         self.assertEqual(result[1]["model"]["coord"], self.extra_aux_coord)
         self.assertEqual(result[1]["model"]["data_dims"], None)
         self.assertEqual(result[1]["model"]["aux_dims"], 0)
+
+    def test_second_cube_has_extra_ignored_coordinate(self):
+        """Test for comparing coordinate between cubes, where the second
+        cube in the list has an extra dimension coordinate which is
+        explicitly ignored in the comparison."""
+        cube1 = self.cube.copy()
+        cube2 = self.cube.copy()
+        cube2.add_aux_coord(self.extra_dim_coord)
+        cube2 = iris.util.new_axis(cube2, "height")
+        cubelist = iris.cube.CubeList([cube1, cube2])
+        result = compare_coords(cubelist, ignored_coords=["height"])
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, [{}, {}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The compare_coords function now accepts an additional argument that takes the form of a list of coordinate names. This list is checked when cycling through the cubes to ensure that the presence / absence of a coordinate in this list from one or more cubes is not flagged as a difference. Differences in values for an ignored coordinate are also ignored.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)