### PR TITLE
RainForests clearsky solar radiation cube functionality

### DIFF
--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -266,7 +266,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
         if isinstance(linke_turbidity, Cube):
             if not spatial_coords_match([target_grid, linke_turbidity]):
                 raise ValueError(
-                    "linke_turbidity_climatology spatial coordinates do not match target_grid"
+                    "linke_turbidity spatial coordinates do not match target_grid"
                 )
             # we will work with numpy array for calculating irradiance.
             linke_turbidity_data = linke_turbidity.data

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -142,7 +142,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
         """Get evenly-spaced times over the specied time period at which
         to evaluate irradiance values which will later be integrated to
         give accumulated solar-radiation values.
-        
+
         Args:
             time:
                 Datetime specifying the end of the accumulation period.
@@ -152,7 +152,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
             temporal_spacing:
                 Spacing between irradiance times used in the evaluation of the
                 accumulated solar radiation, specified in minutes.
-        
+
         Returns:
             A list of datetimes.
         """
@@ -166,10 +166,14 @@ class GenerateClearskySolarRadiation(BasePlugin):
 
         accumulation_start_time = time - timedelta(hours=accumulation_period)
         time_step = timedelta(minutes=temporal_spacing)
-        n_time_steps = timedelta(hours=accumulation_period) // timedelta(minutes=temporal_spacing)
+        n_time_steps = timedelta(hours=accumulation_period) // timedelta(
+            minutes=temporal_spacing
+        )
 
