### PR TITLE
Adds a freezing rain plugin

### DIFF
--- a/improver/lapse_rate.py
+++ b/improver/lapse_rate.py
@@ -120,12 +120,12 @@ class ApplyGriddedLapseRate(PostProcessingPlugin):
 
         self._check_dim_coords(temperature, lapse_rate)
 
-        if not spatial_coords_match(temperature, source_orog):
+        if not spatial_coords_match([temperature, source_orog]):
             raise ValueError(
                 "Source orography spatial coordinates do not match " "temperature grid"
             )
 
-        if not spatial_coords_match(temperature, dest_orog):
+        if not spatial_coords_match([temperature, dest_orog]):
             raise ValueError(
                 "Destination orography spatial coordinates do not match "
                 "temperature grid"

--- a/improver/lightning.py
+++ b/improver/lightning.py
@@ -117,7 +117,7 @@ class LightningFromCapePrecip(PostProcessingPlugin):
             raise ValueError(
                 "Supplied cubes must have the same forecast reference times"
             )
-        if not spatial_coords_match(cape, precip):
+        if not spatial_coords_match([cape, precip]):
             raise ValueError("Supplied cubes do not have the same spatial coordinates")
         return cape, precip
 

--- a/improver/precipitation_type/freezing_rain.py
+++ b/improver/precipitation_type/freezing_rain.py
@@ -41,10 +41,7 @@ from improver.metadata.utilities import (
 )
 from improver.utilities.cube_checker import spatial_coords_match
 from improver.utilities.cube_extraction import extract_subcube
-from improver.utilities.probability_manipulation import (
-    comparison_operator_dict,
-    invert_probabilities,
-)
+from improver.utilities.probability_manipulation import to_threshold_inequality
 
 
 class FreezingRain(PostProcessingPlugin):
@@ -123,11 +120,7 @@ class FreezingRain(PostProcessingPlugin):
 
         # Ensure probabilities relate to temperatures below a threshold
         temperature_threshold = self.temperature.coord(var_name="threshold")
-        inequality = temperature_threshold.attributes["spp__relative_to_threshold"]
-        spp_lookup = comparison_operator_dict()
-        greater_attr = [spp_lookup[ineq]["spp_string"] for ineq in ["ge", "gt"]]
-        if inequality in greater_attr:
-            self.temperature = invert_probabilities(self.temperature)
+        self.temperature = to_threshold_inequality(self.temperature, above=False)
 
         # Simplify the temperature cube to the critical threshold of 273.15K,
         # the freezing point of water under typical pressures.
@@ -156,7 +149,7 @@ class FreezingRain(PostProcessingPlugin):
         Raises:
             ValueError: If two input cubes have the same name.
             ValueError: If rain, sleet, and temperature cubes cannot be
-                        distinquished by their names.
+                        distinguished by their names.
         """
         cube_names = [cube.name() for cube in input_cubes]
         if not sorted(list(set(cube_names))) == sorted(cube_names):

--- a/improver/precipitation_type/freezing_rain.py
+++ b/improver/precipitation_type/freezing_rain.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module containing the FreezingRain class."""
+
+from typing import Optional, Tuple
+
+from iris.cube import Cube, CubeList
+
+from improver import PostProcessingPlugin
+from improver.metadata.utilities import (
+    create_new_diagnostic_cube,
+    generate_mandatory_attributes,
+)
+from improver.utilities.cube_checker import spatial_coords_match
+from improver.utilities.cube_extraction import extract_subcube
+from improver.utilities.probability_manipulation import (
+    comparison_operator_dict,
+    invert_probabilities,
+)
+
+
+class FreezingRain(PostProcessingPlugin):
+    """
+    Calculates a probability of freezing rain using rain, sleet and temperature
+    probabilities.
+    """
+
+    def __init__(self, model_id_attr: Optional[str] = None) -> None:
+        """
+        Initialise the class
+
+        Args:
+            model_id_attr:
+                Name of the attribute used to identify the source model for
+                blending.
+        """
+        self.model_id_attr = model_id_attr
+
+    def _get_input_cubes(self, input_cubes: CubeList) -> None:
+        """
+        Separates out the rain, sleet, and temperature cubes, checking that:
+            * No other cubes are present
+            * Cubes have same dimensions
+            * Cubes represent the same time quantity (instantaneous or accumulation length)
+            * Precipitation cube threshold units are compatible
+            * Precipitation cubes have the same set of thresholds
+            * A 273.15K (0 Celsius) temperature threshold is available
+
+        The temperature cube is also modified if necessary to return probabilties
+        below threshold values. This data is then thinned to return only the
+        probabilities of temperature being below the freezing point of water,
+        0 Celsius.
+
+        Args:
+            input_cubes:
+                Contains exactly three cubes, a rain rate or accumulation, a
+                sleet rate or accumulation, and an instantaneous or period
+                temperature. Accumulations and periods must all represent the
+                same length of time.
+
+        Raises:
+            ValueError:
+                If any of the criteria above are not met.
+        """
+        if len(input_cubes) != 3:
+            raise ValueError(
+                f"Expected exactly 3 input cubes, found {len(input_cubes)}"
+            )
+        rain_name, sleet_name, temperature_name = self._get_input_cube_names(
+            input_cubes
+        )
+        (self.rain,) = input_cubes.extract(rain_name)
+        (self.sleet,) = input_cubes.extract(sleet_name)
+        (self.temperature,) = input_cubes.extract(temperature_name)
+
+        if not spatial_coords_match(self.rain, self.sleet):
+            raise ValueError("Input cubes are not on the same grid")
+        if (
+            not self.rain.coord("time")
+            == self.sleet.coord("time")
+            == self.temperature.coord("time")
+        ):
+            raise ValueError("Input cubes do not have the same time coord")
+
+        # Ensure rain and sleet cubes are compatible
+        rain_threshold = self.rain.coord(var_name="threshold")
+        sleet_threshold = self.sleet.coord(var_name="threshold")
+        try:
+            sleet_threshold.convert_units(rain_threshold.units)
+        except ValueError:
+            raise ValueError("Rain and sleet cubes have incompatible units")
+
+        if not all(rain_threshold.points == sleet_threshold.points):
+            raise ValueError("Rain and sleet cubes have different threshold values")
+
+        # Ensure probabilities relate to temperatures below a threshold
+        temperature_threshold = self.temperature.coord(var_name="threshold")
+        inequality = temperature_threshold.attributes["spp__relative_to_threshold"]
+        spp_lookup = comparison_operator_dict()
+        greater_attr = [spp_lookup[ineq]["spp_string"] for ineq in ["ge", "gt"]]
+        if inequality in greater_attr:
+            self.temperature = invert_probabilities(self.temperature)
+
+        # Simplify the temperature cube to the critical threshold of 273.15K,
+        # the freezing point of water under typical pressures.
+        self.temperature = extract_subcube(
+            self.temperature, [f"{temperature_threshold.name()}=273.15"], units=["K"]
+        )
+        if self.temperature is None:
+            raise ValueError(
+                "No 0 Celsius or equivalent threshold is available "
+                "in the temperature data"
+            )
+
+    @staticmethod
+    def _get_input_cube_names(input_cubes: CubeList) -> Tuple[str, str, str]:
+        """
+        Identifies the rain, sleet, and temperature cubes from the diagnostic
+        names.
+
+        Args:
+            input_cubes:
+                The unsorted rain, sleet, and temperature cubes.
+
+        Returns:
+            rain_name, sleet_name, and temperature_name in that order.
+
+        Raises:
+            ValueError: If two input cubes have the same name.
+            ValueError: If rain, sleet, and temperature cubes cannot be
+                        distinquished by their names.
+        """
+        cube_names = [cube.name() for cube in input_cubes]
+        if not sorted(list(set(cube_names))) == sorted(cube_names):
+            raise ValueError(
+                "Duplicate input cube provided. Unable to find unique rain, "
+                f"sleet, and temperature cubes from {cube_names}"
+            )
+
+        try:
+            (rain_name,) = [x for x in cube_names if "rain" in x]
+            (sleet_name,) = [x for x in cube_names if "sleet" in x]
+            (temperature_name,) = [x for x in cube_names if "temperature" in x]
+        except ValueError:
+            raise ValueError(
+                "Could not find unique rain, sleet, and temperature diagnostics"
+                f"in {cube_names}"
+            )
+        return rain_name, sleet_name, temperature_name
+
+    def _calculate_freezing_rain_probability(self) -> Cube:
+        """Calculate the probability of freezing rain from the probabilities
+        of rain and sleet rates or accumulations, and the provided probabilities
+        of temperature being below the freezing point of water.
+
+        (probability of rain + probability of sleet) x (probability T < 0C)
+
+        Returns:
+            Cube of freezing rain probabilities.
+        """
+
+        freezing_rain_prob = (self.rain.data + self.sleet.data) * self.temperature.data
+        diagnostic_name = self.sleet.name().replace("sleet", "freezing_rain")
+        threshold_name = (
+            self.sleet.coord(var_name="threshold")
+            .name()
+            .replace("sleet", "freezing_rain")
+        )
+        freezing_rain_cube = create_new_diagnostic_cube(
+            diagnostic_name,
+            "1",
+            template_cube=self.sleet,
+            mandatory_attributes=generate_mandatory_attributes(
+                CubeList([self.rain, self.sleet]), model_id_attr=self.model_id_attr,
+            ),
+            data=freezing_rain_prob,
+        )
+        freezing_rain_cube.coord(var_name="threshold").rename(threshold_name)
+        freezing_rain_cube.coord(threshold_name).var_name = "threshold"
+        return freezing_rain_cube
+
+    def process(self, input_cubes: CubeList) -> Cube:
+        """Check input cubes, then calculate a probability of freezing rain
+        diagnostic.
+
+        Args:
+            input_cubes:
+                Contains exactly three cubes, a rain rate or accumulation, a
+                sleet rate or accumulation, and an instantaneous or period
+                temperature. Accumulations and periods must all represent the
+                same length of time.
+
+        Returns:
+            Cube of freezing rain probabilties.
+        """
+        self._get_input_cubes(input_cubes)
+        return self._calculate_freezing_rain_probability()

--- a/improver/precipitation_type/freezing_rain.py
+++ b/improver/precipitation_type/freezing_rain.py
@@ -102,7 +102,7 @@ class FreezingRain(PostProcessingPlugin):
         (self.sleet,) = input_cubes.extract(sleet_name)
         (self.temperature,) = input_cubes.extract(temperature_name)
 
-        if not spatial_coords_match(self.rain, self.sleet):
+        if not spatial_coords_match([self.rain, self.sleet, self.temperature]):
             raise ValueError("Input cubes are not on the same grid")
         if (
             not self.rain.coord("time")

--- a/improver/precipitation_type/snow_fraction.py
+++ b/improver/precipitation_type/snow_fraction.py
@@ -91,7 +91,7 @@ class SnowFraction(PostProcessingPlugin):
         self.rain = input_cubes.extract(rain_name).merge_cube()
         self.snow = input_cubes.extract(snow_name).merge_cube()
         self.snow.convert_units(self.rain.units)
-        if not spatial_coords_match(self.rain, self.snow):
+        if not spatial_coords_match([self.rain, self.snow]):
             raise ValueError("Rain and snow cubes are not on the same grid")
         if not self.rain.coord("time") == self.snow.coord("time"):
             raise ValueError("Rain and snow cubes do not have the same time coord")

--- a/improver/psychrometric_calculations/precip_phase_probability.py
+++ b/improver/psychrometric_calculations/precip_phase_probability.py
@@ -104,7 +104,7 @@ class PrecipPhaseProbability(BasePlugin):
         if len(cubes) != 2:
             raise ValueError(f"Expected 2 cubes, found {len(cubes)}")
 
-        if not spatial_coords_match(cubes[0], cubes[1]):
+        if not spatial_coords_match(cubes):
             raise ValueError(
                 "Spatial coords mismatch between " f"{cubes[0]} and " f"{cubes[1]}"
             )

--- a/improver/regrid/landsea.py
+++ b/improver/regrid/landsea.py
@@ -354,7 +354,7 @@ class AdjustLandSeaPoints(BasePlugin):
             Cube of regridding results.
         """
         # Check cube and output_land are on the same grid:
-        if not spatial_coords_match(cube, output_land):
+        if not spatial_coords_match([cube, output_land]):
             raise ValueError(
                 "X and Y coordinates do not match for cubes {}"
                 "and {}".format(repr(cube), repr(output_land))
@@ -400,7 +400,7 @@ def grid_contains_cutout(grid: Cube, cutout: Cube) -> bool:
         True if cutout is contained within grid, False otherwise.
     """
 
-    if spatial_coords_match(grid, cutout):
+    if spatial_coords_match([grid, cutout]):
         return True
 
     # check whether "cutout" coordinate points match a subset of "grid"

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -251,7 +251,7 @@ class BasicThreshold(PostProcessingPlugin):
         """
         threshold_coord = cube.coord(self.threshold_coord_name)
         threshold_coord.attributes.update(
-            {"spp__relative_to_threshold": self.comparison_operator["spp_string"]}
+            {"spp__relative_to_threshold": self.comparison_operator.spp_string}
         )
         if cube.cell_methods:
             format_cell_methods_for_probability(cube, self.threshold_coord_name)
@@ -306,7 +306,7 @@ class BasicThreshold(PostProcessingPlugin):
             # if upper and lower bounds are equal, set a deterministic 0/1
             # probability based on exceedance of the threshold
             if bounds[0] == bounds[1]:
-                truth_value = self.comparison_operator["function"](cube.data, threshold)
+                truth_value = self.comparison_operator.function(cube.data, threshold)
             # otherwise, scale exceedance probabilities linearly between 0/1
             # at the min/max fuzzy bounds and 0.5 at the threshold value
             else:
@@ -329,7 +329,7 @@ class BasicThreshold(PostProcessingPlugin):
                 # less_than_or_equal_to the threshold (rather than
                 # greater_than or greater_than_or_equal_to), invert
                 # the exceedance probability
-                if "less_than" in self.comparison_operator["spp_string"]:
+                if "less_than" in self.comparison_operator.spp_string:
                     truth_value = 1.0 - truth_value
 
             truth_value = truth_value.astype(FLOAT_DTYPE)
@@ -464,7 +464,7 @@ class LatitudeDependentThreshold(BasicThreshold):
 
         # Add a scalar axis for the longitude axis so that numpy's array-
         # broadcasting knows what we want to do
-        truth_value = self.comparison_operator["function"](
+        truth_value = self.comparison_operator.function(
             cube.data, np.expand_dims(threshold_over_latitude, 1),
         )
 

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -30,8 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing thresholding classes."""
 
-import operator
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import iris
 import numpy as np
@@ -45,6 +44,7 @@ from improver.metadata.probabilistic import (
     probability_is_above_or_below,
 )
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
+from improver.utilities.probability_manipulation import comparison_operator_dict
 from improver.utilities.rescale import rescale
 
 
@@ -163,7 +163,7 @@ class BasicThreshold(PostProcessingPlugin):
             )
             self._check_fuzzy_bounds()
 
-        self.comparison_operator_dict = self._comparison_operator_dict()
+        self.comparison_operator_dict = comparison_operator_dict()
         self.comparison_operator_string = comparison_operator
         self._decode_comparison_operator_string()
 
@@ -202,39 +202,6 @@ class BasicThreshold(PostProcessingPlugin):
                     "!( {} <= {} <= {} )".format(bounds[0], thr, bounds[1])
                 )
                 raise ValueError(bounds_msg)
