### PR TITLE
Minor correction of docstring listing truth dataframe columns

### DIFF
--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -281,7 +281,7 @@ def _prepare_dataframes(
             DataFrame expected to contain the following columns: forecast,
             blend_time, forecast_period, forecast_reference_time, time,
             wmo_id, percentile, diagnostic, latitude, longitude, period,
-            height, cf_name and units. Any other columns are ignored.
+            height, cf_name, units and experiment. Any other columns are ignored.
         truth_df:
             DataFrame expected to contain the following columns: ob_value,
             time, wmo_id, diagnostic, latitude, longitude and altitude.

--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -280,8 +280,9 @@ def _prepare_dataframes(
         forecast_df:
             DataFrame expected to contain the following columns: forecast,
             blend_time, forecast_period, forecast_reference_time, time,
-            wmo_id, percentile, diagnostic, latitude, longitude, period,
-            height, cf_name, units and experiment. Any other columns are ignored.
+            wmo_id, percentile, diagnostic, latitude, longitude, altitude,
+            period, height, cf_name, units and experiment. Any other
+            columns are ignored.
         truth_df:
             DataFrame expected to contain the following columns: ob_value,
             time, wmo_id, diagnostic, latitude, longitude and altitude.

--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -281,7 +281,7 @@ def _prepare_dataframes(
             DataFrame expected to contain the following columns: forecast,
             blend_time, forecast_period, forecast_reference_time, time,
             wmo_id, percentile, diagnostic, latitude, longitude, period,
-            height, cf_name, units. Any other columns are ignored.
+            height, cf_name and units. Any other columns are ignored.
         truth_df:
             DataFrame expected to contain the following columns: ob_value,
             time, wmo_id, diagnostic, latitude, longitude and altitude.
@@ -481,8 +481,8 @@ def truth_dataframe_to_cube(df: DataFrame, training_dates: DatetimeIndex,) -> Cu
     Args:
         df:
             DataFrame expected to contain the following columns: ob_value,
-            time, wmo_id, diagnostic, latitude, longitude and altitude.
-            Any other columns are ignored.
+            time, wmo_id, diagnostic, latitude, longitude, altitude, cf_name,
+            height, period and units. Any other columns are ignored.
         training_dates:
             Datetimes spanning the training period.
 


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/207

Description
This PR makes a minor correction to a docstring listing the input columns for the truth dataframe.

Testing:
 - [x] Ran tests and they passed OK
