### PR TITLE
Sphinx 5.0 requires setting language

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -113,7 +113,7 @@ release = ""
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Tests run against latest package versions [failed](https://github.com/metoppv/improver/runs/6648768416?check_suite_focus=true#step:5:10) due to newly released [Sphinx 5.0.0](https://www.sphinx-doc.org/en/master/changes.html#release-5-0-0-released-may-30-2022) requiring the configuration file set [language](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language). The existing `None` value now results in a warning.

Testing:
 - [x] Ran tests and they passed OK