-
-    @staticmethod
-    def _comparison_operator_dict() -> Dict[str, Any]:
-        """Generate dictionary linking string comparison operators to functions.
-        Each key contains a dict of:
-        - 'function': The operator function for this comparison_operator,
-        - 'spp_string': Comparison_Operator string for use in CF-convention metadata
-        """
-        comparison_operator_dict = {}
-        comparison_operator_dict.update(
-            dict.fromkeys(
-                ["ge", "GE", ">="],
-                {"function": operator.ge, "spp_string": "greater_than_or_equal_to"},
-            )
-        )
-        comparison_operator_dict.update(
-            dict.fromkeys(
-                ["gt", "GT", ">"],
-                {"function": operator.gt, "spp_string": "greater_than"},
-            )
-        )
-        comparison_operator_dict.update(
-            dict.fromkeys(
-                ["le", "LE", "<="],
-                {"function": operator.le, "spp_string": "less_than_or_equal_to"},
-            )
-        )
-        comparison_operator_dict.update(
-            dict.fromkeys(
-                ["lt", "LT", "<"], {"function": operator.lt, "spp_string": "less_than"}
-            )
-        )
-        return comparison_operator_dict
 
     def _add_threshold_coord(self, cube: Cube, threshold: float) -> None:
         """

--- a/improver/utilities/cube_checker.py
+++ b/improver/utilities/cube_checker.py
@@ -30,11 +30,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """ Provides support utilities for checking cubes."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import iris
 import numpy as np
