### PR TITLE
github actions mamba error workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
+        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
@@ -82,6 +83,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
+        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
@@ -125,6 +127,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
+        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
+        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
@@ -66,6 +67,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
+        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
@@ -96,6 +98,7 @@ jobs:
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda install -c conda-forge mamba
+        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -28,7 +28,7 @@ dependencies:
   # Development
   - astroid
   - bandit
-  - black=19.10b0
+  - black>=22.3.0
   - codacy-coverage
   - filelock
   - flake8

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -28,7 +28,8 @@ dependencies:
   # Development
   - astroid
   - bandit
-  - black>=22.3.0
+  - black=19.10b0
+  - click=8.0.2
   - codacy-coverage
   - filelock
   - flake8

--- a/envs/environment_b.yml
+++ b/envs/environment_b.yml
@@ -28,7 +28,8 @@ dependencies:
   # Development
   - astroid
   - bandit
-  - black>=22.3.0
+  - black=19.10b0
+  - click=8.0.2
   - filelock
   - flake8
   - isort=5

--- a/envs/environment_b.yml
+++ b/envs/environment_b.yml
@@ -28,7 +28,7 @@ dependencies:
   # Development
   - astroid
   - bandit
-  - black=19.10b0
+  - black>=22.3.0
   - filelock
   - flake8
   - isort=5


### PR DESCRIPTION
Applying the same change as @BelligerG made in https://github.com/MetOffice/improver_suite/pull/1282 to this repo.
That is to remove the json files under cache.

Additionally pinned 'click' to avoid issue with the version of black we are pinning, as per https://github.com/MetOffice/paraflow/pull/42

There is now a [recent version of black](https://github.com/psf/black/issues/2964) (>=22.3.0) which fixes/avoids the issue.  I tried updating black but this resulted in a number of formatting issues found by this more recent version of black.  Fixing these would be out of scope of this PR (updating black can be discussed in a separate issue).

## Background

- Removal of cache as per https://github.com/mamba-org/mamba/issues/488
- Pinning of 'click' (dependency of black) due to a failure of black (with the current pinned version of black we are using).  More info here: https://github.com/psf/black/issues/2964