### PR TITLE
Fix snow falling level nan/masked issue

### DIFF
--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy<=1.6.2
+  - scipy<1.7
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy=1.6.2
+  - scipy<=1.6.2
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy<1.8.0
+  - scipy=1.6.2
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy
+  - scipy<1.8.0
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy<1.7
+  - scipy<1.5.4
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy<1.5
+  - scipy<1.7
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -18,7 +18,7 @@ dependencies:
   - iris>=3.0,<3.1
   - netCDF4
   - numpy<1.21
-  - scipy<1.5.4
+  - scipy<1.5
   - sigtools
   - sphinx
   # Additional libraries to run tests, not included in improver-feedstock

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -921,9 +921,7 @@ class PhaseChangeLevel(BasePlugin):
         # These can be filled by optional horizontal interpolation.
         if self.horizontal_interpolation:
             phase_change_data = self._horizontally_interpolate_phase(
-                phase_change_data,
-                orography,
-                max_nbhood_orog,
+                phase_change_data, orography, max_nbhood_orog
             )
 
         # Mask any points that are still set to np.nan; this should be no

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -920,25 +920,57 @@ class PhaseChangeLevel(BasePlugin):
         # lands points where the phase-change-level is below the orography.
         # These can be filled by optional horizontal interpolation.
         if self.horizontal_interpolation:
-            with np.errstate(invalid="ignore"):
-                max_nbhood_mask = phase_change_data <= max_nbhood_orog
-            updated_phase_cl = interpolate_missing_data(
-                phase_change_data, limit=orography, valid_points=max_nbhood_mask
-            )
-
-            with np.errstate(invalid="ignore"):
-                max_nbhood_mask = updated_phase_cl <= max_nbhood_orog
-            phase_change_data = interpolate_missing_data(
-                updated_phase_cl,
-                method="nearest",
-                limit=orography,
-                valid_points=max_nbhood_mask,
+            phase_change_data = self._horizontally_interpolate_phase(
+                phase_change_data,
+                orography,
+                max_nbhood_orog,
             )
 
         # Mask any points that are still set to np.nan; this should be no
         # points if horizontal interpolation has been used.
         phase_change_data = np.ma.masked_invalid(phase_change_data)
 
+        return phase_change_data
+
+    def _horizontally_interpolate_phase(
+        self, phase_change_data: ndarray, orography: ndarray, max_nbhood_orog: ndarray
+    ) -> ndarray:
+        """
+        Fill in missing points via horizontal interpolation.
+
+        Args:
+            phase_change_data:
+                Level (height) at which the phase changes.
+            orography:
+                Orography heights
+            max_nbhood_orog:
+                Maximum orography height in neighbourhood (used to determine points that
+                can be used for interpolation)
+
+        Returns:
+            Level at which phase changes, with missing data filled in
+        """
+
+        with np.errstate(invalid="ignore"):
+            max_nbhood_mask = phase_change_data <= max_nbhood_orog
+        updated_phase_cl = interpolate_missing_data(
+            phase_change_data, limit=orography, valid_points=max_nbhood_mask
+        )
+
+        with np.errstate(invalid="ignore"):
+            max_nbhood_mask = updated_phase_cl <= max_nbhood_orog
+        phase_change_data = interpolate_missing_data(
+            updated_phase_cl,
+            method="nearest",
+            limit=orography,
+            valid_points=max_nbhood_mask,
+        )
+
+        if np.isnan(phase_change_data).any():
+            # This should be rare.
+            phase_change_data = interpolate_missing_data(
+                phase_change_data, method="nearest"
+            )
         return phase_change_data
 
     def create_phase_change_level_cube(


### PR DESCRIPTION
We sometimes get NaNs passing through in falling level interpolation, even when horizontal interpolation is used.

This adds a fix to just interpolate without anything fancy when we get NaNs falling through the rest of the interpolation. It may just be for discussion and comment rather than going in as-is, but I think the work is useful either way.

As the method was getting a little long I split it out, but the actual substantive change is the block with the comment saying 'This should be rare'.

I've added unit tests that cover the behaviour, all of which except the peaked grid radius 2 case pass through NaNs and fail when the code change is commented out.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