-from iris.cube import Cube
+from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError
 
 
@@ -181,21 +181,25 @@ def find_dimension_coordinate_mismatch(
     return mismatch
 
 
-def spatial_coords_match(first_cube: Cube, second_cube: Cube) -> bool:
+def spatial_coords_match(cubes: Union[List, CubeList]) -> bool:
     """
-    Determine if the x and y coords in the two cubes are the same.
+    Determine if the x and y coords of all the input cubes are the same.
 
     Args:
-        first_cube:
-            First cube to compare.
-        second_cube:
-            Second cube to compare.
+        cubes:
+            A list of cubes to compare.
 
     Returns:
         True if the x and y coords are the exactly the same to the
         precision of the floating-point values (this should be true for
         any cubes derived using cube.regrid()), otherwise False.
     """
-    return first_cube.coord(axis="x") == second_cube.coord(
-        axis="x"
-    ) and first_cube.coord(axis="y") == second_cube.coord(axis="y")
+    ref = cubes[0]
+    match = True
+    for cube in cubes[1:]:
+        match = (
+            cube.coord(axis="x") == ref.coord(axis="x")
+            and cube.coord(axis="y") == ref.coord(axis="y")
+            and match
+        )
+    return match

--- a/improver/utilities/probability_manipulation.py
+++ b/improver/utilities/probability_manipulation.py
@@ -101,9 +101,12 @@ def to_threshold_inequality(cube: Cube, above: bool = True) -> Cube:
             Targets an above (gt, ge) threshold inequality if True, otherwise
             targets a below (lt, le) threshold inequality if False.
 
-    Reurns:
+    Returns:
         A cube with the probabilities relative to the threshold values with
         the target inequality.
+
+    Raised:
+        ValueError: If the input cube has no threshold coordinate.
     """
     try:
         threshold = cube.coord(var_name="threshold")

--- a/improver/utilities/probability_manipulation.py
+++ b/improver/utilities/probability_manipulation.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module for utilities that manipulate probabilities."""
+
+import operator
+from typing import Any, Dict
+
+from iris.cube import Cube
+from iris.exceptions import CoordinateNotFoundError
+
+
+def comparison_operator_dict() -> Dict[str, Any]:
+    """Generate dictionary linking string comparison operators to functions.
+    Each key contains a dict of:
+    - 'function': The operator function for this comparison_operator,
+    - 'spp_string': Comparison_Operator string for use in CF-convention metadata
+    """
+    comparison_operator_dict = {}
+    comparison_operator_dict.update(
+        dict.fromkeys(
+            ["ge", "GE", ">="],
+            {
+                "function": operator.ge,
+                "spp_string": "greater_than_or_equal_to",
+                "inverse": "lt",
+            },
+        )
+    )
+    comparison_operator_dict.update(
+        dict.fromkeys(
+            ["gt", "GT", ">"],
+            {"function": operator.gt, "spp_string": "greater_than", "inverse": "le"},
+        )
+    )
+    comparison_operator_dict.update(
+        dict.fromkeys(
+            ["le", "LE", "<="],
+            {
+                "function": operator.le,
+                "spp_string": "less_than_or_equal_to",
+                "inverse": "gt",
+            },
+        )
+    )
+    comparison_operator_dict.update(
+        dict.fromkeys(
+            ["lt", "LT", "<"],
+            {"function": operator.lt, "spp_string": "less_than", "inverse": "ge"},
+        )
+    )
+    return comparison_operator_dict
+
+
+def invert_probabilities(cube: Cube) -> Cube:
+    """Given a cube with a probability threshold, invert the probabilities
+    relative to the existing thresholding inequality. Update the coordinate
+    metadata to indicate the new threshold inequality.
+
+    Args:
+        cube:
+            A probability cube with a threshold coordinate.
+
+    Returns:
+        Cube with the probabilities inverted relative to the input thresholding
+        inequality.
+
+    Raises:
+        ValueError: If no threshold coordinate is found.
+    """
+    try:
+        threshold = cube.coord(var_name="threshold")
+    except CoordinateNotFoundError:
+        raise ValueError(
+            "Cube does not have a threshold coordinate, probabilities "
+            "cannot be inverted if present."
+        )
+
+    comparison_operator_lookup = comparison_operator_dict()
+    inequality = threshold.attributes["spp__relative_to_threshold"]
+    (inverse,) = set(
+        [
+            value["inverse"]
+            for key, value in comparison_operator_lookup.items()
+            if value["spp_string"] == inequality
+        ]
+    )
+    new_inequality = comparison_operator_lookup[inverse]["spp_string"]
+    inverted_probabilities = cube.copy(data=(1.0 - cube.data))
+    inverted_probabilities.coord(threshold).attributes[
+        "spp__relative_to_threshold"
+    ] = new_inequality
+
+    new_name = (
+        cube.name().replace("above", "below")
+        if "above" in cube.name()
+        else cube.name().replace("below", "above")
+    )
+    inverted_probabilities.rename(new_name)
+
+    return inverted_probabilities

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -486,7 +486,9 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
             Cube containing the occurrences within a vicinity for each
             xy 2d slice, which have been merged back together.
         """
-        if self.land_mask_cube and not spatial_coords_match(cube, self.land_mask_cube):
+        if self.land_mask_cube and not spatial_coords_match(
+            [cube, self.land_mask_cube]
+        ):
             raise ValueError(
                 "Supplied cube do not have the same spatial coordinates and land mask"
             )

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -472,7 +472,7 @@ class TimezoneExtraction(PostProcessingPlugin):
         enforce_coordinate_ordering(
             self.timezone_cube, ["UTC_offset"], anchor_start=False
         )
-        if not spatial_coords_match(input_cube, self.timezone_cube):
+        if not spatial_coords_match([input_cube, self.timezone_cube]):
             raise ValueError(
                 "Spatial coordinates on input_cube and timezone_cube do not match."
             )

--- a/improver_tests/precipitation_type/freezing_rain/conftest.py
+++ b/improver_tests/precipitation_type/freezing_rain/conftest.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Fixtures for freezing rain tests"""
+
+from datetime import datetime
+
+import iris
+import numpy as np
+import pytest
+
+from improver.synthetic_data.set_up_test_cubes import set_up_probability_cube
+
+COMMON_ATTRS = {
+    "source": "Unit test",
+    "institution": "Met Office",
+    "title": "Post-Processed IMPROVER unit test",
+}
+PERIOD_TIMEBOUNDS = (datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0))
+
+
+def setup_cube(
+    data, thresholds, threshold_units, cube_name, time_bounds, inequality="greater_than"
+):
+    """Construct a probability cube"""
+    return set_up_probability_cube(
+        data,
+        thresholds,
+        variable_name=cube_name,
+        threshold_units=threshold_units,
+        time_bounds=time_bounds,
+        spatial_grid="equalarea",
+        attributes=COMMON_ATTRS,
+        standard_grid_metadata="uk_ens",
+        spp__relative_to_threshold=inequality,
+    )
+
+
+def rain_cube(cube_name, thresholds, threshold_units, time_bounds):
+    """Construct a rainfall rate or accumulation cube."""
+    threshold_0 = np.linspace(0.1, 0.4, 4).reshape(2, 2).astype(np.float32)
+    data = np.stack([threshold_0, threshold_0 - 0.1])
+    return setup_cube(
+        data, thresholds, threshold_units, cube_name.format("rain"), time_bounds
+    )
+
+
+def sleet_cube(cube_name, thresholds, threshold_units, time_bounds):
+    """Construct a sleetfall rate or accumulation cube."""
+    threshold_0 = np.linspace(0.2, 0.5, 4).reshape(2, 2).astype(np.float32)
+    data = np.stack([threshold_0, threshold_0 - 0.1])
+    return setup_cube(
+        data, thresholds, threshold_units, cube_name.format("lwe_sleet"), time_bounds
+    )
+
+
+def precipitation_cubes(period):
+    """Construct rain and sleet rate or accumulation cubes."""
+    thresholds = [0.1, 0.2]
+    if period == "instantaneous":
+        cube_name = "{}rate"
+        threshold_units = "mm hr-1"
+        time_bounds = None
+    if period == "period":
+        cube_name = "thickness_of_{}fall_amount"
+        threshold_units = "mm"
+        time_bounds = PERIOD_TIMEBOUNDS
+
+    return (
+        rain_cube(cube_name, thresholds, threshold_units, time_bounds),
+        sleet_cube(cube_name, thresholds, threshold_units, time_bounds),
+    )
+
+
+def temperature_cube(period, inequality="greater_than"):
+    """Construct an instantaneous or minimum in period air temperature cube."""
+    cube_name = "air_temperature"
+    thresholds = [273.15, 274.15]
+    threshold_units = "K"
+
+    if period == "instantaneous":
+        time_bounds = None
+    if period == "period":
+        time_bounds = PERIOD_TIMEBOUNDS
+
+    data = np.linspace(1, 0.3, 8).reshape(2, 2, 2).astype(np.float32)
+    return setup_cube(data, thresholds, threshold_units, cube_name, time_bounds)
+
+
+@pytest.fixture(params=["instantaneous", "period"])
+def input_cubes(request):
+    """Return rain, sleet, and air temperature cubes as an iris CubeList. This
+    fixture is parameterised such that any test using it will be run with both
+    instantaneous and period diagnostics."""
+    return iris.cube.CubeList(
+        [*precipitation_cubes(request.param), temperature_cube(request.param)]
+    )
+
+
+@pytest.fixture(params=["instantaneous", "period"])
+def precipitation_only(request):
+    """Return rain and sleet cubes as a tuple. This fixture is parameterised
+    such that any test using it will be run with both instantaneous and period
+    diagnostics."""
+    return precipitation_cubes(request.param)
+
+
+@pytest.fixture(params=["instantaneous", "period"])
+def temperature_only(request):
+    """Return an air temperature cube. This fixture is parameterised such that
+    any test using it will be run with both instantaneous and period air
+    temperature as an input."""
+    return temperature_cube(request.param)
+
+
+@pytest.fixture(params=["instantaneous", "period"])
+def temperature_below(request):
+    """Return an air temperature cube that has thresholds created using a
+    "less than" inequality. This fixture is parameterised such that any test
+    using it will be run with both instantaneous and period air temperature as
+    an input."""
+    return temperature_cube(request.param, inequality="less_than")
+
+
+@pytest.fixture
+def expected_probabilities():
+    """Return the expected freezing rain probabilities."""
+    return np.array(
+        [[[0.0, 0.05], [0.14, 0.27]], [[0.0, 0.03], [0.1, 0.21]]], dtype=np.float32
+    )
+
+
+@pytest.fixture
+def expected_attributes():
+    """Return the expected freezing rain cube attributes."""
+    return {
+        "source": "Unit test",
+        "institution": "Met Office",
+        "title": "Post-Processed IMPROVER unit test",
+    }

