### PR TITLE
Increase leniency of EMOS application

### DIFF
--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -1315,6 +1315,9 @@ class CalibratedForecastDistributionParameters(BasePlugin):
             ValueError: If the points or bounds of the specified axis of the
                 current_forecast and coefficients_cube do not match.
         """
+        # If not spot data, check the spatial domain matches.
+        if self.current_forecast.coords("wmo_id"):
+            return
         msg = (
             "The points or bounds of the {} axis given by the current forecast {} "
             "do not match those given by the coefficients cube {}."

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -1309,13 +1309,14 @@ class CalibratedForecastDistributionParameters(BasePlugin):
     def _spatial_domain_match(self) -> None:
         """
         Check that the domain of the current forecast and coefficients cube
-        match.
+        match of gridded forecast. For spot forecasts, the spatial domain check
+        is skipped.
 
         Raises:
             ValueError: If the points or bounds of the specified axis of the
                 current_forecast and coefficients_cube do not match.
         """
-        # If not spot data, check the spatial domain matches.
+        # If spot data, skip the spatial domain check.
         if self.current_forecast.coords("wmo_id"):
             return
         msg = (

--- a/improver/calibration/utilities.py
+++ b/improver/calibration/utilities.py
@@ -281,28 +281,28 @@ def merge_land_and_sea(calibrated_land_only: Cube, uncalibrated: Cube) -> None:
         calibrated_land_only.data = new_data
 
 
-def floor_fp(cube: Cube) -> np.ndarray:
-    """Floor the forecast period points to the nearest hour.
+def _ceiling_fp(cube: Cube) -> np.ndarray:
+    """Find the ceiling of the forecast period points to the nearest hour.
 
     Args:
         cube:
-            Cube with a forecast_period coordinates.
+            Cube with a forecast_period coordinate.
 
     Returns:
-        The forecast period points floored to the nearest hour.
+        The forecast period points after computing the ceiling to the
+        nearest hour.
     """
     hour_in_secs = 3600
-    return np.floor(cube.coord("forecast_period").points / hour_in_secs)
+    return np.ceil(cube.coord("forecast_period").points / hour_in_secs)
 
 
 def forecast_coords_match(first_cube: Cube, second_cube: Cube) -> None:
     """
     Determine if two cubes have equivalent forecast_periods and
     forecast_reference_time coordinates with an accepted leniency.
-    The forecast period is floored to the nearest hour to enable 15 minute
-    Only the point of the
-    forecast reference time coordinate is checked to ensure that a calibration
-    / coefficient cube matches the forecast cube, as appropriate.
+    The ceiling of the forecast period to the nearest hour is computed to
+    support calibrating subhourly forecasts with coefficients taken from on
+    the hour. For forecast reference time, only the hour is checked.
 
     Args:
         first_cube:
@@ -314,7 +314,7 @@ def forecast_coords_match(first_cube: Cube, second_cube: Cube) -> None:
         ValueError: The two cubes are not equivalent.
     """
     mismatches = []
