### PR TITLE
Remove __repr__ methods from all neighbourhood plugins

### DIFF
--- a/improver/nbhood/circular_kernel.py
+++ b/improver/nbhood/circular_kernel.py
@@ -164,11 +164,6 @@ class CircularNeighbourhood:
         self.re_mask = re_mask
         self.kernel = None
 
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        result = "<CircularNeighbourhood: weighted_mode: {}, " "sum_or_fraction: {}>"
-        return result.format(self.weighted_mode, self.sum_or_fraction)
-
     def apply_circular_kernel(self, cube: Cube, ranges: int) -> Cube:
         """
         Method to apply a circular kernel to the data within the input cube in
@@ -262,11 +257,6 @@ class GeneratePercentilesFromACircularNeighbourhood:
             self.percentiles = tuple(percentiles)
         except TypeError:
             self.percentiles = (percentiles,)
-
-    def __repr__(self) -> str:
-        """Represent the configured class instance as a string."""
-        result = "<GeneratePercentilesFromACircularNeighbourhood: " "percentiles: {}>"
-        return result.format(self.percentiles)
 
     def pad_and_unpad_cube(self, slice_2d: Cube, kernel: ndarray) -> Cube:
         """

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -128,18 +128,6 @@ class BaseNeighbourhoodProcessing(PostProcessingPlugin):
         radii = np.interp(cube_lead_times, self.lead_times, self.radii)
         return radii
 
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        if callable(self.neighbourhood_method):
-            neighbourhood_method = self.neighbourhood_method()
-        else:
-            neighbourhood_method = self.neighbourhood_method
-        result = (
-            "<BaseNeighbourhoodProcessing: neighbourhood_method: {}; "
-            "radii: {}; lead_times: {}>"
-        )
-        return result.format(neighbourhood_method, self.radii, self.lead_times)
-
     def process(self, cube: Cube, mask_cube: Optional[Cube] = None) -> Cube:
         """
         Supply neighbourhood processing method, in order to smooth the

--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -82,11 +82,6 @@ class RecursiveFilter(PostProcessingPlugin):
         self.edge_width = edge_width
         self.smoothing_coefficient_name_format = "smoothing_coefficient_{}"
 
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        result = "<RecursiveFilter: iterations: {}, edge_width: {}"
-        return result.format(self.iterations, self.edge_width)
-
     @staticmethod
     def _recurse_forward(
         grid: ndarray, smoothing_coefficients: ndarray, axis: int

--- a/improver/nbhood/square_kernel.py
+++ b/improver/nbhood/square_kernel.py
@@ -89,14 +89,6 @@ class SquareNeighbourhood:
         self.sum_or_fraction = sum_or_fraction
         self.re_mask = re_mask
 
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        result = (
-            "<SquareNeighbourhood: weighted_mode: {}, "
-            "sum_or_fraction: {}, re_mask: {}>"
-        )
-        return result.format(self.weighted_mode, self.sum_or_fraction, self.re_mask)
-
     @staticmethod
     def _calculate_neighbourhood(
         data: ndarray, mask: ndarray, nb_size: int, sum_only: bool, re_mask: bool

--- a/improver/nbhood/use_nbhood.py
+++ b/improver/nbhood/use_nbhood.py
@@ -199,25 +199,6 @@ class ApplyNeighbourhoodProcessingWithAMask(PostProcessingPlugin):
             message = "re_mask should be set to False when using collapse_weights"
             raise ValueError(message)
 
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        result = (
-            "<ApplyNeighbourhoodProcessingWithAMask: "
-            "coord_for_masking: {}, neighbourhood_method: {}, "
-            "radii: {}, lead_times: {}, collapse_weights: {}, "
-            "weighted_mode: {}, sum_or_fraction: {}, re_mask: {}>"
-        )
-        return result.format(
-            self.coord_for_masking,
-            self.neighbourhood_method,
-            self.radii,
-            self.lead_times,
-            self.collapse_weights,
-            self.weighted_mode,
-            self.sum_or_fraction,
-            self.re_mask,
-        )
-
     def collapse_mask_coord(self, cube: Cube) -> Cube:
         """
         Collapse the chosen coordinate with the available weights. The result

