### PR TITLE
Fix Sphinx documentation stylesheet

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -206,9 +206,7 @@ html_static_path = ["../_static"]
 # Added to apply correction css from _static that ensures text in tables
 # wraps. This prevents tables from becoming very wide which necessitates
 # scroll bars.
-html_context = {
-    "css_files": ["_static/theme_overrides.css"],  # override wide tables in RTD theme
-}
+html_css_files = ["theme_overrides.css"]  # override wide tables in RTD theme
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Stylesheets are currently broken on readthedocs  and the resulting appearance of the documentation is degraded. This is caused by the readthedocs sphinx theme not applying due to broken configuration. Similar stylesheet issues occur on local documentation builds via sphinx.

Current readthedocs: https://improver.readthedocs.io/en/latest/index.html
This PR branch: https://improver-tjtg.readthedocs.io/en/fixdocscss/index.html

Testing:
 - [x] Ran tests and they passed OK
 - [n/a] Added new tests for the new feature(s)