### PR TITLE
Replace environment variable threads setting with threadpoolctl library

### DIFF
--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -26,3 +26,4 @@ dependencies:
   - filelock
   - pytest
   - sphinx-autodoc-typehints
+  - threadpoolctl

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -41,3 +41,4 @@ dependencies:
   - pytest-xdist
   - safety
   - sphinx-autodoc-typehints
+  - threadpoolctl

--- a/envs/environment_b.yml
+++ b/envs/environment_b.yml
@@ -42,3 +42,4 @@ dependencies:
   - pytest-xdist
   - safety
   - sphinx-autodoc-typehints
+  - threadpoolctl

--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -44,3 +44,4 @@ dependencies:
   - pytest-xdist
   - safety
   - sphinx-autodoc-typehints
+  - threadpoolctl

--- a/improver_tests/conftest.py
+++ b/improver_tests/conftest.py
@@ -31,11 +31,24 @@
 """Test wide setup and configuration"""
 
 import pytest
-from threadpoolctl import threadpool_limits
-
 
 @pytest.fixture(autouse=True)
 def thread_control(monkeypatch):
-    with threadpool_limits(limits=1):
+    """
+    Wrap all tests with a limit to one thread via threadpoolctl.
+
+    The threadpoolctl library handles a variety of numerical libraries including
+    OpenBLAS, MKL and OpenMP, using their library specific interfaces during runtime.
+    Environment variable settings for these need to be applied before starting the
+    python interpreter, which is not possible from inside pytest.
+    This limitation to one thread avoids thread contention when parallel processing
+    is handled at larger scale such as Dask or pytest-xdist. See dask documentation:
+    https://docs.dask.org/en/stable/array-best-practices.html#avoid-oversubscribing-threads
+    """
+    try:
+        from threadpoolctl import threadpool_limits
+        with threadpool_limits(limits=1):
+            yield
+    except ModuleNotFoundError:
         yield
     return

--- a/improver_tests/conftest.py
+++ b/improver_tests/conftest.py
@@ -31,17 +31,11 @@
 """Test wide setup and configuration"""
 
 import pytest
+from threadpoolctl import threadpool_limits
 
 
 @pytest.fixture(autouse=True)
-def env_setup(monkeypatch):
-    """
-    Set environment variables to restrict math libraries to a single thread.
-    For details, see Dask documentation:
-    https://docs.dask.org/en/stable/array-best-practices.html#avoid-oversubscribing-threads
-    """
-    monkeypatch.setenv("OMP_NUM_THREADS", "1")
-    monkeypatch.setenv("OPENBLAS_NUM_THREADS", "1")
-    monkeypatch.setenv("MKL_NUM_THREADS", "1")
-    monkeypatch.setenv("VECLIB_MAXIMUM_THREADS", "1")
-    monkeypatch.setenv("NUMEXPR_NUM_THREADS", "1")
+def thread_control(monkeypatch):
+    with threadpool_limits(limits=1):
+        yield
+    return

--- a/improver_tests/conftest.py
+++ b/improver_tests/conftest.py
@@ -32,6 +32,7 @@
 
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def thread_control(monkeypatch):
     """
@@ -47,6 +48,7 @@ def thread_control(monkeypatch):
     """
     try:
         from threadpoolctl import threadpool_limits
+
         with threadpool_limits(limits=1):
             yield
     except ModuleNotFoundError:


### PR DESCRIPTION
The current approach of setting environment variables inside pytest is not effective, as these libraries check the environment variables once at startup rather than as the process runs - setting inside pytest is too late. This is now mentioned in the [dask docs](https://docs.dask.org/en/stable/array-best-practices.html#avoid-oversubscribing-threads): "You need to run this before you start your Python process for it to take effect"

The [threadpoolctl library](https://github.com/joblib/threadpoolctl) is about 20kb on [conda-forge](https://anaconda.org/conda-forge/threadpoolctl/files) and has no required dependencies - it works with a variety of maths and thread libraries such as Intel MKL, OpenBLAS and OpenMP depending on what is in use on the system.
This PR adds the library as a development dependency across all environments. In the case where threadpoolctl is not available (eg. already created conda environments), the thread limit will be skipped and tests will still run as-is.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

On an 8 core/16 thread system, applying this change reduces the time for a unit and acceptance test run (via pytest-xdist) from 3 minutes 6 seconds to 2 minutes 23 seconds (~23% faster). This performance increase is due to less oversubscription of threads and associated unproductive context switching.
There is no significant performance impact on a unit-tests-only run (31 seconds).

When running pytest-xdist with a number of parallel jobs less than the number of hardware threads on the system, this change is likely to increase test run times, due to the existing approach using more CPU resources than specified (and being a bad neighbour to any other jobs running on the system). The solution here would be to increase the number of parallel jobs to recover expected performance.