### PR TITLE
Workaround for slow scipy truncnorm by using the version from 1.3.3

### DIFF
--- a/improver/ensemble_copula_coupling/_scipy_continuous_distns.py
+++ b/improver/ensemble_copula_coupling/_scipy_continuous_distns.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+This module defines the truncnorm as per scipy v1.3.3 to overcome performance
+issue introduced in later versions:
+- https://github.com/scipy/scipy/issues/12370
+- https://github.com/scipy/scipy/issues/12733
+
+"""
+import numpy as np
+import scipy.special as sc
+from scipy.stats._distn_infrastructure import rv_continuous
+
+
+# ============================================================================
+# |                        Copyright SciPy                                   |
+# | Code from this point unto the termination banner is copyright SciPy.     |
+# | License details can be found at scipy.org/scipylib/license.html          |
+# ============================================================================
+
+# Source: https://github.com/scipy/scipy/blob/v1.3.3/scipy/stats/_continuous_\
+# distns.py
+
+
+# In numpy 1.12 and above, np.power refuses to raise integers to negative
+# powers, and `np.float_power` is a new replacement.
+try:
+    float_power = np.float_power
+except AttributeError:
+    float_power = np.power
+
+
+## Normal distribution
+
+# loc = mu, scale = std
+# Keep these implementations out of the class definition so they can be reused
+# by other distributions.
+_norm_pdf_C = np.sqrt(2*np.pi)
+_norm_pdf_logC = np.log(_norm_pdf_C)
+
+
+def _norm_pdf(x):
+    return np.exp(-x**2/2.0) / _norm_pdf_C
+
+
+def _norm_logpdf(x):
+    return -x**2 / 2.0 - _norm_pdf_logC
+
+
+def _norm_cdf(x):
+    return sc.ndtr(x)
+
+
+def _norm_logcdf(x):
+    return sc.log_ndtr(x)
+
+
+def _norm_ppf(q):
+    return sc.ndtri(q)
+
+
+def _norm_sf(x):
+    return _norm_cdf(-x)
+
+
+def _norm_logsf(x):
+    return _norm_logcdf(-x)
+
+
+def _norm_isf(q):
+    return -_norm_ppf(q)
+
+
+class truncnorm_gen(rv_continuous):
+    r"""A truncated normal continuous random variable.
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The standard form of this distribution is a standard normal truncated to
+    the range [a, b] --- notice that a and b are defined over the domain of the
+    standard normal.  To convert clip values for a specific mean and standard
+    deviation, use::
+
+        a, b = (myclip_a - my_mean) / my_std, (myclip_b - my_mean) / my_std
+
+    `truncnorm` takes :math:`a` and :math:`b` as shape parameters.
+
+    %(after_notes)s
+
+    %(example)s
+
+    """
+    def _argcheck(self, a, b):
+        return a < b
+
+    def _get_support(self, a, b):
+        return a, b
+
+    def _get_norms(self, a, b):
+        _nb = _norm_cdf(b)
+        _na = _norm_cdf(a)
+        _sb = _norm_sf(b)
+        _sa = _norm_sf(a)
+        _delta = np.where(a > 0, _sa - _sb, _nb - _na)
+        with np.errstate(divide='ignore'):
+            return _na, _nb, _sa, _sb, _delta, np.log(_delta)
+
+    def _pdf(self, x, a, b):
+        ans = self._get_norms(a, b)
+        _delta = ans[4]
+        return _norm_pdf(x) / _delta
+
+    def _logpdf(self, x, a, b):
+        ans = self._get_norms(a, b)
+        _logdelta = ans[5]
+        return _norm_logpdf(x) - _logdelta
+
+    def _cdf(self, x, a, b):
+        ans = self._get_norms(a, b)
+        _na, _delta = ans[0], ans[4]
+        return (_norm_cdf(x) - _na) / _delta
+
+    def _ppf(self, q, a, b):
+        # XXX Use _lazywhere...
+        ans = self._get_norms(a, b)
+        _na, _nb, _sa, _sb = ans[:4]
+        ppf = np.where(a > 0,
+                       _norm_isf(q*_sb + _sa*(1.0-q)),
+                       _norm_ppf(q*_nb + _na*(1.0-q)))
+        return ppf
+
+    def _stats(self, a, b):
+        ans = self._get_norms(a, b)
+        nA, nB = ans[:2]
+        d = nB - nA
+        pA, pB = _norm_pdf(a), _norm_pdf(b)
+        mu = (pA - pB) / d   # correction sign
+        mu2 = 1 + (a*pA - b*pB) / d - mu*mu
+        return mu, mu2, None, None
+
+
+truncnorm = truncnorm_gen(name='truncnorm')
+
+
+# ============================================================================
+# |                        END SciPy copyright                               |
+# ============================================================================

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -44,6 +44,8 @@ from scipy import stats
 
 from improver import BasePlugin
 from improver.calibration.utilities import convert_cube_data_to_2d
+import improver.ensemble_copula_coupling._scipy_continuous_distns as \
+    scipy_cont_distns
 from improver.ensemble_copula_coupling.utilities import (
     choose_set_of_percentiles,
     concatenate_2d_array_with_2d_array_endpoints,
@@ -727,14 +729,18 @@ calculate_truncated_normal_crps`,
                 a lower bound of zero should be [0, np.inf].
 
         """
-        try:
-            self.distribution = getattr(stats, distribution)
-        except AttributeError as err:
-            msg = (
-                "The distribution requested {} is not a valid distribution "
-                "in scipy.stats. {}".format(distribution, err)
-            )
-            raise AttributeError(msg)
+        if distribution is "truncnorm":
+            # Use scipy v1.3.3 truncnorm
+            self.distribution = scipy_cont_distns.truncnorm
+        else:
+            try:
+                self.distribution = getattr(stats, distribution)
+            except AttributeError as err:
+                msg = (
+                    "The distribution requested {} is not a valid distribution "
+                    "in scipy.stats. {}".format(distribution, err)
+                )
+                raise AttributeError(msg)
 
         if shape_parameters is None:
             if self.distribution.name == "truncnorm":

--- a/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParameters.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParameters.py
@@ -37,6 +37,8 @@ import numpy as np
 from iris.tests import IrisTest
 from scipy import stats
 
+import improver.ensemble_copula_coupling._scipy_continuous_distns as \
+    scipy_cont_distns
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     ConvertLocationAndScaleParameters as Plugin,
 )
@@ -55,7 +57,7 @@ class Test__init__(IrisTest):
     def test_valid_distribution_with_shape_parameters(self):
         """Test for a valid distribution with shape parameters."""
         plugin = Plugin(distribution="truncnorm", shape_parameters=[0, np.inf])
-        self.assertEqual(plugin.distribution, stats.truncnorm)
+        self.assertEqual(plugin.distribution, scipy_cont_distns.truncnorm)
         self.assertEqual(plugin.shape_parameters, [0, np.inf])
 
     def test_error_shape_parameters_required(self):


### PR DESCRIPTION
Addresses #1567

Description

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA

Note that for now this is a draft until I have spent some time understanding the differences in the acceptance test results.