### PR TITLE
add rtol for calculating grid spacing

### DIFF
--- a/improver/regrid/grid.py
+++ b/improver/regrid/grid.py
@@ -66,8 +66,8 @@ def calculate_input_grid_spacing(cube_in: Cube) -> Tuple[float, float]:
         raise ValueError("Input grid is not on a latitude/longitude system")
 
     # calculate grid spacing
-    lon_spacing = calculate_grid_spacing(cube_in, "degree", axis="x", rtol=7.0e-5)
-    lat_spacing = calculate_grid_spacing(cube_in, "degree", axis="y", rtol=7.0e-5)
+    lon_spacing = calculate_grid_spacing(cube_in, "degree", axis="x", rtol=3.0e-5)
+    lat_spacing = calculate_grid_spacing(cube_in, "degree", axis="y", rtol=3.0e-5)
 
     if lon_spacing < 0 or lat_spacing < 0:
         raise ValueError("Input grid coordinates are not ascending.")

--- a/improver/regrid/grid.py
+++ b/improver/regrid/grid.py
@@ -66,8 +66,8 @@ def calculate_input_grid_spacing(cube_in: Cube) -> Tuple[float, float]:
         raise ValueError("Input grid is not on a latitude/longitude system")
 
     # calculate grid spacing
-    lon_spacing = calculate_grid_spacing(cube_in, "degree", axis="x", rtol=1.0e-5)
-    lat_spacing = calculate_grid_spacing(cube_in, "degree", axis="y", rtol=1.0e-5)
+    lon_spacing = calculate_grid_spacing(cube_in, "degree", axis="x", rtol=7.0e-5)
+    lat_spacing = calculate_grid_spacing(cube_in, "degree", axis="y", rtol=7.0e-5)
 
     if lon_spacing < 0 or lat_spacing < 0:
         raise ValueError("Input grid coordinates are not ascending.")

--- a/improver/regrid/grid.py
+++ b/improver/regrid/grid.py
@@ -66,8 +66,8 @@ def calculate_input_grid_spacing(cube_in: Cube) -> Tuple[float, float]:
         raise ValueError("Input grid is not on a latitude/longitude system")
 
     # calculate grid spacing
