### PR TITLE
Filter by experiment when reading a parquet file

### DIFF
--- a/improver/cli/estimate_emos_coefficients_from_table.py
+++ b/improver/cli/estimate_emos_coefficients_from_table.py
@@ -164,7 +164,9 @@ def process(
         periods=int(training_length),
         freq="D",
     ).tz_localize(None)
-    filters = [[("diagnostic", "==", diagnostic), ("blend_time", "in", cycletimes)]]
+    filters = [[("blend_time", "in", cycletimes), ("diagnostic", "==", diagnostic)]]
+    if experiment:
+        filters[0].append(("experiment", "==", experiment))
     forecast_df = pd.read_parquet(forecast, filters=filters)
 
     # Load truths from parquet file filtering by diagnostic.

--- a/improver_tests/acceptance/test_estimate_emos_coefficients_from_table.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients_from_table.py
@@ -60,12 +60,13 @@ EST_EMOS_TOL = str(EST_EMOS_TOLERANCE)
 
 
 @pytest.mark.parametrize(
-    "forecast_input,distribution,diagnostic,percentiles,additional_predictor,kgo_name",
+    "forecast_input,distribution,diagnostic,experiment,percentiles,additional_predictor,kgo_name",
     [
         (
             "forecast_table",
             "norm",
             "temperature_at_screen_level",
+            None,
             "10,20,30,40,50,60,70,80,90",
             None,
             "screen_temperature",
@@ -74,6 +75,7 @@ EST_EMOS_TOL = str(EST_EMOS_TOLERANCE)
             "forecast_table",
             "truncnorm",
             "wind_speed_at_10m",
+            None,
             "20,40,60,80",
             None,
             "wind_speed",
@@ -84,12 +86,14 @@ EST_EMOS_TOL = str(EST_EMOS_TOLERANCE)
             "temperature_at_screen_level",
             None,
             None,
+            None,
             "screen_temperature_input_quantiles",
         ),
         (
             "forecast_table",
             "norm",
             "temperature_at_screen_level",
+            "mix-latestblend",
             "10,20,30,40,50,60,70,80,90",
             "altitude.nc",
             "screen_temperature_additional_predictor",
@@ -102,6 +106,7 @@ def test_basic(
     forecast_input,
     distribution,
     diagnostic,
+    experiment,
     percentiles,
     additional_predictor,
     kgo_name,
@@ -134,6 +139,8 @@ def test_basic(
     ]
     if additional_predictor:
         compulsory_args += [kgo_dir / additional_predictor]
+    if experiment:
+        named_args += ["--experiment", experiment]
     if percentiles:
         named_args += ["--percentiles", percentiles]
     run_cli(compulsory_args + named_args)


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/108

Description
Add filtering by experiment when reading a parquet file. If a parquet file is partitioned by experiment then filtering by experiment when reading the parquet file can significantly reduce the memory overhead depending upon the dataset.

The need to remove the existing filtering by experiment after reading the parquet file is recorded in https://github.com/metoppv/mo-blue-team/issues/132.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

