### PR TITLE
Fix noise in precip accumulation thresholds

### DIFF
--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -110,8 +110,6 @@ def process(
         ValueError: If threshold_config and threshold_values are both set
         ValueError: If threshold_config is used for fuzzy thresholding
     """
-    import numpy as np
-
     from improver.metadata.probabilistic import in_vicinity_name_format
     from improver.threshold import BasicThreshold
     from improver.utilities.cube_manipulation import collapse_realizations

--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -129,7 +129,7 @@ def process(
         thresholds = []
         fuzzy_bounds = []
         for key in threshold_config.keys():
-            thresholds.append(np.float32(key))
+            thresholds.append(float(key))
             # If the first threshold has no bounds, fuzzy_bounds is
             # set to None and subsequent bounds checks are skipped
             if threshold_config[key] == "None":
@@ -137,7 +137,7 @@ def process(
                 continue
             fuzzy_bounds.append(tuple(threshold_config[key]))
     else:
-        thresholds = [np.float32(x) for x in threshold_values]
+        thresholds = [float(x) for x in threshold_values]
         fuzzy_bounds = None
 
     each_threshold_func_list = []

--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -127,6 +127,7 @@ def process(
         thresholds = []
         fuzzy_bounds = []
         for key in threshold_config.keys():
+            # Ensure thresholds are float64 to avoid rounding errors during possible unit conversion.
             thresholds.append(float(key))
             # If the first threshold has no bounds, fuzzy_bounds is
             # set to None and subsequent bounds checks are skipped
@@ -135,6 +136,7 @@ def process(
                 continue
             fuzzy_bounds.append(tuple(threshold_config[key]))
     else:
+        # Ensure thresholds are float64 to avoid rounding errors during possible unit conversion.
         thresholds = [float(x) for x in threshold_values]
         fuzzy_bounds = None
 

--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -127,7 +127,8 @@ def process(
         thresholds = []
         fuzzy_bounds = []
         for key in threshold_config.keys():
-            # Ensure thresholds are float64 to avoid rounding errors during possible unit conversion.
+            # Ensure thresholds are float64 to avoid rounding errors during
+            # possible unit conversion.
             thresholds.append(float(key))
             # If the first threshold has no bounds, fuzzy_bounds is
             # set to None and subsequent bounds checks are skipped
@@ -136,7 +137,8 @@ def process(
                 continue
             fuzzy_bounds.append(tuple(threshold_config[key]))
     else:
-        # Ensure thresholds are float64 to avoid rounding errors during possible unit conversion.
+        # Ensure thresholds are float64 to avoid rounding errors during possible
+        # unit conversion.
         thresholds = [float(x) for x in threshold_values]
         fuzzy_bounds = None
 

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -241,6 +241,9 @@ class BasicThreshold(PostProcessingPlugin):
         Add a scalar threshold-type coordinate with correct name and units
         to a 2D slice containing thresholded data.
 
+        The 'threshold' coordinate will be float64 to avoid rounding errors
+        during possible unit conversion.
+
         Args:
             cube:
                 Cube containing thresholded data (1s and 0s)
@@ -379,6 +382,7 @@ class BasicThreshold(PostProcessingPlugin):
             thresholded_cubes.append(cube)
 
         (cube,) = thresholded_cubes.merge()
+        # Re-cast to 32bit now that any unit conversion has already taken place.
         cube.coord(var_name="threshold").points = cube.coord(
             var_name="threshold"
         ).points.astype(FLOAT_DTYPE)

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -248,7 +248,7 @@ class BasicThreshold(PostProcessingPlugin):
                 Value at which the data has been thresholded
         """
         coord = iris.coords.DimCoord(
-            np.array([threshold], dtype=FLOAT_DTYPE), units=cube.units
+            np.array([threshold], dtype="float64"), units=cube.units
         )
         coord.rename(self.threshold_coord_name)
         coord.var_name = "threshold"
@@ -379,6 +379,9 @@ class BasicThreshold(PostProcessingPlugin):
             thresholded_cubes.append(cube)
 
         (cube,) = thresholded_cubes.merge()
+        cube.coord(var_name="threshold").points = cube.coord(
+            var_name="threshold"
+        ).points.astype(FLOAT_DTYPE)
 
         self._update_metadata(cube)
         enforce_coordinate_ordering(cube, ["realization", "percentile"])

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -450,8 +450,10 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
     def test_threshold_unit_conversion_2(self):
-        """Test threshold coordinate points after unit conversion of small
-        numbers."""
+        """Test threshold coordinate points after undergoing unit conversion.
+        Specifically ensuring that small floating point values have no floating
+        point precision errors after the conversion (float equality check with no
+        tolerance)."""
         plugin = Threshold([0.03, 0.09, 0.1], threshold_units="mm s-1")
         result = plugin(self.rate_cube)
         self.assertArrayEqual(

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -452,7 +452,6 @@ class Test_process(IrisTest):
     def test_threshold_unit_conversion_2(self):
         """Test threshold coordinate points after unit conversion of small
         numbers."""
-        expected_result_array = np.zeros((2, 5, 5))
         plugin = Threshold([0.03, 0.09, 0.1], threshold_units="mm s-1")
         result = plugin(self.rate_cube)
         self.assertArrayEqual(

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -449,6 +449,17 @@ class Test_process(IrisTest):
         result = plugin(self.rate_cube)
         self.assertArrayAlmostEqual(result.data, expected_result_array)
 
+    def test_threshold_unit_conversion_2(self):
+        """Test threshold coordinate points after unit conversion of small
+        numbers."""
+        expected_result_array = np.zeros((2, 5, 5))
+        plugin = Threshold([0.03, 0.09, 0.1], threshold_units="mm s-1")
+        result = plugin(self.rate_cube)
+        self.assertArrayEqual(
+            result.coord(var_name="threshold").points,
+            np.array([3e-5, 9.0e-05, 1e-4], dtype="float32"),
+        )
+
     def test_threshold_unit_conversion_fuzzy_factor(self):
         """Test for sensible fuzzy factor behaviour when units of threshold
         are different from input cube.  A fuzzy factor of 0.75 is equivalent


### PR DESCRIPTION
Addresses #https://github.com/MetOffice/improver_suite/issues/1048

## Description

Unit conversion is currently causing noise in the representation of the thresholds coordinate.
This is due to floating point arithmetic which is made worse by representation of the thresholds as 32-bit floats.
This PR proposes to define these thresholds as 64-bit but converting them to 32-bit post unit conversion before returning the final cube.
Confirmed that this gives reasonable representation for thresholds defined in the [precip_accumulation_thresholds.json](https://github.com/MetOffice/improver_suite/blob/master/etc/precip_accumulation_thresholds.json)

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)