### PR TITLE
Modifies LightningFromCapePrecip plugin to accept 3h precipitation-rate-max data

### DIFF
--- a/improver_tests/lightning/test_LightningFromCapePrecip.py
+++ b/improver_tests/lightning/test_LightningFromCapePrecip.py
@@ -129,17 +129,19 @@ def test_basic(cape_cube, precip_cube, expected_cube):
     assert np.allclose(result.data, expected_cube.data)
 
 
-def test_3d_cubes(cape_cube, precip_cube, expected_cube):
+def test_3h_cubes(cape_cube, precip_cube, expected_cube):
     """Run the plugin again with 3h cubes"""
     cape_cube.coord("time").points = cape_cube.coord("time").points - 2 * 3600
     bounds = precip_cube.coord("time").bounds
     precip_cube.coord("time").bounds = (bounds[0][0] - 2 * 3600, bounds[0][1])
+    precip_cube.rename("precipitation_rate_max-PT03H")
     expected_cube.coord("time").bounds = (bounds[0][0] - 2 * 3600, bounds[0][1])
     result = LightningFromCapePrecip()(CubeList([cape_cube, precip_cube]))
     assert result.xml().splitlines(keepends=True) == expected_cube.xml().splitlines(
         keepends=True
     )
     assert np.allclose(result.data, expected_cube.data)
+
 
 
 def test_with_model_attribute(cape_cube, precip_cube, expected_cube):
@@ -162,7 +164,7 @@ def break_time_point(cape_cube, precip_cube):
 
 
 def break_time_bound(cape_cube, precip_cube):
-    """Modifies lower bound on precip_cube time coord to be incremented by 1 second and
+    """Modifies upper bound on precip_cube time coord to be incremented by 1 second and
     returns the error message this will trigger"""
     bounds = precip_cube.coord("time").bounds
     precip_cube.coord("time").bounds = (bounds[0][0], bounds[0][1] + 1)

--- a/improver_tests/lightning/test_LightningFromCapePrecip.py
+++ b/improver_tests/lightning/test_LightningFromCapePrecip.py
@@ -143,7 +143,6 @@ def test_3h_cubes(cape_cube, precip_cube, expected_cube):
     assert np.allclose(result.data, expected_cube.data)
 
 
-
 def test_with_model_attribute(cape_cube, precip_cube, expected_cube):
     """Run the plugin with model_id_attr and check the result cube matches the expected_cube"""
     expected_cube.attributes["mosg__model_configuration"] = "gl_ens"


### PR DESCRIPTION
Addresses #1518

We need this so we can generate data for days 6-8 when only 3h data are available.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
