### PR TITLE
Reduce the memory requirements for read-the-docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,5 +10,3 @@ conda:
 
 python:
     system_packages: true
-formats:
-    - htmlzip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,14 @@
-conda:
-    file: doc/rtd_environment.yml
+version: 2
+
 build:
-    image: latest
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
+conda:
+  environment: doc/rtd_environment.yml
+
 python:
-    version: 3.6
     system_packages: true
 formats:
     - htmlzip


### PR DESCRIPTION
Closes https://github.com/metoppv/mo-blue-team/issues/234

This PR reduces the memory requirements for building read-the-docs pages by:
- replacing conda with mamba for the environment building step.
- removing the `htmlzip` build process, which seems unlikely to be getting much use.

These are the steps recommended in the read-the-docs documentation.

Testing:
 - [x] Ran tests and they passed OK