### PR TITLE
Update workflow to run coverage on both a and b envs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
         conda activate im${{ matrix.env }}
         make -C doc html SPHINXOPTS="-W --keep-going"
     - name: pytest without coverage
-      if: matrix.env != 'environment_a'
+      if: matrix.env == 'conda-forge'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate im${{ matrix.env }}
         pytest
     - name: pytest with coverage
-      if: matrix.env == 'environment_a'
+      if: matrix.env != 'conda-forge'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate im${{ matrix.env }}
@@ -61,7 +61,9 @@ jobs:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
     - name: codecov upload
       uses: codecov/codecov-action@v1
-      if: matrix.env == 'environment_a'
+      with:
+        name:  ${{ matrix.env }}
+      if: matrix.env != 'conda_forge'
   Codestyle-and-flake8:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Currently the codecov report is generated on `environment_a.yml` only. Any tests that are run only on `environment_b.yml` will be skipped in the coverage report and get reported as not being covered by associated unit tests; this brings down the project coverage, despite the relevant code being covered by unit tests.

Codecov allows for automatic merging or reports, so by running tests with coverage on both `environment_a.yml` and `environment_b.yml`, a better coverage report can be generated by uploading both reports to codecov. This PR updates `ci.yml` to allow running of pytest on both environment a and b, with both reports uploaded to codecov.

Testing:
 - [x] Ran tests and they passed OK
