### PR TITLE
Remove cache from scheduled actions run using latest environment

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,16 +14,7 @@ jobs:
     if: github.repository_owner == 'metoppv'
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      id: cache
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 2
-      with:
-        path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
     - name: conda env update
-      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
@@ -71,16 +62,7 @@ jobs:
     if: github.repository_owner == 'metoppv'
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      id: cache
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 2
-      with:
-        path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
     - name: conda env update
-      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
@@ -110,16 +92,7 @@ jobs:
     if: github.repository_owner == 'metoppv'
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      id: cache
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 2
-      with:
-        path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
     - name: conda env update
-      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba


### PR DESCRIPTION
Github actions cache [expires after no usage in 7 days](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).
As the latest environment tests action is scheduled to run daily, the conda environment in cache never expires, so it would never update with newly available package versions from conda. 

This commit removes the cache which will increase time to run these tasks, but this only affects scheduled tasks rather than tasks triggered by pushes and pull requests. The time increases from ~4 minutes to ~7 minutes. 

Scheduled actions only run [on the default branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule). In this repository, that's the master branch, so I have run similar changes in master branch of my personal fork in order to test this change. See https://github.com/tjtg/improver/actions/workflows/scheduled.yml for recent runs.

Testing:
 - [x] Ran tests and they passed OK