--- a/improver_tests/precipitation_type/freezing_rain/conftest.py
+++ b/improver_tests/precipitation_type/freezing_rain/conftest.py
@@ -36,7 +36,10 @@ import iris
 import numpy as np
 import pytest
 
-from improver.synthetic_data.set_up_test_cubes import set_up_probability_cube
+from improver.synthetic_data.set_up_test_cubes import (
+    add_coordinate,
+    set_up_probability_cube,
+)
 
 COMMON_ATTRS = {
     "source": "Unit test",
@@ -134,11 +137,34 @@ def precipitation_only(request):
 
 
 @pytest.fixture(params=PARAMS)
+def precipitation_multi_realization(request):
+    """Return multi-realization rain and sleet cubes as a tuple. This fixture
+    is parameterised such that any test using it will be run with both
+    instantaneous and period diagnostics."""
+    rain, sleet = precipitation_cubes(request.param)
+    rain = add_coordinate(rain, [0, 1], "realization", coord_units=1, dtype=np.int32)
+    sleet = add_coordinate(sleet, [0, 1], "realization", coord_units=1, dtype=np.int32)
+    return rain, sleet
+
+
+@pytest.fixture(params=PARAMS)
 def temperature_only(request):
     """Return an air temperature cube. This fixture is parameterised such that
     any test using it will be run with both instantaneous and period air
     temperature as an input."""
     return temperature_cube(request.param)
+
+
+@pytest.fixture(params=PARAMS)
+def temperature_multi_realization(request):
+    """Return a multi-realization air temperature cube. This fixture is
+    parameterised such that any test using it will be run with both instantaneous
+    and period air temperature as an input."""
+    temperature = temperature_cube(request.param)
+    temperature = add_coordinate(
+        temperature, [0, 1, 2], "realization", coord_units=1, dtype=np.int32
+    )
+    return temperature
 
 
 @pytest.fixture(params=PARAMS)

--- a/improver_tests/precipitation_type/freezing_rain/conftest.py
+++ b/improver_tests/precipitation_type/freezing_rain/conftest.py
@@ -47,7 +47,6 @@ COMMON_ATTRS = {
     "title": "Post-Processed IMPROVER unit test",
 }
 PERIOD_TIMEBOUNDS = (datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0))