-        return [accumulation_start_time + step * time_step for step in range(n_time_steps + 1)]
-
+        return [
+            accumulation_start_time + step * time_step
+            for step in range(n_time_steps + 1)
+        ]
 
     def _get_solar_radiation_cube(
         self,
@@ -196,7 +200,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
                 Flag denoting whether solar radiation is defined at mean-sea-level
                 or at the Earth's surface. The appropriate vertical coordinate will
                 be assigned accordingly.
-        
+
         Returns:
             Cube containing clearsky solar radaition.
         """
@@ -317,6 +321,10 @@ class GenerateClearskySolarRadiation(BasePlugin):
                 target_grid.coord(axis="X").shape[0],
             ),
             dtype=np.float32,
+        )
+
+        irradiance_times = self._get_irradiance_times(
+            time, accumulation_period, temporal_spacing
         )
 
         solar_radiation_cube = self._get_solar_radiation_cube(

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -185,16 +185,16 @@ class GenerateClearskySolarRadiation(BasePlugin):
         linke_turbidity: ndarray,
         temporal_spacing: int,
     ) -> ndarray:
-        """Evaluated the gridded irradiance data over the specified period, calculated on
-        the same spatial grid points as target_grid.
+        """Evaluate the gridded clearsky solar radiation data over the specified period,
+        calculated on the same spatial grid points as target_grid.
 
         Args:
             target_grid:
                 Cube containing the target spatial grid on which to evaluate irradiance.
             irradiance_times:
                 Datetimes at which to evaluate the irradiance data.
-            altitude:
-                Altitude data, specified in metres.
+            surface_altitude:
+                Surface altitude data, specified in metres.
             linke_turbidity:
                 Linke turbidity data.
             temporal_spacing:
@@ -229,7 +229,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
         target_grid: Cube,
         time: datetime,
         accumulation_period: int,
-        at_mean_sea_level: str,
+        at_mean_sea_level: bool,
     ) -> Cube:
         """Create a cube of accumulated clearsky solar radiation.
 

--- a/improver/generate_ancillaries/generate_derived_solar_fields.py
+++ b/improver/generate_ancillaries/generate_derived_solar_fields.py
@@ -189,7 +189,7 @@ class GenerateClearskySolarRadiation(BasePlugin):
         the same spatial grid points as target_grid.
 
         Args:
-            target_cube:
+            target_grid:
                 Cube containing the target spatial grid on which to evaluate irradiance.
             irradiance_times:
                 Datetimes at which to evaluate the irradiance data.

--- a/improver_tests/generate_ancillaries/test_GenerateClearskySolarRadiation.py
+++ b/improver_tests/generate_ancillaries/test_GenerateClearskySolarRadiation.py
@@ -126,37 +126,40 @@ def test__initialise_input_cubes(
         )
 
 
-def test__get_irradiance_times():
-
-    time = datetime(2022, 1, 1, 00, 00, tzinfo=timezone.utc)
+def test__irradiance_times():
+    """Test returned irradiance times are equispaced time-steps
+    on the specified interval, with spacing temporal_spacing.
+    Where temporal_spacing does not fit evenly into the total interval,
+    a ValueError should be raised."""
+    time = datetime(2022, 1, 1, 0, 0, tzinfo=timezone.utc)
     accumulation_period = 3  # in hours
     temporal_spacing = 60  # in mins
 
     expected_times = [
-        datetime(2021, 12, 31, 21, 00, tzinfo=timezone.utc),
-        datetime(2021, 12, 31, 22, 00, tzinfo=timezone.utc),
-        datetime(2021, 12, 31, 23, 00, tzinfo=timezone.utc),
-        datetime(2022, 1, 1, 00, 00, tzinfo=timezone.utc),
+        datetime(2021, 12, 31, 21, 0, tzinfo=timezone.utc),
+        datetime(2021, 12, 31, 22, 0, tzinfo=timezone.utc),
+        datetime(2021, 12, 31, 23, 0, tzinfo=timezone.utc),
+        datetime(2022, 1, 1, 0, 0, tzinfo=timezone.utc),
     ]
-    result = GenerateClearskySolarRadiation()._get_irradiance_times(
+    result = GenerateClearskySolarRadiation()._irradiance_times(
         time, accumulation_period, temporal_spacing
     )
     assert np.all(result == expected_times)
 
     accumulation_period = 1
     expected_times = [
-        datetime(2021, 12, 31, 23, 00, tzinfo=timezone.utc),
-        datetime(2022, 1, 1, 00, 00, tzinfo=timezone.utc),
+        datetime(2021, 12, 31, 23, 0, tzinfo=timezone.utc),
+        datetime(2022, 1, 1, 0, 0, tzinfo=timezone.utc),
     ]
-    result = GenerateClearskySolarRadiation()._get_irradiance_times(
+    result = GenerateClearskySolarRadiation()._irradiance_times(
         time, accumulation_period, temporal_spacing
     )
     assert np.all(result == expected_times)
 
-    misaligned_temporal_spcaing = 19
+    misaligned_temporal_spacing = 19
     with pytest.raises(ValueError, match="must be integer multiple"):
-        GenerateClearskySolarRadiation()._get_irradiance_times(
-            time, accumulation_period, misaligned_temporal_spcaing
+        GenerateClearskySolarRadiation()._irradiance_times(
+            time, accumulation_period, misaligned_temporal_spacing
         )
 
 
@@ -171,7 +174,7 @@ def test_process(
     linke_turbidity_cube,
 ):
     """Test process method returns cubes with correct structure."""
-    time = datetime(2022, 1, 1, 00, 00)
+    time = datetime(2022, 1, 1, 0, 0)
 
     optional_vars = {}
     if surface_altitude_cube is not None:

--- a/improver_tests/generate_ancillaries/test_GenerateClearskySolarRadiation.py
+++ b/improver_tests/generate_ancillaries/test_GenerateClearskySolarRadiation.py
@@ -31,7 +31,6 @@
 """Unit tests for the GenerateClearskySolarRadiation plugin."""
 
 from datetime import datetime, timedelta, timezone
-from itertools import accumulate
 
 import numpy as np
 import pytest
@@ -127,10 +126,10 @@ def test__initialise_input_cubes(
         )
 
 def test__get_irradiance_times():
-    
+
     time = datetime(2022, 1, 1, 00, 00, tzinfo=timezone.utc)
-    accumulation_period = 3 # in hours
-    temporal_spacing = 60 # in mins
+    accumulation_period = 3  # in hours
+    temporal_spacing = 60  # in mins
 
     expected_times = [
         datetime(2021, 12, 31, 21, 00, tzinfo=timezone.utc),
@@ -138,7 +137,9 @@ def test__get_irradiance_times():
         datetime(2021, 12, 31, 23, 00, tzinfo=timezone.utc),
         datetime(2022, 1, 1, 00, 00, tzinfo=timezone.utc),
     ]
-    result = GenerateClearskySolarRadiation()._get_irradiance_times(time, accumulation_period, temporal_spacing)
+    result = GenerateClearskySolarRadiation()._get_irradiance_times(
+        time, accumulation_period, temporal_spacing
+    )
     assert np.all(result == expected_times)
 
     accumulation_period = 1
@@ -146,12 +147,16 @@ def test__get_irradiance_times():
         datetime(2021, 12, 31, 23, 00, tzinfo=timezone.utc),
         datetime(2022, 1, 1, 00, 00, tzinfo=timezone.utc),
     ]
-    result = GenerateClearskySolarRadiation()._get_irradiance_times(time, accumulation_period, temporal_spacing)
+    result = GenerateClearskySolarRadiation()._get_irradiance_times(
+        time, accumulation_period, temporal_spacing
+    )
     assert np.all(result == expected_times)
 
     misaligned_temporal_spcaing = 19
     with pytest.raises(ValueError, match="must be integer multiple"):
-        GenerateClearskySolarRadiation()._get_irradiance_times(time, accumulation_period, misaligned_temporal_spcaing)
+        GenerateClearskySolarRadiation()._get_irradiance_times(
+            time, accumulation_period, misaligned_temporal_spcaing
+        )
 
 
 @pytest.mark.parametrize("accumulation_period", [1, 3, 24])


### PR DESCRIPTION
This PR builds on #1705, and adds in functionality to construct the solar radiation cube based on the inputs provided. Calculations of clearsky irradiance will be added in a follow-up PR, so the emphasis here is on the cube properties and adding in the steps to extract solar radiation from irradiance values.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)