### PR TITLE
Remove duplicates in the forecast and truth for EMOS

### DIFF
--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -324,6 +324,7 @@ def _prepare_dataframes(
         subset=["diagnostic", "forecast_period", "percentile", "time", "wmo_id"],
         keep="last",
     )
+    # Sort to ensure a consistent ordering after removing duplicates.
     forecast_df.sort_values(
         by=["blend_time", "percentile", "wmo_id"], inplace=True, ignore_index=True,
     )
@@ -331,6 +332,7 @@ def _prepare_dataframes(
     # Remove truth duplicates.
     truth_cols = ["diagnostic", "time", "wmo_id"]
     truth_df = truth_df.drop_duplicates(subset=truth_cols, keep="last",)
+    # Sort to ensure a consistent ordering after removing duplicates.
     truth_df.sort_values(
         by=truth_cols, inplace=True, ignore_index=True,
     )

--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -324,10 +324,15 @@ def _prepare_dataframes(
         subset=["diagnostic", "forecast_period", "percentile", "time", "wmo_id"],
         keep="last",
     )
+    forecast_df.sort_values(
+        by=["blend_time", "percentile", "wmo_id"], inplace=True, ignore_index=True,
+    )
 
     # Remove truth duplicates.
-    truth_df = truth_df.drop_duplicates(
-        subset=["diagnostic", "time", "wmo_id"], keep="last",
+    truth_cols = ["diagnostic", "time", "wmo_id"]
+    truth_df = truth_df.drop_duplicates(subset=truth_cols, keep="last",)
+    truth_df.sort_values(
+        by=truth_cols, inplace=True, ignore_index=True,
     )
 
     # Find the common set of WMO IDs.

--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -268,9 +268,10 @@ def _prepare_dataframes(
     experiment: Optional[str] = None,
 ) -> Tuple[DataFrame, DataFrame]:
     """Prepare dataframes for conversion to cubes by: 1) checking
-    that the expected columns are present, 2) finding the sites
-    common to both the forecast and truth dataframes and 3)
-    replacing and supplementing the truth dataframe with
+    that the expected columns are present, 2) checking the percentiles
+    are as expected, 3) removing duplicates from the forecast and truth,
+    4) finding the sites common to both the forecast and truth dataframes
+    and 5) replacing and supplementing the truth dataframe with
     information from the forecast dataframe. Note that this third
     step will also ensure that a row containing a NaN for the
     ob_value is inserted for any missing observations.
@@ -317,6 +318,17 @@ def _prepare_dataframes(
 
     # Check the percentiles can be considered to be equally space quantiles.
     _quantile_check(forecast_df)
+
+    # Remove forecast duplicates.
+    forecast_df = forecast_df.drop_duplicates(
+        subset=["diagnostic", "forecast_period", "percentile", "time", "wmo_id"],
+        keep="last",
+    )
+
+    # Remove truth duplicates.
+    truth_df = truth_df.drop_duplicates(
+        subset=["diagnostic", "time", "wmo_id"], keep="last",
+    )
 
     # Find the common set of WMO IDs.
     common_wmo_ids = sorted(

--- a/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
+++ b/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
@@ -638,9 +638,9 @@ class Test_forecast_and_truth_dataframes_to_cubes(
                 self.training_length,
             )
 
-    def test_duplicate_forecasts(self):
-        """Test that a forecast cube is still produced if duplicate forecasts
-        are provided."""
+    def test_duplicate_cycle_forecasts(self):
+        """Test that a forecast cube is still produced if a duplicated
+        cycle of forecasts is provided."""
         forecast_df_with_duplicates = self.forecast_df.append(
             self.forecast_df.iloc[:9], ignore_index=True
         )
@@ -655,11 +655,45 @@ class Test_forecast_and_truth_dataframes_to_cubes(
         self.assertCubeEqual(result[0], self.expected_period_forecast)
         self.assertCubeEqual(result[1], self.expected_period_truth)
 
-    def test_duplicate_truths(self):
-        """Test that a truth cube is still produced if duplicate truths
-        are provided."""
+    def test_duplicate_cycle_truths(self):
+        """Test that a truth cube is still produced if duplicate
+        truths for a given validity time are provided."""
         truth_df_with_duplicates = self.truth_subset_df.append(
             self.truth_subset_df.iloc[:3], ignore_index=True
+        )
+        result = forecast_and_truth_dataframes_to_cubes(
+            self.forecast_df,
+            truth_df_with_duplicates,
+            self.cycletime,
+            self.forecast_period,
+            self.training_length,
+        )
+        self.assertEqual(len(result), 2)
+        self.assertCubeEqual(result[0], self.expected_period_forecast)
+        self.assertCubeEqual(result[1], self.expected_period_truth)
+
+    def test_duplicate_row_forecasts(self):
+        """Test that a forecast cube is still produced if a single
+        duplicated forecast is provided."""
+        forecast_df_with_duplicates = self.forecast_df.append(
+            self.forecast_df.iloc[0], ignore_index=True
+        )
+        result = forecast_and_truth_dataframes_to_cubes(
+            forecast_df_with_duplicates,
+            self.truth_subset_df,
+            self.cycletime,
+            self.forecast_period,
+            self.training_length,
+        )
+        self.assertEqual(len(result), 2)
+        self.assertCubeEqual(result[0], self.expected_period_forecast)
+        self.assertCubeEqual(result[1], self.expected_period_truth)
+
+    def test_duplicate_row_truths(self):
+        """Test that a truth cube is still produced if a single
+        duplicated truth for a given validity time is provided."""
+        truth_df_with_duplicates = self.truth_subset_df.append(
+            self.truth_subset_df.iloc[0], ignore_index=True
         )
         result = forecast_and_truth_dataframes_to_cubes(
             self.forecast_df,

--- a/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
+++ b/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
@@ -638,6 +638,40 @@ class Test_forecast_and_truth_dataframes_to_cubes(
                 self.training_length,
             )
 
+    def test_duplicate_forecasts(self):
+        """Test that a forecast cube is still produced if duplicate forecasts
+        are provided."""
+        forecast_df_with_duplicates = self.forecast_df.append(
+            self.forecast_df.iloc[:9], ignore_index=True
+        )
+        result = forecast_and_truth_dataframes_to_cubes(
+            forecast_df_with_duplicates,
+            self.truth_subset_df,
+            self.cycletime,
+            self.forecast_period,
+            self.training_length,
+        )
+        self.assertEqual(len(result), 2)
+        self.assertCubeEqual(result[0], self.expected_period_forecast)
+        self.assertCubeEqual(result[1], self.expected_period_truth)
+
+    def test_duplicate_truths(self):
+        """Test that a truth cube is still produced if duplicate truths
+        are provided."""
+        truth_df_with_duplicates = self.truth_subset_df.append(
+            self.truth_subset_df.iloc[:3], ignore_index=True
+        )
+        result = forecast_and_truth_dataframes_to_cubes(
+            self.forecast_df,
+            truth_df_with_duplicates,
+            self.cycletime,
+            self.forecast_period,
+            self.training_length,
+        )
+        self.assertEqual(len(result), 2)
+        self.assertCubeEqual(result[0], self.expected_period_forecast)
+        self.assertCubeEqual(result[1], self.expected_period_truth)
+
     def test_forecast_additional_columns_present(self):
         """Test that if there are additional columns present
         in the forecast dataframe, these have no impact."""

--- a/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
+++ b/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
@@ -673,11 +673,28 @@ class Test_forecast_and_truth_dataframes_to_cubes(
         self.assertCubeEqual(result[1], self.expected_period_truth)
 
     def test_duplicate_row_forecasts(self):
-        """Test that a forecast cube is still produced if a single
-        duplicated forecast is provided."""
-        forecast_df_with_duplicates = self.forecast_df.append(
-            self.forecast_df.iloc[0], ignore_index=True
+        """Test that a forecast cube is still produced if duplicated
+        forecasts are provided."""
+        # Use results from the first realization,
+        # equivalent to the 50th percentile.
+        expected_period_forecast = self.expected_period_forecast[1, :, :]
+        expected_period_forecast.coord("realization").points = np.array([0], np.int32)
+
+        # Use 50th percentile only
+        forecast_subset_df = self.forecast_df[self.forecast_df["percentile"] == 50.0]
+
+        # Duplicate first row twice.
+        forecast_df_with_duplicates = pd.concat(
+            [
+                forecast_subset_df,
+                forecast_subset_df.iloc[[0]],
+                forecast_subset_df.iloc[[0]],
+            ],
+            ignore_index=True,
         )
+        forecast_df_with_duplicates.at[0, "forecast"] = 6.0
+        forecast_df_with_duplicates.at[9, "forecast"] = 8.0
+
         result = forecast_and_truth_dataframes_to_cubes(
             forecast_df_with_duplicates,
             self.truth_subset_df,
@@ -685,16 +702,25 @@ class Test_forecast_and_truth_dataframes_to_cubes(
             self.forecast_period,
             self.training_length,
         )
+
         self.assertEqual(len(result), 2)
-        self.assertCubeEqual(result[0], self.expected_period_forecast)
+        self.assertCubeEqual(result[0], expected_period_forecast)
         self.assertCubeEqual(result[1], self.expected_period_truth)
 
     def test_duplicate_row_truths(self):
-        """Test that a truth cube is still produced if a single
-        duplicated truth for a given validity time is provided."""
-        truth_df_with_duplicates = self.truth_subset_df.append(
-            self.truth_subset_df.iloc[0], ignore_index=True
+        """Test that a truth cube is still produced if duplicated
+        truths for a given validity time are provided."""
+        # Duplicate first row twice.
+        truth_df_with_duplicates = pd.concat(
+            [
+                self.truth_subset_df,
+                self.truth_subset_df.iloc[[0]],
+                self.truth_subset_df.iloc[[0]],
+            ],
+            ignore_index=True,
         )
+        truth_df_with_duplicates.at[0, "ob_value"] = 6.0
+        truth_df_with_duplicates.at[9, "ob_value"] = 8.0
         result = forecast_and_truth_dataframes_to_cubes(
             self.forecast_df,
             truth_df_with_duplicates,
@@ -702,6 +728,7 @@ class Test_forecast_and_truth_dataframes_to_cubes(
             self.forecast_period,
             self.training_length,
         )
+
         self.assertEqual(len(result), 2)
         self.assertCubeEqual(result[0], self.expected_period_forecast)
         self.assertCubeEqual(result[1], self.expected_period_truth)


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/108

Description
This PR adds resilience by removing duplicates in the forecasts and truths. These duplicates would typically arise in the form of a whole cycle of duplicates. Support is also provided for a one-off duplicate.

Testing is described in [this comment](https://github.com/metoppv/mo-blue-team/issues/108#issuecomment-964995604).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

