### PR TITLE
Add filtering by cycletime to estimate_emos_coefficients_from_table.py

### DIFF
--- a/improver/cli/estimate_emos_coefficients_from_table.py
+++ b/improver/cli/estimate_emos_coefficients_from_table.py
@@ -154,19 +154,16 @@ def process(
     )
 
     # Load forecasts from parquet file filtering by diagnostic and blend_time.
+    forecast_period_td = pd.Timedelta(int(forecast_period), unit="seconds")
     cycletimes = pd.date_range(
-        end=pd.Timestamp(cycletime) - pd.Timedelta(1, unit="days"),
+        end=pd.Timestamp(cycletime)
+        - pd.Timedelta(1, unit="days")
+        - forecast_period_td.floor("D"),
         periods=int(training_length),
         freq="D",
     ).tz_localize(None)
     filters = [[("diagnostic", "==", diagnostic), ("blend_time", "in", cycletimes)]]
     forecast_df = pd.read_parquet(forecast, filters=filters)
-    if forecast_df.empty:
-        msg = (
-            f"The requested filepath {forecast} does not contain the "
-            f"requested contents: {filters}"
-        )
-        raise IOError(msg)
 
     # Load truths from parquet file filtering by diagnostic.
     filters = [[("diagnostic", "==", diagnostic)]]

--- a/improver/cli/estimate_emos_coefficients_from_table.py
+++ b/improver/cli/estimate_emos_coefficients_from_table.py
@@ -155,6 +155,8 @@ def process(
 
     # Load forecasts from parquet file filtering by diagnostic and blend_time.
     forecast_period_td = pd.Timedelta(int(forecast_period), unit="seconds")
+    # tz_localize(None) is used to facilitate filtering, although the dataframe
+    # is expected to be timezone aware upon load.
     cycletimes = pd.date_range(
         end=pd.Timestamp(cycletime)
         - pd.Timedelta(1, unit="days")

--- a/improver_tests/acceptance/test_estimate_emos_coefficients_from_table.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients_from_table.py
@@ -143,37 +143,6 @@ def test_basic(
 
 
 @pytest.mark.slow
-def test_invalid_forecast_filter(tmp_path,):
-    """
-    Test using an invalid diagnostic name to filter the forecast table.
-    """
-    kgo_dir = acc.kgo_root() / "estimate-emos-coefficients-from-table/"
-    history_path = kgo_dir / "forecast_table"
-    truth_path = kgo_dir / "truth_table"
-    output_path = tmp_path / "output.nc"
-    args = [
-        history_path,
-        truth_path,
-        "--diagnostic",
-        "fake_diagnostic",
-        "--cycletime",
-        "20210805T2100Z",
-        "--forecast-period",
-        "86400",
-        "--training-length",
-        "5",
-        "--distribution",
-        "norm",
-        "--tolerance",
-        EST_EMOS_TOL,
-        "--output",
-        output_path,
-    ]
-    with pytest.raises(IOError, match="The requested filepath.*fake_diagnostic.*"):
-        run_cli(args)
-
-
-@pytest.mark.slow
 def test_invalid_truth_filter(tmp_path,):
     """
     Test using an invalid diagnostic name to filter the truth table.


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/108

Description
This PRs amends the estimate_emos_coefficients_from_table to add filtering by cycletime (blend_time) as part of loading of the parquet file. This reduces the time taken to load from the parquet files (from 2 minutes 45 seconds to ~2 minutes for a test dataset) but also significantly reduces the memory usage. Please see comment: [#1](https://github.com/metoppv/mo-blue-team/issues/108#issuecomment-960539811) and [#2](https://github.com/metoppv/mo-blue-team/issues/108#issuecomment-961243485).

As we're now filtering on diagnostic and cycletime, rather than just diagnostic, we now expect there to be instances where the forecast dataframe is empty but we don't want to fail e.g. because we're trying to calibrate at a cycletime that doesn't have any matches within the forecast table. This situation would also occur within the first 24 hours of spin-up. With this PR, if the forecast dataframe is empty None is returned.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