-    lon_spacing = calculate_grid_spacing(cube_in, "degree", axis="x", rtol=3.0e-5)
-    lat_spacing = calculate_grid_spacing(cube_in, "degree", axis="y", rtol=3.0e-5)
+    lon_spacing = calculate_grid_spacing(cube_in, "degree", axis="x", rtol=4.0e-5)
+    lat_spacing = calculate_grid_spacing(cube_in, "degree", axis="y", rtol=4.0e-5)
 
     if lon_spacing < 0 or lat_spacing < 0:
         raise ValueError("Input grid coordinates are not ascending.")

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -70,8 +70,8 @@ def check_if_grid_is_equal_area(
             axis (from calculate_grid_spacing)
         ValueError: If point spacing is not equal for the two spatial axes
     """
-    x_diff = calculate_grid_spacing(cube, "metres", axis="x")
-    y_diff = calculate_grid_spacing(cube, "metres", axis="y")
+    x_diff = calculate_grid_spacing(cube, "metres", axis="x", rtol=7.0e-5)
+    y_diff = calculate_grid_spacing(cube, "metres", axis="y", rtol=7.0e-5)
     if require_equal_xy_spacing and not np.isclose(x_diff, y_diff):
         raise ValueError("Grid does not have equal spacing in x and y dimensions")
 
@@ -144,7 +144,7 @@ def distance_to_number_of_grid_cells(
         raise ValueError(f"Please specify a positive distance in metres. {d_error}")
 
     # calculate grid spacing along chosen axis
-    grid_spacing_metres = calculate_grid_spacing(cube, "metres", axis=axis)
+    grid_spacing_metres = calculate_grid_spacing(cube, "metres", axis=axis, rtol=7.0e-5)
     grid_cells = distance / abs(grid_spacing_metres)
 
     if return_int:
@@ -171,7 +171,7 @@ def number_of_grid_cells_to_distance(cube: Cube, grid_points: int) -> float:
         The radius in metres.
     """
     check_if_grid_is_equal_area(cube)
-    spacing = calculate_grid_spacing(cube, "metres")
+    spacing = calculate_grid_spacing(cube, "metres", rtol=7.0e-5)
     radius_in_metres = spacing * grid_points
     return radius_in_metres
 

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -70,14 +70,14 @@ def check_if_grid_is_equal_area(
             axis (from calculate_grid_spacing)
         ValueError: If point spacing is not equal for the two spatial axes
     """
-    x_diff = calculate_grid_spacing(cube, "metres", axis="x", rtol=7.0e-5)
-    y_diff = calculate_grid_spacing(cube, "metres", axis="y", rtol=7.0e-5)
+    x_diff = calculate_grid_spacing(cube, "metres", axis="x")
+    y_diff = calculate_grid_spacing(cube, "metres", axis="y")
     if require_equal_xy_spacing and not np.isclose(x_diff, y_diff):
         raise ValueError("Grid does not have equal spacing in x and y dimensions")
 
 
 def calculate_grid_spacing(
-    cube: Cube, units: Union[Unit, str], axis: str = "x", rtol: float = 0.0
+    cube: Cube, units: Union[Unit, str], axis: str = "x", rtol: float = 1.0e-6
 ) -> float:
     """
     Returns the grid spacing of a given spatial axis
@@ -144,7 +144,7 @@ def distance_to_number_of_grid_cells(
         raise ValueError(f"Please specify a positive distance in metres. {d_error}")
 
     # calculate grid spacing along chosen axis
-    grid_spacing_metres = calculate_grid_spacing(cube, "metres", axis=axis, rtol=7.0e-5)
+    grid_spacing_metres = calculate_grid_spacing(cube, "metres", axis=axis)
     grid_cells = distance / abs(grid_spacing_metres)
 
     if return_int:
@@ -171,7 +171,7 @@ def number_of_grid_cells_to_distance(cube: Cube, grid_points: int) -> float:
         The radius in metres.
     """
     check_if_grid_is_equal_area(cube)
-    spacing = calculate_grid_spacing(cube, "metres", rtol=7.0e-5)
+    spacing = calculate_grid_spacing(cube, "metres")
     radius_in_metres = spacing * grid_points
     return radius_in_metres
 

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -77,7 +77,7 @@ def check_if_grid_is_equal_area(
 
 
 def calculate_grid_spacing(
-    cube: Cube, units: Union[Unit, str], axis: str = "x", rtol: float = 1.0e-6
+    cube: Cube, units: Union[Unit, str], axis: str = "x", rtol: float = 1.0e-5
 ) -> float:
     """
     Returns the grid spacing of a given spatial axis

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -270,7 +270,7 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
         with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
 
-    def test_lat_lon_equal_spacing_recurring_decimal_spacing_2(self):
+    def test_lat_lon_equal_spacing_recurring_decimal_spacing_passes(self):
         """Test grid spacing outputs with lat-lon grid with 1/3 degree
         intervals with tolerance of 3.0e-5"""
         self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -255,15 +255,15 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
 
     def test_lat_lon_equal_spacing_recurring_decimal_spacing_fails(self):
         """Test grid spacing with lat-lon grid with with 1/3 degree
-        intervals with tolerance of1.0e-5"""
+        intervals with tolerance of 1.0e-5"""
         self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds
         msg = "Coordinate longitude points are not equally spaced"
         with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
 
-    def test_lat_lon_equal_spacing_recurring_decimal_spacing_2(self):
+    def test_lat_lon_equal_spacing_recurring_decimal_spacing_passes(self):
         """Test grid spacing outputs with lat-lon grid with 1/3 degree
-        intervals with tolerance of 3.0e-5"""
+        intervals with tolerance of 4.0e-5"""
         self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds
         result = calculate_grid_spacing(
             self.lat_lon_cube, "degrees", rtol=self.rtol_thirds

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -263,7 +263,7 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
 
     def test_lat_lon_equal_spacing_recurring_decimal_spacing_fails(self):
-        """Test grid spacing with lat-lon grid with with 1/3 degree 
+        """Test grid spacing with lat-lon grid with with 1/3 degree
         intervals with tolerance of 1.0e-5"""
         self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds
         msg = "Coordinate longitude points are not equally spaced"

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -228,8 +228,17 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
             10.0,
             20.00001,
         ]
+        self.longitude_points_2 = [
+            160.0,
+            160.33333,
+            160.66667,
+            161.0,
+            161.33333,
+        ]
         self.rtol = 1.0e-5
         self.expected = 10.0
+        self.expected_2 = 0.33333
+        self.rtol_2 = 3.0e-5
 
     def test_lat_lon_equal_spacing(self):
         """Test grid spacing outputs with lat-lon grid with tolerance"""
@@ -252,6 +261,19 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
         msg = "Coordinate longitude points are not equally spaced"
         with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
+
+    def test_lat_lon_equal_spacing_recurring_decimal_spacing(self):
+        """Test grid spacing outputs with lat-lon grid with tolerance"""
+        self.lat_lon_cube.coord("longitude").points = self.longitude_points_2
+        msg = "Coordinate longitude points are not equally spaced"
+        with self.assertRaisesRegex(ValueError, msg):
+            calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
+
+    def test_lat_lon_equal_spacing_recurring_decimal_spacing_2(self):
+        """Test grid spacing outputs with lat-lon grid with tolerance 3.0e-5"""
+        self.lat_lon_cube.coord("longitude").points = self.longitude_points_2
+        result = calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol_2)
+        self.assertAlmostEqual(result, self.expected_2, places=5)
 
 
 class Test_convert_distance_into_number_of_grid_cells(IrisTest):

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -228,7 +228,7 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
             10.0,
             20.00001,
         ]
-        self.longitude_points_2 = [
+        self.longitude_points_thirds = [
             160.0,
             160.33333,
             160.66667,
@@ -237,8 +237,8 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
         ]
         self.rtol = 1.0e-5
         self.expected = 10.0
-        self.expected_2 = 0.33333
-        self.rtol_2 = 3.0e-5
+        self.expected_thirds = 0.33333
+        self.rtol_thirds = 3.0e-5
 
     def test_lat_lon_equal_spacing(self):
         """Test grid spacing outputs with lat-lon grid with tolerance"""
@@ -262,18 +262,22 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
         with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
 
-    def test_lat_lon_equal_spacing_recurring_decimal_spacing(self):
-        """Test grid spacing outputs with lat-lon grid with tolerance"""
-        self.lat_lon_cube.coord("longitude").points = self.longitude_points_2
+    def test_lat_lon_equal_spacing_recurring_decimal_spacing_fails(self):
+        """Test grid spacing with lat-lon grid with with 1/3 degree 
+        intervals with tolerance of 1.0e-5"""
+        self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds
         msg = "Coordinate longitude points are not equally spaced"
         with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
 
     def test_lat_lon_equal_spacing_recurring_decimal_spacing_2(self):
-        """Test grid spacing outputs with lat-lon grid with tolerance 3.0e-5"""
-        self.lat_lon_cube.coord("longitude").points = self.longitude_points_2
-        result = calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol_2)
-        self.assertAlmostEqual(result, self.expected_2, places=5)
+        """Test grid spacing outputs with lat-lon grid with 1/3 degree
+        intervals with tolerance of 3.0e-5"""
+        self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds
+        result = calculate_grid_spacing(
+            self.lat_lon_cube, "degrees", rtol=self.rtol_thirds
+        )
+        self.assertAlmostEqual(result, self.expected_thirds, places=5)
 
 
 class Test_convert_distance_into_number_of_grid_cells(IrisTest):

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -221,24 +221,16 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
     def setUp(self):
         """Set up an equal area cube"""
         super().setUp()
-        self.longitude_points = [
-            -19.99999,
-            -10.0,
-            0.0,
-            10.0,
-            20.00001,
-        ]
-        self.longitude_points_thirds = [
-            160.0,
-            160.33333,
-            160.66667,
-            161.0,
-            161.33333,
-        ]
+        self.longitude_points = np.array(
+            [-19.99999, -10.0, 0.0, 10.0, 20.00001], dtype=np.float32
+        )
+        self.longitude_points_thirds = np.array(
+            [160.0, 160.33333, 160.66667, 161.0, 161.33333], dtype=np.float32
+        )
         self.rtol = 1.0e-5
         self.expected = 10.0
         self.expected_thirds = 0.33333
-        self.rtol_thirds = 3.0e-5
+        self.rtol_thirds = 4.0e-5
 
     def test_lat_lon_equal_spacing(self):
         """Test grid spacing outputs with lat-lon grid with tolerance"""
@@ -248,8 +240,7 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
 
     def test_lat_lon_negative_spacing(self):
         """Test negative grid spacing outputs with lat-lon grid in degrees"""
-        self.longitude_points.reverse()
-        self.lat_lon_cube.coord("longitude").points = self.longitude_points
+        self.lat_lon_cube.coord("longitude").points = self.longitude_points[::-1]
         result = calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
         self.assertAlmostEqual(result, -self.expected)
 
@@ -264,13 +255,13 @@ class Test_calculate_grid_spacing_with_tolerance(GridSpacingTest):
 
     def test_lat_lon_equal_spacing_recurring_decimal_spacing_fails(self):
         """Test grid spacing with lat-lon grid with with 1/3 degree
-        intervals with tolerance of 1.0e-5"""
+        intervals with tolerance of1.0e-5"""
         self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds
         msg = "Coordinate longitude points are not equally spaced"
         with self.assertRaisesRegex(ValueError, msg):
             calculate_grid_spacing(self.lat_lon_cube, "degrees", rtol=self.rtol)
 
-    def test_lat_lon_equal_spacing_recurring_decimal_spacing_passes(self):
+    def test_lat_lon_equal_spacing_recurring_decimal_spacing_2(self):
         """Test grid spacing outputs with lat-lon grid with 1/3 degree
         intervals with tolerance of 3.0e-5"""
         self.lat_lon_cube.coord("longitude").points = self.longitude_points_thirds


### PR DESCRIPTION
I had several running errors during running neighbourhood processing and regridding. 

"ValueError: Coordinate longitude points are not equally spaced"

It is from calculate_grid_spacing function.  It happened for several BOM-commonly-used grids.
Grid spacing is from np.diff(coord). I think that it is reasonable to add rtol=7.0e-5 which made all failure grids passed.

Testing:
 - [X] Ran unit and acceptance tests and they passed OK