### PR TITLE
ENH: Avoiding lazy loading in select command calls

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -156,6 +156,25 @@ def inputcube(to_convert):
 
 
 @value_converter
+def inputcube_nolazy(to_convert):
+    """Loads cube from file or returns passed object.
+    Where a load is performed, it will not have lazy data.
+    Args:
+        to_convert (string or iris.cube.Cube):
+            File name or Cube object.
+    Returns:
+        Loaded cube or passed object.
+    """
+    from improver.utilities.load import load_cube
+
+    if getattr(to_convert, "has_lazy_data", False):
+        # Realise data if lazy
+        to_convert.data
+
+    return maybe_coerce_with(load_cube, to_convert, no_lazy_load=True)
+
+
+@value_converter
 def inputcubelist(to_convert):
     """Loads a cubelist from file or returns passed object.
     Args:

--- a/improver/cli/blend_adjacent_points.py
+++ b/improver/cli/blend_adjacent_points.py
@@ -38,7 +38,7 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(
-    *cubes: cli.inputcube,
+    *cubes: cli.inputcube_nolazy,
     coordinate,
     central_point: float,
     units=None,

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -45,7 +45,6 @@ def name_constraint(names: List[str]) -> Callable:
 
     The callable constraint will realise the data of those cubes matching the
     constraint.
-    cube names
 
     Args:
         name:

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -61,7 +61,7 @@ def name_constraint(names: List[str]) -> Callable:
         ret = False
         if cube.name() in names:
             ret = True
-            _ = cube.data
+            cube.data
         return ret
 
     return constraint

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -52,7 +52,7 @@ def name_constraint(names: List[str]) -> Callable:
 
     Returns:
         A callable which when called, returns True or False for the provided cube,
-        depending on whether it matches the names provided.  These matching cube
+        depending on whether it matches the names provided.  A matching cube
         will also have its data realised by the callable.
     """
 

--- a/improver/cli/phase_change_level.py
+++ b/improver/cli/phase_change_level.py
@@ -37,7 +37,7 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(
-    *cubes: cli.inputcube,
+    *cubes: cli.inputcube_nolazy,
     phase_change,
     grid_point_radius=2,
     horizontal_interpolation=True,

--- a/improver/cli/wxcode.py
+++ b/improver/cli/wxcode.py
@@ -37,7 +37,7 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(
-    *cubes: cli.inputcube_nolazy,
+    *cubes: cli.inputcube,
     wxtree: cli.inputjson = None,
     model_id_attr: str = None,
     check_tree: bool = False,

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -30,10 +30,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for cli.__init__"""
 
-import dask.array as da
 import unittest
 from unittest.mock import patch
 
+import dask.array as da
 import numpy as np
 from iris.cube import Cube, CubeList
 from iris.exceptions import ConstraintMismatchError

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -30,11 +30,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for cli.__init__"""
 
+import dask.array as da
 import unittest
 from unittest.mock import patch
 
 import numpy as np
-from iris.cube import CubeList
+from iris.cube import Cube, CubeList
 from iris.exceptions import ConstraintMismatchError
 
 import improver
@@ -43,6 +44,7 @@ from improver.cli import (
     create_constrained_inputcubelist_converter,
     docutilize,
     inputcube,
+    inputcube_nolazy,
     inputcubelist,
     inputjson,
     maybe_coerce_with,
@@ -133,6 +135,37 @@ class Test_inputcube(unittest.TestCase):
         """Tests that input cube calls load_cube with the string"""
         result = inputcube("foo")
         m.assert_called_with(improver.utilities.load.load_cube, "foo")
+        self.assertEqual(result, "return")
+
+
+class Test_inputcube_nolazy(unittest.TestCase):
+    """Tests the input cube no lazy function"""
+
+    def setUp(self):
+        coerce_patch = patch("improver.cli.maybe_coerce_with", return_value="return")
+        self.coerce_patch = coerce_patch.start()
+        self.addCleanup(coerce_patch.stop)
+
+    def test_string_arg(self):
+        """
+        Check that inputcube_nolazy calls the coerce func with the input
+        string.
+        """
+        result = inputcube_nolazy("foo")
+        self.coerce_patch.assert_called_with(
+            improver.utilities.load.load_cube, "foo", no_lazy_load=True
+        )
+        self.assertEqual(result, "return")
+
+    def test_cube_arg(self):
+        """Check that a input lazy cube will be realised before return."""
+        cube = Cube(da.zeros((1, 1), chunks=(1, 1)), long_name="dummy")
+        self.assertTrue(cube.has_lazy_data())
+        result = inputcube_nolazy(cube)
+        self.coerce_patch.assert_called_with(
+            improver.utilities.load.load_cube, cube, no_lazy_load=True
+        )
+        self.assertFalse(cube.has_lazy_data())
         self.assertEqual(result, "return")
 
 


### PR DESCRIPTION
Addresses #1612

Description

- Ensures no lazy loading in the following improver CLI calls: `blend-adjacent-points`, `nowcast-accumulate`, `nowcast-extrapolate`, `phase-change-level` and `wxcode`.
- Introduces new `cli.inputcube_nolazy` type (a non-lazy load type).

Testing:
 - [ ] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

----

lazy vs non-lazy comparison of these function calls as per https://github.com/metoppv/improver/issues/1612#issuecomment-968841368:

```
  min % diff	min t lazy(s)	min t nolazy(s)	mean % diff	mean t lazy(s)	mean t nolazy(s) max % diff	max t lazy(s)	max t nolazy(s)	ncalls lazy	ncalls nolazy	Command
* 119%		34		8		129%		83		17		93%		103		37		980		1120		improver blend-adjacent-points --coordinate --central-point --blend-time-using-forecast-period --units --width
* 25%		129		99		24%		139		109		28%		168		126		17		21		improver nowcast-accumulate --attributes-config --max-lead-time
  7%		8		8		4%		28		30		9%		53		48		973		1112		improver phase-change-level --phase-change
* 124%		12		2		113%		16		4		105%		26		8		102		38		improver phase-change-level --phase-change --grid-point-radius
  2%		5		5		3%		22		23		33%		47		33		973		1112		improver phase-change-level --phase-change --horizontal-interpolation
* 130%		12		2		118%		17		4		106%		25		7		102		38		improver phase-change-level --phase-change --horizontal-interpolation --grid-point-radius
* 50%		13		8		64%		36		18		21%		51		41		2021		2554		improver wxcode --wxtree
```

No-lazy load suites: `*_nolazy`