-PARAMS = ["instantaneous", "period"]
 
 
 def setup_cube(
@@ -118,7 +117,7 @@ def temperature_cube(period, inequality="greater_than"):
     return setup_cube(data, thresholds, threshold_units, cube_name, time_bounds)
 
 
-@pytest.fixture(params=PARAMS)
+@pytest.fixture(params=["instantaneous", "period"])
 def input_cubes(request):
     """Return rain, sleet, and air temperature cubes as an iris CubeList. This
     fixture is parameterised such that any test using it will be run with both
@@ -128,52 +127,52 @@ def input_cubes(request):
     )
 
 
-@pytest.fixture(params=PARAMS)
-def precipitation_only(request):
+@pytest.fixture
+def precipitation_only(period):
     """Return rain and sleet cubes as a tuple. This fixture is parameterised
     such that any test using it will be run with both instantaneous and period
     diagnostics."""
-    return precipitation_cubes(request.param)
+    return precipitation_cubes(period)
 
 
-@pytest.fixture(params=PARAMS)
-def precipitation_multi_realization(request):
+@pytest.fixture
+def precipitation_multi_realization(period):
     """Return multi-realization rain and sleet cubes as a tuple. This fixture
     is parameterised such that any test using it will be run with both
     instantaneous and period diagnostics."""
-    rain, sleet = precipitation_cubes(request.param)
+    rain, sleet = precipitation_cubes(period)
     rain = add_coordinate(rain, [0, 1], "realization", coord_units=1, dtype=np.int32)
     sleet = add_coordinate(sleet, [0, 1], "realization", coord_units=1, dtype=np.int32)
     return rain, sleet
 
 
-@pytest.fixture(params=PARAMS)
-def temperature_only(request):
+@pytest.fixture
+def temperature_only(period):
     """Return an air temperature cube. This fixture is parameterised such that
     any test using it will be run with both instantaneous and period air
     temperature as an input."""
-    return temperature_cube(request.param)
+    return temperature_cube(period)
 
 
-@pytest.fixture(params=PARAMS)
-def temperature_multi_realization(request):
+@pytest.fixture
+def temperature_multi_realization(period):
     """Return a multi-realization air temperature cube. This fixture is
     parameterised such that any test using it will be run with both instantaneous
     and period air temperature as an input."""
-    temperature = temperature_cube(request.param)
+    temperature = temperature_cube(period)
     temperature = add_coordinate(
         temperature, [0, 1, 2], "realization", coord_units=1, dtype=np.int32
     )
     return temperature
 
 
-@pytest.fixture(params=PARAMS)
-def temperature_below(request):
+@pytest.fixture
+def temperature_below(period):
     """Return an air temperature cube that has thresholds created using a
     "less than" inequality. This fixture is parameterised such that any test
     using it will be run with both instantaneous and period air temperature as
     an input."""
-    return temperature_cube(request.param, inequality="less_than")
+    return temperature_cube(period, inequality="less_than")
 
 
 @pytest.fixture

--- a/improver_tests/precipitation_type/freezing_rain/conftest.py
+++ b/improver_tests/precipitation_type/freezing_rain/conftest.py
@@ -44,6 +44,7 @@ COMMON_ATTRS = {
     "title": "Post-Processed IMPROVER unit test",
 }
 PERIOD_TIMEBOUNDS = (datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0))
+PARAMS = ["instantaneous", "period"]
 
 
 def setup_cube(
@@ -114,7 +115,7 @@ def temperature_cube(period, inequality="greater_than"):
     return setup_cube(data, thresholds, threshold_units, cube_name, time_bounds)
 
 
-@pytest.fixture(params=["instantaneous", "period"])
+@pytest.fixture(params=PARAMS)
 def input_cubes(request):
     """Return rain, sleet, and air temperature cubes as an iris CubeList. This
     fixture is parameterised such that any test using it will be run with both
@@ -124,7 +125,7 @@ def input_cubes(request):
     )
 
 
