### PR TITLE
MOBT127 tiny tweak to filter_realizations

### DIFF
--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -639,9 +639,9 @@ def filter_realizations(cubes: CubeList) -> Cube:
         realizations.update(cube.coord("realization").points)
     filtered_cubes = CubeList()
     for realization in realizations:
-        realization_cube = cubes.extract(
-            iris.Constraint(realization=realization)
-        ).merge_cube()
+        realization_cube = MergeCubes()(
+            cubes.extract(iris.Constraint(realization=realization))
+        )
         if set([c.point for c in realization_cube.coord("time").cells()]) == times:
             filtered_cubes.append(realization_cube)
     return filtered_cubes.merge_cube()

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -644,4 +644,4 @@ def filter_realizations(cubes: CubeList) -> Cube:
         )
         if set([c.point for c in realization_cube.coord("time").cells()]) == times:
             filtered_cubes.append(realization_cube)
-    return filtered_cubes.merge_cube()
+    return MergeCubes()(filtered_cubes)

--- a/improver_tests/utilities/cube_manipulation/test_filter_realizations.py
+++ b/improver_tests/utilities/cube_manipulation/test_filter_realizations.py
@@ -59,7 +59,9 @@ def realization_cubes_fixture() -> CubeList:
             )
         )
     cube = cubes.merge_cube()
-    return CubeList(cube.slices_over("realization"))
+    sliced_cubes = CubeList(cube.slices_over("realization"))
+    [s.attributes.update({"history": f"20171110T{i:02d}00Z"}) for i, s in enumerate(sliced_cubes)]
+    return sliced_cubes
 
 
 @pytest.mark.parametrize("short_realizations", [0, 1, 2, 3])
@@ -77,6 +79,12 @@ def test_filter_realizations(realization_cubes, short_realizations):
     assert isinstance(result, Cube)
     assert np.allclose(cubes[0].coord("time").points, result.coord("time").points)
     assert np.allclose(result.coord("realization").points, expected_realization_points)
+    if short_realizations == 3:
+        # History attribute is retained if there are no differing values
+        assert result.attributes["history"] == cubes[0].attributes["history"]
+    else:
+        # History attribute is removed if differing values are supplied
+        assert "history" not in result.attributes.keys()
 
 
 def test_different_time_lengths(realization_cubes):

--- a/improver_tests/utilities/cube_manipulation/test_filter_realizations.py
+++ b/improver_tests/utilities/cube_manipulation/test_filter_realizations.py
@@ -60,7 +60,10 @@ def realization_cubes_fixture() -> CubeList:
         )
     cube = cubes.merge_cube()
     sliced_cubes = CubeList(cube.slices_over("realization"))
-    [s.attributes.update({"history": f"20171110T{i:02d}00Z"}) for i, s in enumerate(sliced_cubes)]
+    [
+        s.attributes.update({"history": f"20171110T{i:02d}00Z"})
+        for i, s in enumerate(sliced_cubes)
+    ]
     return sliced_cubes
 
 


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/127

Testing the use of the `--minimum-realizations` option with MOGREPS-G data showed that we have implemented the wrong merge-cubes method in `filter_realizations`. This PR changes it to use IMPROVER's `MergeCubes` plugin which silently removes attributes such as history on merging.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
