### PR TITLE
Add skeleton for generation of derived solar fields for RainForests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ below:
 * Daniel Mentiplay (Bureau of Meteorology, Australia)
 * Stephen Moseley (Met Office, UK)
 * Meabh NicGuidhir (Met Office, UK)
+* Benjamin Owen (Bureau of Meteorology, Australia)
 * Carwyn Pelley (Met Office, UK)
 * Tim Pillinger (Met Office, UK)
 * Fiona Rust (Met Office, UK)

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -250,6 +250,23 @@ def inputpath(to_convert):
     return maybe_coerce_with(pathlib.Path, to_convert)
 
 
+@value_converter
+def inputdatetime(to_convert):
+    """Converts string to datetime or returns passed object.
+
+    Args:
+        to_convert (string or datetime):
+            datetime represented as string of the format YYYYMMDDTHHMMZ
+
+    Returns:
+        (datetime): datetime object
+
+    """
+    from improver.utilities.temporal import cycletime_to_datetime
+
+    return maybe_coerce_with(cycletime_to_datetime, to_convert)
+
+
 def create_constrained_inputcubelist_converter(*constraints):
     """Makes function that the input constraints are used in a loop.
 

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -37,11 +37,11 @@ from improver import cli
 @cli.with_output
 def process(
     target_grid: cli.inputcube,
-    time: cli.inputdatetime,
-    accumulation_period: int,
-    *,
     surface_altitude: cli.inputcube = None,
     linke_turbidity: cli.inputcube = None,
+    *,
+    time: cli.inputdatetime,
+    accumulation_period: int,
     temporal_spacing: int = 30,
 ):
     """Generate a cube containing clearsky solar radiation data, evaluated on the target grid
