### PR TITLE
MOBT-246: Remove flawed interpretation of the blend_time coordinate

### DIFF
--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -45,7 +45,6 @@ from improver.metadata.constants.attributes import (
 )
 from improver.metadata.constants.time_types import TIME_COORDS
 from improver.metadata.forecast_times import add_blend_time, forecast_period_coord
-from improver.utilities.cube_checker import is_model_blended
 from improver.utilities.round import round_close
 from improver.utilities.temporal import cycletime_to_number
 
@@ -244,18 +243,18 @@ def set_record_run_attr(
 
     There are three ways this method may work:
 
-      - None of the input cubes have been previously cycle or model blended.
+      - None of the input cubes have an existing record_run attribute.
         The model_id_attr argument must be provided to enable the model
         identifiers to be extracted and used in conjunction with the forecast
         reference time to build the record_run attribute.
-      - All of the input cubes have been previously cycle or model blended. The
+      - All of the input cubes have an existing record_run attribute. The
         model_id_attr argument is not required as a new record_run attribute
         will be constructed by combining the existing record_run attributes on
         each input cube.
-      - Some of the input cubes have been previously cycle or model blended, and
-        some have not. The model_id_attr argument must be provided so that those
-        cubes without an existing record_run attribute can be interrogated for
-        their model identifier.
+      - Some of the input cubes have an existing record_run attribute, and some
+        have not. The model_id_attr argument must be provided so that those cubes
+        without an existing record_run attribute can be interrogated for their
+        model identifier.
 
     The cubes are modified in place.
 
@@ -271,8 +270,6 @@ def set_record_run_attr(
     Raises:
         ValueError: If model_id_attr is not set and is required to construct a
                     new record_run_attr.
-        Exception: A cube has previously been model blended but contains no
-                   record_run_attr.
         Exception: The model_id_attr name provided is not present on one or more
                    of the input cubes.
     """
@@ -293,15 +290,6 @@ def set_record_run_attr(
                 if model_attr not in cycle_strings:
                     cycle_strings.append(model_attr)
             continue
-
-        if is_model_blended(cube):
-            raise Exception(
-                "This cube has been through model blending but there is no "
-                f"record_run attribute. This indicates cube {cube.name()} has "
-                "been previously model blended without recording the cycles "
-                "from which data was taken. It is not possible to create a "
-                "record_run attribute."
-            )
 
         if model_id_attr not in cube.attributes:
             raise Exception(

--- a/improver/utilities/cube_checker.py
+++ b/improver/utilities/cube_checker.py
@@ -199,20 +199,3 @@ def spatial_coords_match(first_cube: Cube, second_cube: Cube) -> bool:
     return first_cube.coord(axis="x") == second_cube.coord(
         axis="x"
     ) and first_cube.coord(axis="y") == second_cube.coord(axis="y")
-
-
-def is_model_blended(cube: Cube) -> bool:
-    """
-    Determine whether a cube has been through model blending by looking for a
-    "blend_time" coordinate. This doesn't guarantee that multiple models have
-    contributed to the blend, only that it has been through the model blending
-    process.
-
-    Args:
-        cube:
-            The cube to test.
-
-    Returns:
-        True if the cube has been through model blending, false if not.
-    """
-    return "blend_time" in [c.name() for c in cube.coords()]

--- a/improver_tests/blending/test_utilities.py
+++ b/improver_tests/blending/test_utilities.py
@@ -264,19 +264,3 @@ def test_set_record_run_attr_exception_model_id(model_cube):
 
     with pytest.raises(Exception, match="Failure to record run information"):
         set_record_run_attr(cubes, record_run_attr, model_id_attr)
-
-
-def test_set_record_run_attr_exception_blended(model_cube):
-    """Test an exception is raised if an input cube has been through model
-    blending but has no record_run attribute. It is not possible to create a
-    record_run attribute in this case as the source cycle information has been
-    lost on this input cube."""
-    record_run_attr = "mosg__model_run"
-    model_id_attr = "mosg__model_configuration"
-    cubes = [model_cube[0], model_cube[1]]
-    blend_time = cubes[0].coord("forecast_reference_time").copy()
-    blend_time.rename("blend_time")
-    cubes[0].add_aux_coord(blend_time)
-
-    with pytest.raises(Exception, match="This cube has been through model blending"):
-        set_record_run_attr(cubes, record_run_attr, model_id_attr)

--- a/improver_tests/utilities/test_cube_checker.py
+++ b/improver_tests/utilities/test_cube_checker.py
@@ -46,7 +46,6 @@ from improver.utilities.cube_checker import (
     check_cube_coordinates,
     check_for_x_and_y_axes,
     find_dimension_coordinate_mismatch,
-    is_model_blended,
     spatial_coords_match,
 )
 
@@ -300,30 +299,6 @@ class Test_spatial_coords_match(IrisTest):
         y_coord.points = [y * 1.01 for y in y_coord.points]
         result = spatial_coords_match(self.cube_a, cube_c)
         self.assertFalse(result)
-
-
-class Test_is_model_blended(unittest.TestCase):
-
-    """Test is_model_blended behaves as expected."""
-
-    def setUp(self):
-        """Set up a cube."""
-        data = np.ones((1, 5, 5), dtype=np.float32)
-        cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
-        )
-        self.cube_without = cube
-        blend_time = cube.coord("forecast_reference_time").copy()
-        blend_time.rename("blend_time")
-        self.cube_with = cube.copy()
-        self.cube_with.add_aux_coord(blend_time)
-
-    def test_basic(self):
-        """Test correct result is returned for cube with and without a
-        blend_time coordinate."""
-
-        self.assertFalse(is_model_blended(self.cube_without))
-        self.assertTrue(is_model_blended(self.cube_with))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removes flawed interpretation of the blend_time coordinate as evidence of model blending having occurred. See https://github.com/metoppv/mo-blue-team/issues/246 for a long description of what's going on here.

Testing:
 - [x] Ran tests and they passed OK