### PR TITLE
MOBT-271: Freezing rain calculation to record a single model configuration

### DIFF
--- a/improver/precipitation_type/freezing_rain.py
+++ b/improver/precipitation_type/freezing_rain.py
@@ -231,8 +231,12 @@ class FreezingRain(PostProcessingPlugin):
         )
         optional_attributes = {}
         if self.model_id_attr:
+            # Rain and sleet will always be derived from the same model, but temperature
+            # may be diagnosed from a different model when creating a nowcast forecast.
+            # The output in such a case is fundamentally a nowcast product, so we exclude
+            # the temperature diagnostic when determining the model_id_attr.
             optional_attributes = update_model_id_attr_attribute(
-                CubeList([self.rain, self.sleet, self.temperature]), self.model_id_attr
+                CubeList([self.rain, self.sleet]), self.model_id_attr
             )
         freezing_rain_cube = create_new_diagnostic_cube(
             diagnostic_name,

--- a/improver_tests/precipitation_type/freezing_rain/test_FreezingRain.py
+++ b/improver_tests/precipitation_type/freezing_rain/test_FreezingRain.py
@@ -83,9 +83,9 @@ def test_model_config_attribute(
     precipitation_only, temperature_only, expected_attributes
 ):
     """Test that the returned model configuration attribute is correct when the
-    inputs are derived from a mixture of models."""
+    inputs are derived from a mixture of models. The uk_ens attribute of the
+    temperature input should be ignored."""
 
-    expected_attributes.update({"mosg__model_configuration": "uk_det uk_ens"})
     temperature_only.attributes["mosg__model_configuration"] = "uk_ens"
     cubes = iris.cube.CubeList([*precipitation_only, temperature_only])
     result = FreezingRain(model_id_attr="mosg__model_configuration")(


### PR DESCRIPTION
The freezing rain diagnostic produced by the nowcast is constructed using advection precipitation accumulations, but the temperature diagnostic comes from the UKV model. Prior to this change the model_configuration attribute was recording both as sources of data. However it has been decided that the resulting diagnostic is a nowcast product and should be recorded as such.

This change removes an issue that was manifesting in blending as a result of the original change; the model "ncuk uk_det" is not a single model and no single weight could be ascertained to use when model blending it with other models.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)