### PR TITLE
Added square as the default neighbourhood shape to neighbourhood CLIS.

### DIFF
--- a/improver/cli/nbhood.py
+++ b/improver/cli/nbhood.py
@@ -42,7 +42,7 @@ def process(
     mask: cli.inputcube = None,
     *,
     neighbourhood_output,
-    neighbourhood_shape,
+    neighbourhood_shape="square",
     radii: cli.comma_separated_list,
     lead_times: cli.comma_separated_list = None,
     degrees_as_complex=False,
@@ -76,6 +76,7 @@ def process(
             neighbourhood shape is applicable for calculating "percentiles"
             output.
             Options: "circular", "square".
+            Default: "square".
         radii (list of float):
             The radius or a list of radii in metres of the neighbourhood to
             apply.

--- a/improver/cli/nbhood_iterate_with_mask.py
+++ b/improver/cli/nbhood_iterate_with_mask.py
@@ -43,7 +43,7 @@ def process(
     weights: cli.inputcube = None,
     *,
     coord_for_masking,
-    neighbourhood_shape,
+    neighbourhood_shape="square",
     radii: cli.comma_separated_list,
     lead_times: cli.comma_separated_list = None,
     area_sum=False,
@@ -76,6 +76,7 @@ def process(
         neighbourhood_shape (str):
             Name of the neighbourhood method to use.
             Options: "circular", "square".
+            Default: "square".
         radii (list of float):
             The radius or a list of radii in metres of the neighbourhood to
             apply.

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -42,7 +42,7 @@ def process(
     mask: cli.inputcube,
     weights: cli.inputcube = None,
     *,
-    neighbourhood_shape,
+    neighbourhood_shape="square",
     radii: cli.comma_separated_list,
     lead_times: cli.comma_separated_list = None,
     area_sum=False,
@@ -72,6 +72,7 @@ def process(
         neighbourhood_shape (str):
             Name of the neighbourhood method to use.
             Options: "circular", "square".
+            Default: "square".
         radii (list of float):
             The radius or a list of radii in metres of the neighbourhood to
             apply.

--- a/improver_tests/acceptance/test_nbhood.py
+++ b/improver_tests/acceptance/test_nbhood.py
@@ -162,8 +162,6 @@ def test_wind_direction(tmp_path):
         input_path,
         "--neighbourhood-output",
         "probabilities",
-        "--neighbourhood-shape",
-        "square",
         "--radii",
         "20000",
         "--degrees-as-complex",

--- a/improver_tests/acceptance/test_nbhood_iterate_with_mask.py
+++ b/improver_tests/acceptance/test_nbhood_iterate_with_mask.py
@@ -54,8 +54,6 @@ def test_basic(tmp_path):
         mask_path,
         "--coord-for-masking",
         "topographic_zone",
-        "--neighbourhood-shape",
-        "square",
         "--radii",
         "20000",
         "--output",

--- a/improver_tests/acceptance/test_nbhood_land_and_sea.py
+++ b/improver_tests/acceptance/test_nbhood_land_and_sea.py
@@ -76,8 +76,6 @@ def test_radii_with_lead_times(tmp_path):
     args = [
         input_path,
         mask_path,
-        "--neighbourhood-shape",
-        "square",
         "--radii",
         "18000,54000,90000,162000",
         "--lead-times",


### PR DESCRIPTION
Partially addresses https://github.com/metoppv/mo-blue-team/issues/157

Add square as the default neighbourhood shape to all neighbourhood CLIs. Also made sure at least one test for each CLI used the default value rather than passing it in explicitly

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

