### PR TITLE
Remove raising of unnecessary warnings from calibration code

### DIFF
--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -325,17 +325,15 @@ def _prepare_dataframes(
         keep="last",
     )
     # Sort to ensure a consistent ordering after removing duplicates.
-    forecast_df.sort_values(
-        by=["blend_time", "percentile", "wmo_id"], inplace=True, ignore_index=True,
+    forecast_df = forecast_df.sort_values(
+        by=["blend_time", "percentile", "wmo_id"], ignore_index=True,
     )
 
     # Remove truth duplicates.
     truth_cols = ["diagnostic", "time", "wmo_id"]
     truth_df = truth_df.drop_duplicates(subset=truth_cols, keep="last",)
     # Sort to ensure a consistent ordering after removing duplicates.
-    truth_df.sort_values(
-        by=truth_cols, inplace=True, ignore_index=True,
-    )
+    truth_df = truth_df.sort_values(by=truth_cols, ignore_index=True)
 
     # Find the common set of WMO IDs.
     common_wmo_ids = sorted(

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -1130,7 +1130,7 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
             IndexError: if the cube and landsea_mask shapes are not compatible.
         """
         try:
-            cube.data[..., ~landsea_mask.data.astype(np.bool)] = np.nan
+            cube.data[..., ~landsea_mask.data.astype(bool)] = np.nan
         except IndexError as err:
             msg = "Cube and landsea_mask shapes are not compatible. {}".format(err)
             raise IndexError(msg)
@@ -1380,7 +1380,6 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
             forecast_var,
             number_of_realizations,
         )
-
         return coefficients_cubelist
 
 

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -260,7 +260,7 @@ def _create_dimension_coord(
 
         coord_array = np.array(coord_array)
 
-        if issubclass(coord_array.dtype.type, np.float):
+        if issubclass(coord_array.dtype.type, float):
             # option needed for realizations percentile & probability cube setup
             # and heights coordinate
             coord_array = coord_array.astype(np.float32)


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/209

Description
Warnings removed:
- Remove deprecation warning from improver/synthetic_data/set_up_test_cubes.py: ```DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.```
- Remove `SettingWithCopyWarning` in improver/calibration/dataframe_utilities.py: ```SettingWithCopyWarning: A value is trying to be set on a copy of a slice from a DataFrame```
- Remove deprecation warning from improver/calibration/ensemble_calibration.py : ```DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.```


Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