@@ -51,12 +51,6 @@ def process(
     Args:
         target_grid (iris.cube.Cube):
             A cube containing the desired spatial grid.
-        time (str):
-            A datetime specified in the format YYYYMMDDTHHMMZ at which to evaluate the
-            accumulated clearsky solar radiation. This time is taken to be the end of
-            the accumulation period.
-        accumulation_period (int):
-            The number of hours over which the solar radiation accumulation is defined.
         surface_altitude (iris.cube.Cube):
             Surface altitude data, specified in metres, used in the evaluation of the clearsky
             solar irradiance values.
@@ -65,6 +59,12 @@ def process(
             values. Linke turbidity is a dimensionless quantity that accounts for the
             atmospheric scattering of radiation due to aerosols and water vapour, relative
             to a dry atmosphere.
+        time (str):
+            A datetime specified in the format YYYYMMDDTHHMMZ at which to evaluate the
+            accumulated clearsky solar radiation. This time is taken to be the end of
+            the accumulation period.
+        accumulation_period (int):
+            The number of hours over which the solar radiation accumulation is defined.
         temporal_spacing (int):
             The time stepping, specified in mins, used in the integration of solar irradiance
             to produce the accumulated solar radiation.

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -41,7 +41,7 @@ def process(
     time,
     accumulation_period: int,
     *,
-    temporal_spacing=30,
+    temporal_spacing: int = 30,
     altitude: cli.inputcube = 0.0,
     linke_turbidity: cli.inputcube = 3.0,
 ):

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -45,36 +45,36 @@ def process(
     altitude: cli.inputcube = 0.0,
     linke_turbidity_climatology: cli.inputcube = 3.0,
 ):
-    """Generate clearsky solar radiation data. The clearsky solar radiation is evaluated on the
-    target grid for specified time and accumulation period. The clearsky solar radiation data is
-    used as an input to the RainForests calibration for rainfall.
+    """Generate a cube containing clearsky solar radiation data, evaluated on the target grid
+    for the specified time and accumulation period. Accumulated clearsky solar radiation is used
+    as an input to the RainForests calibration for rainfall.
 
     Args:
         target_grid:
-            A cube with the desired grid.
+            A cube containing the desired spatial grid.
         time:
-            A datetime specified in the format YYYYMMDDTHHMMZ at which to calculate the
-            accumulated clearsky solar radiation.
+            A datetime specified in the format YYYYMMDDTHHMMZ at which to evaluate the
+            accumulated clearsky solar radiation. This time is taken to be the end of
+            the accumulation period.
         accumulation_period:
-            The period over which the accumulation is calculated, specified in hours.
+            The number of hours over which the solar radiation accumulation is defined.
         temporal_spacing:
-            The spacing between irradiance values used in the evaluation of accumulated
-            solar radiation, specified in minutes.
+            The temporal spacing between irradiance values used in the evaluation of the
+            accumulated solar radiation, specified in minutes.
         altitude:
-            Altitude data to use in the evaluation of clearsky solar irradiance, which is
-            intergated to give the accumulated solar radiation.
+            Altitude data used in the evaluation of the clearsky solar irradiance values,
+            specified in metres.
         linke_turbidity_climatology:
-            Linke turbidity climatology data used in the evaluation of solar irradiance.
-            Linke turbidity is a dimensionless value that accounts for relative atmospheric
-            scattering of radiation due to aerosols and water vapour.
-            The linke turbidity climatology must contain a time dimension that represents
-            the day-of-year, from which the associated climatological linke turbidity values
-            can be interpolated to for the specified time.
+            Linke turbidity data used in the evaluation of the clearsky solar irradiance
+            values. Linke turbidity is a dimensionless quantity that accounts for the
+            atmospheric scattering of radiation due to aerosols and water vapour, relative
+            to a dry atmosphere. The linke turbidity climatology data is assumed to a time
+            dimension that represents the day-of-year from which the associated climatological
+            linke turbidity values can be interpolated to the specified valid-time.
 
     Returns:
         iris.cube.Cube:
-            A cube containing clearsky solar radiation accumulated over the specified
-            period, on the same spatial grid as target_grid.
+            A cube containing accumulated clearsky solar radiation.
     """
     from improver.generate_ancillaries.generate_derived_solar_fields import (
         GenerateClearskySolarRadiation,

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -53,12 +53,14 @@ def process(
             A cube containing the desired spatial grid.
         surface_altitude (iris.cube.Cube):
             Surface altitude data, specified in metres, used in the evaluation of the clearsky
-            solar irradiance values.
+            solar irradiance values. If not provided, a cube with constant value 0.0 m is used,
+            created from target_grid.
         linke_turbidity (iris.cube.Cube):
             Linke turbidity data used in the evaluation of the clearsky solar irradiance
             values. Linke turbidity is a dimensionless quantity that accounts for the
             atmospheric scattering of radiation due to aerosols and water vapour, relative
-            to a dry atmosphere.
+            to a dry atmosphere. If not provided, a cube with constant value 3.0 is used,
+            created from target_grid.
         time (str):
             A datetime specified in the format YYYYMMDDTHHMMZ at which to evaluate the
             accumulated clearsky solar radiation. This time is taken to be the end of

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -40,7 +40,7 @@ def process(
     time: cli.inputdatetime,
     accumulation_period: int,
     *,
-    altitude: cli.inputcube = None,
+    surface_altitude: cli.inputcube = None,
     linke_turbidity: cli.inputcube = None,
     temporal_spacing: int = 30,
 ):
@@ -57,8 +57,8 @@ def process(
             the accumulation period.
         accumulation_period (int):
             The number of hours over which the solar radiation accumulation is defined.
-        altitude (iris.cube.Cube):
-            Altitude data used in the evaluation of the clearsky solar irradiance values,
+        surface_altitude (iris.cube.Cube):
+            Surface altitude data used in the evaluation of the clearsky solar irradiance values,
             specified in metres.
         linke_turbidity (iris.cube.Cube):
             Linke turbidity data used in the evaluation of the clearsky solar irradiance
@@ -83,16 +83,16 @@ def process(
         generate_mandatory_attributes,
     )
 
-    if altitude is None:
-        # Create altitude cube using target_grid as template.
-        altitude_data = np.zeros(shape=target_grid.shape, dtype=np.float32)
-        altitude = create_new_diagnostic_cube(
+    if surface_altitude is None:
+        # Create surface_altitude cube using target_grid as template.
+        surface_altitude_data = np.zeros(shape=target_grid.shape, dtype=np.float32)
+        surface_altitude = create_new_diagnostic_cube(
             name="surface_altitude",
             units="m",
             template_cube=target_grid,
             mandatory_attributes=generate_mandatory_attributes([target_grid]),
             optional_attributes=target_grid.attributes,
-            data=altitude_data,
+            data=surface_altitude_data,
         )
 
     if linke_turbidity is None:
@@ -111,7 +111,7 @@ def process(
         target_grid,
         time,
         accumulation_period,
-        altitude=altitude,
+        surface_altitude=surface_altitude,
         linke_turbidity=linke_turbidity,
         temporal_spacing=temporal_spacing,
     )

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -38,10 +38,10 @@ from improver import cli
 @cli.with_output
 def process(
     target_grid: cli.inputcube,
-    time: str,
+    time,
     accumulation_period: int,
     *,
-    temporal_spacing: int = 30,
+    temporal_spacing = 30,
     altitude: cli.inputcube = 0.0,
     linke_turbidity: cli.inputcube = 3.0,
 ):
@@ -50,21 +50,21 @@ def process(
     as an input to the RainForests calibration for rainfall.
 
     Args:
-        target_grid:
+        target_grid (iris.cube.Cube):
             A cube containing the desired spatial grid.
-        time:
+        time (str):
             A datetime specified in the format YYYYMMDDTHHMMZ at which to evaluate the
             accumulated clearsky solar radiation. This time is taken to be the end of
             the accumulation period.
-        accumulation_period:
+        accumulation_period (int):
             The number of hours over which the solar radiation accumulation is defined.
-        temporal_spacing:
+        temporal_spacing (int):
             The temporal spacing between irradiance values used in the evaluation of the
             accumulated solar radiation, specified in minutes.
-        altitude:
+        altitude (iris.cube.Cube):
             Altitude data used in the evaluation of the clearsky solar irradiance values,
             specified in metres.
-        linke_turbidity:
+        linke_turbidity (iris.cube.Cube):
             Linke turbidity data used in the evaluation of the clearsky solar irradiance
             values. Linke turbidity is a dimensionless quantity that accounts for the
             atmospheric scattering of radiation due to aerosols and water vapour, relative

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -40,9 +40,9 @@ def process(
     time: cli.inputdatetime,
     accumulation_period: int,
     *,
+    altitude: cli.inputcube = None,
+    linke_turbidity: cli.inputcube = None,
     temporal_spacing: int = 30,
-    altitude: cli.inputcube = 0.0,
-    linke_turbidity: cli.inputcube = 3.0,
 ):
     """Generate a cube containing clearsky solar radiation data, evaluated on the target grid
     for the specified time and accumulation period. Accumulated clearsky solar radiation is used
@@ -57,9 +57,6 @@ def process(
             the accumulation period.
         accumulation_period (int):
             The number of hours over which the solar radiation accumulation is defined.
-        temporal_spacing (int):
-            The temporal spacing between irradiance values used in the evaluation of the
-            accumulated solar radiation, specified in minutes.
         altitude (iris.cube.Cube):
             Altitude data used in the evaluation of the clearsky solar irradiance values,
             specified in metres.
@@ -68,6 +65,9 @@ def process(
             values. Linke turbidity is a dimensionless quantity that accounts for the
             atmospheric scattering of radiation due to aerosols and water vapour, relative
             to a dry atmosphere.
+        temporal_spacing (int):
+            The temporal spacing between irradiance values used in the evaluation of the
+            accumulated solar radiation, specified in minutes.
 
     Returns:
         iris.cube.Cube:
@@ -77,11 +77,19 @@ def process(
         GenerateClearskySolarRadiation,
     )
 
+    if altitude is None:
+        # Create altitude cube using target_grid as template.
+        pass
+    
+    if linke_turbidity is None:
+        # Create altitude cube using target_grid as template.
+        pass
+
     return GenerateClearskySolarRadiation()(
         target_grid,
         time,
         accumulation_period,
-        temporal_spacing,
         altitude=altitude,
         linke_turbidity=linke_turbidity,
+        temporal_spacing=temporal_spacing,
     )

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -73,39 +73,9 @@ def process(
         iris.cube.Cube:
             A cube containing accumulated clearsky solar radiation.
     """
-    import numpy as np
-
     from improver.generate_ancillaries.generate_derived_solar_fields import (
         GenerateClearskySolarRadiation,
     )
-    from improver.metadata.utilities import (
-        create_new_diagnostic_cube,
-        generate_mandatory_attributes,
-    )
-
-    if surface_altitude is None:
-        # Create surface_altitude cube using target_grid as template.
-        surface_altitude_data = np.zeros(shape=target_grid.shape, dtype=np.float32)
-        surface_altitude = create_new_diagnostic_cube(
-            name="surface_altitude",
-            units="m",
-            template_cube=target_grid,
-            mandatory_attributes=generate_mandatory_attributes([target_grid]),
-            optional_attributes=target_grid.attributes,
-            data=surface_altitude_data,
-        )
-
-    if linke_turbidity is None:
-        # Create linke_turbidity cube using target_grid as template.
-        linke_turbidity_data = 3.0 * np.ones(shape=target_grid.shape, dtype=np.float32)
-        linke_turbidity = create_new_diagnostic_cube(
-            name="linke_turbidity",
-            units="1",
-            template_cube=target_grid,
-            mandatory_attributes=generate_mandatory_attributes([target_grid]),
-            optional_attributes=target_grid.attributes,
-            data=linke_turbidity_data,
-        )
 
     return GenerateClearskySolarRadiation()(
         target_grid,

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -58,16 +58,16 @@ def process(
         accumulation_period (int):
             The number of hours over which the solar radiation accumulation is defined.
         surface_altitude (iris.cube.Cube):
-            Surface altitude data used in the evaluation of the clearsky solar irradiance values,
-            specified in metres.
+            Surface altitude data, specified in metres, used in the evaluation of the clearsky
+            solar irradiance values.
         linke_turbidity (iris.cube.Cube):
             Linke turbidity data used in the evaluation of the clearsky solar irradiance
             values. Linke turbidity is a dimensionless quantity that accounts for the
             atmospheric scattering of radiation due to aerosols and water vapour, relative
             to a dry atmosphere.
         temporal_spacing (int):
-            The temporal spacing between irradiance values used in the evaluation of the
-            accumulated solar radiation, specified in minutes.
+            The time stepping, specified in mins, used in the integration of solar irradiance
+            to produce the accumulated solar radiation.
 
     Returns:
         iris.cube.Cube:

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -77,13 +77,19 @@ def process(
         GenerateClearskySolarRadiation,
     )
 
+    clearsky_plugin = GenerateClearskySolarRadiation()
+
     if altitude is None:
         # Create altitude cube using target_grid as template.
-        pass
-    
+        altitude = clearsky_plugin.cube_from_target_grid(
+            target_grid, 0.0, "altitude", "m"
+        )
+
     if linke_turbidity is None:
         # Create altitude cube using target_grid as template.
-        pass
+        linke_turbidity = clearsky_plugin.cube_from_target_grid(
+            target_grid, 3.0, "linke-turbidity", "1"
+        )
 
     return GenerateClearskySolarRadiation()(
         target_grid,

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2022 Met Office.
+# (C) British Crown Copyright 2017-2021 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -29,7 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to run GenerateClearSkySolarRadiation ancillary generation."""
-from datetime import datetime, timezone
 
 from improver import cli
 
@@ -38,7 +37,7 @@ from improver import cli
 @cli.with_output
 def process(
     target_grid: cli.inputcube,
-    time,
+    time: cli.inputdatetime,
     accumulation_period: int,
     *,
     temporal_spacing: int = 30,
@@ -77,8 +76,6 @@ def process(
     from improver.generate_ancillaries.generate_derived_solar_fields import (
         GenerateClearskySolarRadiation,
     )
-
-    time = datetime.strptime(time, "%Y%m%dT%H%MZ").replace(tzinfo=timezone.utc)
 
     return GenerateClearskySolarRadiation()(
         target_grid,

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -43,7 +43,7 @@ def process(
     *,
     temporal_spacing: int = 30,
     altitude: cli.inputcube = 0.0,
-    linke_turbidity_climatology: cli.inputcube = 3.0,
+    linke_turbidity: cli.inputcube = 3.0,
 ):
     """Generate a cube containing clearsky solar radiation data, evaluated on the target grid
     for the specified time and accumulation period. Accumulated clearsky solar radiation is used
@@ -64,13 +64,11 @@ def process(
         altitude:
             Altitude data used in the evaluation of the clearsky solar irradiance values,
             specified in metres.
-        linke_turbidity_climatology:
+        linke_turbidity:
             Linke turbidity data used in the evaluation of the clearsky solar irradiance
             values. Linke turbidity is a dimensionless quantity that accounts for the
             atmospheric scattering of radiation due to aerosols and water vapour, relative
-            to a dry atmosphere. The linke turbidity climatology data is assumed to a time
-            dimension that represents the day-of-year from which the associated climatological
-            linke turbidity values can be interpolated to the specified valid-time.
+            to a dry atmosphere.
 
     Returns:
         iris.cube.Cube:
@@ -88,5 +86,5 @@ def process(
         accumulation_period,
         temporal_spacing,
         altitude=altitude,
-        linke_turbidity_climatology=linke_turbidity_climatology,
+        linke_turbidity=linke_turbidity,
     )

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -86,7 +86,6 @@ def process(
     if altitude is None:
         # Create altitude cube using target_grid as template.
         altitude_data = np.zeros(shape=target_grid.shape, dtype=np.float32)
-
         altitude = create_new_diagnostic_cube(
             name="surface_altitude",
             units="m",
@@ -97,8 +96,8 @@ def process(
         )
 
     if linke_turbidity is None:
+        # Create linke_turbidity cube using target_grid as template.
         linke_turbidity_data = 3.0 * np.ones(shape=target_grid.shape, dtype=np.float32)
-        # Create altitude cube using target_grid as template.
         linke_turbidity = create_new_diagnostic_cube(
             name="linke_turbidity",
             units="1",

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -73,22 +73,39 @@ def process(
         iris.cube.Cube:
             A cube containing accumulated clearsky solar radiation.
     """
+    import numpy as np
+
     from improver.generate_ancillaries.generate_derived_solar_fields import (
         GenerateClearskySolarRadiation,
     )
-
-    clearsky_plugin = GenerateClearskySolarRadiation()
+    from improver.metadata.utilities import (
+        create_new_diagnostic_cube,
+        generate_mandatory_attributes,
+    )
 
     if altitude is None:
         # Create altitude cube using target_grid as template.
-        altitude = clearsky_plugin.cube_from_target_grid(
-            target_grid, 0.0, "altitude", "m"
+        altitude_data = np.zeros(shape=target_grid.shape, dtype=np.float32)
+
+        altitude = create_new_diagnostic_cube(
+            name="surface_altitude",
+            units="m",
+            template_cube=target_grid,
+            mandatory_attributes=generate_mandatory_attributes([target_grid]),
+            optional_attributes=target_grid.attributes,
+            data=altitude_data,
         )
 
     if linke_turbidity is None:
+        linke_turbidity_data = 3.0 * np.ones(shape=target_grid.shape, dtype=np.float32)
         # Create altitude cube using target_grid as template.
-        linke_turbidity = clearsky_plugin.cube_from_target_grid(
-            target_grid, 3.0, "linke-turbidity", "1"
+        linke_turbidity = create_new_diagnostic_cube(
+            name="linke_turbidity",
+            units="1",
+            template_cube=target_grid,
+            mandatory_attributes=generate_mandatory_attributes([target_grid]),
+            optional_attributes=target_grid.attributes,
+            data=linke_turbidity_data,
         )
 
     return GenerateClearskySolarRadiation()(

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -41,7 +41,7 @@ def process(
     time,
     accumulation_period: int,
     *,
-    temporal_spacing = 30,
+    temporal_spacing=30,
     altitude: cli.inputcube = 0.0,
     linke_turbidity: cli.inputcube = 3.0,
 ):

--- a/improver/cli/generate_clearsky_solar_radiation.py
+++ b/improver/cli/generate_clearsky_solar_radiation.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2022 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to run GenerateClearSkySolarRadiation ancillary generation."""

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -37,15 +37,15 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(target_grid: cli.inputcube, time: str):
+def process(target_grid: cli.inputcube, time):
     """Generate a cube containing local solar time, evaluated on the target grid for
     specified time. Local solar time is used as an input to the RainForests calibration
     for rainfall.
 
     Args:
-        target_grid:
+        target_grid (iris.cube.Cube):
             A cube with the desired grid.
-        time:
+        time (str):
             A datetime specified in the format YYYYMMDDTHHMMZ at which to calculate the
             local solar time.
 

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2022 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to run GenerateSolarTime ancillary generation."""

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -38,8 +38,8 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(target_grid: cli.inputcube, time: str):
-    """Generate local solar time data on the target grid for specified time.
-    The local solar time data is used as an input to the RainForests calibration
+    """Generate a cube containing local solar time, evaluated on the target grid for
+    specified time. Local solar time is used as an input to the RainForests calibration
     for rainfall.
 
     Args:
@@ -47,7 +47,7 @@ def process(target_grid: cli.inputcube, time: str):
             A cube with the desired grid.
         time:
             A datetime specified in the format YYYYMMDDTHHMMZ at which to calculate the
-            accumulated clearsky solar radiation.
+            local solar time.
 
     Returns:
         iris.cube.Cube:

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -35,7 +35,7 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(target_grid: cli.inputcube, time: cli.inputdatetime):
+def process(target_grid: cli.inputcube, *, time: cli.inputdatetime):
     """Generate a cube containing local solar time, evaluated on the target grid for
     specified time. Local solar time is used as an input to the RainForests calibration
     for rainfall.

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -30,14 +30,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to run GenerateSolarTime ancillary generation."""
 
-from datetime import datetime, timezone
-
 from improver import cli
 
 
 @cli.clizefy
 @cli.with_output
-def process(target_grid: cli.inputcube, time):
+def process(target_grid: cli.inputcube, time: cli.inputdatetime):
     """Generate a cube containing local solar time, evaluated on the target grid for
     specified time. Local solar time is used as an input to the RainForests calibration
     for rainfall.
@@ -56,7 +54,5 @@ def process(target_grid: cli.inputcube, time):
     from improver.generate_ancillaries.generate_derived_solar_fields import (
         GenerateSolarTime,
     )
-
-    time = datetime.strptime(time, "%Y%m%dT%H%MZ").replace(tzinfo=timezone.utc)
 
     return GenerateSolarTime()(target_grid, time)

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -29,3 +29,30 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Script to run GenerateSolarTime ancillary generation."""
+
+from datetime import datetime, timezone
+from improver import cli
+
+@cli.clizefy
+@cli.with_output
+def process(target_grid: cli.inputcube, time: str):
+    """Generate local solar time data on the target grid for specified time.
+    The local solar time data is used as an input to the RainForests calibration for
+    rainfall.
+    Args:
+        target_grid:
+            A cube with the desired grid.
+        time:
+            A datetime specified in the format YYYYMMDDTHHMMZ at which to calculate the
+            accumulated clearsky solar radiation.
+    Returns:
+        iris.cube.Cube:
+            A cube containing local solar time.
+    """
+    from improver.generate_ancillaries.generate_derived_solar_fields import (
+        GenerateSolarTime,
+    )
+
+    time = datetime.strptime(time, "%Y%m%dT%H%MZ").replace(tzinfo=timezone.utc)
+
+    return GenerateSolarTime()(target_grid, time)

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2022 Met Office.
+# (C) British Crown Copyright 2017-2021 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/cli/generate_solar_time.py
+++ b/improver/cli/generate_solar_time.py
@@ -31,20 +31,24 @@
 """Script to run GenerateSolarTime ancillary generation."""
 
 from datetime import datetime, timezone
+
 from improver import cli
+
 
 @cli.clizefy
 @cli.with_output
 def process(target_grid: cli.inputcube, time: str):
     """Generate local solar time data on the target grid for specified time.
-    The local solar time data is used as an input to the RainForests calibration for
-    rainfall.
+    The local solar time data is used as an input to the RainForests calibration
+    for rainfall.
+
     Args:
         target_grid:
             A cube with the desired grid.
         time:
             A datetime specified in the format YYYYMMDDTHHMMZ at which to calculate the
             accumulated clearsky solar radiation.
+
     Returns:
         iris.cube.Cube:
             A cube containing local solar time.

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2021 Met Office.
+# (C) British Crown Copyright 2017-2022 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -64,7 +64,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
         target_grid: Cube,
         time: datetime,
         accumulation_period: int,
-        altitude: Cube,
+        surface_altitude: Cube,
         linke_turbidity: Cube,
         temporal_spacing: int = DEFAULT_TEMPORAL_SPACING_IN_MINUTES,
     ) -> Cube:
@@ -82,8 +82,8 @@ class GenerateClearskySolarRadiation(BasePlugin):
             temporal_spacing:
                 The spacing between irradiance times used in the evaluation of the accumulated
                 solar radiation, specified in mins.
-            altitude:
-                Altitude data used in the evaluation of the clearsky solar irradiance values,
+            surface_altitude:
+                Surface altitude data used in the evaluation of the clearsky solar irradiance values,
                 specified in metres.
             linke_turbidity:
                 Linke turbidity data used in the evaluation of the clearsky solar irradiance

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -29,3 +29,28 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for generating derived solar fields."""
+from datetime import datetime
+
+from iris.cube import Cube
+
+from improver import BasePlugin
+
+class GenerateSolarTime(BasePlugin):
+    """A plugin to evaluate local solar time."""
+
+    def process(self, target_grid: Cube, time:datetime) -> Cube:
+        """Calculate the local solar time associated with the specified time.
+
+        Args:
+            target_grid:
+                A cube with the desired grid.
+            time:
+                A datetime specified at which to calculate the accumulated clearsky solar
+                radiation.
+
+        Returns:
+            Solar time cube.
+
+        """
+        pass
+

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -30,8 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for generating derived solar fields."""
 from datetime import datetime
-from typing import Optional, Union
 
+import numpy as np
 from iris.cube import Cube
 
 from improver import BasePlugin
@@ -59,6 +59,42 @@ class GenerateSolarTime(BasePlugin):
 
 class GenerateClearskySolarRadiation(BasePlugin):
     """A plugin to evaluate clearsky solar radiation."""
+
+    def cube_from_target_grid(
+        target_grid: Cube,
+        constant_value: float,
+        variable_name: str,
+        variable_units: str,
+    ) -> Cube:
+        """Create a constant valued cube using the spatial coords from the target_grid.
+
+        Args:
+            target_grid:
+                A cube containing the desired spatial grid.
+            constant_value:
+                The constant value to assign to the new cube.
+            variable_name:
+                The variable name to assign to the new cube.
+            variable_units:
+                The units to assign to the new cube.
+        Returns:
+            A constant value cube defined on over the same spatial grid as the target_grid.
+        """
+        X_coord = target_grid.coord(axis="X")
+        Y_coord = target_grid.coord(axis="Y")
+
+        data = constant_value * np.ones(
+            shape=(*Y_coord.shape, *X_coord.shape), dtype=np.float32
+        )
+
+        cube = Cube(
+            data,
+            var_name=variable_name,
+            units=variable_units,
+            dim_coords_and_dims=[(Y_coord, 0), (X_coord, 1)],
+        )
+
+        return cube
 
     def process(
         self,

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -67,7 +67,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
         accumulation_period: int,
         temporal_spacing: int = DEFAULT_TEMPORAL_SPACING_IN_MINUTES,
         altitude: Optional[Union[Cube, float]] = 0.0,
-        linke_turbidity_climatology: Optional[Union[Cube, float]] = 3.0,
+        linke_turbidity: Optional[Union[Cube, float]] = 3.0,
     ) -> Cube:
         """Calculate the gridded clearsky solar radiation by integrating clearsky solar irradiance
         values over the specified time-period, and on the specified grid.
@@ -86,13 +86,11 @@ class GenerateClearskySolarRadiation(BasePlugin):
             altitude:
                 Altitude data used in the evaluation of the clearsky solar irradiance values,
                 specified in metres.
-            linke_turbidity_climatology:
+            linke_turbidity:
                 Linke turbidity data used in the evaluation of the clearsky solar irradiance
                 values. Linke turbidity is a dimensionless quantity that accounts for the
                 atmospheric scattering of radiation due to aerosols and water vapour, relative
-                to a dry atmosphere. The linke turbidity climatology data is assumed to a time
-                dimension that represents the day-of-year from which the associated climatological
-                linke turbidity values can be interpolated to the specified valid-time.
+                to a dry atmosphere.
 
         Returns:
             A cube containing the clearsky solar radiation accumulated over the specified

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -43,18 +43,16 @@ class GenerateSolarTime(BasePlugin):
     """A plugin to evaluate local solar time."""
 
     def process(self, target_grid: Cube, time: datetime) -> Cube:
-        """Calculate the local solar time associated with the specified time.
+        """Calculate the local solar time over the specified grid.
 
         Args:
             target_grid:
-                A cube with the desired grid.
+                A cube containing the desired spatial grid.
             time:
-                A datetime specified at which to calculate the accumulated clearsky solar
-                radiation.
+                The valid time at which to evaluate the local solar time.
 
         Returns:
-            Solar time cube.
-
+            A cube containing local solar time, on the same spatial grid as target_grid.
         """
         pass
 
@@ -72,30 +70,32 @@ class GenerateClearskySolarRadiation(BasePlugin):
         linke_turbidity_climatology: Optional[Union[Cube, float]] = 3.0,
     ) -> Cube:
         """Calculate the gridded clear sky radiation data by integrating clear sky irradiance
-        over the specified time_period.
+        over the specified time-period.
+
         Args:
             target_grid:
-                A cube with the desired grid.
+                A cube containing the desired spatial grid.
             time:
-                A datetime specified at which to calculate the accumulated clearsky solar
-                radiation.
+                The valid time at which to evaluate the accumulated clearsky solar
+                radiation. This time is taken to be the end of the accumulation period.
             accumulation_period:
-                Number of hours over which the solar radiation accumulation is defined.
+                The number of hours over which the solar radiation accumulation is defined.
             temporal_spacing:
-                Spacing between irradiance times used in the evaluation of the
-                accumulated solar radiation, specified in mins.
+                The spacing between irradiance times used in the evaluation of the accumulated
+                solar radiation, specified in mins.
             altitude:
-                Altitude data to use in the evaluation of solar irradiance values, specified in
-                metres.
+                Altitude data used in the evaluation of the clearsky solar irradiance values,
+                specified in metres.
             linke_turbidity_climatology:
-                Linke turbidity climatology data used in the evaluation of solar irradiance.
-                Linke turbidity is a dimensionless quantity that accounts for relative atmospheric
-                scattering of radiation due to aerosols and water vapour. It is assumed the
-                linke turbidity data contains a time dimension that represents the day-of-year,
-                from which the associated climatological linke turbidity values can be interpolated
-                to for the specified time.
+                Linke turbidity data used in the evaluation of the clearsky solar irradiance
+                values. Linke turbidity is a dimensionless quantity that accounts for the
+                atmospheric scattering of radiation due to aerosols and water vapour, relative
+                to a dry atmosphere. The linke turbidity climatology data is assumed to a time
+                dimension that represents the day-of-year from which the associated climatological
+                linke turbidity values can be interpolated to the specified valid-time.
+
         Returns:
-            A cube containing clearsky solar radiation accumulated over the specified
+            A cube containing the clearsky solar radiation accumulated over the specified
             period, on the same spatial grid as target_grid.
         """
         pass

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -65,9 +65,9 @@ class GenerateClearskySolarRadiation(BasePlugin):
         target_grid: Cube,
         time: datetime,
         accumulation_period: int,
+        altitude: Cube,
+        linke_turbidity: Cube,
         temporal_spacing: int = DEFAULT_TEMPORAL_SPACING_IN_MINUTES,
-        altitude: Optional[Union[Cube, float]] = 0.0,
-        linke_turbidity: Optional[Union[Cube, float]] = 3.0,
     ) -> Cube:
         """Calculate the gridded clearsky solar radiation by integrating clearsky solar irradiance
         values over the specified time-period, and on the specified grid.

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -71,7 +71,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
     ) -> Tuple[Cube, Cube]:
         """Assign default values to input cubes where none have been passed, and ensure
         that all cubes are defined over consistent spatial grid.
-        
+
         Args:
             target_grid:
                 A cube containing the desired spatial grid.
@@ -86,7 +86,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
 
         Raises:
             ValueError:
-                If surface_altitude or linke_turbidity have inconsistent spatial cooords
+                If surface_altitude or linke_turbidity have inconsistent spatial coords
                 relative to target_grid.
         """
         if surface_altitude is None:

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -30,15 +30,19 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module for generating derived solar fields."""
 from datetime import datetime
+from typing import Optional, Union
 
 from iris.cube import Cube
 
 from improver import BasePlugin
 
+DEFAULT_TEMPORAL_SPACING_IN_MINUTES = 30
+
+
 class GenerateSolarTime(BasePlugin):
     """A plugin to evaluate local solar time."""
 
-    def process(self, target_grid: Cube, time:datetime) -> Cube:
+    def process(self, target_grid: Cube, time: datetime) -> Cube:
         """Calculate the local solar time associated with the specified time.
 
         Args:
@@ -54,3 +58,44 @@ class GenerateSolarTime(BasePlugin):
         """
         pass
 
+
+class GenerateClearskySolarRadiation(BasePlugin):
+    """A plugin to evaluate clearsky solar radiation."""
+
+    def process(
+        self,
+        target_grid: Cube,
+        time: datetime,
+        accumulation_period: int,
+        temporal_spacing: int = DEFAULT_TEMPORAL_SPACING_IN_MINUTES,
+        altitude: Optional[Union[Cube, float]] = 0.0,
+        linke_turbidity_climatology: Optional[Union[Cube, float]] = 3.0,
+    ) -> Cube:
+        """Calculate the gridded clear sky radiation data by integrating clear sky irradiance
+        over the specified time_period.
+        Args:
+            target_grid:
+                A cube with the desired grid.
+            time:
+                A datetime specified at which to calculate the accumulated clearsky solar
+                radiation.
+            accumulation_period:
+                Number of hours over which the solar radiation accumulation is defined.
+            temporal_spacing:
+                Spacing between irradiance times used in the evaluation of the
+                accumulated solar radiation, specified in mins.
+            altitude:
+                Altitude data to use in the evaluation of solar irradiance values, specified in
+                metres.
+            linke_turbidity_climatology:
+                Linke turbidity climatology data used in the evaluation of solar irradiance.
+                Linke turbidity is a dimensionless quantity that accounts for relative atmospheric
+                scattering of radiation due to aerosols and water vapour. It is assumed the
+                linke turbidity data contains a time dimension that represents the day-of-year,
+                from which the associated climatological linke turbidity values can be interpolated
+                to for the specified time.
+        Returns:
+            A cube containing clearsky solar radiation accumulated over the specified
+            period, on the same spatial grid as target_grid.
+        """
+        pass

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2022 Met Office.
+# (C) British Crown Copyright 2017-2021 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -69,8 +69,8 @@ class GenerateClearskySolarRadiation(BasePlugin):
         altitude: Optional[Union[Cube, float]] = 0.0,
         linke_turbidity_climatology: Optional[Union[Cube, float]] = 3.0,
     ) -> Cube:
-        """Calculate the gridded clear sky radiation data by integrating clear sky irradiance
-        over the specified time-period.
+        """Calculate the gridded clearsky solar radiation by integrating clearsky solar irradiance
+        values over the specified time-period, and on the specified grid.
 
         Args:
             target_grid:

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2017-2022 Met Office.
+# (C) British Crown Copyright 2017-2021 Met Office.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -80,11 +80,11 @@ class GenerateClearskySolarRadiation(BasePlugin):
             accumulation_period:
                 The number of hours over which the solar radiation accumulation is defined.
             temporal_spacing:
-                The spacing between irradiance times used in the evaluation of the accumulated
-                solar radiation, specified in mins.
+                The time stepping, specified in mins, used in the integration of solar irradiance
+                to produce the accumulated solar radiation.
             surface_altitude:
-                Surface altitude data used in the evaluation of the clearsky solar irradiance values,
-                specified in metres.
+                Surface altitude data, specified in metres, used in the evaluation of the clearsky
+                solar irradiance values.
             linke_turbidity:
                 Linke turbidity data used in the evaluation of the clearsky solar irradiance
                 values. Linke turbidity is a dimensionless quantity that accounts for the

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2022 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Module for generating derived solar fields."""

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -81,7 +81,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
                 Input linke-turbidity value.
 
         Returns:
-            - Cube containing surface alitiude, defined on the same grid as target_grid.
+            - Cube containing surface altitude, defined on the same grid as target_grid.
             - Cube containing linke-turbidity, defined on the same grid as target_grid.
 
         Raises:

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -31,7 +31,6 @@
 """Module for generating derived solar fields."""
 from datetime import datetime
 
-import numpy as np
 from iris.cube import Cube
 
 from improver import BasePlugin
@@ -59,42 +58,6 @@ class GenerateSolarTime(BasePlugin):
 
 class GenerateClearskySolarRadiation(BasePlugin):
     """A plugin to evaluate clearsky solar radiation."""
-
-    def cube_from_target_grid(
-        target_grid: Cube,
-        constant_value: float,
-        variable_name: str,
-        variable_units: str,
-    ) -> Cube:
-        """Create a constant valued cube using the spatial coords from the target_grid.
-
-        Args:
-            target_grid:
-                A cube containing the desired spatial grid.
-            constant_value:
-                The constant value to assign to the new cube.
-            variable_name:
-                The variable name to assign to the new cube.
-            variable_units:
-                The units to assign to the new cube.
-        Returns:
-            A constant value cube defined on over the same spatial grid as the target_grid.
-        """
-        X_coord = target_grid.coord(axis="X")
-        Y_coord = target_grid.coord(axis="Y")
-
-        data = constant_value * np.ones(
-            shape=(*Y_coord.shape, *X_coord.shape), dtype=np.float32
-        )
-
-        cube = Cube(
-            data,
-            var_name=variable_name,
-            units=variable_units,
-            dim_coords_and_dims=[(Y_coord, 0), (X_coord, 1)],
-        )
-
-        return cube
 
     def process(
         self,

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -46,6 +46,7 @@ from improver.cli import (
     inputcube,
     inputcube_nolazy,
     inputcubelist,
+    inputdatetime,
     inputjson,
     maybe_coerce_with,
     run_main,
@@ -189,6 +190,17 @@ class Test_inputjson(unittest.TestCase):
         result = inputjson("foo")
         m.assert_called_with(improver.utilities.cli_utilities.load_json_or_none, "foo")
         self.assertEqual(result, {"mocked": 1})
+
+
+class Test_inputdatetime(unittest.TestCase):
+    """Tests the input datetime function"""
+
+    @patch("improver.cli.maybe_coerce_with", return_value="return")
+    def test_basic(self, m):
+        """Tests that input cube calls load_cube with the string"""
+        result = inputdatetime("foo")
+        m.assert_called_with(improver.utilities.temporal.cycletime_to_datetime, "foo")
+        self.assertEqual(result, "return")
 
 
 class Test_with_output(unittest.TestCase):

--- a/improver_tests/generate_ancillaries/test_GenerateClearskySolarRadiation.py
+++ b/improver_tests/generate_ancillaries/test_GenerateClearskySolarRadiation.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2021 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the GenerateClearskySolarRadiation plugin."""
+
+import numpy as np
+import pytest
+from iris.cube import Cube
+
+from improver.generate_ancillaries.generate_derived_solar_fields import (
+    GenerateClearskySolarRadiation,
+)
+from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
+
+
+@pytest.fixture
+def target_grid() -> Cube:
+    return set_up_variable_cube(
+        data=np.ones((10, 8), dtype=np.float32), name="template",
+    )
+
+
+@pytest.fixture
+def surface_altitude() -> Cube:
+    return set_up_variable_cube(
+        data=np.ones((10, 8), dtype=np.float32), name="surface_altitude", units="m",
+    )
+
+
+@pytest.fixture
+def linke_turbidity() -> Cube:
+    return set_up_variable_cube(
+        data=np.ones((10, 8), dtype=np.float32), name="linke_turbidity", units="1",
+    )
+
+
+@pytest.fixture
+def surface_altitude_on_alternate_grid() -> Cube:
+    return set_up_variable_cube(
+        data=np.ones((12, 10), dtype=np.float32), name="surface_altitude", units="m",
+    )
+
+
+@pytest.fixture
+def linke_turbidity_on_alternate_grid() -> Cube:
+    return set_up_variable_cube(
+        data=np.ones((12, 10), dtype=np.float32), name="linke_turbidity", units="1",
+    )
+
+
+def test__initialise_input_cubes(
+    target_grid,
+    surface_altitude,
+    linke_turbidity,
+    surface_altitude_on_alternate_grid,
+    linke_turbidity_on_alternate_grid,
+):
+    """Test initialisation of input cubes."""
+    # Check arguments remained unchanged when valid cubes are passed in.
+    (
+        initialised_surface_altitude,
+        initialised_linke_turbidity,
+    ) = GenerateClearskySolarRadiation()._initialise_input_cubes(
+        target_grid, surface_altitude, linke_turbidity
+    )
+    assert initialised_surface_altitude == surface_altitude
+    assert initialised_linke_turbidity == linke_turbidity
+    # Check default cubes are returned None is passed in.
+    (
+        initialised_surface_altitude,
+        initialised_linke_turbidity,
+    ) = GenerateClearskySolarRadiation()._initialise_input_cubes(
+        target_grid, None, None
+    )
+    # Check surface_altitude cube is initialised when None is passed in.
+    assert initialised_surface_altitude.coords() == target_grid.coords()
+    assert np.all(initialised_surface_altitude.data == 0.0)
+    assert initialised_surface_altitude.data.dtype == np.float32
+    assert initialised_surface_altitude.name() == "surface_altitude"
+    assert initialised_surface_altitude.units == "m"
+    # Check linke_turbidity cube is initialised when None is passed in.
+    assert initialised_linke_turbidity.coords() == target_grid.coords()
+    assert np.all(initialised_linke_turbidity.data == 3.0)
+    assert initialised_linke_turbidity.data.dtype == np.float32
+    assert initialised_linke_turbidity.name() == "linke_turbidity"
+    assert initialised_linke_turbidity.units == "1"
+    # Should fail when inconsistent surface_altitude cube is passed in.
+    with pytest.raises(ValueError):
+        GenerateClearskySolarRadiation()._initialise_input_cubes(
+            target_grid, surface_altitude_on_alternate_grid, None
+        )
+    # Should fail when inconsistent linke_turbidity cube is passed in.
+    with pytest.raises(ValueError):
+        GenerateClearskySolarRadiation()._initialise_input_cubes(
+            target_grid, None, linke_turbidity_on_alternate_grid
+        )


### PR DESCRIPTION
This PR adds a skeleton for CLIs and plugins for generation of derived solar fields that are required as inputs for RainForests calibration of precipitation accumulations.

Future PRs following on from this will add in functionality and tests, however the CLI interfaces should remain unchanged from those presented herein.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s) **(No new features added)**

CLA
 - [x] If a new developer, signed up to CLA
