### PR TITLE
DOC: No cache context

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,3 +1,5 @@
+# Note that this file intentionally uses no cache, see
+# https://github.com/metoppv/improver/pull/1651#issue-1108889073
 name: Scheduled Tests
 
 on:


### PR DESCRIPTION
Originally raised in https://github.com/metoppv/improver/pull/1702#issuecomment-1109210445
This PR simply references the PR that removed the cache usage from scheduled actions (so that this context remains with the file).