### PR TITLE
ENH Add independent point processing to `ManipulateReliabilityTable`

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1037,17 +1037,9 @@ class ManipulateReliabilityTable(BasePlugin):
         for rel_table_threshold in reliability_table.slices_over(threshold_coord):
             if self.point_by_point:
                 rel_table_processed = iris.cube.CubeList()
-                coord_order = [
-                    c.name() for c in rel_table_threshold.coords(dim_coords=True)
-                ]
                 for rel_table_point in rel_table_threshold.slices_over([y_name, x_name]):
-                    rel_table_processed.append(
-                        self._enforce_min_count_and_montonicity(rel_table_point)
-                    )
-                rel_table_processed = rel_table_processed.merge_cube()
-                enforce_coordinate_ordering(
-                    rel_table_processed, coord_order,
-                )
+                    rel_table_point_emcam = self._enforce_min_count_and_montonicity(rel_table_point)
+                    rel_table_processed.append(rel_table_point_emcam)
             else:
                 rel_table_processed = self._enforce_min_count_and_montonicity(
                     rel_table_threshold

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -54,10 +54,7 @@ from improver.metadata.probabilistic import (
     probability_is_above_or_below,
 )
 from improver.metadata.utilities import generate_mandatory_attributes
-from improver.utilities.cube_manipulation import (
-    MergeCubes,
-    collapsed,
-)
+from improver.utilities.cube_manipulation import MergeCubes, collapsed
 
 
 class ConstructReliabilityCalibrationTables(BasePlugin):

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -632,6 +632,8 @@ class ManipulateReliabilityTable(BasePlugin):
                 The default value of 200 is that used in Flowerdew 2014.
             point_by_point:
                 Whether to process each point in the input cube independently.
+                Please note this option is memory intensive and is unsuitable
+                for gridded input
 
         Raises:
             ValueError: If minimum_forecast_count is less than 1.

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -935,7 +935,74 @@ class ManipulateReliabilityTable(BasePlugin):
         reliability_table.replace_coord(probability_bin_coord)
         return reliability_table
 
-    def process(self, reliability_table: Cube) -> CubeList:
+    def _enforce_min_count_and_montonicity(self, rel_table_slice: Cube) -> Cube:
+        """Apply the steps needed to produce a reliability diagram on a single
+        slice of reliability table cube.
+
+        Args:
+            reliability_table_slice:
+                The reliability table slice to be manipulated. The only
+                coordinates expected on this cube are a table_row_index
+                coordinate and corresponding table_row_name coordinate and a
+                probability_bin coordinate.
+        Returns:
+            Processed reliability table slice, with reliability steps applied.
+        """
+        (
+            observation_count,
+            forecast_probability_sum,
+            forecast_count,
+            probability_bin_coord,
+        ) = self._extract_reliability_table_components(rel_table_slice)
+
+        if np.any(forecast_count < self.minimum_forecast_count):
+            (
+                observation_count,
+                forecast_probability_sum,
+                forecast_count,
+                probability_bin_coord,
+            ) = self._combine_undersampled_bins(
+                observation_count,
+                forecast_probability_sum,
+                forecast_count,
+                probability_bin_coord,
+            )
+            rel_table_slice = self._update_reliability_table(
+                rel_table_slice,
+                observation_count,
+                forecast_probability_sum,
+                forecast_count,
+                probability_bin_coord,
+            )
+
+        # If the observation frequency is non-monotonic adjust the
+        # reliability table
+        observation_frequency = np.array(observation_count / forecast_count)
+        if not np.all(np.diff(observation_frequency) >= 0):
+            (
+                observation_count,
+                forecast_probability_sum,
+                forecast_count,
+                probability_bin_coord,
+            ) = self._combine_bin_pair(
+                observation_count,
+                forecast_probability_sum,
+                forecast_count,
+                probability_bin_coord,
+            )
+            observation_count = self._assume_constant_observation_frequency(
+                observation_count, forecast_count
+            )
+            rel_table_slice = self._update_reliability_table(
+                rel_table_slice,
+                observation_count,
+                forecast_probability_sum,
+                forecast_count,
+                probability_bin_coord,
+            )
+        return rel_table_slice
+
+    def process(self, reliability_table: Cube, point_by_point: bool) -> CubeList:
         """
         Apply the steps needed to produce a reliability diagram with a
         monotonic observation frequency.
@@ -946,6 +1013,8 @@ class ManipulateReliabilityTable(BasePlugin):
                 expected on this cube are a threshold coordinate,
                 a table_row_index coordinate and corresponding table_row_name
                 coordinate and a probability_bin coordinate.
+            point_by_point:
+                Whether to process each point in the input cube independently.
 
         Returns:
             CubeList containing a reliability table cube for each threshold in
@@ -959,61 +1028,24 @@ class ManipulateReliabilityTable(BasePlugin):
             to reach the minimum_forecast_count.
         """
         threshold_coord = find_threshold_coordinate(reliability_table)
+        if point_by_point:
+            y_name = reliability_table.coord(axis="y").name()
+            x_name = reliability_table.coord(axis="x").name()
+
         reliability_table_cubelist = iris.cube.CubeList()
-        for rel_table_slice in reliability_table.slices_over(threshold_coord):
-            (
-                observation_count,
-                forecast_probability_sum,
-                forecast_count,
-                probability_bin_coord,
-            ) = self._extract_reliability_table_components(rel_table_slice)
-
-            if np.any(forecast_count < self.minimum_forecast_count):
-                (
-                    observation_count,
-                    forecast_probability_sum,
-                    forecast_count,
-                    probability_bin_coord,
-                ) = self._combine_undersampled_bins(
-                    observation_count,
-                    forecast_probability_sum,
-                    forecast_count,
-                    probability_bin_coord,
+        for rel_table_threshold in reliability_table.slices_over(threshold_coord):
+            if point_by_point:
+                rel_table_points_cubelist = iris.cube.CubeList()
+                for rel_table_point in rel_table_threshold.slices_over([y_name, x_name]):
+                    rel_table_points_cubelist.append(
+                        self._enforce_min_count_and_montonicity(rel_table_point)
+                    )
+                rel_table_threshold = rel_table_points_cubelist.merge_cube()
+            else:
+                rel_table_threshold = self._enforce_min_count_and_montonicity(
+                    rel_table_threshold
                 )
-                rel_table_slice = self._update_reliability_table(
-                    rel_table_slice,
-                    observation_count,
-                    forecast_probability_sum,
-                    forecast_count,
-                    probability_bin_coord,
-                )
-
-            # If the observation frequency is non-monotonic adjust the
-            # reliability table
-            observation_frequency = np.array(observation_count / forecast_count)
-            if not np.all(np.diff(observation_frequency) >= 0):
-                (
-                    observation_count,
-                    forecast_probability_sum,
-                    forecast_count,
-                    probability_bin_coord,
-                ) = self._combine_bin_pair(
-                    observation_count,
-                    forecast_probability_sum,
-                    forecast_count,
-                    probability_bin_coord,
-                )
-                observation_count = self._assume_constant_observation_frequency(
-                    observation_count, forecast_count
-                )
-                rel_table_slice = self._update_reliability_table(
-                    rel_table_slice,
-                    observation_count,
-                    forecast_probability_sum,
-                    forecast_count,
-                    probability_bin_coord,
-                )
-            reliability_table_cubelist.append(rel_table_slice)
+            reliability_table_cubelist.append(rel_table_threshold)
         return reliability_table_cubelist
 
 

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -620,17 +620,17 @@ class ManipulateReliabilityTable(BasePlugin):
     constant observation frequency.
     """
 
-    def __init__(self, point_by_point: bool, minimum_forecast_count: int = 200) -> None:
+    def __init__(self, minimum_forecast_count: int = 200, point_by_point: bool = False) -> None:
         """
         Initialise class for manipulating a reliability table.
 
         Args:
-            point_by_point:
-                Whether to process each point in the input cube independently.
             minimum_forecast_count:
                 The minimum number of forecast counts in a forecast probability
                 bin for it to be used in calibration.
                 The default value of 200 is that used in Flowerdew 2014.
+            point_by_point:
+                Whether to process each point in the input cube independently.
 
         Raises:
             ValueError: If minimum_forecast_count is less than 1.
@@ -640,13 +640,13 @@ class ManipulateReliabilityTable(BasePlugin):
             preserving spatial structure. Tellus, Ser. A Dyn. Meteorol.
             Oceanogr. 66.
         """
-        self.point_by_point = point_by_point
         if minimum_forecast_count < 1:
             raise ValueError(
                 "The minimum_forecast_count must be at least 1 as empty "
                 "bins in the reliability table are not handled."
             )
         self.minimum_forecast_count = minimum_forecast_count
+        self.point_by_point = point_by_point
 
     @staticmethod
     def _extract_reliability_table_components(

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -44,7 +44,6 @@ from numpy import ndarray
 from numpy.ma.core import MaskedArray
 
 from improver import BasePlugin, PostProcessingPlugin
-from improver.utilities.cube_manipulation import enforce_coordinate_ordering
 from improver.calibration.utilities import (
     check_forecast_consistency,
     create_unified_frt_coord,
@@ -55,7 +54,10 @@ from improver.metadata.probabilistic import (
     probability_is_above_or_below,
 )
 from improver.metadata.utilities import generate_mandatory_attributes
-from improver.utilities.cube_manipulation import MergeCubes, collapsed
+from improver.utilities.cube_manipulation import (
+    MergeCubes,
+    collapsed,
+)
 
 
 class ConstructReliabilityCalibrationTables(BasePlugin):
@@ -621,7 +623,9 @@ class ManipulateReliabilityTable(BasePlugin):
     constant observation frequency.
     """
 
-    def __init__(self, minimum_forecast_count: int = 200, point_by_point: bool = False) -> None:
+    def __init__(
+        self, minimum_forecast_count: int = 200, point_by_point: bool = False
+    ) -> None:
         """
         Initialise class for manipulating a reliability table.
 
@@ -1039,8 +1043,12 @@ class ManipulateReliabilityTable(BasePlugin):
         for rel_table_threshold in reliability_table.slices_over(threshold_coord):
             if self.point_by_point:
                 rel_table_processed = iris.cube.CubeList()
-                for rel_table_point in rel_table_threshold.slices_over([y_name, x_name]):
-                    rel_table_point_emcam = self._enforce_min_count_and_montonicity(rel_table_point)
+                for rel_table_point in rel_table_threshold.slices_over(
+                    [y_name, x_name]
+                ):
+                    rel_table_point_emcam = self._enforce_min_count_and_montonicity(
+                        rel_table_point
+                    )
                     rel_table_processed.append(rel_table_point_emcam)
             else:
                 rel_table_processed = self._enforce_min_count_and_montonicity(

--- a/improver_tests/calibration/reliability_calibration/conftest.py
+++ b/improver_tests/calibration/reliability_calibration/conftest.py
@@ -390,7 +390,7 @@ def reliability_table_point_grid(forecast_grid, truth_grid, reliability_data):
     return reliability_table
 
 
-RelTables = namedtuple("RelTables", ["table", "indicies0", "indicies1"])
+RelTables = namedtuple("RelTables", ["table", "indices0", "indices1"])
 
 
 @pytest.fixture(params=["point_spot", "point_grid"])
@@ -400,14 +400,14 @@ def create_rel_tables_point(
     if request.param == "point_spot":
         return RelTables(
             table=reliability_table_point_spot,
-            indicies0=(0, slice(0, None), slice(0, None), 0),
-            indicies1=(0, slice(0, None), slice(0, None), 1),
+            indices0=(0, slice(0, None), slice(0, None), 0),
+            indices1=(0, slice(0, None), slice(0, None), 1),
         )
     else:
         return RelTables(
             table=reliability_table_point_grid,
-            indicies0=(0, slice(0, None), slice(0, None), 0, 0),
-            indicies1=(0, slice(0, None), slice(0, None), 0, 1),
+            indices0=(0, slice(0, None), slice(0, None), 0, 0),
+            indices1=(0, slice(0, None), slice(0, None), 0, 1),
         )
 
 

--- a/improver_tests/calibration/reliability_calibration/conftest.py
+++ b/improver_tests/calibration/reliability_calibration/conftest.py
@@ -385,9 +385,7 @@ def reliability_table_point_spot(forecast_spot, truth_spot, reliability_data):
 @pytest.fixture
 def reliability_table_point_grid(forecast_grid, truth_grid, reliability_data):
     reliability_cube_format = CalPlugin().process(forecast_grid, truth_grid)
-    data = np.stack(
-        [np.stack([reliability_data] * 3, axis=-1)] * 3, axis=-1
-    )
+    data = np.stack([np.stack([reliability_data] * 3, axis=-1)] * 3, axis=-1)
     reliability_table = reliability_cube_format.copy(data=data)
     return reliability_table
 
@@ -397,9 +395,7 @@ RelTables = namedtuple("RelTables", ["table", "indicies0", "indicies1"])
 
 @pytest.fixture(params=["point_spot", "point_grid"])
 def create_rel_tables_point(
-    request,
-    reliability_table_point_spot,
-    reliability_table_point_grid,
+    request, reliability_table_point_spot, reliability_table_point_grid,
 ):
     if request.param == "point_spot":
         return RelTables(

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -518,8 +518,7 @@ def test_emcam_lowest_bin_non_monotonic(reliability_table_slice):
 
 
 def test_process_no_change_agg(reliability_table_agg):
-    """Test with no changes required to preserve monotonicity. Parameterized
-    using `create_rel_tables` fixture."""
+    """Test with no changes required to preserve monotonicity."""
     result = Plugin().process(reliability_table_agg.copy())
     assert_array_equal(result[0].data, reliability_table_agg[0].data)
     assert result[0].coords() == reliability_table_agg[0].coords()
@@ -545,10 +544,10 @@ def test_process_no_change_point(create_rel_tables_point):
 
 
 def test_process_undersampled_non_monotonic_point(create_rel_tables_point):
-    """Test expected values are returned when one slice contains a bin is below
-    the minimum forecast count when the observed frequency is non-monotonic and
-    remaining data, which requires no change, is not changed. Parameterized
-    using `create_rel_tables` fixture."""
+    """Test expected values are returned when one slice contains a bin that is
+    below the minimum forecast count, whilst the observed frequency is
+    non-monotonic. Test that remaining data, which requires no change, is not
+    changed. Parameterized using `create_rel_tables` fixture."""
     expected_data = np.array([[1000, 425, 1000], [1000, 425, 1000], [2000, 600, 1000]])
     expected_bin_coord_points = np.array([0.2, 0.6, 0.9], dtype=np.float32)
     expected_bin_coord_bounds = np.array(

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -521,7 +521,6 @@ def test_process_no_change_agg(reliability_table_agg):
     """Test with no changes required to preserve monotonicity. Parameterized
     using `create_rel_tables` fixture."""
     result = Plugin().process(reliability_table_agg.copy())
-    print(result[0].data)
     assert_array_equal(result[0].data, reliability_table_agg[0].data)
     assert result[0].coords() == reliability_table_agg[0].coords()
     assert_array_equal(result[1].data, reliability_table_agg[1].data)
@@ -535,7 +534,7 @@ def test_process_no_change_point(create_rel_tables_point):
     result = Plugin(point_by_point=True).process(rel_table.copy())
 
     assert all(len(result_list) == 9 for result_list in result)
-    expected = rel_table.data[create_rel_tables_point.indicies0]
+    expected = rel_table.data[create_rel_tables_point.indices0]
     assert all([np.array_equal(cube.data, expected) for cube in result[0]])
 
     coords_exclude = ["latitude", "longitude", "spot_index", "wmo_id"]
@@ -556,9 +555,7 @@ def test_process_undersampled_non_monotonic_point(create_rel_tables_point):
         [[0.0, 0.4], [0.4, 0.8], [0.8, 1.0]], dtype=np.float32,
     )
     rel_table = create_rel_tables_point.table
-    # print(rel_table.data.shape)
-    # print(rel_table.data[create_rel_tables_point.indicies].shape)
-    rel_table.data[create_rel_tables_point.indicies0] = np.array(
+    rel_table.data[create_rel_tables_point.indices0] = np.array(
         [
             [750, 250, 50, 375, 1000],  # Observation count
             [750, 250, 50, 375, 1000],  # Sum of forecast probability
@@ -575,5 +572,5 @@ def test_process_undersampled_non_monotonic_point(create_rel_tables_point):
         result[0][0].coord("probability_bin").bounds, expected_bin_coord_bounds
     )
     # Check the unchanged data remains unchanged
-    expected = rel_table.data[create_rel_tables_point.indicies1]
+    expected = rel_table.data[create_rel_tables_point.indices1]
     assert all([np.array_equal(cube.data, expected) for cube in result[0][1:]])

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -386,16 +386,12 @@ def test_emcam_combine_undersampled_bins_monotonic(reliability_table_slice):
             [0, 250, 50, 375, 1000],  # Sum of forecast probability
             [1000, 1000, 100, 500, 1000],  # Forecast count
         ],
-        dtype=np.float32
+        dtype=np.float32,
     )
     result = Plugin()._enforce_min_count_and_montonicity(reliability_table_slice.copy())
     assert_array_equal(result.data, expected_data)
-    assert_allclose(
-        result.coord("probability_bin").points, expected_bin_coord_points
-    )
-    assert_allclose(
-        result.coord("probability_bin").bounds, expected_bin_coord_bounds
-    )
+    assert_allclose(result.coord("probability_bin").points, expected_bin_coord_points)
+    assert_allclose(result.coord("probability_bin").bounds, expected_bin_coord_bounds)
 
 
 def test_emcam_combine_undersampled_bins_non_monotonic(reliability_table_slice):
@@ -413,17 +409,13 @@ def test_emcam_combine_undersampled_bins_non_monotonic(reliability_table_slice):
             [750, 250, 50, 375, 1000],  # Sum of forecast probability
             [1000, 1000, 100, 500, 1000],  # Forecast count
         ],
-        dtype=np.float32
+        dtype=np.float32,
     )
 
     result = Plugin()._enforce_min_count_and_montonicity(reliability_table_slice.copy())
     assert_array_equal(result.data, expected_data)
-    assert_allclose(
-        result.coord("probability_bin").points, expected_bin_coord_points
-    )
-    assert_allclose(
-        result.coord("probability_bin").bounds, expected_bin_coord_bounds
-    )
+    assert_allclose(result.coord("probability_bin").points, expected_bin_coord_points)
+    assert_allclose(result.coord("probability_bin").bounds, expected_bin_coord_bounds)
 
 
 def test_emcam_highest_bin_non_monotonic(reliability_table_slice):
@@ -447,12 +439,8 @@ def test_emcam_highest_bin_non_monotonic(reliability_table_slice):
 
     result = Plugin()._enforce_min_count_and_montonicity(reliability_table_slice.copy())
     assert_array_equal(result.data, expected_data)
-    assert_allclose(
-        result.coord("probability_bin").points, expected_bin_coord_points
-    )
-    assert_allclose(
-        result.coord("probability_bin").bounds, expected_bin_coord_bounds
-    )
+    assert_allclose(result.coord("probability_bin").points, expected_bin_coord_points)
+    assert_allclose(result.coord("probability_bin").bounds, expected_bin_coord_bounds)
 
 
 def test_emcam_central_bin_non_monotonic(reliability_table_slice):
@@ -475,12 +463,8 @@ def test_emcam_central_bin_non_monotonic(reliability_table_slice):
 
     result = Plugin()._enforce_min_count_and_montonicity(reliability_table_slice.copy())
     assert_array_equal(result.data, expected_data)
-    assert_allclose(
-        result.coord("probability_bin").points, expected_bin_coord_points
-    )
-    assert_allclose(
-        result.coord("probability_bin").bounds, expected_bin_coord_bounds
-    )
+    assert_allclose(result.coord("probability_bin").points, expected_bin_coord_points)
+    assert_allclose(result.coord("probability_bin").bounds, expected_bin_coord_bounds)
 
 
 def test_emcam_upper_bins_non_monotonic(reliability_table_slice):
@@ -503,12 +487,8 @@ def test_emcam_upper_bins_non_monotonic(reliability_table_slice):
 
     result = Plugin()._enforce_min_count_and_montonicity(reliability_table_slice.copy())
     assert_array_equal(result.data, expected_data)
-    assert_allclose(
-        result.coord("probability_bin").points, expected_bin_coord_points
-    )
-    assert_allclose(
-        result.coord("probability_bin").bounds, expected_bin_coord_bounds
-    )
+    assert_allclose(result.coord("probability_bin").points, expected_bin_coord_points)
+    assert_allclose(result.coord("probability_bin").bounds, expected_bin_coord_bounds)
 
 
 def test_emcam_lowest_bin_non_monotonic(reliability_table_slice):
@@ -533,12 +513,8 @@ def test_emcam_lowest_bin_non_monotonic(reliability_table_slice):
     )
     result = Plugin()._enforce_min_count_and_montonicity(reliability_table_slice.copy())
     assert_array_equal(result.data, expected_data)
-    assert_allclose(
-        result.coord("probability_bin").points, expected_bin_coord_points
-    )
-    assert_allclose(
-        result.coord("probability_bin").bounds, expected_bin_coord_bounds
-    )
+    assert_allclose(result.coord("probability_bin").points, expected_bin_coord_points)
+    assert_allclose(result.coord("probability_bin").bounds, expected_bin_coord_bounds)
 
 
 def test_process_no_change_agg(reliability_table_agg):
@@ -562,7 +538,7 @@ def test_process_no_change_point(create_rel_tables_point):
     expected = rel_table.data[create_rel_tables_point.indicies0]
     assert all([np.array_equal(cube.data, expected) for cube in result[0]])
 
-    coords_exclude = ['latitude', 'longitude', 'spot_index', 'wmo_id']
+    coords_exclude = ["latitude", "longitude", "spot_index", "wmo_id"]
     coords_table = [c for c in rel_table[0].coords() if c.name() not in coords_exclude]
     # Ensure coords are in the same order
     coords_result = [result[0][0].coords(c.name())[0] for c in coords_table]

--- a/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
+++ b/improver_tests/calibration/reliability_calibration/test_ManipulateReliabilityTable.py
@@ -369,13 +369,14 @@ def test_acof_non_monotonic_higher_forecast_count_on_left():
     assert_array_equal(result.data, expected_result)
 
 
-def test_process_no_change(reliability_table_agg):
-    """Test with no changes required to preserve monotonicity"""
-    result = Plugin().process(reliability_table_agg.copy())
-    assert_array_equal(result[0].data, reliability_table_agg[0].data)
-    assert result[0].coords() == reliability_table_agg[0].coords()
-    assert_array_equal(result[1].data, reliability_table_agg[1].data)
-    assert result[1].coords() == reliability_table_agg[1].coords()
+def test_process_no_change(create_rel_tables):
+    """Test with no changes required to preserve monotonicity. Parameterized
+    using `create_rel_tables` fixture."""
+    result = Plugin().process(create_rel_tables.copy())
+    assert_array_equal(result[0].data, create_rel_tables[0].data)
+    assert result[0].coords() == create_rel_tables[0].coords()
+    assert_array_equal(result[1].data, create_rel_tables[1].data)
+    assert result[1].coords() == create_rel_tables[1].coords()
 
 
 def test_process_combine_undersampled_bins_monotonic(reliability_table_agg):


### PR DESCRIPTION
Addresses #1669

Adds `point_by_point` to `ManipulateReliabilityTable`. This is similar to what has been done in EMOS #1170

Considerations:
* independent processing is done via for loop, looping over x, y slices. This is similar to what has been done in EMOS but it is slow - not sure if there is a better way to do this with iris (@anja-bom says there is not)
* the min forecast count processing results in variable sized probability bin coord, this means that reliability tables independently processed cannot be merged. Currently this is handled by using a CubeList. With this functionality the output is a CubeList of CubeLists, when both thresholds and points are independently processed. This is not a nice/clean data structure but I could not think of a better solution. Happy to change to better alternative.
* Tests use parametrized fixtures as in #1667

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
