### PR TITLE
Extend ResamplePercentiles to simplify ensuring of consistent percentiles within EMOS

### DIFF
--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -348,10 +348,20 @@ class ResamplePercentiles(BasePlugin):
         Returns:
             Cube with forecast values at the desired set of percentiles.
             The percentile coordinate is always the zeroth dimension.
+
+        Raises:
+            ValueError: The percentiles supplied must be between 0 and 100.
         """
         percentile_coord = find_percentile_coordinate(forecast_at_percentiles)
 
-        if not percentiles:
+        if percentiles:
+            if any(p < 0 or p > 100 for p in percentiles):
+                msg = (
+                    "The percentiles supplied must be between 0 and 100. "
+                    f"Percentiles supplied: {percentiles}"
+                )
+                raise ValueError(msg)
+        else:
             if no_of_percentiles is None:
                 no_of_percentiles = len(
                     forecast_at_percentiles.coord(percentile_coord).points

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -314,10 +314,11 @@ class ResamplePercentiles(BasePlugin):
         self,
         forecast_at_percentiles: Cube,
         no_of_percentiles: Optional[int] = None,
-        sampling: str = "quantile",
+        sampling: Optional[str] = "quantile",
+        percentiles: Optional[List] = None,
     ) -> Cube:
         """
-        1. Creates a list of percentiles.
+        1. Creates a list of percentiles, if not provided.
         2. Accesses the lower and upper bound pair of the forecast values,
            in order to specify lower and upper bounds for the percentiles.
         3. Interpolate the percentile coordinate into an alternative
@@ -341,6 +342,8 @@ class ResamplePercentiles(BasePlugin):
                      at dividing a Cumulative Distribution Function into
                      blocks of equal probability.
                 * Random: A random set of ordered percentiles.
+            percentiles:
+                List of the desired output percentiles.
 
         Returns:
             Cube with forecast values at the desired set of percentiles.
@@ -348,12 +351,14 @@ class ResamplePercentiles(BasePlugin):
         """
         percentile_coord = find_percentile_coordinate(forecast_at_percentiles)
 
-        if no_of_percentiles is None:
-            no_of_percentiles = len(
-                forecast_at_percentiles.coord(percentile_coord).points
+        if not percentiles:
+            if no_of_percentiles is None:
+                no_of_percentiles = len(
+                    forecast_at_percentiles.coord(percentile_coord).points
+                )
+            percentiles = choose_set_of_percentiles(
+                no_of_percentiles, sampling=sampling
             )
-
-        percentiles = choose_set_of_percentiles(no_of_percentiles, sampling=sampling)
 
         cube_units = forecast_at_percentiles.units
         bounds_pairing = get_bounds_of_distribution(

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -446,46 +446,6 @@ def test_no_coefficients_percentiles(tmp_path):
     acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
 
 
-def test_no_coefficients_partial_subset_percentiles(tmp_path):
-    """Test if no coefficients are provided and some of the percentiles
-    requested do not match the percentiles within the input forecast."""
-    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/subsetted_percentiles"
-    input_path = kgo_dir / "input.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        "--random-seed",
-        "0",
-        "--percentiles",
-        "1,2,5",
-        "--output",
-        output_path,
-    ]
-    with pytest.raises(ValueError, match=".*The percentiles within the forecast.*"):
-        run_cli(args)
-
-
-def test_no_coefficients_non_subset_percentiles(tmp_path):
-    """Test if no coefficients are provided and none of the percentiles
-    requested match the percentiles within the input forecast."""
-    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/subsetted_percentiles"
-    input_path = kgo_dir / "input.nc"
-    output_path = tmp_path / "output.nc"
-    args = [
-        input_path,
-        "--random-seed",
-        "0",
-        "--percentiles",
-        "1,2,3",
-        "--output",
-        output_path,
-    ]
-    with pytest.raises(
-        ValueError, match=".*No percentiles are present within the forecast.*"
-    ):
-        run_cli(args)
-
-
 def test_no_coefficients_with_prob_template(tmp_path):
     """Test no coefficients provided with a probability template."""
     kgo_dir = acc.kgo_root() / "apply-emos-coefficients/sites/additional_predictor"

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -445,38 +445,40 @@ class Test_process(IrisTest):
             name="air_temperature",
             units="degC",
         )
+        self.expected = np.array(
+            [
+                [[4.75, 5.375, 6.0], [6.625, 7.25, 7.875], [8.5, 9.125, 9.75]],
+                [[6.0, 6.625, 7.25], [7.875, 8.5, 9.125], [9.75, 10.375, 11.0]],
+                [[7.25, 7.875, 8.5], [9.125, 9.75, 10.375], [11.0, 11.625, 12.25]],
+            ]
+        )
+
+    @ManageWarnings(ignored_messages=["Only a single cube so no differences"])
+    def test_check_data_specifying_percentile_number(self):
+        """
+        Test that the plugin returns an Iris.cube.Cube with the expected
+        data values for a specific number of percentiles.
+        """
+        result = Plugin().process(self.percentile_cube, no_of_percentiles=3)
+        self.assertArrayAlmostEqual(result.data, self.expected)
+
+    @ManageWarnings(ignored_messages=["Only a single cube so no differences"])
+    def test_check_data_not_specifying_percentile_number(self):
+        """
+        Test that the plugin returns an Iris.cube.Cube with the expected
+        data values without specifying the number of percentiles.
+        """
+        result = Plugin().process(self.percentile_cube)
+        self.assertArrayAlmostEqual(result.data, self.expected)
 
     @ManageWarnings(ignored_messages=["Only a single cube so no differences"])
     def test_check_data_specifying_percentiles(self):
         """
         Test that the plugin returns an Iris.cube.Cube with the expected
