### PR TITLE
Moves position of land-sea-mask in threshold CLI

### DIFF
--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -38,6 +38,7 @@ from improver import cli
 @cli.with_output
 def process(
     cube: cli.inputcube,
+    land_sea_mask: cli.inputcube = None,
     *,
     threshold_values: cli.comma_separated_list = None,
     threshold_config: cli.inputjson = None,
@@ -46,7 +47,6 @@ def process(
     fuzzy_factor: float = None,
     collapse_coord: str = None,
     vicinity: float = None,
-    land_sea_mask: cli.inputcube = None,
 ):
     """Module to apply thresholding to a parameter dataset.
 

--- a/improver_tests/acceptance/test_threshold.py
+++ b/improver_tests/acceptance/test_threshold.py
@@ -146,15 +146,11 @@ def test_collapse_realization_masked_data(tmp_path):
         ([], "kgo.nc"),
         (["--collapse-coord", "realization"], "kgo_collapsed.nc"),
         (
-            [
-                "--land-sea-mask",
-                acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc",
-            ],
+            [acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc",],
             "kgo_landmask.nc",
         ),
         (
             [
-                "--land-sea-mask",
                 acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc",
                 "--collapse-coord",
                 "realization",
@@ -169,8 +165,10 @@ def test_vicinity(tmp_path, extra_args, kgo):
     kgo_path = kgo_dir / kgo
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
+    args = [input_path]
+    if extra_args:
+        args += extra_args
+    args += [
         "--output",
         output_path,
         "--threshold-values",
@@ -180,8 +178,6 @@ def test_vicinity(tmp_path, extra_args, kgo):
         "--vicinity",
         "10000",
     ]
-    if extra_args:
-        args += extra_args
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
@@ -213,10 +209,9 @@ def test_landmask_without_vicinity():
     input_path = kgo_dir / "input.nc"
     args = [
         input_path,
+        acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc",
         "--threshold-values",
         "0.03",
-        "--land-sea-mask",
-        acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc",
     ]
     with pytest.raises(
         ValueError, match="Cannot apply land-mask cube without in-vicinity processing"

--- a/improver_tests/acceptance/test_threshold.py
+++ b/improver_tests/acceptance/test_threshold.py
@@ -146,7 +146,7 @@ def test_collapse_realization_masked_data(tmp_path):
         ([], "kgo.nc"),
         (["--collapse-coord", "realization"], "kgo_collapsed.nc"),
         (
-            [acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc",],
+            [acc.kgo_root() / "threshold" / "vicinity" / "landmask.nc"],
             "kgo_landmask.nc",
         ),
         (


### PR DESCRIPTION
Moves position of land-sea-mask in threshold CLI to be positional so that the suite can supply it as a node.

Addresses #1518 

The suite now supplies ancillary files in the list of input cubes. Therefore, this must be a positional argument, not a keyword argument.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
