### PR TITLE
Altered envs

### DIFF
--- a/envs/environment_py37_iris30.yml
+++ b/envs/environment_py37_iris30.yml
@@ -18,7 +18,7 @@ dependencies:
   - python-dateutil
   - python-stratify
   - pytz=2020.5
-  - scipy=1.6
+  - scipy=1.4.1
   - sigtools
   - sphinx
   # Optional

--- a/envs/environment_py38_iris30.yml
+++ b/envs/environment_py38_iris30.yml
@@ -18,7 +18,7 @@ dependencies:
   - python-dateutil
   - python-stratify
   - pytz=2020.5
-  - scipy=1.6
+  - scipy=1.4.1
   - sigtools
   - sphinx
   # Optional


### PR DESCRIPTION
We use a `truncnorm` distribution for apply-emos, which as of `scipy 1.5.0` is very very slow.

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)
