### PR TITLE
 Support for a static additional predictor within the CRPS minimisation plugin

### DIFF
--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -38,6 +38,7 @@ Statistics (EMOS).
 
 """
 import warnings
+from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import iris
@@ -61,6 +62,7 @@ from improver.calibration.utilities import (
     flatten_ignoring_masked_data,
     forecast_coords_match,
     merge_land_and_sea,
+    reshape_forecast_predictors,
     statsmodels_available,
 )
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
@@ -227,13 +229,13 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
 
         return optimised_coeffs
 
+    @staticmethod
     def _set_float64_precision(
-        self,
         initial_guess: Union[List[float], ndarray],
-        forecast_predictor_data: ndarray,
-        truth_data: ndarray,
-        forecast_var_data: ndarray,
-    ) -> Tuple[ndarray, ndarray, ndarray, ndarray, float]:
+        forecast_predictors: CubeList,
+        forecast_var: Cube,
+        truth: Cube,
+    ) -> Tuple[ndarray, CubeList, Cube, Cube, float]:
         """Set values to float64 precision and define a square root of pi
         variable for later usage. The increased precision is need for stable
         coefficient calculation.
@@ -250,19 +252,61 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
             as well as defining a square root of pi variable with float64
             precision.
         """
-        return (
-            np.array(initial_guess, dtype=np.float64),
-            forecast_predictor_data.astype(np.float64),
-            truth_data.astype(np.float64),
-            forecast_var_data.astype(np.float64),
-            np.sqrt(np.pi).astype(np.float64),
+        initial_guess = np.array(initial_guess, dtype=np.float64)
+        for index in range(len(forecast_predictors)):
+            forecast_predictors[index].data = forecast_predictors[index].data.astype(
+                np.float64
+            )
+        forecast_var.data = forecast_var.data.astype(np.float64)
+        truth.data = truth.data.astype(np.float64)
+        sqrt_pi = np.sqrt(np.pi).astype(np.float64)
+        return (initial_guess, forecast_predictors, forecast_var, truth, sqrt_pi)
+
+    @staticmethod
+    def _prepare_forecasts(
+        forecast_predictors: CubeList,
+        predictor: str,
+        constr: Optional[iris.Constraint] = None,
+    ) -> np.ndarray:
+        """Prepare forecasts for minimisation by flattening and reshaping.
+
+        Args:
+            forecast_predictors:
+                The forecast predictors to be reshaped.
+            predictor:
+                String to specify the form of the predictor used to calculate
+                the location parameter when estimating the EMOS coefficients.
+                Currently the ensemble mean ("mean") and the ensemble
+                realizations ("realizations") are supported as the predictors.
+            constr:
+                A constraint for selecting the required forecast predictor.
+
+        Returns:
+            Reshaped array with a first dimension representing the flattened
+            spatiotemporal dimensions and an optional second dimension for
+            flattened non-spatiotemporal dimensions (e.g. realizations).
+        """
+        preserve_leading_dimension = (
+            True if predictor.lower() == "realizations" else False
         )
+        partial_func = partial(
+            flatten_ignoring_masked_data,
+            preserve_leading_dimension=preserve_leading_dimension,
+        )
+        forecast_predictor_data = reshape_forecast_predictors(
+            forecast_predictors, constr=constr, func=partial_func
+        )
+        if len(forecast_predictors) > 1:
+            forecast_predictor_data = np.ma.vstack(forecast_predictor_data)
+        else:
+            (forecast_predictor_data,) = forecast_predictor_data
+        return forecast_predictor_data
 
     def _process_points_independently(
         self,
         minimisation_function: Callable,
         initial_guess: Union[List[float], ndarray],
-        forecast_predictor: Cube,
+        forecast_predictors: CubeList,
         truth: Cube,
         forecast_var: Cube,
         predictor: str,
@@ -288,54 +332,77 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
         """
         (
             initial_guess,
-            forecast_predictor.data,
-            forecast_var.data,
-            truth.data,
+            forecast_predictors,
+            forecast_var,
+            truth,
             sqrt_pi,
         ) = self._set_float64_precision(
-            initial_guess, forecast_predictor.data, forecast_var.data, truth.data
+            initial_guess, forecast_predictors, forecast_var, truth
         )
 
