### PR TITLE
IM-1621: Make ECC error and warning tests more rigorous

### DIFF
--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -114,7 +114,12 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         """
         probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
         threshold_points = np.array([8, 10, 60])
-        msg = "The calculated threshold values"
+        msg = (
+            "The calculated threshold values \\[-40   8  10  60  50\\] are "
+            "not in ascending order as required for the cumulative distribution "
+            "function \\(CDF\\). This is due to the threshold values exceeding "
+            "the range given by the ECC bounds \\(-40, 50\\)."
+        )
         with self.assertRaisesRegex(ValueError, msg):
             Plugin()._add_bounds_to_thresholds_and_probabilities(
                 threshold_points, probabilities_for_cdf, self.bounds_pairing
@@ -131,7 +136,14 @@ class Test__add_bounds_to_thresholds_and_probabilities(IrisTest):
         probabilities_for_cdf = np.array([[0.05, 0.7, 0.95]])
         threshold_points = np.array([8, 10, 60])
         plugin = Plugin(ecc_bounds_warning=True)
-        warning_msg = "The calculated threshold values"
+        warning_msg = (
+            "The calculated threshold values [-40   8  10  60  50] are "
+            "not in ascending order as required for the cumulative distribution "
+            "function (CDF). This is due to the threshold values exceeding "
+            "the range given by the ECC bounds (-40, 50). The threshold "
+            "points that have exceeded the existing bounds will be used as "
+            "new bounds."
+        )
         plugin._add_bounds_to_thresholds_and_probabilities(
             threshold_points, probabilities_for_cdf, self.bounds_pairing
         )

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -118,12 +118,14 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         forecast_at_percentiles = np.array([[8, 10, 60]])
         percentiles = np.array([5, 70, 95])
 
-        msg = ("Forecast values exist that fall outside the expected extrema "
-               "values that are defined as bounds in ensemble_copula_coupling"
-               "\\/constants.py. Applying the extrema values as end points to "
-               "the distribution would result in non-monotonically increasing "
-               "values. The defined extremes are \\(-40, 50\\), whilst the "
-               "following forecast values exist outside this range: \\[60\\].")
+        msg = (
+            "Forecast values exist that fall outside the expected extrema "
+            "values that are defined as bounds in ensemble_copula_coupling"
+            "\\/constants.py. Applying the extrema values as end points to "
+            "the distribution would result in non-monotonically increasing "
+            "values. The defined extremes are \\(-40, 50\\), whilst the "
+            "following forecast values exist outside this range: \\[60\\]."
+        )
 
         with self.assertRaisesRegex(ValueError, msg):
             Plugin()._add_bounds_to_percentiles_and_forecast_at_percentiles(
@@ -149,7 +151,8 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
             "values. The defined extremes are (-40, 50), whilst the "
             "following forecast values exist outside this range: [60]. "
             "The percentile values that have exceeded the existing bounds "
-            "will be used as new bounds.")
+            "will be used as new bounds."
+        )
         plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
             percentiles, forecast_at_percentiles, self.bounds_pairing
         )

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -117,7 +117,14 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         """
         forecast_at_percentiles = np.array([[8, 10, 60]])
         percentiles = np.array([5, 70, 95])
-        msg = "Forecast values exist that fall outside the expected extrema"
+
+        msg = ("Forecast values exist that fall outside the expected extrema "
+               "values that are defined as bounds in ensemble_copula_coupling"
+               "\\/constants.py. Applying the extrema values as end points to "
+               "the distribution would result in non-monotonically increasing "
+               "values. The defined extremes are \\(-40, 50\\), whilst the "
+               "following forecast values exist outside this range: \\[60\\].")
+
         with self.assertRaisesRegex(ValueError, msg):
             Plugin()._add_bounds_to_percentiles_and_forecast_at_percentiles(
                 percentiles, forecast_at_percentiles, self.bounds_pairing
@@ -134,7 +141,15 @@ class Test__add_bounds_to_percentiles_and_forecast_values(IrisTest):
         forecast_at_percentiles = np.array([[8, 10, 60]])
         percentiles = np.array([5, 70, 95])
         plugin = Plugin(ecc_bounds_warning=True)
-        warning_msg = "Forecast values exist that fall outside the expected extrema"
+        warning_msg = (
+            "Forecast values exist that fall outside the expected extrema "
+            "values that are defined as bounds in ensemble_copula_coupling"
+            "/constants.py. Applying the extrema values as end points to "
+            "the distribution would result in non-monotonically increasing "
+            "values. The defined extremes are (-40, 50), whilst the "
+            "following forecast values exist outside this range: [60]. "
+            "The percentile values that have exceeded the existing bounds "
+            "will be used as new bounds.")
         plugin._add_bounds_to_percentiles_and_forecast_at_percentiles(
             percentiles, forecast_at_percentiles, self.bounds_pairing
         )


### PR DESCRIPTION
#1621 describes a potential issue with the errors returned when ECC bounds are exceeded. There are some logs from suites suffering ECC bounds exceeded errors available (added to ticket), but these do not show the problem described. This PR simply makes the unit tests more rigorous by checking the entire returned error to ensure the expected values are included.

Closes #1621 

Testing:
 - [x] Ran tests and they passed OK