### PR TITLE
Add time mismatch tolerating for apply emos

### DIFF
--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -44,6 +44,7 @@ def process(
     randomise=False,
     random_seed: int = None,
     ignore_ecc_bounds=False,
+    tolerate_time_mismatch=False,
     predictor="mean",
     land_sea_mask_name: str = None,
     percentiles: cli.comma_separated_list = None,
@@ -105,6 +106,9 @@ def process(
             current forecasts is in the form of probabilities and is
             converted to percentiles, as part of converting the input
             probabilities into realizations.
+        tolerate_time_mismatch (bool):
+            If True, tolerate a mismatch in validity time and forecast period
+            for coefficients vs forecasts. Use with caution!
         predictor (str):
             String to specify the form of the predictor used to calculate
             the location parameter when estimating the EMOS coefficients.
@@ -175,6 +179,7 @@ def process(
         prob_template=prob_template,
         realizations_count=realizations_count,
         ignore_ecc_bounds=ignore_ecc_bounds,
+        tolerate_time_mismatch=tolerate_time_mismatch,
         predictor=predictor,
         randomise=randomise,
         random_seed=random_seed,

--- a/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
+++ b/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
@@ -459,13 +459,21 @@ class Test_process(SetupCoefficientsCubes, EnsembleCalibrationAssertions):
 
     @ManageWarnings(ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_time_match_tolerate(self):
-        """Test that an error is raised if the diagnostic_standard_name does
-        not match when comparing a forecast cube and coefficients cubelist."""
-        _ = self.plugin.process(
+        """Test that no error is raised when using a coefficients file with
+        a mismatching forecast_period coordinate, if the
+        tolerate_time_mismatch option is enabled."""
+        calibrated_forecast_predictor, calibrated_forecast_var = self.plugin.process(
             self.current_temperature_forecast_cube,
             self.coeffs_from_mean_timeshift,
             tolerate_time_mismatch=True,
         )
+        self.assertCalibratedVariablesAlmostEqual(
+            calibrated_forecast_predictor.data, self.expected_loc_param_mean
+        )
+        self.assertCalibratedVariablesAlmostEqual(
+            calibrated_forecast_var.data, self.expected_scale_param_mean
+        )
+        self.assertEqual(calibrated_forecast_predictor.dtype, np.float32)
 
     @ManageWarnings(ignored_messages=["Collapsing a non-contiguous coordinate."])
     def test_variable_setting(self):


### PR DESCRIPTION
This is one way of working around an issue we've had with using coefficients that happen to be an hour out. They are still the best available coefficient, so add an option to try to use this. May end up abandoned if we figure out we want a different solution!
