### PR TITLE
Update making a release guidelines

### DIFF
--- a/doc/source/Code-Style-Guide.rst
+++ b/doc/source/Code-Style-Guide.rst
@@ -774,19 +774,21 @@ Making a new release
 
 New release steps:
 
-1. On the command line, check out the commit on master that you want
+1. Inform the core developers across institutions and wait for approval.
+2. On the command line, check out the commit on master that you want
    to tag. For a given version such as 1.1.0, run:
    `git tag -a 1.1.0 -m "IMPROVER release 1.1.0"`. Then run:
    `git push upstream 1.1.0`.
-2. Go to `Draft a new
+3. Go to `Draft a new
    release <https://github.com/metoppv/improver/releases/new>`_ page.
    Select your new tag under 'tag version'.
    The **release title** should be the version number (e.g., ``1.1.0``).
    Publish the release after adding any description text.
-3. Update the version number and sha256 checksum in the ``meta.yaml``
+4. Update the version number and sha256 checksum in the ``meta.yaml``
    file of the conda-forge recipe by opening a pull request in the
    `improver-feedstock <https://github.com/conda-forge/improver-feedstock>`_
-   repository. The checksum of the compressed ``.tar.gz`` IMPROVER
+   repository. A pull request may be opened automatically for you, in which
+   case just check it. The checksum of the compressed ``.tar.gz`` IMPROVER
    source code can be obtained via ``openssl sha256 <file name>``.
    Currently the people with write access to the improver-feedstock
    repository are @benfitzpatrick, @PaulAbernethy, @tjtg and @lucyleeow.


### PR DESCRIPTION
We jumped the gun a bit, a bit hypocritically, with making the last tag. I've added text to the release process to help us not do that in the future.