### PR TITLE
Handle mismatches coordinate dimensions and coordinate system when transforming to lat-lon

### DIFF
--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -554,6 +554,21 @@ def transform_grid_to_lat_lon(cube: Cube) -> Tuple[ndarray, ndarray]:
     """
     trg_latlon = ccrs.PlateCarree()
     trg_crs = cube.coord_system().as_cartopy_crs()
+    cube = cube.copy()
+    # TODO use the proj units that are accesible with later versions of proj
+    # to determine the default units to convert to for a given projection.
+
+    # Assuming proj units of metre for all projections not in degrees.
+    for axis in ["x", "y"]:
+        try:
+            cube.coord(axis=axis).convert_units("m")
+        except ValueError as err:
+            msg = (
+                "Cube passed to transform_grid_to_lat_lon does not have an "
+                f"{axis} coordinate with units that can be converted to metres. "
+            )
+            raise ValueError(msg + str(err))
+
     x_points = cube.coord(axis="x").points
     y_points = cube.coord(axis="y").points
     x_zeros = np.zeros_like(x_points)


### PR DESCRIPTION
The units of the spatial coordinates in an iris cube can have various units. The underlying coordinate system is based on proj which has an assumed unit for each projection. These are metres for cases that are not in degrees, with some possible undocumented exceptions; these are likely to be projections we do not encounter commonly. This change assumes metres for all coordinates that can be converted to metres.

When we can embrace a newer version of cartopy, and thus proj, we will be able to access the default unit of any given projection. This will enable us to do away with the assumption of metres used in this change; TODO added to this effect.

Addresses #1514 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)