-        data values for a specific number of percentiles.
+        data values corresponding to the set of percentiles requested.
         """
-        data = np.array(
-            [
-                [[4.75, 5.375, 6.0], [6.625, 7.25, 7.875], [8.5, 9.125, 9.75]],
-                [[6.0, 6.625, 7.25], [7.875, 8.5, 9.125], [9.75, 10.375, 11.0]],
-                [[7.25, 7.875, 8.5], [9.125, 9.75, 10.375], [11.0, 11.625, 12.25]],
-            ]
-        )
-        result = Plugin().process(self.percentile_cube, no_of_percentiles=3)
-        self.assertArrayAlmostEqual(result.data, data)
-
-    @ManageWarnings(ignored_messages=["Only a single cube so no differences"])
-    def test_check_data_not_specifying_percentiles(self):
-        """
-        Test that the plugin returns an Iris.cube.Cube with the expected
-        data values without specifying the number of percentiles.
-        """
-        data = np.array(
-            [
-                [[4.75, 5.375, 6.0], [6.625, 7.25, 7.875], [8.5, 9.125, 9.75]],
-                [[6.0, 6.625, 7.25], [7.875, 8.5, 9.125], [9.75, 10.375, 11.0]],
-                [[7.25, 7.875, 8.5], [9.125, 9.75, 10.375], [11.0, 11.625, 12.25]],
-            ]
-        )
-        result = Plugin().process(self.percentile_cube)
-        self.assertArrayAlmostEqual(result.data, data)
+        result = Plugin().process(self.percentile_cube, percentiles=[25, 50, 75])
+        self.assertArrayAlmostEqual(result.data, self.expected)
 
 
 if __name__ == "__main__":

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -477,8 +477,26 @@ class Test_process(IrisTest):
         Test that the plugin returns an Iris.cube.Cube with the expected
         data values corresponding to the set of percentiles requested.
         """
-        result = Plugin().process(self.percentile_cube, percentiles=[25, 50, 75])
-        self.assertArrayAlmostEqual(result.data, self.expected)
+        result = Plugin().process(self.percentile_cube, percentiles=[35, 60, 85])
+        self.assertArrayAlmostEqual(result.data, self.expected + 0.5)
+
+    @ManageWarnings(ignored_messages=["Only a single cube so no differences"])
+    def test_percentiles_too_low(self):
+        """
+        Test that an exception is raised if a percentile value is below 0.
+        """
+        msg = "The percentiles supplied must be between 0 and 100"
+        with self.assertRaisesRegex(ValueError, msg):
+            Plugin().process(self.percentile_cube, percentiles=[-5, 50, 75])
+
+    @ManageWarnings(ignored_messages=["Only a single cube so no differences"])
+    def test_percentiles_too_high(self):
+        """
+        Test that an exception is raised if a percentile value is above 100.
+        """
+        msg = "The percentiles supplied must be between 0 and 100"
+        with self.assertRaisesRegex(ValueError, msg):
+            Plugin().process(self.percentile_cube, percentiles=[25, 50, 105])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes: https://github.com/metoppv/improver/issues/1618

Description
This PR provides a simpler solution compared to https://github.com/metoppv/improver/pull/1615 by making a minor extension to the `ResamplePercentiles` plugin to support passing in a list of percentiles that are not necessarily quantiles.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