-@pytest.fixture(params=["instantaneous", "period"])
+@pytest.fixture(params=PARAMS)
 def precipitation_only(request):
     """Return rain and sleet cubes as a tuple. This fixture is parameterised
     such that any test using it will be run with both instantaneous and period
@@ -132,7 +133,7 @@ def precipitation_only(request):
     return precipitation_cubes(request.param)
 
 
-@pytest.fixture(params=["instantaneous", "period"])
+@pytest.fixture(params=PARAMS)
 def temperature_only(request):
     """Return an air temperature cube. This fixture is parameterised such that
     any test using it will be run with both instantaneous and period air
@@ -140,7 +141,7 @@ def temperature_only(request):
     return temperature_cube(request.param)
 
 
-@pytest.fixture(params=["instantaneous", "period"])
+@pytest.fixture(params=PARAMS)
 def temperature_below(request):
     """Return an air temperature cube that has thresholds created using a
     "less than" inequality. This fixture is parameterised such that any test

--- a/improver_tests/precipitation_type/freezing_rain/test_FreezingRain.py
+++ b/improver_tests/precipitation_type/freezing_rain/test_FreezingRain.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+""" Tests of FreezingRain plugin"""
+
+import itertools
+
+import iris
+import pytest
+from iris.cube import Cube
+from numpy.testing import assert_almost_equal
+
+from improver.precipitation_type.freezing_rain import FreezingRain
+
+RATE_NAME = "lwe_freezing_rainrate"
+ACCUM_NAME = "thickness_of_lwe_freezing_rainfall_amount"
+PROB_NAME = "probability_of_{}_above_threshold"
+
+
+def modify_coordinate(cube, coord):
+    """Modify a coordinate to enable testing for mismatches."""
+    points = cube.coord(coord).points.copy()
+    points += 1
+    cube.coord(coord).points = points
+
+
+def test_expected_result(input_cubes, expected_probabilities, expected_attributes):
+    """Test that the returned probabilities are correct. This test also loops
+    through all permutations of input cube order to ensure the result is
+    consistent. The input_cubes fixture provides a set of either instantaneous
+    or period diagnostics, such that both are tested here."""
+
+    input_cubes = list(itertools.permutations(input_cubes))
+    for cubes in input_cubes:
+        result = FreezingRain()(iris.cube.CubeList(cubes))
+
+        assert_almost_equal(result.data, expected_probabilities)
+        assert isinstance(result, Cube)
+        assert result.attributes == expected_attributes
+        assert result.coord("time") == cubes[-1].coord("time")
+        if result.coord("time").has_bounds():
+            assert result.name() == PROB_NAME.format(ACCUM_NAME)
+            assert result.coord(var_name="threshold").name() == ACCUM_NAME
+            assert result.coord(var_name="threshold").units == "mm"
+        else:
+            assert result.name() == PROB_NAME.format(RATE_NAME)
+            assert result.coord(var_name="threshold").name() == RATE_NAME
+            assert result.coord(var_name="threshold").units == "mm hr-1"
+
+
+@pytest.mark.parametrize("n_cubes", [1, 2, 4])
+def test_wrong_number_of_cubes(temperature_only, n_cubes):
+    """Test that an exception is raised if fewer or more than 3 cubes are
+    provided as input."""
+    cubes = iris.cube.CubeList([*[temperature_only] * n_cubes])
+    with pytest.raises(
+        ValueError, match=f"Expected exactly 3 input cubes, found {n_cubes}"
+    ):
+        FreezingRain()(cubes)
+
+
+def test_duplicate_cubes(temperature_only):
+    """Test that an exception is raised if duplicate cubes are passed in."""
+    cubes = iris.cube.CubeList([*[temperature_only] * 3])
+    with pytest.raises(ValueError, match="Duplicate input cube provided."):
+        FreezingRain()(cubes)
+
+
+def test_wrong_cubes(input_cubes):
+    """Test that an exception is raised if the cubes provided do not relate to
+    the expected diagnostics."""
+    input_cubes[0].rename("kittens_playing_snooker")
+    with pytest.raises(ValueError, match="Could not find unique"):
+        FreezingRain()(input_cubes)
+
+
+def test_inseperable_cubes(input_cubes):
+    """Test that an exception is raised if the cubes cannot be differentiated
+    using expected name components."""
+    input_cubes[0].rename("kittens_frolicking_in_rain_and_sleet")
+    input_cubes[1].rename("kittens_watching_the_rain_and_sleet")
+    with pytest.raises(ValueError, match="Could not find unique"):
+        FreezingRain()(input_cubes)
+
+
+def test_mismatched_grids(input_cubes):
+    """Test that an exception is raised if the input cubes do not all share the
+    same grid."""
+    modify_coordinate(input_cubes[0], input_cubes[0].coord(axis="x").name())
+    with pytest.raises(ValueError, match="Input cubes are not on the same grid"):
+        FreezingRain()(input_cubes)
+
+
+def test_mismatched_time_coord(input_cubes):
+    """Test that an exception is raised if the input cubes do not all share the
+    same time coordinate."""
+
+    if input_cubes[0].coord("time").has_bounds():
+        input_cubes[0].coord("time").bounds = None
+    else:
+        modify_coordinate(input_cubes[0], "time")
+
+    with pytest.raises(ValueError, match="Input cubes do not have the same time coord"):
+        FreezingRain()(input_cubes)
+
+
+def test_compatible_precipitation_units(input_cubes, expected_probabilities):
+    """Test that differing but compatible precipitation units are handled,
+    giving the expected probabilities."""
+    if input_cubes[0].coord("time").has_bounds():
+        input_cubes[0].coord(var_name="threshold").convert_units("cm")
+    else:
+        input_cubes[0].coord(var_name="threshold").convert_units("cm s-1")
+
+    result = FreezingRain()(input_cubes)
+    assert_almost_equal(result.data, expected_probabilities)
+    assert (
+        input_cubes[0].coord(var_name="threshold").units
+        == result.coord(var_name="threshold").units
+    )
+
+
+def test_incompatible_precipitation_units(input_cubes):
+    """Test that an exception is raised if the precipitation diagnostics do not
+    have compatible units."""
+    input_cubes[0].coord(var_name="threshold").units = "K"
+
+    with pytest.raises(
+        ValueError, match="Rain and sleet cubes have incompatible units"
+    ):
+        FreezingRain()(input_cubes)
+
+
+def test_differing_precipitation_thresholds(input_cubes):
+    """Test that an exception is raised if the precipitation diagnostics do not
+    have identical thresholds."""
+    modify_coordinate(input_cubes[0], input_cubes[0].coord(var_name="threshold").name())
+
+    with pytest.raises(
+        ValueError, match="Rain and sleet cubes have different threshold values"
+    ):
+        FreezingRain()(input_cubes)
+
+
+def test_temperatures_below_thresholds(
+    precipitation_only, temperature_below, expected_probabilities
+):
+    """Test that temperature probabilities that are calculated below thresholds
+    give the expected result. In all other tests the probabilities are being
+    inverted within the plugin."""
+    cubes = iris.cube.CubeList([*precipitation_only, temperature_below])
+
+    # Sourcing cubes from independently parameterised fixtures, so we will get
+    # a mix of period and instantaneous precip / temperature diagnostics. We
+    # only want to use the matching types.
+    if not all([cube.coord("time").has_bounds() for cube in cubes]):
+        return
+    result = FreezingRain()(cubes)
+    assert_almost_equal(result.data, expected_probabilities)
+
+
+def test_no_freezing_threshold(input_cubes):
+    """Test that an exception is raised if the temperature diagnostic does not
+    include a threshold at the freezing point of water."""
+    modify_coordinate(
+        input_cubes[-1], input_cubes[-1].coord(var_name="threshold").name()
+    )
+
+    with pytest.raises(ValueError, match="No 0 Celsius or equivalent threshold"):
+        FreezingRain()(input_cubes)

--- a/improver_tests/utilities/test_cube_checker.py
+++ b/improver_tests/utilities/test_cube_checker.py
@@ -249,14 +249,24 @@ class Test_spatial_coords_match(IrisTest):
             data_b, "precipitation_amount", "kg m^-2", "equalarea",
         )
 
-    def test_basic(self):
+    def test_single_cube(self):
+        """Test that True is returned if a single cube is provided as input."""
+        result = spatial_coords_match([self.cube_a])
+        self.assertTrue(result)
+
+    def test_matching(self):
         """Test bool return when given one cube twice."""
-        result = spatial_coords_match(self.cube_a, self.cube_a)
+        result = spatial_coords_match([self.cube_a, self.cube_a])
+        self.assertTrue(result)
+
+    def test_matching_multiple(self):
+        """Test when given more than two cubes to test, these matching."""
+        result = spatial_coords_match([self.cube_a, self.cube_a, self.cube_a])
         self.assertTrue(result)
 
     def test_copy(self):
         """Test when given one cube copied."""
-        result = spatial_coords_match(self.cube_a, self.cube_a.copy())
+        result = spatial_coords_match([self.cube_a, self.cube_a.copy()])
         self.assertTrue(result)
 
     def test_other_coord_diffs(self):
@@ -264,7 +274,7 @@ class Test_spatial_coords_match(IrisTest):
         cube_c = self.cube_a.copy()
         r_coord = cube_c.coord("realization")
         r_coord.points = [r * 2 for r in r_coord.points]
-        result = spatial_coords_match(self.cube_a, cube_c)
+        result = spatial_coords_match([self.cube_a, cube_c])
         self.assertTrue(result)
 
     def test_other_coord_bigger_diffs(self):
@@ -276,28 +286,35 @@ class Test_spatial_coords_match(IrisTest):
         )
         r_coord = cube_c.coord("realization")
         r_coord.points = [r * 2 for r in r_coord.points]
-        result = spatial_coords_match(self.cube_a, cube_c)
+        result = spatial_coords_match([self.cube_a, cube_c])
         self.assertTrue(result)
 
     def test_unmatching(self):
         """Test when given two spatially different cubes of same resolution."""
-        result = spatial_coords_match(self.cube_a, self.cube_b)
+        result = spatial_coords_match([self.cube_a, self.cube_b])
+        self.assertFalse(result)
+
+    def test_unmatching_multiple(self):
+        """Test when given more than two cubes to test, these unmatching."""
+        result = spatial_coords_match([self.cube_a, self.cube_b, self.cube_a])
         self.assertFalse(result)
 
     def test_unmatching_x(self):
-        """Test when given two spatially different cubes of same length."""
+        """Test when given two cubes of the same shape, but with differing
+        x coordinate values."""
         cube_c = self.cube_a.copy()
         x_coord = cube_c.coord(axis="x")
         x_coord.points = [x * 2.0 for x in x_coord.points]
-        result = spatial_coords_match(self.cube_a, cube_c)
+        result = spatial_coords_match([self.cube_a, cube_c])
         self.assertFalse(result)
 
     def test_unmatching_y(self):
-        """Test when given two spatially different cubes of same length."""
+        """Test when given two cubes of the same shape, but with differing
+        y coordinate values."""
         cube_c = self.cube_a.copy()
         y_coord = cube_c.coord(axis="y")
         y_coord.points = [y * 1.01 for y in y_coord.points]
-        result = spatial_coords_match(self.cube_a, cube_c)
+        result = spatial_coords_match([self.cube_a, cube_c])
         self.assertFalse(result)
 
 

--- a/improver_tests/utilities/test_probability_manipulation.py
+++ b/improver_tests/utilities/test_probability_manipulation.py
@@ -128,3 +128,15 @@ def test_invert_probabilities(
     )
     assert expected_name in result.name()
     assert_almost_equal(result.data, expected_inverted_probabilities)
+
+
+@pytest.mark.parametrize("inequality", ["greater_than"])
+def test_no_threshold_coordinate(probability_cube):
+    """Test an exception is raised if no threshold coordinate is found."""
+
+    cube = probability_cube[0]
+    threshold = cube.coord(var_name="threshold")
+    cube.remove_coord(threshold)
+
+    with pytest.raises(ValueError, match="Cube does not have a threshold coordinate"):
+        invert_probabilities(cube)

--- a/improver_tests/utilities/test_probability_manipulation.py
+++ b/improver_tests/utilities/test_probability_manipulation.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests of probability_manipulation utilities"""
+
+import operator
+from collections import namedtuple
+
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal
+
+from improver.synthetic_data.set_up_test_cubes import set_up_probability_cube
+from improver.utilities.probability_manipulation import (
+    comparison_operator_dict,
+    invert_probabilities,
+)
+
+ComparisonResult = namedtuple("ComparisonResult", ["function", "spp_string", "inverse"])
+
+
+@pytest.mark.parametrize(
+    "inequalities, expected",
+    (
+        (
+            ("ge", "GE", ">="),
+            ComparisonResult(
+                function=operator.ge,
+                spp_string="greater_than_or_equal_to",
+                inverse="lt",
+            ),
+        ),
+        (
+            ("gt", "GT", ">"),
+            ComparisonResult(
+                function=operator.gt, spp_string="greater_than", inverse="le",
+            ),
+        ),
+        (
+            ("le", "LE", "<="),
+            ComparisonResult(
+                function=operator.le, spp_string="less_than_or_equal_to", inverse="gt",
+            ),
+        ),
+        (
+            ("lt", "LT", "<"),
+            ComparisonResult(
+                function=operator.lt, spp_string="less_than", inverse="ge",
+            ),
+        ),
+    ),
+)
+def test_comparison_operator_dict(inequalities, expected):
+    """Test that calling this function returns a dictionary containing
+    the expected values / functions."""
+    for inequality in inequalities:
+        result = comparison_operator_dict()[inequality]
+
+        assert isinstance(result, dict)
+        assert result["function"] == expected.function
+        assert result["spp_string"] == expected.spp_string
+        assert result["inverse"] == expected.inverse
+
+
+@pytest.fixture
+def probability_cube(inequality):
+    """Set up probability cube"""
+    data = np.linspace(0.0, 0.7, 8).reshape(2, 2, 2).astype(np.float32)
+    cube = set_up_probability_cube(
+        data,
+        thresholds=[273.15, 278.15],
+        spatial_grid="equalarea",
+        spp__relative_to_threshold=inequality,
+    )
+    return cube
+
+
+@pytest.fixture
+def expected_inverted_probabilities():
+    return np.linspace(1.0, 0.3, 8).reshape(2, 2, 2).astype(np.float32)
+
+
+@pytest.mark.parametrize(
+    "inequality, expected_attr, expected_name",
+    (
+        ("greater_than_or_equal_to", "less_than", "below"),
+        ("greater_than", "less_than_or_equal_to", "below"),
+        ("less_than_or_equal_to", "greater_than", "above"),
+        ("less_than", "greater_than_or_equal_to", "above"),
+    ),
+)
+def test_invert_probabilities(
+    probability_cube, expected_attr, expected_name, expected_inverted_probabilities
+):
+    """Test function inverts probabilities and updates cube metadata."""
+    result = invert_probabilities(probability_cube)
+
+    assert (
+        result.coord(var_name="threshold").attributes["spp__relative_to_threshold"]
+        == expected_attr
+    )
+    assert expected_name in result.name()
+    assert_almost_equal(result.data, expected_inverted_probabilities)


### PR DESCRIPTION
Addresses #1660 

This is the first PR of two. It does the following, which can be reviewed by selecting each commit in turn:
1. Creates a utility to invert probabilities, updating the relevant metadata on the output cube.
2. Adds a plugin to calculate the freezing rain probability by the agreed method.
3. Adds unit tests for the freezing rain plugin.

The probability inversion plugin was not necessary, but seemed like a useful generic utility to have available. Factoring out the `_comparison_operator_dict` from `BasicThreshold` was necessary as the freezing rain plugin needs to check whether the temperature data has been thresholded above or below the threshold values. The `spp__relative_to_threshold` attributes should be defined in only one place, such that changing these attributes is reflected everywhere.

The next PR will include a CLI and acceptance tests.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