+        fp_template = forecast_predictors[0]
         sindex = [
-            forecast_predictor.coord(axis="y"),
-            forecast_predictor.coord(axis="x"),
+            fp_template.coord(axis="y"),
+            fp_template.coord(axis="x"),
         ]
 
+        y_name = truth.coord(axis="y").name()
+        x_name = truth.coord(axis="x").name()
+
         optimised_coeffs = []
-        for index, (fp_slice, truth_slice, fv_slice) in enumerate(
-            zip(
-                forecast_predictor.slices_over(sindex),
-                truth.slices_over(sindex),
-                forecast_var.slices_over(sindex),
-            )
+        for index, (truth_slice, fv_slice) in enumerate(
+            zip(truth.slices_over(sindex), forecast_var.slices_over(sindex))
         ):
-            optimised_coeffs.append(
-                self._minimise_caller(
-                    minimisation_function,
-                    initial_guess[index],
-                    fp_slice.data.T,
-                    truth_slice.data,
-                    fv_slice.data,
-                    sqrt_pi,
-                    predictor,
-                ).x.astype(np.float32)
+            # For site forecasts, with a wmo_id coordinate, the WMO ID is
+            # more reliable as the specific x and y location of a site can
+            # be subject to change.
+            if truth_slice.coords("wmo_id"):
+                constr = iris.Constraint(wmo_id=truth_slice.coord("wmo_id").points)
+            else:
+                constr = iris.Constraint(
+                    coord_values={
+                        y_name: lambda cell: any(
+                            np.isclose(cell.point, truth_slice.coord(axis="y").points)
+                        ),
+                        x_name: lambda cell: any(
+                            np.isclose(cell.point, truth_slice.coord(axis="x").points)
+                        ),
+                    }
+                )
+
+            forecast_predictor_data = self._prepare_forecasts(
+                forecast_predictors, predictor, constr
             )
 
-        y_coord = forecast_predictor.coord(axis="y")
-        x_coord = forecast_predictor.coord(axis="x")
+            if all(np.isnan(truth_slice.data)):
+                optimised_coeffs.append(
+                    np.array(initial_guess[index], dtype=np.float32)
+                )
+            else:
+                optimised_coeffs.append(
+                    self._minimise_caller(
+                        minimisation_function,
+                        initial_guess[index],
+                        forecast_predictor_data.T,
+                        truth_slice.data,
+                        fv_slice.data,
+                        sqrt_pi,
+                        predictor,
+                    ).x.astype(np.float32)
+                )
+        y_coord = fp_template.coord(axis="y")
+        x_coord = fp_template.coord(axis="x")
 
-        if forecast_predictor.coord_dims(y_coord) == forecast_predictor.coord_dims(
-            x_coord
-        ):
+        if fp_template.coord_dims(y_coord) == fp_template.coord_dims(x_coord):
             return np.array(np.transpose(optimised_coeffs)).reshape(
-                (len(initial_guess[0]), len(forecast_predictor.coord(axis="y").points),)
+                (len(initial_guess[0]), len(fp_template.coord(axis="y").points),)
             )
         else:
             return np.array(np.transpose(optimised_coeffs)).reshape(
                 (
                     len(initial_guess[0]),
-                    len(forecast_predictor.coord(axis="y").points),
-                    len(forecast_predictor.coord(axis="x").points),
+                    len(fp_template.coord(axis="y").points),
+                    len(fp_template.coord(axis="x").points),
                 )
             )
 
@@ -343,7 +410,7 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
         self,
         minimisation_function: Callable,
         initial_guess: Union[List[float], ndarray],
-        forecast_predictor: Cube,
+        forecast_predictors: CubeList,
         truth: Cube,
         forecast_var: Cube,
         predictor: str,
@@ -363,39 +430,32 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
         Returns:
             The optimised coefficients. Order of coefficients is [alpha, beta, gamma, delta].
         """
+        (
+            initial_guess,
+            forecast_predictors,
+            forecast_var,
+            truth,
+            sqrt_pi,
+        ) = self._set_float64_precision(
+            initial_guess, forecast_predictors, forecast_var, truth
+        )
+
         # Flatten the data arrays and remove any missing data.
         truth_data = flatten_ignoring_masked_data(truth.data)
         forecast_var_data = flatten_ignoring_masked_data(forecast_var.data)
-        if predictor.lower() == "mean":
-            forecast_predictor_data = flatten_ignoring_masked_data(
-                forecast_predictor.data
-            )
-        elif predictor.lower() == "realizations":
-            # Need to transpose this array so there are columns for each
-            # ensemble member rather than rows.
-            forecast_predictor_data = flatten_ignoring_masked_data(
-                forecast_predictor.data, preserve_leading_dimension=True
-            ).T
-        (
-            initial_guess,
-            forecast_predictor_data,
-            forecast_var_data,
-            truth_data,
-            sqrt_pi,
-        ) = self._set_float64_precision(
-            initial_guess, forecast_predictor_data, forecast_var_data, truth_data
+        forecast_predictor_data = self._prepare_forecasts(
+            forecast_predictors, predictor
         )
 
         optimised_coeffs = self._minimise_caller(
             minimisation_function,
             initial_guess,
-            forecast_predictor_data,
+            forecast_predictor_data.T,
             truth_data,
             forecast_var_data,
             sqrt_pi,
             predictor,
         )
-
         if not optimised_coeffs.success:
             msg = (
                 "Minimisation did not result in convergence after "
@@ -410,7 +470,7 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
     def process(
         self,
         initial_guess: List[float],
-        forecast_predictor: Cube,
+        forecast_predictors: CubeList,
         truth: Cube,
         forecast_var: Cube,
         predictor: str,
@@ -420,16 +480,18 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
         Function to pass a given function to the scipy minimize
         function to estimate optimised values for the coefficients.
 
-        Further information is available in the :mod:`module level docstring \
-<improver.calibration.ensemble_calibration>`.
+        Further information is available in the
+        :mod:`module level docstring <improver.calibration.ensemble_calibration>`.
 
         Args:
             initial_guess:
                 List of optimised coefficients.
                 Order of coefficients is [alpha, beta, gamma, delta].
-            forecast_predictor:
-                Cube containing the fields to be used as the predictor,
-                either the ensemble mean or the ensemble realizations.
+            forecast_predictors:
+                CubeList containing the fields to be used as the predictor.
+                These will include the ensemble mean or realizations of the
+                predictand variable and additional static predictors,
+                as required.
             truth:
                 Cube containing the field, which will be used as truth.
             forecast_var:
@@ -472,13 +534,14 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
         check_predictor(predictor)
 
         if predictor.lower() == "realizations":
-            enforce_coordinate_ordering(forecast_predictor, "realization")
+            for forecast_predictor in forecast_predictors:
+                enforce_coordinate_ordering(forecast_predictor, "realization")
 
         if self.point_by_point:
             optimised_coeffs = self._process_points_independently(
                 minimisation_function,
                 initial_guess,
-                forecast_predictor,
+                forecast_predictors,
                 truth,
                 forecast_var,
                 predictor,
@@ -487,11 +550,12 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
             optimised_coeffs = self._process_points_together(
                 minimisation_function,
                 initial_guess,
-                forecast_predictor,
+                forecast_predictors,
                 truth,
                 forecast_var,
                 predictor,
             )
+
         return optimised_coeffs
 
     def calculate_normal_crps(
@@ -517,8 +581,8 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
                 List of optimised coefficients.
                 Order of coefficients is [alpha, beta, gamma, delta].
             forecast_predictor:
-                Data to be used as the predictor,
-                either the ensemble mean or the ensemble realizations.
+                Data to be used as the predictor, either the ensemble mean
+                or the ensemble realizations.
             truth:
                 Data to be used as truth.
             forecast_var:
@@ -535,17 +599,18 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
             CRPS for the current set of coefficients. This CRPS is a mean
             value across all points.
         """
+        aa, bb, gamma, delta = (
+            initial_guess[0],
+            initial_guess[1:-2],
+            initial_guess[-2],
+            initial_guess[-1],
+        )
+
         if predictor.lower() == "mean":
-            a, b, gamma, delta = initial_guess
-            a_b = np.array([a, b], dtype=np.float64)
+            a_b = np.array([aa, *np.atleast_1d(bb)], dtype=np.float64)
         elif predictor.lower() == "realizations":
-            a, b, gamma, delta = (
-                initial_guess[0],
-                initial_guess[1:-2] * initial_guess[1:-2],
-                initial_guess[-2],
-                initial_guess[-1],
-            )
-            a_b = np.array([a] + b.tolist(), dtype=np.float64)
+            bb = bb * bb
+            a_b = np.array([aa] + bb.tolist(), dtype=np.float64)
 
         new_col = np.ones(truth.shape, dtype=np.float32)
         all_data = np.column_stack((new_col, forecast_predictor))
@@ -587,8 +652,8 @@ class ContinuousRankedProbabilityScoreMinimisers(BasePlugin):
                 List of optimised coefficients.
                 Order of coefficients is [alpha, beta, gamma, delta].
             forecast_predictor:
-                Data to be used as the predictor,
-                either the ensemble mean or the ensemble realizations.
+                Data to be used as the predictor, either the ensemble mean
+                or the ensemble realizations.
             truth:
                 Data to be used as truth.
             forecast_var:
@@ -1135,7 +1200,7 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
         # Calculate coefficients if there are no nans in the initial guess.
         optimised_coeffs = self.minimiser(
             initial_guess,
-            forecast_predictor,
+            CubeList([forecast_predictor]),
             truths,
             forecast_var,
             self.predictor,

--- a/improver/calibration/utilities.py
+++ b/improver/calibration/utilities.py
@@ -34,12 +34,12 @@ specific for ensemble calibration.
 
 """
 import importlib
-from typing import Set, Tuple, Union
+from typing import Callable, List, Optional, Set, Tuple, Union
 
 import iris
 import numpy as np
 from iris.coords import DimCoord
-from iris.cube import Cube
+from iris.cube import Cube, CubeList
 from numpy import ndarray
 from numpy.ma.core import MaskedArray
 
@@ -353,6 +353,42 @@ def check_forecast_consistency(forecasts: Cube) -> None:
     if len(forecasts.coord("forecast_period").points) != 1:
         msg = "Forecasts have been provided with differing forecast periods {}"
         raise ValueError(msg.format(forecasts.coord("forecast_period").points))
+
+
+def reshape_forecast_predictors(
+    forecast_predictors: CubeList,
+    constr: Optional[iris.Constraint] = None,
+    func: Optional[Callable] = lambda x: x,
+) -> List[ndarray]:
+    """Reshape forecast predictors without a time by broadcasting to the required shape.
+
+    Args:
+        forecast_predictors:
+            The forecast predictors to be reshaped.
+        constr:
+            A constraint for selecting the required forecast predictor.
+
+    Returns:
+       Consistently-shaped forecast predictors where static forecast predictors
+       have been reshaped to account for a time dimensions.
+    """
+    reshaped_forecast_predictors = []
+    num_times = [
+        len(fp_cube.coord("time").points)
+        for fp_cube in forecast_predictors
+        if fp_cube.coords("time", dim_coords=True)
+    ]
+    for fp_cube in forecast_predictors:
+        if constr:
+            fp_cube = fp_cube.extract(constr)
+
+        fp_data = fp_cube.data
+        if not fp_cube.coords("time"):
+            # Broadcast static predictors to the required shape.
+            fp_data = np.broadcast_to(fp_data, tuple(num_times) + fp_data.shape)
+
+        reshaped_forecast_predictors.append(func(fp_data))
+    return reshaped_forecast_predictors
 
 
 def statsmodels_available() -> bool:

--- a/improver_tests/calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -32,12 +32,12 @@
 Unit tests for the
 `ensemble_calibration.ContinuousRankedProbabilityScoreMinimisers`
 class.
-
 """
 import unittest
 
 import iris
 import numpy as np
+from iris.cube import CubeList
 from iris.tests import IrisTest
 
 from improver.calibration.ensemble_calibration import (
@@ -77,11 +77,15 @@ class SetupNormalInputs(SetupInputs, SetupCubes):
         """Set up expected inputs."""
         super().setUp()
         # Set up cubes and associated data arrays for temperature.
-        self.forecast_predictor_mean = self.historic_temperature_forecast_cube.collapsed(
-            "realization", iris.analysis.MEAN
+        self.forecast_predictor_mean = CubeList(
+            [
+                self.historic_temperature_forecast_cube.collapsed(
+                    "realization", iris.analysis.MEAN
+                )
+            ]
         )
-        self.forecast_predictor_realizations = (
-            self.historic_temperature_forecast_cube.copy()
+        self.forecast_predictor_realizations = CubeList(
+            [(self.historic_temperature_forecast_cube.copy())]
         )
         self.forecast_variance = self.historic_temperature_forecast_cube.collapsed(
             "realization", iris.analysis.VARIANCE
@@ -89,8 +93,8 @@ class SetupNormalInputs(SetupInputs, SetupCubes):
         self.truth = self.historic_temperature_forecast_cube.collapsed(
             "realization", iris.analysis.MAX
         )
-        self.forecast_predictor_data = self.forecast_predictor_mean.data.flatten().astype(
-            np.float64
+        self.forecast_predictor_data = (
+            self.forecast_predictor_mean[0].data.flatten().astype(np.float64)
         )
         self.forecast_predictor_data_realizations = convert_cube_data_to_2d(
             self.historic_temperature_forecast_cube.copy()
@@ -506,7 +510,7 @@ class Test_process_normal_distribution(
         plugin = Plugin(tolerance=self.tolerance, point_by_point=True)
         result = plugin.process(
             initial_guess,
-            forecast_spot_cube,
+            CubeList([forecast_spot_cube]),
             self.truth_spot_cube,
             forecast_var_spot_cube,
             predictor,
@@ -621,6 +625,50 @@ class Test_process_normal_distribution(
         self.assertTrue(any(warning_msg_min in str(item) for item in warning_list))
         self.assertTrue(any(warning_msg_iter in str(item) for item in warning_list))
 
+    @ManageWarnings(
+        ignored_messages=[
+            "Collapsing a non-contiguous coordinate.",
+            "Minimisation did not result in convergence",
+            "divide by zero encountered in",
+        ],
+        warning_types=[UserWarning, UserWarning, RuntimeWarning],
+    )
+    def test_point_by_point_with_nans(self):
+        """
+        Test that the expected coefficients are generated when the ensemble
+        mean is the predictor for a normal distribution and coefficients are
+        calculated independently at each grid point with one grid point
+        having NaN values for the truth.
+        """
+        predictor = "mean"
+        distribution = "norm"
+
+        initial_guess = np.broadcast_to(
+            self.initial_guess_for_mean,
+            (
+                len(self.truth.coord(axis="y").points)
+                * len(self.truth.coord(axis="x").points),
+                len(self.initial_guess_for_mean),
+            ),
+        )
+
+        self.truth.data[:, 0, 0] = np.nan
+        plugin = Plugin(tolerance=self.tolerance, point_by_point=True)
+        result = plugin.process(
+            initial_guess,
+            self.forecast_predictor_mean,
+            self.truth,
+            self.forecast_variance,
+            predictor,
+            distribution,
+        )
+        self.expected_mean_coefficients_point_by_point[
+            :, 0, 0
+        ] = self.initial_guess_for_mean
+        self.assertEMOSCoefficientsAlmostEqual(
+            result, self.expected_mean_coefficients_point_by_point
+        )
+
 
 class SetupTruncatedNormalInputs(SetupInputs, SetupCubes):
 
@@ -634,11 +682,15 @@ class SetupTruncatedNormalInputs(SetupInputs, SetupCubes):
         """Set up expected inputs."""
         super().setUp()
         # Set up cubes and associated data arrays for wind speed.
-        self.forecast_predictor_mean = self.historic_wind_speed_forecast_cube.collapsed(
-            "realization", iris.analysis.MEAN
+        self.forecast_predictor_mean = CubeList(
+            [
+                self.historic_wind_speed_forecast_cube.collapsed(
+                    "realization", iris.analysis.MEAN
+                )
+            ]
         )
-        self.forecast_predictor_realizations = (
-            self.historic_wind_speed_forecast_cube.copy()
+        self.forecast_predictor_realizations = CubeList(
+            [(self.historic_wind_speed_forecast_cube.copy())]
         )
         self.forecast_variance = self.historic_wind_speed_forecast_cube.collapsed(
             "realization", iris.analysis.VARIANCE
@@ -646,8 +698,8 @@ class SetupTruncatedNormalInputs(SetupInputs, SetupCubes):
         self.truth = self.historic_wind_speed_forecast_cube.collapsed(
             "realization", iris.analysis.MAX
         )
-        self.forecast_predictor_data = self.forecast_predictor_mean.data.flatten().astype(
-            np.float64
+        self.forecast_predictor_data = (
+            self.forecast_predictor_mean[0].data.flatten().astype(np.float64)
         )
         self.forecast_predictor_data_realizations = convert_cube_data_to_2d(
             self.historic_wind_speed_forecast_cube.copy()

--- a/improver_tests/calibration/utilities/test_utilities.py
+++ b/improver_tests/calibration/utilities/test_utilities.py
@@ -39,6 +39,7 @@ import unittest
 
 import iris
 import numpy as np
+from iris.cube import CubeList
 from iris.tests import IrisTest
 from iris.util import squeeze
 from numpy.testing import assert_array_equal
@@ -53,6 +54,7 @@ from improver.calibration.utilities import (
     forecast_coords_match,
     get_frt_hours,
     merge_land_and_sea,
+    reshape_forecast_predictors,
     statsmodels_available,
 )
 from improver.metadata.constants.time_types import TIME_COORDS
@@ -661,6 +663,76 @@ class Test_check_forecast_consistency(IrisTest):
 
         with self.assertRaisesRegex(ValueError, msg):
             check_forecast_consistency(forecasts)
+
+
+class Test_reshape_forecast_predictors(IrisTest):
+
+    """Test the reshape_forecast_predictors function."""
+
+    def setUp(self):
+        """Set-up cubes for testing."""
+        frts = [
+            datetime.datetime(2017, 11, 10, 1, 0),
+            datetime.datetime(2017, 11, 11, 1, 0),
+            datetime.datetime(2017, 11, 12, 1, 0),
+        ]
+        forecast_cubes = CubeList()
+        for frt in frts:
+            forecast_cubes.append(
+                set_up_variable_cube(
+                    np.ones((2, 3, 3), dtype=np.float32),
+                    frt=frt,
+                    time=frt + datetime.timedelta(hours=3),
+                )
+            )
+        self.forecast = forecast_cubes.merge_cube()
+        self.forecast.transpose([1, 0, 2, 3])
+
+        self.altitude = set_up_variable_cube(
+            np.ones((3, 3), dtype=np.float32), name="surface_altitude", units="m"
+        )
+        for coord in ["time", "forecast_reference_time", "forecast_period"]:
+            self.altitude.remove_coord(coord)
+
+        self.expected_forecast = self.forecast.data.shape
+        self.expected_altitude = (
+            len(self.forecast.coord("time").points),
+        ) + self.altitude.shape
+
+    def test_one_forecast_predictor(self):
+        """Test reshaping one forecast predictor"""
+        self.forecast_predictors = iris.cube.CubeList([self.forecast])
+        results = reshape_forecast_predictors(self.forecast_predictors)
+        self.assertEqual(len(results), 1)
+        self.assertTupleEqual(results[0].shape, self.expected_forecast)
+        self.assertArrayEqual(results[0], self.forecast.data)
+
+    def test_two_forecast_predictors(self):
+        """Test reshaping two forecast predictors, where one is a static predictor."""
+        self.forecast_predictors = iris.cube.CubeList([self.forecast, self.altitude])
+        results = reshape_forecast_predictors(self.forecast_predictors)
+        self.assertEqual(len(results), 2)
+        self.assertTupleEqual(results[0].shape, self.expected_forecast)
+        self.assertTupleEqual(results[1].shape, self.expected_altitude)
+
+    def test_constr(self):
+        """Test reshaping two forecast predictors when passing a constraint."""
+        self.forecast_predictors = iris.cube.CubeList([self.forecast, self.altitude])
+        constr = iris.Constraint(
+            latitude=self.forecast.coord("latitude").points[0]
+        ) & iris.Constraint(longitude=self.forecast.coord("longitude").points[0])
+        results = reshape_forecast_predictors(self.forecast_predictors, constr=constr)
+        self.assertTupleEqual(results[0].shape, self.expected_forecast[:2])
+        self.assertTupleEqual(results[1].shape, self.expected_altitude[:1])
+
+    def test_func(self):
+        """Test reshaping two forecast predictors when passing a function."""
+        self.forecast_predictors = iris.cube.CubeList([self.forecast, self.altitude])
+        results = reshape_forecast_predictors(
+            self.forecast_predictors, func=lambda x: np.expand_dims(x, 0)
+        )
+        self.assertTupleEqual(results[0].shape, (1,) + self.expected_forecast)
+        self.assertTupleEqual(results[1].shape, (1,) + self.expected_altitude)
 
 
 class Test_statsmodels_available(IrisTest):


### PR DESCRIPTION
Addresses part of #1537 

Related to #1564 

Description
This PR includes the changes required to the ContinuousRankedProbabilityScoreMinimisers plugin required to support the use of static additional predictors.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