--- a/improver_tests/nbhood/circular_kernel/test_CircularNeighbourhood.py
+++ b/improver_tests/nbhood/circular_kernel/test_CircularNeighbourhood.py
@@ -61,20 +61,6 @@ class Test__init__(IrisTest):
             CircularNeighbourhood(sum_or_fraction=sum_or_fraction)
 
 
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-
-        result = str(CircularNeighbourhood())
-        msg = (
-            "<CircularNeighbourhood: weighted_mode: True, " "sum_or_fraction: fraction>"
-        )
-        self.assertEqual(str(result), msg)
-
-
 class Test_apply_circular_kernel(IrisTest):
 
     """Test neighbourhood circular probabilities plugin."""

--- a/improver_tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/improver_tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -51,21 +51,6 @@ from improver.synthetic_data.set_up_test_cubes import (
 )
 
 
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-
-        result = str(GeneratePercentilesFromACircularNeighbourhood())
-        msg = (
-            "<GeneratePercentilesFromACircularNeighbourhood: "
-            "percentiles: {}>".format(DEFAULT_PERCENTILES)
-        )
-        self.assertEqual(str(result), msg)
-
-
 class Test_make_percentile_cube(IrisTest):
 
     """Test the make_percentile_cube method from

--- a/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -189,31 +189,6 @@ class Test__init__(IrisTest):
             NBHood(neighbourhood_method, radii, lead_times=lead_times)
 
 
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_callable(self):
-        """Test that the __repr__ returns the expected string."""
-        result = str(NBHood(CircularNeighbourhood(), 10000))
-        msg = (
-            "<BaseNeighbourhoodProcessing: neighbourhood_method: "
-            "<CircularNeighbourhood: weighted_mode: True, "
-            "sum_or_fraction: fraction>; "
-            "radii: 10000.0; lead_times: None>"
-        )
-        self.assertEqual(result, msg)
-
-    def test_not_callable(self):
-        """Test that the __repr__ returns the expected string."""
-        result = str(NBHood("circular", 10000))
-        msg = (
-            "<BaseNeighbourhoodProcessing: neighbourhood_method: "
-            "circular; radii: 10000.0; lead_times: None>"
-        )
-        self.assertEqual(result, msg)
-
-
 class Test__find_radii(IrisTest):
 
     """Test the internal _find_radii function is working correctly."""

--- a/improver_tests/nbhood/nbhood/test_GeneratePercentilesFromANeighbourhood.py
+++ b/improver_tests/nbhood/nbhood/test_GeneratePercentilesFromANeighbourhood.py
@@ -52,12 +52,7 @@ class Test__init__(IrisTest):
         """
         neighbourhood_method = "circular"
         radii = 10000
-        result = NBHood(neighbourhood_method, radii)
-        msg = (
-            "<GeneratePercentilesFromACircularNeighbourhood: percentiles: "
-            "(0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100)>"
-        )
-        self.assertEqual(str(result.neighbourhood_method), msg)
+        NBHood(neighbourhood_method, radii)
 
     def test_neighbourhood_method_does_not_exist(self):
         """
@@ -69,22 +64,6 @@ class Test__init__(IrisTest):
         msg = "The neighbourhood_method requested: "
         with self.assertRaisesRegex(KeyError, msg):
             NBHood(neighbourhood_method, radii)
-
-
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-        result = str(NBHood("circular", 10000))
-        msg = (
-            "<BaseNeighbourhoodProcessing: neighbourhood_method: "
-            "<GeneratePercentilesFromACircularNeighbourhood: percentiles: "
-            "(0, 5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 100)>; "
-            "radii: 10000.0; lead_times: None>"
-        )
-        self.assertEqual(result, msg)
 
 
 class Test_process(IrisTest):

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -50,11 +50,7 @@ class Test__init__(IrisTest):
          method exists."""
         neighbourhood_method = "circular"
         radii = 10000
