### PR TITLE
Manual update of all copyright years preceding GitHub actions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-British Crown Copyright 2017-2021 Met Office.
+British Crown Copyright 2017-2022 Met Office.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/bin/improver
+++ b/bin/improver
@@ -1,6 +1,6 @@
 #!/bin/bash
 #------------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/improver-tests
+++ b/bin/improver-tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 #------------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -96,7 +96,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "IMPROVER"
-copyright = "2019, Met Office"
+copyright = "2022, Met Office"
 author = "Met Office"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/improver/__init__.py
+++ b/improver/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/between_thresholds.py
+++ b/improver/between_thresholds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/__init__.py
+++ b/improver/blending/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/blend_across_adjacent_points.py
+++ b/improver/blending/blend_across_adjacent_points.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/calculate_weights_and_blend.py
+++ b/improver/blending/calculate_weights_and_blend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/spatial_weights.py
+++ b/improver/blending/spatial_weights.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/blending/weights.py
+++ b/improver/blending/weights.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/calibration/dataframe_utilities.py
+++ b/improver/calibration/dataframe_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/calibration/utilities.py
+++ b/improver/calibration/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/__main__.py
+++ b/improver/cli/__main__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/aggregate_reliability_tables.py
+++ b/improver/cli/aggregate_reliability_tables.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/apply_lapse_rate.py
+++ b/improver/cli/apply_lapse_rate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/apply_night_mask.py
+++ b/improver/cli/apply_night_mask.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/apply_reliability_calibration.py
+++ b/improver/cli/apply_reliability_calibration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/between_thresholds.py
+++ b/improver/cli/between_thresholds.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/blend_adjacent_points.py
+++ b/improver/cli/blend_adjacent_points.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/blend_cycles_and_realizations.py
+++ b/improver/cli/blend_cycles_and_realizations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/combine.py
+++ b/improver/cli/combine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/compare.py
+++ b/improver/cli/compare.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/construct_reliability_tables.py
+++ b/improver/cli/construct_reliability_tables.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/convection_ratio.py
+++ b/improver/cli/convection_ratio.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/create_grid_with_halo.py
+++ b/improver/cli/create_grid_with_halo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/estimate_emos_coefficients.py
+++ b/improver/cli/estimate_emos_coefficients.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/estimate_emos_coefficients_from_table.py
+++ b/improver/cli/estimate_emos_coefficients_from_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/extend_radar_mask.py
+++ b/improver/cli/extend_radar_mask.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/extract.py
+++ b/improver/cli/extract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/feels_like_temp.py
+++ b/improver/cli/feels_like_temp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/field_texture.py
+++ b/improver/cli/field_texture.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/fill_radar_holes.py
+++ b/improver/cli/fill_radar_holes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_landmask_ancillary.py
+++ b/improver/cli/generate_landmask_ancillary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_metadata_cube.py
+++ b/improver/cli/generate_metadata_cube.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_orographic_smoothing_coefficients.py
+++ b/improver/cli/generate_orographic_smoothing_coefficients.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_percentiles.py
+++ b/improver/cli/generate_percentiles.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_realizations.py
+++ b/improver/cli/generate_realizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_timezone_mask_ancillary.py
+++ b/improver/cli/generate_timezone_mask_ancillary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_topography_bands_mask.py
+++ b/improver/cli/generate_topography_bands_mask.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_topography_bands_weights.py
+++ b/improver/cli/generate_topography_bands_weights.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/interpolate_using_difference.py
+++ b/improver/cli/interpolate_using_difference.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/interpret_metadata.py
+++ b/improver/cli/interpret_metadata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/lightning_from_cape_and_precip.py
+++ b/improver/cli/lightning_from_cape_and_precip.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/manipulate_reliability_table.py
+++ b/improver/cli/manipulate_reliability_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/map_to_timezones.py
+++ b/improver/cli/map_to_timezones.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/merge.py
+++ b/improver/cli/merge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nbhood.py
+++ b/improver/cli/nbhood.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nbhood_iterate_with_mask.py
+++ b/improver/cli/nbhood_iterate_with_mask.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/neighbour_finding.py
+++ b/improver/cli/neighbour_finding.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nowcast_accumulate.py
+++ b/improver/cli/nowcast_accumulate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nowcast_extrapolate.py
+++ b/improver/cli/nowcast_extrapolate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nowcast_optical_flow.py
+++ b/improver/cli/nowcast_optical_flow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/nowcast_optical_flow_from_winds.py
+++ b/improver/cli/nowcast_optical_flow_from_winds.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/orographic_enhancement.py
+++ b/improver/cli/orographic_enhancement.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/phase_change_level.py
+++ b/improver/cli/phase_change_level.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/phase_mask.py
+++ b/improver/cli/phase_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/phase_probability.py
+++ b/improver/cli/phase_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/regrid.py
+++ b/improver/cli/regrid.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/relabel_to_period.py
+++ b/improver/cli/relabel_to_period.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/remake_as_shower_condition.py
+++ b/improver/cli/remake_as_shower_condition.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/resolve_wind_components.py
+++ b/improver/cli/resolve_wind_components.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/shower_condition_probability.py
+++ b/improver/cli/shower_condition_probability.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/snow_fraction.py
+++ b/improver/cli/snow_fraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/spot_extract.py
+++ b/improver/cli/spot_extract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/standardise.py
+++ b/improver/cli/standardise.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/temp_lapse_rate.py
+++ b/improver/cli/temp_lapse_rate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/temporal_interpolate.py
+++ b/improver/cli/temporal_interpolate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/time_lagged_ensembles.py
+++ b/improver/cli/time_lagged_ensembles.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/uv_index.py
+++ b/improver/cli/uv_index.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/weighted_blending.py
+++ b/improver/cli/weighted_blending.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wet_bulb_temperature.py
+++ b/improver/cli/wet_bulb_temperature.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wet_bulb_temperature_integral.py
+++ b/improver/cli/wet_bulb_temperature_integral.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wind_direction.py
+++ b/improver/cli/wind_direction.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wind_downscaling.py
+++ b/improver/cli/wind_downscaling.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wind_gust_diagnostic.py
+++ b/improver/cli/wind_gust_diagnostic.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wxcode.py
+++ b/improver/cli/wxcode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/wxcode_modal.py
+++ b/improver/cli/wxcode_modal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/constants.py
+++ b/improver/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/developer_tools/metadata_interpreter.py
+++ b/improver/developer_tools/metadata_interpreter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/ensemble_copula_coupling/_scipy_continuous_distns.py
+++ b/improver/ensemble_copula_coupling/_scipy_continuous_distns.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/ensemble_copula_coupling/numba_utilities.py
+++ b/improver/ensemble_copula_coupling/numba_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/ensemble_copula_coupling/utilities.py
+++ b/improver/ensemble_copula_coupling/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/feels_like_temperature.py
+++ b/improver/feels_like_temperature.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/__init__.py
+++ b/improver/generate_ancillaries/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_ancillary.py
+++ b/improver/generate_ancillaries/generate_ancillary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_orographic_smoothing_coefficients.py
+++ b/improver/generate_ancillaries/generate_orographic_smoothing_coefficients.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_svp_table.py
+++ b/improver/generate_ancillaries/generate_svp_table.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_timezone_mask.py
+++ b/improver/generate_ancillaries/generate_timezone_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_topographic_zone_weights.py
+++ b/improver/generate_ancillaries/generate_topographic_zone_weights.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/grids.py
+++ b/improver/grids.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/lapse_rate.py
+++ b/improver/lapse_rate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/lightning.py
+++ b/improver/lightning.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/memprofile.py
+++ b/improver/memprofile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/amend.py
+++ b/improver/metadata/amend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/check_datatypes.py
+++ b/improver/metadata/check_datatypes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/constants/__init__.py
+++ b/improver/metadata/constants/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/constants/attributes.py
+++ b/improver/metadata/constants/attributes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/constants/mo_attributes.py
+++ b/improver/metadata/constants/mo_attributes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/constants/time_types.py
+++ b/improver/metadata/constants/time_types.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/metadata/utilities.py
+++ b/improver/metadata/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nbhood/__init__.py
+++ b/improver/nbhood/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nbhood/circular_kernel.py
+++ b/improver/nbhood/circular_kernel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nbhood/square_kernel.py
+++ b/improver/nbhood/square_kernel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nbhood/use_nbhood.py
+++ b/improver/nbhood/use_nbhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nowcasting/accumulation.py
+++ b/improver/nowcasting/accumulation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nowcasting/forecasting.py
+++ b/improver/nowcasting/forecasting.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nowcasting/lightning.py
+++ b/improver/nowcasting/lightning.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nowcasting/optical_flow.py
+++ b/improver/nowcasting/optical_flow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nowcasting/pysteps_advection.py
+++ b/improver/nowcasting/pysteps_advection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/nowcasting/utilities.py
+++ b/improver/nowcasting/utilities.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/orographic_enhancement.py
+++ b/improver/orographic_enhancement.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/percentile.py
+++ b/improver/percentile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/precipitation_type/calculate_sleet_prob.py
+++ b/improver/precipitation_type/calculate_sleet_prob.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/precipitation_type/convection.py
+++ b/improver/precipitation_type/convection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/precipitation_type/shower_condition_probability.py
+++ b/improver/precipitation_type/shower_condition_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/precipitation_type/snow_fraction.py
+++ b/improver/precipitation_type/snow_fraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/precipitation_type/utilities.py
+++ b/improver/precipitation_type/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/profile.py
+++ b/improver/profile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/psychrometric_calculations/precip_phase_probability.py
+++ b/improver/psychrometric_calculations/precip_phase_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/psychrometric_calculations/significant_phase_mask.py
+++ b/improver/psychrometric_calculations/significant_phase_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/regrid/bilinear.py
+++ b/improver/regrid/bilinear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/regrid/grid.py
+++ b/improver/regrid/grid.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/regrid/idw.py
+++ b/improver/regrid/idw.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/regrid/landsea.py
+++ b/improver/regrid/landsea.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/regrid/landsea2.py
+++ b/improver/regrid/landsea2.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/regrid/nearest.py
+++ b/improver/regrid/nearest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/spotdata/__init__.py
+++ b/improver/spotdata/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/spotdata/apply_lapse_rate.py
+++ b/improver/spotdata/apply_lapse_rate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/spotdata/build_spotdata_cube.py
+++ b/improver/spotdata/build_spotdata_cube.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/spotdata/neighbour_finding.py
+++ b/improver/spotdata/neighbour_finding.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/spotdata/spot_extraction.py
+++ b/improver/spotdata/spot_extraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/synthetic_data/generate_metadata.py
+++ b/improver/synthetic_data/generate_metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/synthetic_data/utilities.py
+++ b/improver/synthetic_data/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/threshold.py
+++ b/improver/threshold.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/cli_utilities.py
+++ b/improver/utilities/cli_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/compare.py
+++ b/improver/utilities/compare.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/cube_checker.py
+++ b/improver/utilities/cube_checker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/cube_constraints.py
+++ b/improver/utilities/cube_constraints.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/indexing_operations.py
+++ b/improver/utilities/indexing_operations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/load.py
+++ b/improver/utilities/load.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/mathematical_operations.py
+++ b/improver/utilities/mathematical_operations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/neighbourhood_tools.py
+++ b/improver/utilities/neighbourhood_tools.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/pad_spatial.py
+++ b/improver/utilities/pad_spatial.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/redirect_stdout.py
+++ b/improver/utilities/redirect_stdout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/rescale.py
+++ b/improver/utilities/rescale.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/round.py
+++ b/improver/utilities/round.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/solar.py
+++ b/improver/utilities/solar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/textural.py
+++ b/improver/utilities/textural.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/time_lagging.py
+++ b/improver/utilities/time_lagging.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/utilities/warnings_handler.py
+++ b/improver/utilities/warnings_handler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/uv_index.py
+++ b/improver/uv_index.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wind_calculations/wind_components.py
+++ b/improver/wind_calculations/wind_components.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wind_calculations/wind_direction.py
+++ b/improver/wind_calculations/wind_direction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wind_calculations/wind_downscaling.py
+++ b/improver/wind_calculations/wind_downscaling.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/improver/wind_calculations/wind_gust_diagnostic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wxcode/modal_code.py
+++ b/improver/wxcode/modal_code.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wxcode/utilities.py
+++ b/improver/wxcode/utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/__init__.py
+++ b/improver_tests/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_aggregate_reliability_tables.py
+++ b/improver_tests/acceptance/test_aggregate_reliability_tables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_apply_lapse_rate.py
+++ b/improver_tests/acceptance/test_apply_lapse_rate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_apply_night_mask.py
+++ b/improver_tests/acceptance/test_apply_night_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_apply_reliability_calibration.py
+++ b/improver_tests/acceptance/test_apply_reliability_calibration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_between_thresholds.py
+++ b/improver_tests/acceptance/test_between_thresholds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_blend_adjacent_points.py
+++ b/improver_tests/acceptance/test_blend_adjacent_points.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_blend_cycles_and_realizations.py
+++ b/improver_tests/acceptance/test_blend_cycles_and_realizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_checksums.py
+++ b/improver_tests/acceptance/test_checksums.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_combine.py
+++ b/improver_tests/acceptance/test_combine.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_compare.py
+++ b/improver_tests/acceptance/test_compare.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_construct_reliability_tables.py
+++ b/improver_tests/acceptance/test_construct_reliability_tables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_convection_ratio.py
+++ b/improver_tests/acceptance/test_convection_ratio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_create_grid_with_halo.py
+++ b/improver_tests/acceptance/test_create_grid_with_halo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_estimate_emos_coefficients.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_estimate_emos_coefficients_from_table.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients_from_table.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_extend_radar_mask.py
+++ b/improver_tests/acceptance/test_extend_radar_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_extract.py
+++ b/improver_tests/acceptance/test_extract.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_feels_like_temp.py
+++ b/improver_tests/acceptance/test_feels_like_temp.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_field_texture.py
+++ b/improver_tests/acceptance/test_field_texture.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_fill_radar_holes.py
+++ b/improver_tests/acceptance/test_fill_radar_holes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_landmask_ancillary.py
+++ b/improver_tests/acceptance/test_generate_landmask_ancillary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_metadata_cube.py
+++ b/improver_tests/acceptance/test_generate_metadata_cube.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_orographic_smoothing_coefficients.py
+++ b/improver_tests/acceptance/test_generate_orographic_smoothing_coefficients.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_percentiles.py
+++ b/improver_tests/acceptance/test_generate_percentiles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_realizations.py
+++ b/improver_tests/acceptance/test_generate_realizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_timezone_mask_ancillary.py
+++ b/improver_tests/acceptance/test_generate_timezone_mask_ancillary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_generate_topography_bands.py
+++ b/improver_tests/acceptance/test_generate_topography_bands.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_interpolate_using_difference.py
+++ b/improver_tests/acceptance/test_interpolate_using_difference.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_interpret_metadata.py
+++ b/improver_tests/acceptance/test_interpret_metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_lightning_from_cape_and_precip.py
+++ b/improver_tests/acceptance/test_lightning_from_cape_and_precip.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_manipulate_reliability_table.py
+++ b/improver_tests/acceptance/test_manipulate_reliability_table.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_map_to_timezones.py
+++ b/improver_tests/acceptance/test_map_to_timezones.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_merge.py
+++ b/improver_tests/acceptance/test_merge.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nbhood.py
+++ b/improver_tests/acceptance/test_nbhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nbhood_iterate_with_mask.py
+++ b/improver_tests/acceptance/test_nbhood_iterate_with_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nbhood_land_and_sea.py
+++ b/improver_tests/acceptance/test_nbhood_land_and_sea.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_neighbour_finding.py
+++ b/improver_tests/acceptance/test_neighbour_finding.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nowcast_accumulate.py
+++ b/improver_tests/acceptance/test_nowcast_accumulate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nowcast_extrapolate.py
+++ b/improver_tests/acceptance/test_nowcast_extrapolate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nowcast_optical_flow.py
+++ b/improver_tests/acceptance/test_nowcast_optical_flow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_nowcast_optical_flow_from_winds.py
+++ b/improver_tests/acceptance/test_nowcast_optical_flow_from_winds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_orographic_enhancement.py
+++ b/improver_tests/acceptance/test_orographic_enhancement.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_phase_change_level.py
+++ b/improver_tests/acceptance/test_phase_change_level.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_phase_mask.py
+++ b/improver_tests/acceptance/test_phase_mask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_phase_probability.py
+++ b/improver_tests/acceptance/test_phase_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_recursive_filter.py
+++ b/improver_tests/acceptance/test_recursive_filter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_regrid.py
+++ b/improver_tests/acceptance/test_regrid.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_relabel_to_period.py
+++ b/improver_tests/acceptance/test_relabel_to_period.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_remake_as_shower_condition.py
+++ b/improver_tests/acceptance/test_remake_as_shower_condition.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_resolve_wind_components.py
+++ b/improver_tests/acceptance/test_resolve_wind_components.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_shower_condition_probability.py
+++ b/improver_tests/acceptance/test_shower_condition_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_sleet_probability.py
+++ b/improver_tests/acceptance/test_sleet_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_snow_fraction.py
+++ b/improver_tests/acceptance/test_snow_fraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_spot_extract.py
+++ b/improver_tests/acceptance/test_spot_extract.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_standardise.py
+++ b/improver_tests/acceptance/test_standardise.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_temp_lapse_rate.py
+++ b/improver_tests/acceptance/test_temp_lapse_rate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_temporal_interpolate.py
+++ b/improver_tests/acceptance/test_temporal_interpolate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_threshold.py
+++ b/improver_tests/acceptance/test_threshold.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_time_lagged_ensembles.py
+++ b/improver_tests/acceptance/test_time_lagged_ensembles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_uv_index.py
+++ b/improver_tests/acceptance/test_uv_index.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_weighted_blending.py
+++ b/improver_tests/acceptance/test_weighted_blending.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wet_bulb_temperature.py
+++ b/improver_tests/acceptance/test_wet_bulb_temperature.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wet_bulb_temperature_integral.py
+++ b/improver_tests/acceptance/test_wet_bulb_temperature_integral.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wind_direction.py
+++ b/improver_tests/acceptance/test_wind_direction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wind_downscaling.py
+++ b/improver_tests/acceptance/test_wind_downscaling.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wind_gust_diagnostic.py
+++ b/improver_tests/acceptance/test_wind_gust_diagnostic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wxcode.py
+++ b/improver_tests/acceptance/test_wxcode.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/acceptance/test_wxcode_modal.py
+++ b/improver_tests/acceptance/test_wxcode_modal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/between_thresholds/test_between_thresholds.py
+++ b/improver_tests/between_thresholds/test_between_thresholds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
+++ b/improver_tests/blending/blend_across_adjacent_points/test_TriangularWeightedBlendAcrossAdjacentPoints.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
+++ b/improver_tests/blending/calculate_weights_and_blend/test_WeightAndBlend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/spatial_weights/test_SpatiallyVaryingWeightsFromMask.py
+++ b/improver_tests/blending/spatial_weights/test_SpatiallyVaryingWeightsFromMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/test_utilities.py
+++ b/improver_tests/blending/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weighted_blend/test_MergeCubesForWeightedBlending.py
+++ b/improver_tests/blending/weighted_blend/test_MergeCubesForWeightedBlending.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weighted_blend/test_PercentileBlendingAggregator.py
+++ b/improver_tests/blending/weighted_blend/test_PercentileBlendingAggregator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/improver_tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
+++ b/improver_tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weights/test_ChooseDefaultWeightsTriangular.py
+++ b/improver_tests/blending/weights/test_ChooseDefaultWeightsTriangular.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weights/test_ChooseWeightsLinear.py
+++ b/improver_tests/blending/weights/test_ChooseWeightsLinear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/blending/weights/test_WeightsUtilities.py
+++ b/improver_tests/blending/weights/test_WeightsUtilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
+++ b/improver_tests/calibration/dataframe_utilities/test_dataframe_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/ensemble_calibration/helper_functions.py
+++ b/improver_tests/calibration/ensemble_calibration/helper_functions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
+++ b/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ContinuousRankedProbabilityScoreMinimisers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/reliability_calibration/conftest.py
+++ b/improver_tests/calibration/reliability_calibration/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_AggregateReliabilityCalibrationTables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
+++ b/improver_tests/calibration/reliability_calibration/test_ConstructReliabilityCalibrationTables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/utilities/conftest.py
+++ b/improver_tests/calibration/utilities/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/calibration/utilities/test_utilities.py
+++ b/improver_tests/calibration/utilities/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/cli/nowcast_accumulate/test_name_constraint.py
+++ b/improver_tests/cli/nowcast_accumulate/test_name_constraint.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/conftest.py
+++ b/improver_tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/cube_combiner/test_Combine.py
+++ b/improver_tests/cube_combiner/test_Combine.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/cube_combiner/test_CubeMultiplier.py
+++ b/improver_tests/cube_combiner/test_CubeMultiplier.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/developer_tools/conftest.py
+++ b/improver_tests/developer_tools/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/developer_tools/test_MOMetadataInterpreter.py
+++ b/improver_tests/developer_tools/test_MOMetadataInterpreter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/developer_tools/test_display_interpretation.py
+++ b/improver_tests/developer_tools/test_display_interpretation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/ecc_test_data.py
+++ b/improver_tests/ensemble_copula_coupling/ecc_test_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParameters.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParametersToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParametersToPercentiles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParametersToProbabilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParametersToProbabilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/improver_tests/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test__scipy_continuous_distns.py
+++ b/improver_tests/ensemble_copula_coupling/test__scipy_continuous_distns.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/feels_like_temperature/test_feels_like_temperature.py
+++ b/improver_tests/feels_like_temperature/test_feels_like_temperature.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_CorrectLandSeaMask.py
+++ b/improver_tests/generate_ancillaries/test_CorrectLandSeaMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_GenerateOrographyBandAncils.py
+++ b/improver_tests/generate_ancillaries/test_GenerateOrographyBandAncils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTimezoneMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_GenerateTopographicZoneWeights.py
+++ b/improver_tests/generate_ancillaries/test_GenerateTopographicZoneWeights.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_OrographicSmoothingCoefficients.py
+++ b/improver_tests/generate_ancillaries/test_OrographicSmoothingCoefficients.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_SaturatedVapourPressureTable.py
+++ b/improver_tests/generate_ancillaries/test_SaturatedVapourPressureTable.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/generate_ancillaries/test_generate_ancillary.py
+++ b/improver_tests/generate_ancillaries/test_generate_ancillary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/lapse_rate/test_ApplyGriddedLapseRate.py
+++ b/improver_tests/lapse_rate/test_ApplyGriddedLapseRate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/lapse_rate/test_LapseRate.py
+++ b/improver_tests/lapse_rate/test_LapseRate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/lightning/test_LightningFromCapePrecip.py
+++ b/improver_tests/lightning/test_LightningFromCapePrecip.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/metadata/test_amend.py
+++ b/improver_tests/metadata/test_amend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/metadata/test_check_datatypes.py
+++ b/improver_tests/metadata/test_check_datatypes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/metadata/test_forecast_times.py
+++ b/improver_tests/metadata/test_forecast_times.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/metadata/test_probabilistic.py
+++ b/improver_tests/metadata/test_probabilistic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/circular_kernel/test_CircularNeighbourhood.py
+++ b/improver_tests/nbhood/circular_kernel/test_CircularNeighbourhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
+++ b/improver_tests/nbhood/circular_kernel/test_GeneratePercentilesFromACircularNeighbourhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/circular_kernel/test_check_radius_against_distance.py
+++ b/improver_tests/nbhood/circular_kernel/test_check_radius_against_distance.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/circular_kernel/test_circular_kernel.py
+++ b/improver_tests/nbhood/circular_kernel/test_circular_kernel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/nbhood/test_GeneratePercentilesFromANeighbourhood.py
+++ b/improver_tests/nbhood/nbhood/test_GeneratePercentilesFromANeighbourhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/square_kernel/test_SquareNeighbourhood.py
+++ b/improver_tests/nbhood/square_kernel/test_SquareNeighbourhood.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/test_init.py
+++ b/improver_tests/nbhood/test_init.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/accumulation/test_Accumulation.py
+++ b/improver_tests/nowcasting/accumulation/test_Accumulation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/forecasting/test_AdvectField.py
+++ b/improver_tests/nowcasting/forecasting/test_AdvectField.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
+++ b/improver_tests/nowcasting/forecasting/test_CreateExtrapolationForecast.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/improver_tests/nowcasting/lightning/test_NowcastLightning.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/optical_flow/__init__.py
+++ b/improver_tests/nowcasting/optical_flow/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/improver_tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/optical_flow/test_generate_advection_velocities_from_winds.py
+++ b/improver_tests/nowcasting/optical_flow/test_generate_advection_velocities_from_winds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/optical_flow/test_generate_optical_flow_components.py
+++ b/improver_tests/nowcasting/optical_flow/test_generate_optical_flow_components.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/optical_flow/test_utilities.py
+++ b/improver_tests/nowcasting/optical_flow/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/pysteps_advection/test_PystepsExtrapolate.py
+++ b/improver_tests/nowcasting/pysteps_advection/test_PystepsExtrapolate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/utilities/test_ApplyOrographicEnhancement.py
+++ b/improver_tests/nowcasting/utilities/test_ApplyOrographicEnhancement.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/utilities/test_ExtendRadarMask.py
+++ b/improver_tests/nowcasting/utilities/test_ExtendRadarMask.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/nowcasting/utilities/test_FillRadarHoles.py
+++ b/improver_tests/nowcasting/utilities/test_FillRadarHoles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/orographic_enhancement/test_OrographicEnhancement.py
+++ b/improver_tests/orographic_enhancement/test_OrographicEnhancement.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/percentile/test_PercentileConverter.py
+++ b/improver_tests/percentile/test_PercentileConverter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/precipitation_type/calculate_sleet_prob/test_calculate_sleet_probability.py
+++ b/improver_tests/precipitation_type/calculate_sleet_prob/test_calculate_sleet_probability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/precipitation_type/convection/test_ConvectionRatioFromComponents.py
+++ b/improver_tests/precipitation_type/convection/test_ConvectionRatioFromComponents.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/precipitation_type/convection/test_DiagnoseConvectivePrecipitation.py
+++ b/improver_tests/precipitation_type/convection/test_DiagnoseConvectivePrecipitation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/precipitation_type/shower_condition_probability/test_ShowerConditionProbability.py
+++ b/improver_tests/precipitation_type/shower_condition_probability/test_ShowerConditionProbability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/precipitation_type/snow_fraction/test_SnowFraction.py
+++ b/improver_tests/precipitation_type/snow_fraction/test_SnowFraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/precipitation_type/test_utilities.py
+++ b/improver_tests/precipitation_type/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/psychrometric_calculations/precip_phase_probability/test_PrecipPhaseProbability.py
+++ b/improver_tests/psychrometric_calculations/precip_phase_probability/test_PrecipPhaseProbability.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperature.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
+++ b/improver_tests/psychrometric_calculations/test_WetBulbTemperatureIntegral.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/psychrometric_calculations/test_calculate_svp_in_air.py
+++ b/improver_tests/psychrometric_calculations/test_calculate_svp_in_air.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/psychrometric_calculations/test_significant_phase_mask/test_SignificantPhaseMask.py
+++ b/improver_tests/psychrometric_calculations/test_significant_phase_mask/test_SignificantPhaseMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/regrid/test_AdjustLandSeaPoints.py
+++ b/improver_tests/regrid/test_AdjustLandSeaPoints.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/regrid/test_RegridLandSea.py
+++ b/improver_tests/regrid/test_RegridLandSea.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/regrid/test_RegridWithLandSeaMask.py
+++ b/improver_tests/regrid/test_RegridWithLandSeaMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/regrid/test_grid.py
+++ b/improver_tests/regrid/test_grid.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/regrid/test_grid_contains_cutout.py
+++ b/improver_tests/regrid/test_grid_contains_cutout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/spotdata/test_NeighbourSelection.py
+++ b/improver_tests/spotdata/test_NeighbourSelection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/spotdata/test_SpotExtraction.py
+++ b/improver_tests/spotdata/test_SpotExtraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/spotdata/test_SpotLapseRateAdjust.py
+++ b/improver_tests/spotdata/test_SpotLapseRateAdjust.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/spotdata/test_build_spotdata_cube.py
+++ b/improver_tests/spotdata/test_build_spotdata_cube.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/spotdata/test_check_grid_match.py
+++ b/improver_tests/spotdata/test_check_grid_match.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/standardise/test_StandardiseMetadata.py
+++ b/improver_tests/standardise/test_StandardiseMetadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/synthetic_data/test_generate_metadata.py
+++ b/improver_tests/synthetic_data/test_generate_metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/synthetic_data/test_utilities.py
+++ b/improver_tests/synthetic_data/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/test_PostProcessingPlugin.py
+++ b/improver_tests/test_PostProcessingPlugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/test_licence.py
+++ b/improver_tests/test_licence.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/threshold/test_BasicThreshold.py
+++ b/improver_tests/threshold/test_BasicThreshold.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/threshold/test_LatitudeDependentThreshold.py
+++ b/improver_tests/threshold/test_LatitudeDependentThreshold.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_MergeCubes.py
+++ b/improver_tests/utilities/cube_manipulation/test_MergeCubes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_clip_cube_data.py
+++ b/improver_tests/utilities/cube_manipulation/test_clip_cube_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_collapse_realizations.py
+++ b/improver_tests/utilities/cube_manipulation/test_collapse_realizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_collapsed.py
+++ b/improver_tests/utilities/cube_manipulation/test_collapsed.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_compare_attributes.py
+++ b/improver_tests/utilities/cube_manipulation/test_compare_attributes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_compare_coords.py
+++ b/improver_tests/utilities/cube_manipulation/test_compare_coords.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_enforce_coordinate_ordering.py
+++ b/improver_tests/utilities/cube_manipulation/test_enforce_coordinate_ordering.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_expand_bounds.py
+++ b/improver_tests/utilities/cube_manipulation/test_expand_bounds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_filter_realizations.py
+++ b/improver_tests/utilities/cube_manipulation/test_filter_realizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_get_filtered_attributes.py
+++ b/improver_tests/utilities/cube_manipulation/test_get_filtered_attributes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
+++ b/improver_tests/utilities/cube_manipulation/test_sort_coord_in_cube.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/cube_manipulation/test_strip_var_names.py
+++ b/improver_tests/utilities/cube_manipulation/test_strip_var_names.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/solar/test_DayNightMask.py
+++ b/improver_tests/utilities/solar/test_DayNightMask.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/solar/test_solar.py
+++ b/improver_tests/utilities/solar/test_solar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/temporal/test_TimezoneExtraction.py
+++ b/improver_tests/utilities/temporal/test_TimezoneExtraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/temporal/test_temporal.py
+++ b/improver_tests/utilities/temporal/test_temporal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_FieldTexture.py
+++ b/improver_tests/utilities/test_FieldTexture.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_GenerateTimeLaggedEnsemble.py
+++ b/improver_tests/utilities/test_GenerateTimeLaggedEnsemble.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_GradientBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_GradientBetweenAdjacentGridSquares.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_InterpolateUsingDifference.py
+++ b/improver_tests/utilities/test_InterpolateUsingDifference.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_TemporalInterpolation.py
+++ b/improver_tests/utilities/test_TemporalInterpolation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_cli_utilities.py
+++ b/improver_tests/utilities/test_cli_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_compare.py
+++ b/improver_tests/utilities/test_compare.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_cube_checker.py
+++ b/improver_tests/utilities/test_cube_checker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_cube_constraints.py
+++ b/improver_tests/utilities/test_cube_constraints.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_cube_extraction.py
+++ b/improver_tests/utilities/test_cube_extraction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_indexing_operations.py
+++ b/improver_tests/utilities/test_indexing_operations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_interpolate.py
+++ b/improver_tests/utilities/test_interpolate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_load.py
+++ b/improver_tests/utilities/test_load.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_mathematical_operations.py
+++ b/improver_tests/utilities/test_mathematical_operations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_neighbourhood_tools.py
+++ b/improver_tests/utilities/test_neighbourhood_tools.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_pad_spatial.py
+++ b/improver_tests/utilities/test_pad_spatial.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_rescale.py
+++ b/improver_tests/utilities/test_rescale.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_round.py
+++ b/improver_tests/utilities/test_round.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/utilities/test_warnings_handler.py
+++ b/improver_tests/utilities/test_warnings_handler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/uv_index/test_uv_index.py
+++ b/improver_tests/uv_index/test_uv_index.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wind_calculations/wind_components/test_ResolveWindComponents.py
+++ b/improver_tests/wind_calculations/wind_components/test_ResolveWindComponents.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wind_calculations/wind_direction/test_WindDirection.py
+++ b/improver_tests/wind_calculations/wind_direction/test_WindDirection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wind_calculations/wind_downscaling/test_FrictionVelocity.py
+++ b/improver_tests/wind_calculations/wind_downscaling/test_FrictionVelocity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
+++ b/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/improver_tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wxcode/wxcode/__init__.py
+++ b/improver_tests/wxcode/wxcode/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wxcode/wxcode/test_ModalCode.py
+++ b/improver_tests/wxcode/wxcode/test_ModalCode.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver_tests/wxcode/wxcode/test_utilities.py
+++ b/improver_tests/wxcode/wxcode/test_utilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Addresses #GitHubissuenum

Description

Manual update of all IMPROVER copyright dates, including update of Sphinx file that controls copyright label on ReadTheDocs.
This action will be done using automatically using GitHub actions on the 1st of January every year in the future, PR for that is here: #1685 

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
