### PR TITLE
DOC Remove mention of cycle_hour from reliability calibration

### DIFF
--- a/doc/source/extended_documentation/calibration/reliability_calibration/reliability_calibration_examples.rst
+++ b/doc/source/extended_documentation/calibration/reliability_calibration/reliability_calibration_examples.rst
@@ -12,7 +12,7 @@ The reliability calibration tables returned by this plugin are structured as sho
        Auxiliary coordinates:
             table_row_name                            -                   x                   -                           -                             -
        Scalar coordinates:
-            cycle_hour: 22
+            forecast_reference_time: 2017-11-11 00:00:00, bound=(2017-11-10 00:00:00, 2017-11-11 00:00:00)
             forecast_period: 68400 seconds
        Attributes:
             institution: Met Office

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -233,10 +233,11 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
     ) -> Cube:
         """
         Construct a reliability table cube and populate it with the provided
-        data. The returned cube will include a cycle hour coordinate, which
-        describes the model cycle hour at which the forecast data was produced.
-        It will further include the forecast period, threshold coordinate,
-        and spatial coordinates from the forecast cube.
+        data. The returned cube will include a forecast_reference_time
+        coordinate, which will be the maximum range of bounds of the input
+        forecast reference times, with the point value set to the latest
+        of those in the inputs. It will further include the forecast period,
+        threshold coordinate, and spatial coordinates from the forecast cube.
 
         Args:
             forecast:
@@ -443,11 +444,11 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         whether the data is thresholded below or above a given diagnostic
         threshold.
 
+        `historic_forecasts` and `truths` should have matching validity times.
+
         Args:
             historic_forecasts:
                 A cube containing the historical forecasts used in calibration.
-                These are expected to all have a consistent cycle hour, that is
-                the hour in the forecast reference time.
             truths:
                 A cube containing the thresholded gridded truths used in
                 calibration.


### PR DESCRIPTION
Following from https://github.com/metoppv/improver/pull/1170, removes remaining mentions of cycle/cycle_hour in reliability calibration.

ping @bayliffe who created the original PR.

Testing:
 - [n/a] Ran tests and they passed OK
 - [n/a] Added new tests for the new feature(s)

