### PR TITLE
Update doc-build intersphinx links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -394,10 +394,10 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/": None,
+    "https://docs.python.org/3/": None,
     "https://scitools-iris.readthedocs.io/en/latest/": None,
     "https://scitools.org.uk/cartopy/docs/latest/": None,
-    "https://scitools.org.uk/cf-units/docs/latest/": None,
+    "https://cf-units.readthedocs.io/en/stable/": None,
     "https://numpy.org/doc/stable/": None,
     "https://docs.scipy.org/doc/scipy-1.6.2/reference/": None,
     "https://pandas.pydata.org/pandas-docs/dev/": None,


### PR DESCRIPTION
Following on from #1668, there are some more links that have changed and need updating to ensure that the documentation builds successfully. There are for:
- cf_units
- python 3

Testing:
 - [x] Ran tests and they passed OK