-        result = NBHood(neighbourhood_method, radii)
-        msg = (
-            "<CircularNeighbourhood: weighted_mode: True, " "sum_or_fraction: fraction>"
-        )
-        self.assertEqual(str(result.neighbourhood_method), msg)
+        NBHood(neighbourhood_method, radii)
 
     def test_neighbourhood_method_does_not_exist(self):
         """Test that desired error message is raised, if the neighbourhood
@@ -64,22 +60,6 @@ class Test__init__(IrisTest):
         msg = "The neighbourhood_method requested: "
         with self.assertRaisesRegex(KeyError, msg):
             NBHood(neighbourhood_method, radii)
-
-
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-        result = str(NBHood("circular", 10000))
-        msg = (
-            "<BaseNeighbourhoodProcessing: neighbourhood_method: "
-            "<CircularNeighbourhood: weighted_mode: True, "
-            "sum_or_fraction: fraction>; "
-            "radii: 10000.0; lead_times: None>"
-        )
-        self.assertEqual(result, msg)
 
 
 class Test_process(IrisTest):

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -53,21 +53,6 @@ def _mean_points(points):
     return np.array((points[:-1] + points[1:]) / 2, dtype=np.float32)
 
 
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-        iterations = None
-        edge_width = 1
-        result = str(RecursiveFilter(iterations, edge_width))
-        msg = "<RecursiveFilter: iterations: {}, edge_width: {}".format(
-            iterations, edge_width
-        )
-        self.assertEqual(result, msg)
-
-
 class Test_RecursiveFilter(IrisTest):
 
     """Test class for the RecursiveFilter tests, setting up cubes."""

--- a/improver_tests/nbhood/square_kernel/test_SquareNeighbourhood.py
+++ b/improver_tests/nbhood/square_kernel/test_SquareNeighbourhood.py
@@ -55,20 +55,6 @@ class Test__init__(IrisTest):
             SquareNeighbourhood(sum_or_fraction=sum_or_fraction)
 
 
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-        result = str(SquareNeighbourhood())
-        msg = (
-            "<SquareNeighbourhood: weighted_mode: {}, "
-            "sum_or_fraction: {}, re_mask: {}>".format(True, "fraction", True)
-        )
-        self.assertEqual(result, msg)
-
-
 class Test_run(IrisTest):
 
     """Test the run method on the SquareNeighbourhood class."""

--- a/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -48,19 +48,6 @@ class Test__init__(unittest.TestCase):
 
     """Test the __init__ method of ApplyNeighbourhoodProcessingWithAMask."""
 
-    def test_basic(self):
-        """Test that the __init__ method returns the expected string."""
-        coord_for_masking = "topographic_zone"
-        radii = 2000
-        result = ApplyNeighbourhoodProcessingWithAMask(coord_for_masking, radii)
-        msg = (
-            "<ApplyNeighbourhoodProcessingWithAMask: coord_for_masking: "
-            "topographic_zone, neighbourhood_method: square, radii: 2000, "
-            "lead_times: None, collapse_weights: None, weighted_mode: True, "
-            "sum_or_fraction: fraction, re_mask: False>"
-        )
-        self.assertEqual(str(result), msg)
-
     def test_raises_error(self):
         """Test raises an error if re_mask=True when using collapse_weights"""
         message = "re_mask should be set to False when using collapse_weights"
@@ -71,24 +58,6 @@ class Test__init__(unittest.TestCase):
                 collapse_weights=iris.cube.Cube([0]),
                 re_mask=True,
             )
-
-
-class Test__repr__(unittest.TestCase):
-
-    """Test the __repr__ method of ApplyNeighbourhoodProcessingWithAMask."""
-
-    def test_basic(self):
-        """Test that the __repr__ method returns the expected string."""
-        coord_for_masking = "topographic_zone"
-        radii = 2000
-        result = str(ApplyNeighbourhoodProcessingWithAMask(coord_for_masking, radii))
-        msg = (
-            "<ApplyNeighbourhoodProcessingWithAMask: coord_for_masking: "
-            "topographic_zone, neighbourhood_method: square, radii: 2000, "
-            "lead_times: None, collapse_weights: None, weighted_mode: True, "
-            "sum_or_fraction: fraction, re_mask: False>"
-        )
-        self.assertEqual(result, msg)
 
 
 class Test_collapse_mask_coord(unittest.TestCase):


### PR DESCRIPTION
Part of https://github.com/metoppv/mo-blue-team/issues/157

Removes repr methods and associated tests from all neighbourhood related plugins

Testing:
 - [x] Ran tests and they passed OK
