### PR TITLE
DOC: Removal of unnecessary exclusions in sphinx apidoc build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -32,7 +32,7 @@ clean:
 
 .PHONY: apidoc
 apidoc:
-	sphinx-apidoc -e -P -f -o source ../improver ../improver_tests setup.py
+	sphinx-apidoc -e -P -f -o source ../improver
 
 .PHONY: html
 html:


### PR DESCRIPTION
Confirmed that removal of the sphinx apidoc exclusions have no effect, given the target dir.

Closes https://github.com/metoppv/improver/issues/1676