### PR TITLE
DOC Fix intersphinx links for docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -398,7 +398,7 @@ intersphinx_mapping = {
     "https://scitools-iris.readthedocs.io/en/latest/": None,
     "https://scitools.org.uk/cartopy/docs/latest/": None,
     "https://scitools.org.uk/cf-units/docs/latest/": None,
-    "https://docs.scipy.org/doc/numpy/": None,
+    "https://numpy.org/doc/stable/": None,
     "https://docs.scipy.org/doc/scipy-1.6.2/reference/": None,
     "https://pandas.pydata.org/pandas-docs/dev/": None,
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -399,7 +399,7 @@ intersphinx_mapping = {
     "https://scitools.org.uk/cartopy/docs/latest/": None,
     "https://scitools.org.uk/cf-units/docs/latest/": None,
     "https://docs.scipy.org/doc/numpy/": None,
-    "https://docs.scipy.org/doc/scipy/reference/": None,
+    "https://docs.scipy.org/doc/scipy-1.6.2/reference/": None,
     "https://pandas.pydata.org/pandas-docs/dev/": None,
 }
 


### PR DESCRIPTION
Fix numpy and scipy intersphinx links as docs currently failing (see #1667) with error:

> intersphinx inventory 'https://docs.scipy.org/doc/scipy/reference/objects.inv' not readable due to ValueError: unknown or unsupported inventory version: ValueError('invalid inventory header: ')


Note ongoing hosting issue for scipy hosting: https://github.com/scipy/scipy/issues/14267
I linked to scipy 1.6.2 as this is what we test with in CI but can switch this to 1.8.0 (`https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/`)

Testing:
 - [x] Ran tests and they passed OK
 - [n/a] Added new tests for the new feature(s)