-    if floor_fp(first_cube) != floor_fp(second_cube):
+    if _ceiling_fp(first_cube) != _ceiling_fp(second_cube):
         mismatches.append("forecast_period hours")
 
     if get_frt_hours(first_cube.coord("forecast_reference_time")) != get_frt_hours(

--- a/improver/calibration/utilities.py
+++ b/improver/calibration/utilities.py
@@ -281,10 +281,26 @@ def merge_land_and_sea(calibrated_land_only: Cube, uncalibrated: Cube) -> None:
         calibrated_land_only.data = new_data
 
 
+def floor_fp(cube: Cube) -> np.ndarray:
+    """Floor the forecast period points to the nearest hour.
+
+    Args:
+        cube:
+            Cube with a forecast_period coordinates.
+
+    Returns:
+        The forecast period points floored to the nearest hour.
+    """
+    hour_in_secs = 3600
+    return np.floor(cube.coord("forecast_period").points / hour_in_secs)
+
+
 def forecast_coords_match(first_cube: Cube, second_cube: Cube) -> None:
     """
-    Determine if two cubes have equivalent forecast_periods and that the hours
-    of the forecast_reference_time coordinates match. Only the point of the
+    Determine if two cubes have equivalent forecast_periods and
+    forecast_reference_time coordinates with an accepted leniency.
+    The forecast period is floored to the nearest hour to enable 15 minute
+    Only the point of the
     forecast reference time coordinate is checked to ensure that a calibration
     / coefficient cube matches the forecast cube, as appropriate.
 
@@ -298,8 +314,8 @@ def forecast_coords_match(first_cube: Cube, second_cube: Cube) -> None:
         ValueError: The two cubes are not equivalent.
     """
     mismatches = []
-    if first_cube.coord("forecast_period") != second_cube.coord("forecast_period"):
-        mismatches.append("forecast_period")
+    if floor_fp(first_cube) != floor_fp(second_cube):
+        mismatches.append("forecast_period hours")
 
     if get_frt_hours(first_cube.coord("forecast_reference_time")) != get_frt_hours(
         second_cube.coord("forecast_reference_time")

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -17,6 +17,9 @@ bd56f09033f7a37323e04be7b509e8e363eb2474c04fb8aa4fb5e3769acb81f7  ./apply-emos-c
 330c9a06a05fa72b23a974f7337d2ba9643d64d2aaacb0fe64219e969a5729a8  ./apply-emos-coefficients/realizations/realizations_kgo.nc
 615ddb59a838024bb055b9cbbb44b7c18ce28d5734952777774980760e0f36fc  ./apply-emos-coefficients/rebadged_percentiles/input.nc
 0bc91af1e7003d696aa440a07d79e653bca566733cdf9bf525ca92cff821548f  ./apply-emos-coefficients/sites/input.nc
+8f2cb3792595228278a512ff43dd5228fb1a4608d1940336d01cef1913cb3bd4  ./apply-emos-coefficients/sites/offset/coefficients.nc
+e9d3231227ca7d5fc84d3e601cba380885e21472f5c2f9a9a6a685c11aad9d87  ./apply-emos-coefficients/sites/offset/kgo.nc
+2722b1d08a87cebf1f36ac914d5badb9af38859b2150da83311dc202ce9be4dd  ./apply-emos-coefficients/sites/offset/offset_input.nc
 2b0093f2bc4ca3a32c4d49d618c07426e36fa069fcd0ee927efd8ea0b7dd7c9c  ./apply-emos-coefficients/sites/point_by_point/coefficients.nc
 d0edd044db78d0bfa67a125af2b0721c266666e1cf0cc9120da07387bc8ec4ad  ./apply-emos-coefficients/sites/point_by_point/kgo.nc
 965a1f0565f9192d95eb01d0a61dc7bede6902f5e1a0481d92611e677841a139  ./apply-emos-coefficients/truncated_normal/input.nc

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -99,6 +99,27 @@ def test_normal_point_by_point_sites(tmp_path):
     acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
 
 
+def test_normal_sites_subhourly(tmp_path):
+    """Test using a normal distribution for site forecasts that differ
+    in terms of spatial extent, forecast reference time and forecast period
+    from the coefficients."""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/sites/offset"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "offset_input.nc"
+    emos_est_path = kgo_dir / "coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        emos_est_path,
+        "--random-seed",
+        "0",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
+
+
 def test_realizations_input_land_sea(tmp_path):
     """Test realizations as input with a land sea mask"""
     kgo_dir = acc.kgo_root() / "apply-emos-coefficients/land_sea"

--- a/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
@@ -316,20 +316,22 @@ class Test_process(IrisTest):
     def test_null_percentiles_frt_fp_mismatch(self):
         """Test effect of "neutral" emos coefficients in percentile space
         where the forecast is 15 minutes ahead of the coefficients in terms
-        of the forecast period and forecast reference time."""
+        of the forecast reference time."""
         percentiles = self.percentiles.copy()
         mins_15_to_secs = 900
-        percentiles.coord("forecast_reference_time").points = percentiles.coord("forecast_reference_time").points + mins_15_to_secs
-        percentiles.coord("forecast_period").points = percentiles.coord("forecast_period").points + mins_15_to_secs
+        percentiles.coord("forecast_reference_time").points = (
+            percentiles.coord("forecast_reference_time").points + mins_15_to_secs
+        )
+        percentiles.coord("forecast_period").points = (
+            percentiles.coord("forecast_period").points - mins_15_to_secs
+        )
         expected_frt = percentiles.coord("forecast_reference_time").points
         expected_fp = percentiles.coord("forecast_period").points
         result = ApplyEMOS()(percentiles, self.coefficients, realizations_count=3)
         self.assertAlmostEqual(
             result.coord("forecast_reference_time").points, expected_frt
         )
-        self.assertAlmostEqual(
-            result.coord("forecast_period").points, expected_fp
-        )
+        self.assertAlmostEqual(result.coord("forecast_period").points, expected_fp)
 
     def test_invalid_attribute(self):
         """Test that an exception is raised if multiple different distribution

--- a/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
@@ -313,6 +313,24 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result.data, expected_data)
         self.assertNotAlmostEqual(np.mean(result.data), expected_mean)
 
+    def test_null_percentiles_frt_fp_mismatch(self):
+        """Test effect of "neutral" emos coefficients in percentile space
+        where the forecast is 15 minutes ahead of the coefficients in terms
+        of the forecast period and forecast reference time."""
+        percentiles = self.percentiles.copy()
+        mins_15_to_secs = 900
+        percentiles.coord("forecast_reference_time").points = percentiles.coord("forecast_reference_time").points + mins_15_to_secs
+        percentiles.coord("forecast_period").points = percentiles.coord("forecast_period").points + mins_15_to_secs
+        expected_frt = percentiles.coord("forecast_reference_time").points
+        expected_fp = percentiles.coord("forecast_period").points
+        result = ApplyEMOS()(percentiles, self.coefficients, realizations_count=3)
+        self.assertAlmostEqual(
+            result.coord("forecast_reference_time").points, expected_frt
+        )
+        self.assertAlmostEqual(
+            result.coord("forecast_period").points, expected_fp
+        )
+
     def test_invalid_attribute(self):
         """Test that an exception is raised if multiple different distribution
         attributes are provided within the coefficients cubelist."""

--- a/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
+++ b/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
@@ -245,6 +245,12 @@ class Test__spatial_domain_match(SetupCoefficientsCubes):
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin._spatial_domain_match()
 
+    def test_skipping_spot_forecast(self):
+        """Test passing a spot forecast. In this case, the spatial domain
+        is not checked."""
+        self.plugin.current_forecast = self.current_forecast_spot_cube
+        self.plugin._spatial_domain_match()
+
 
 class Test__calculate_location_parameter_from_mean(
     SetupCoefficientsCubes, EnsembleCalibrationAssertions

--- a/improver_tests/calibration/utilities/test_utilities.py
+++ b/improver_tests/calibration/utilities/test_utilities.py
@@ -542,6 +542,24 @@ class Test_forecast_coords_match(IrisTest):
         """Test returns None when cubes time coordinates match."""
         self.assertIsNone(forecast_coords_match(self.ref_cube, self.ref_cube.copy()))
 
+    def test_match_15_minute_offset(self):
+        """Test returns None when cubes time coordinates match with an
+        allowed leniency for a 15 minute offset."""
+        offset_cube = self.ref_cube.copy()
+        mins_15_to_secs = 900
+        offset_cube.coord("forecast_period").points = offset_cube.coord("forecast_period").points + mins_15_to_secs
+        offset_cube.coord("forecast_reference_time").points = offset_cube.coord("forecast_reference_time").points + mins_15_to_secs
+        self.assertIsNone(forecast_coords_match(self.ref_cube, offset_cube))
+
+    def test_match_45_minute_offset(self):
+        """Test returns None when cubes time coordinates match with an
+        allowed leniency for a 45 minute offset."""
+        offset_cube = self.ref_cube.copy()
+        mins_45_to_secs = 2700
+        offset_cube.coord("forecast_period").points = offset_cube.coord("forecast_period").points + mins_45_to_secs
+        offset_cube.coord("forecast_reference_time").points = offset_cube.coord("forecast_reference_time").points + mins_45_to_secs
+        self.assertIsNone(forecast_coords_match(self.ref_cube, offset_cube))
+
     def test_forecast_period_mismatch(self):
         """Test an error is raised when the forecast period mismatches."""
         self.adjusted_cube = set_up_variable_cube(

--- a/improver_tests/calibration/utilities/test_utilities.py
+++ b/improver_tests/calibration/utilities/test_utilities.py
@@ -537,27 +537,35 @@ class Test_forecast_coords_match(IrisTest):
             time=datetime.datetime(2017, 11, 10, 4, 0),
         )
         self.message = "The following coordinates of the two cubes do not match"
+        self.mins_15_to_secs = 900
 
     def test_match(self):
         """Test returns None when cubes time coordinates match."""
         self.assertIsNone(forecast_coords_match(self.ref_cube, self.ref_cube.copy()))
 
-    def test_match_15_minute_offset(self):
+    def test_15_minute_frt_offset_match(self):
         """Test returns None when cubes time coordinates match with an
         allowed leniency for a 15 minute offset."""
         offset_cube = self.ref_cube.copy()
-        mins_15_to_secs = 900
-        offset_cube.coord("forecast_period").points = offset_cube.coord("forecast_period").points + mins_15_to_secs
-        offset_cube.coord("forecast_reference_time").points = offset_cube.coord("forecast_reference_time").points + mins_15_to_secs
+        offset_cube.coord("forecast_period").points = (
+            offset_cube.coord("forecast_period").points - self.mins_15_to_secs
+        )
+        offset_cube.coord("forecast_reference_time").points = (
+            offset_cube.coord("forecast_reference_time").points + self.mins_15_to_secs
+        )
         self.assertIsNone(forecast_coords_match(self.ref_cube, offset_cube))
 
-    def test_match_45_minute_offset(self):
+    def test_45_minute_frt_offset_match(self):
         """Test returns None when cubes time coordinates match with an
         allowed leniency for a 45 minute offset."""
         offset_cube = self.ref_cube.copy()
-        mins_45_to_secs = 2700
-        offset_cube.coord("forecast_period").points = offset_cube.coord("forecast_period").points + mins_45_to_secs
-        offset_cube.coord("forecast_reference_time").points = offset_cube.coord("forecast_reference_time").points + mins_45_to_secs
+        offset_cube.coord("forecast_period").points = (
+            offset_cube.coord("forecast_period").points - 3 * self.mins_15_to_secs
+        )
+        offset_cube.coord("forecast_reference_time").points = (
+            offset_cube.coord("forecast_reference_time").points
+            + 3 * self.mins_15_to_secs
+        )
         self.assertIsNone(forecast_coords_match(self.ref_cube, offset_cube))
 
     def test_forecast_period_mismatch(self):


### PR DESCRIPTION
Closes #1539 

Description
This PR adds support for leniency within the forecast period check when applying EMOS coefficients. This enables coefficients computed on the hour to be applied to subhourly cycles by ensuring the ceiling of the forecast period matches. For example, consider a 03Z cycle at T+9 given a 12Z validity time at which coefficients are calculated. To get the same validity time from subhourly cycles would require T+8.75 from the 0315Z cycle, T+8.5 from the 0330Z cycle and T+8.25 from the 0345Z. Therefore, a T+8.25 forecast would use coefficients from T+9.

Additionally, support for skipping the spatial domain check is provided for site forecasts, due to the lack of an obvious criteria that would be valid in different circumstances.

Further information is available 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

