### PR TITLE
Add freezing rain precip bounds for ECC

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -61,6 +61,7 @@ BOUNDS_FOR_ECDF = {
     "low_and_medium_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
     "low_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
     # Precipitation amount
+    "lwe_thickness_of_freezing_rainfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),

--- a/improver/precipitation_type/freezing_rain.py
+++ b/improver/precipitation_type/freezing_rain.py
@@ -37,6 +37,7 @@ from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import PostProcessingPlugin
+from improver.metadata.amend import update_model_id_attr_attribute
 from improver.metadata.utilities import (
     create_new_diagnostic_cube,
     generate_mandatory_attributes,
@@ -225,13 +226,20 @@ class FreezingRain(PostProcessingPlugin):
             .name()
             .replace("sleet", "freezing_rain")
         )
+        mandatory_attributes = generate_mandatory_attributes(
+            CubeList([self.rain, self.sleet])
+        )
+        optional_attributes = {}
+        if self.model_id_attr:
+            optional_attributes = update_model_id_attr_attribute(
+                CubeList([self.rain, self.sleet, self.temperature]), self.model_id_attr
+            )
         freezing_rain_cube = create_new_diagnostic_cube(
             diagnostic_name,
             "1",
             template_cube=self.sleet,
-            mandatory_attributes=generate_mandatory_attributes(
-                CubeList([self.rain, self.sleet]), model_id_attr=self.model_id_attr,
-            ),
+            mandatory_attributes=mandatory_attributes,
+            optional_attributes=optional_attributes,
             data=freezing_rain_prob,
         )
         freezing_rain_cube.coord(var_name="threshold").rename(threshold_name)

--- a/improver_tests/precipitation_type/freezing_rain/conftest.py
+++ b/improver_tests/precipitation_type/freezing_rain/conftest.py
@@ -45,6 +45,7 @@ COMMON_ATTRS = {
     "source": "Unit test",
     "institution": "Met Office",
     "title": "Post-Processed IMPROVER unit test",
+    "mosg__model_configuration": "uk_det",
 }
 PERIOD_TIMEBOUNDS = (datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0))
 
@@ -190,4 +191,5 @@ def expected_attributes():
         "source": "Unit test",
         "institution": "Met Office",
         "title": "Post-Processed IMPROVER unit test",
+        "mosg__model_configuration": "uk_det",
     }

--- a/improver_tests/precipitation_type/freezing_rain/test_FreezingRain.py
+++ b/improver_tests/precipitation_type/freezing_rain/test_FreezingRain.py
@@ -60,7 +60,9 @@ def test_expected_result(input_cubes, expected_probabilities, expected_attribute
 
     input_cubes = list(itertools.permutations(input_cubes))
     for cubes in input_cubes:
-        result = FreezingRain()(iris.cube.CubeList(cubes))
+        result = FreezingRain(model_id_attr="mosg__model_configuration")(
+            iris.cube.CubeList(cubes)
+        )
 
         assert_almost_equal(result.data, expected_probabilities)
         assert isinstance(result, Cube)
@@ -74,6 +76,22 @@ def test_expected_result(input_cubes, expected_probabilities, expected_attribute
             assert result.name() == PROB_NAME.format(RATE_NAME)
             assert result.coord(var_name="threshold").name() == RATE_NAME
             assert result.coord(var_name="threshold").units == "mm hr-1"
+
+
+@pytest.mark.parametrize("period", ["instantaneous"])
+def test_model_config_attribute(
+    precipitation_only, temperature_only, expected_attributes
+):
+    """Test that the returned model configuration attribute is correct when the
+    inputs are derived from a mixture of models."""
+
+    expected_attributes.update({"mosg__model_configuration": "uk_det uk_ens"})
+    temperature_only.attributes["mosg__model_configuration"] = "uk_ens"
+    cubes = iris.cube.CubeList([*precipitation_only, temperature_only])
+    result = FreezingRain(model_id_attr="mosg__model_configuration")(
+        iris.cube.CubeList(cubes)
+    )
+    assert result.attributes == expected_attributes
 
 
 @pytest.mark.parametrize("period", ["instantaneous"])


### PR DESCRIPTION
In order that percentiles of freezing rain accumulation can be generated, ECC bounds are required. This PR adds them.

Edit: In addition, this PR now tweaks the way in which the model configuration attribute is set to capture mixed model inputs.

Testing:
 - [x] Ran tests and they passed OK
