### PR TITLE
Amendments to outdated doc strings

### DIFF
--- a/improver/cli/feels_like_temp.py
+++ b/improver/cli/feels_like_temp.py
@@ -67,7 +67,7 @@ def process(
         relative_humidity (iris.cube.Cube):
             Cube of relative humidity at screen level
         pressure (iris.cube.Cube):
-            Cube of mean sea level pressure
+            Cube of surface pressure
         model_id_attr (str):
             Name of the attribute used to identify the source model for
             blending.

--- a/improver/feels_like_temperature.py
+++ b/improver/feels_like_temperature.py
@@ -128,8 +128,8 @@ def _calculate_apparent_temperature(
 
     This function looks up a value for the saturation vapour pressure of
     water vapour using the temperature and a table of values. These tabulated
-    values are found using lookup_svp and are corrected to the saturated
-    vapour pressure in air using pressure_correct_svp, taken from the Goff-Gratch
+    values are found using _svp_from_lookup and are corrected to the saturated
+    vapour pressure in air using calculate_svp_in_air, taken from the Goff-Gratch
     method.
 
     Args:

--- a/improver/feels_like_temperature.py
+++ b/improver/feels_like_temperature.py
@@ -129,8 +129,8 @@ def _calculate_apparent_temperature(
     This function looks up a value for the saturation vapour pressure of
     water vapour using the temperature and a table of values. These tabulated
     values are found using lookup_svp and are corrected to the saturated
-    vapour pressure in air using pressure_correct_svp, both functions are from
-    the WetBulbTemperature plugin which makes use of the Goff-Gratch method.
+    vapour pressure in air using pressure_correct_svp, taken from the Goff-Gratch
+    method.
 
     Args:
         temperature:

--- a/improver/feels_like_temperature.py
+++ b/improver/feels_like_temperature.py
@@ -126,12 +126,6 @@ def _calculate_apparent_temperature(
     Here, the apparent temperature regression equation has been used for all
     wind speeds.
 
-    This function looks up a value for the saturation vapour pressure of
-    water vapour using the temperature and a table of values. These tabulated
-    values are found using _svp_from_lookup and are corrected to the saturated
-    vapour pressure in air using calculate_svp_in_air, taken from the Goff-Gratch
-    method.
-
     Args:
         temperature:
             Temperatures in degrees celsius


### PR DESCRIPTION
Addresses #GitHubissuenum

During the course of documenting the feels like temperature plugin, it was noted that the pressure input was misrepresented as MSLP instead of surface pressure. This and a reference to an outdated class location has now been amended in this PR.

Testing:
 - [X] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
