### PR TITLE
MOBT-273: OccurrenceWithinVicinity invoked using a grid point radius.

### DIFF
--- a/improver/cli/threshold.py
+++ b/improver/cli/threshold.py
@@ -147,7 +147,7 @@ def process(
     if vicinity is not None:
         # smooth thresholded occurrences over local vicinity
         each_threshold_func_list.append(
-            OccurrenceWithinVicinity(vicinity, land_mask_cube=land_sea_mask)
+            OccurrenceWithinVicinity(radius=vicinity, land_mask_cube=land_sea_mask)
         )
     elif land_sea_mask:
         raise ValueError("Cannot apply land-mask cube without in-vicinity processing")

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -52,10 +52,7 @@ from improver.utilities.cube_checker import check_cube_coordinates
 from improver.utilities.cube_manipulation import sort_coord_in_cube
 from improver.utilities.interpolation import interpolate_missing_data
 from improver.utilities.mathematical_operations import Integration, fast_linear_fit
-from improver.utilities.spatial import (
-    OccurrenceWithinVicinity,
-    number_of_grid_cells_to_distance,
-)
+from improver.utilities.spatial import OccurrenceWithinVicinity
 
 SVP_T_MIN = 183.15
 SVP_T_MAX = 338.25
@@ -531,6 +528,10 @@ class PhaseChangeLevel(BasePlugin):
                 orographic feature where high-resolution models can give highly
                 localised results. Zero uses central point only (neighbourhood is disabled).
                 One uses central point and one in each direction. Two goes two points etc.
+                A grid_point_radius may be specified for data on any projection
+                but the effective kernel shape in real space may be irregular.
+                Users must be aware of this when choosing whether to use a non-zero
+                grid_point_radius with a non-equal areas projection
             horizontal_interpolation:
                 If True apply horizontal interpolation to fill in holes in
                 the returned phase-change-level that occur because the level
@@ -553,16 +554,6 @@ class PhaseChangeLevel(BasePlugin):
         self.phase_change_name = phase_change_def["name"]
         self.grid_point_radius = grid_point_radius
         self.horizontal_interpolation = horizontal_interpolation
-
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        result = (
-            "<PhaseChangeLevel: falling_level_threshold:{}, "
-            "grid_point_radius: {}>".format(
-                self.falling_level_threshold, self.grid_point_radius
-            )
-        )
-        return result
 
     def find_falling_level(
         self, wb_int_data: ndarray, orog_data: ndarray, height_points: ndarray
@@ -861,12 +852,9 @@ class PhaseChangeLevel(BasePlugin):
             of the orography data or the orography data itself if the radius is zero
         """
         if self.grid_point_radius >= 1:
-            radius_in_metres = number_of_grid_cells_to_distance(
-                orography_cube, self.grid_point_radius
-            )
-            max_in_nbhood_orog = OccurrenceWithinVicinity(radius_in_metres)(
-                orography_cube
-            )
+            max_in_nbhood_orog = OccurrenceWithinVicinity(
+                grid_point_radius=self.grid_point_radius
+            )(orography_cube)
             return max_in_nbhood_orog
         else:
             return orography_cube.copy()

--- a/improver/regrid/landsea.py
+++ b/improver/regrid/landsea.py
@@ -262,7 +262,7 @@ class AdjustLandSeaPoints(BasePlugin):
         self.output_land = None
         self.output_cube = None
         self.regridder = Nearest(extrapolation_mode=extrapolation_mode)
-        self.vicinity = OccurrenceWithinVicinity(vicinity_radius)
+        self.vicinity = OccurrenceWithinVicinity(radius=vicinity_radius)
 
     @functools.lru_cache(maxsize=2)
     def _get_matches(

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -391,22 +391,36 @@ class GradientBetweenAdjacentGridSquares(BasePlugin):
 
 class OccurrenceWithinVicinity(PostProcessingPlugin):
 
-    """Calculate whether a phenomenon occurs within the specified distance."""
+    """Calculate whether a phenomenon occurs within the specified radius. This
+    radius can be given as a radius in metres, or as a number of grid points.
+    A radius in metres may be used with data on a equal areas projection only.
+    A grid_point_radius will work with any projection but the effective kernel
+    shape in real space may be irregular. Users must be aware of this when
+    choosing whether to use this plugin with a non-equal areas projection."""
 
-    def __init__(self, distance: float, land_mask_cube: Cube = None) -> None:
+    def __init__(
+        self,
+        radius: float = None,
+        grid_point_radius: int = None,
+        land_mask_cube: Cube = None,
+    ) -> None:
         """
-        Initialise the class.
-
         Args:
-            distance:
-                Distance in metres used to define the vicinity within which to
+            radius:
+                Radius in metres used to define the vicinity within which to
                 search for an occurrence.
+            grid_point_radius:
+                Alternatively, a number of grid points that defines the vicinity
+                radius over which to search for an occurence.
             land_mask_cube:
                 Binary land-sea mask data. True for land-points, False for sea.
                 Restricts in-vicinity processing to only include points of a
                 like mask value.
         """
-        self.distance = distance
+        if radius and grid_point_radius:
+            raise ValueError("Only one of radius or grid_point_radius should be set")
+        self.radius = radius
+        self.grid_point_radius = grid_point_radius
         if land_mask_cube:
             if land_mask_cube.name() != "land_binary_mask":
                 raise ValueError(
@@ -418,14 +432,9 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
             self.land_mask = None
         self.land_mask_cube = land_mask_cube
 
-    def __repr__(self) -> str:
-        """Represent the configured plugin instance as a string."""
-        result = "<OccurrenceWithinVicinity: distance: {}>"
-        return result.format(self.distance)
-
     def maximum_within_vicinity(self, cube: Cube) -> Cube:
         """
-        Find grid points where a phenomenon occurs within a defined distance.
+        Find grid points where a phenomenon occurs within a defined radius.
         The occurrences within this vicinity are maximised, such that all
         grid points within the vicinity are recorded as having an occurrence.
         For non-binary fields, if the vicinity of two occurrences overlap,
@@ -440,15 +449,17 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
         Returns:
             Cube where the occurrences have been spatially spread, so that
             they're equally likely to have occurred anywhere within the
-            vicinity defined using the specified distance.
+            vicinity defined using the specified radius.
         """
-        grid_spacing = distance_to_number_of_grid_cells(cube, self.distance)
+        if self.radius:
+            grid_point_radius = distance_to_number_of_grid_cells(cube, self.radius)
+        else:
+            grid_point_radius = self.grid_point_radius
 
-        # Convert the number of grid points (i.e. grid_spacing) represented
-        # by self.distance, e.g. where grid_spacing=1 is an increment to
-        # a central point, into grid_cells which is the total number of points
-        # within the defined vicinity along the y axis e.g grid_cells=3.
-        grid_cells = (2 * grid_spacing) + 1
+        # Convert the grid_point_radius into a number of points along an edge
+        # length, including the central point, e.g. grid_point_radius = 1,
+        # points along the edge = 3
+        grid_points = (2 * grid_point_radius) + 1
 
         max_cube = cube.copy()
         unmasked_cube_data = cube.data.copy()
@@ -460,12 +471,12 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
             for match in (True, False):
                 matched_data = unmasked_cube_data.copy()
                 matched_data[self.land_mask != match] = -np.inf
-                matched_max_data = maximum_filter(matched_data, size=grid_cells)
+                matched_max_data = maximum_filter(matched_data, size=grid_points)
                 max_data = np.where(self.land_mask == match, matched_max_data, max_data)
         else:
             # The following command finds the maximum value for each grid point
             # from within a square of length "size"
-            max_data = maximum_filter(unmasked_cube_data, size=grid_cells)
+            max_data = maximum_filter(unmasked_cube_data, size=grid_points)
         if np.ma.is_masked(cube.data):
             # Update only the unmasked values
             max_cube.data.data[~cube.data.mask] = max_data[~cube.data.mask]

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -417,7 +417,7 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
                 Restricts in-vicinity processing to only include points of a
                 like mask value.
         """
-        if radius and grid_point_radius:
+        if radius is not None and grid_point_radius is not None:
             raise ValueError("Only one of radius or grid_point_radius should be set")
         self.radius = radius
         self.grid_point_radius = grid_point_radius
@@ -453,8 +453,10 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
         """
         if self.radius:
             grid_point_radius = distance_to_number_of_grid_cells(cube, self.radius)
-        else:
+        elif self.grid_point_radius is not None:
             grid_point_radius = self.grid_point_radius
+        else:
+            grid_point_radius = 0
 
         # Convert the grid_point_radius into a number of points along an edge
         # length, including the central point, e.g. grid_point_radius = 1,

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -89,21 +89,6 @@ class Test__init__(IrisTest):
             PhaseChangeLevel(phase_change)
 
 
-class Test__repr__(IrisTest):
-
-    """Test the repr method."""
-
-    def test_basic(self):
-        """Test that the __repr__ returns the expected string."""
-        result = str(PhaseChangeLevel(phase_change="snow-sleet"))
-        msg = (
-            "<PhaseChangeLevel: "
-            "falling_level_threshold:90.0,"
-            " grid_point_radius: 2>"
-        )
-        self.assertEqual(result, msg)
-
-
 class Test_find_falling_level(IrisTest):
 
     """Test the find_falling_level method."""
@@ -431,16 +416,6 @@ class Test_find_max_in_nbhood_orography(IrisTest):
         expected_data = self.cube.data.copy()
         result = plugin.find_max_in_nbhood_orography(cube)
         self.assertArrayAlmostEqual(result.data, expected_data)
-
-    def test_error_lat_lon(self):
-        """Test the function fails when radius is not zero and grid is lat-lon."""
-        cube = self.cube_latlon
-        plugin = PhaseChangeLevel(phase_change="snow-sleet", grid_point_radius=1)
-        with self.assertRaisesRegex(
-            ValueError,
-            r"Unable to convert from 'Unit\('degrees'\)' to 'Unit\('metres'\)'.",
-        ):
-            plugin.find_max_in_nbhood_orography(cube)
 
 
 class Test_process(IrisTest):

--- a/improver_tests/regrid/test_AdjustLandSeaPoints.py
+++ b/improver_tests/regrid/test_AdjustLandSeaPoints.py
@@ -94,7 +94,7 @@ class Test__init__(IrisTest):
         result = AdjustLandSeaPoints(vicinity_radius=30000.0)
         vicinity = getattr(result, "vicinity")
         self.assertTrue(isinstance(vicinity, OccurrenceWithinVicinity))
-        self.assertEqual(vicinity.distance, 30000.0)
+        self.assertEqual(vicinity.radius, 30000.0)
 
     def test_vicinity_arg_error(self):
         """Test with invalid vicinity_radius argument.

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -398,3 +398,12 @@ def test_no_realization_or_time(request, cube_with_realizations, land_fixture):
     assert isinstance(result, Cube)
     assert result.data.shape == orig_shape
     assert np.allclose(result.data, expected)
+
+
+def test_two_radii_provided_exception(cube):
+    """Test an exception is raised if both radius and grid_point_radius are
+    provided as arguments."""
+    with pytest.raises(
+        ValueError, match="Only one of radius or grid_point_radius should be set"
+    ):
+        OccurrenceWithinVicinity(radius=2000, grid_point_radius=2)


### PR DESCRIPTION
Modifications to allow OccurrenceWithinVicinity to work using a grid point radius (N grid points) rather than a distance in metres.

This change allows the vicinity plugin to be called directly with a grid point radius. Doing so avoids the need to calculate such a radius within the code, and thus removes the enforcement that the projection be equal areas. This allows us to use a vicinity neighourbourhood in the phase change level code for a global lat-lon grid. Doc-strings have been updated to indicate that the user must tread carefully here as a grid point radius applied to some projections will lead to a very strange effective kernel shape.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)