### PR TITLE
Added constant for ultraviolet_index_daytime_max.

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -94,4 +94,5 @@ BOUNDS_FOR_ECDF = {
     "relative_humidity": Bounds((0, 1.2), "1"),
     "visibility_in_air": Bounds((0, 100000), "m"),
     "ultraviolet_index": Bounds((0, 25.0), "1"),
+    "ultraviolet_index_daytime_max": Bounds((0, 25.0), "1"),
 }


### PR DESCRIPTION
Addresses #GitHubissuenum

This PR adds a constant for ultraviolet_index_daytime_max so that ECC can find the correct bounds for this chain.
This is related to suite PR: https://github.com/MetOffice/improver_suite/pull/1060

Testing:
 - [X] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
