### PR TITLE
Unit test fix for Pandas 1.4

### DIFF
--- a/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
+++ b/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
@@ -474,9 +474,9 @@ class Test_forecast_and_truth_dataframes_to_cubes(
         and forecasts. In this case, the position (lat/lon/alt) from the
         forecast will be used."""
         df = self.truth_subset_df.copy()
-        df.at[::3, "altitude"] = 45
-        df.at[::3, "latitude"] = 52
-        df.at[::3, "longitude"] = -12
+        df.loc[::3, "altitude"] = 45
+        df.loc[::3, "latitude"] = 52
+        df.loc[::3, "longitude"] = -12
         result = forecast_and_truth_dataframes_to_cubes(
             self.forecast_df,
             df,


### PR DESCRIPTION
[Pandas 1.4](https://pandas.pydata.org/docs/dev/whatsnew/v1.4.0.html) contains more strict checking of `DataFrame.at` usage, which results in a unit test failing - see [example test failure on my personal fork](https://github.com/tjtg/improver/runs/4948060509?check_suite_focus=true). This will likely affect other forks whenever the cached conda environments get refreshed.

`.at` is intended as a faster alternative to `.loc`, but it only works on scalar indices, not more advanced usage such the slicing used in this test case.

This change was in #1651, but I've split it out as a separate PR as the test failure is now also happening on the conda-forge environment.

Testing:
 - [x] Ran tests and they passed OK