### PR TITLE
Implement expected value via integration over probability thresholds

### DIFF
--- a/improver/expected_value.py
+++ b/improver/expected_value.py
@@ -115,14 +115,12 @@ class ExpectedValue(PostProcessingPlugin):
             len(threshold_midpoints) if i == threshold_coord_idx else 1
             for i in range(data_pdf.ndim)
         ]
-        threshold_midpoints = threshold_midpoints.reshape(thresh_mid_shape)
+        threshold_midpoints_bcast = threshold_midpoints.reshape(thresh_mid_shape)
         # apply threshold weightings to produce a weighed PDF suitable for integration
-        weighted_pdf = data_pdf * threshold_midpoints
+        weighted_pdf = data_pdf * threshold_midpoints_bcast
         del data_pdf
-        # numerical integration using trapezoid rule
-        ev_data = np.trapz(
-            weighted_pdf, threshold_midpoints, axis=threshold_coord_idx
-        ).astype(np.float32)
+        # sum of weighted_pdf is equivalent to midpoint rule integration over the CDF
+        ev_data = np.sum(weighted_pdf, axis=threshold_coord_idx, dtype=np.float32)
         del weighted_pdf
         # set up output cube based on input, with the threshold dimension removed
         ev_cube = next(cube.slices_over([threshold_coord])).copy()

--- a/improver/expected_value.py
+++ b/improver/expected_value.py
@@ -73,16 +73,17 @@ class ExpectedValue(PostProcessingPlugin):
         threshold_coord_idx = cube.dim_coords.index(threshold_coord)
         thresholds = threshold_coord.points
         # add an extra threshold below/above with zero/one probability
-        # this ensures the PDF integral covers the full CDF probability range
+        # ensure that the PDF integral covers the full CDF probability range
         try:
-            # use bounds from ECC as an outer bound on the distribution if available
             ecc_bounds = get_bounds_of_distribution(
                 threshold_coord.name(), threshold_coord.units
             )
         except KeyError:
-            # use infinities to fall back to threshold_spacing if ECC bounds missing
+            # no bound available, this will be skipped below via floating point rules
+            # eg. min(infinty, a) = a and max(-infinity, b) = b
             ecc_bounds = np.array([np.inf, -np.inf])
-        # applying the mean spacing between thresholds ensures expand the existing range
+        # expand to the widest of ECC bounds or +/- mean threshold spacing
+        # this will always expand, even if the original data covered the full ECC bounds range
         threshold_spacing = np.mean(np.diff(thresholds))
         thresholds_expanded = np.array(
             [

--- a/improver/expected_value.py
+++ b/improver/expected_value.py
@@ -30,20 +30,99 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Calculation of expected value from a probability distribution."""
 
+import numpy as np
 from iris.coords import CellMethod
 from iris.cube import Cube
 
 from improver import PostProcessingPlugin
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
-    ConvertProbabilitiesToPercentiles,
     RebadgePercentilesAsRealizations,
 )
-from improver.metadata.probabilistic import is_percentile, is_probability
+from improver.metadata.probabilistic import (
+    find_threshold_coordinate,
+    is_percentile,
+    is_probability,
+)
 from improver.utilities.cube_manipulation import collapse_realizations
+from improver.utilities.probability_manipulation import to_threshold_inequality
 
 
 class ExpectedValue(PostProcessingPlugin):
     """Calculation of expected value from a probability distribution"""
+
+    @staticmethod
+    def integrate_over_thresholds(cube: Cube) -> Cube:
+        """
+        Calculation of expected value for threshold data by converting from
+        cumulative distribution (CDF) to probability density (PDF), then
+        integrating over the threshold dimension.
+
+        Args:
+            cube:
+                Probabilistic data with a threshold coordinate.
+
+        Returns:
+            Expected value of probability distribution. Same shape as input cube
+            but with threshold coordinate removed.
+        """
+        # make sure that the threshold direction is "below"
+        cube = to_threshold_inequality(cube, above=False)
+        # set up threshold values, these will be needed as a multiplier during integration
+        threshold_coord = find_threshold_coordinate(cube)
+        threshold_coord_idx = cube.dim_coords.index(threshold_coord)
+        thresholds = threshold_coord.points
+        # add an extra threshold below/above with zero/one probability
+        # this ensures the PDF integral covers the full CDF probability range
+        threshold_spacing = np.mean(np.diff(thresholds))
+        thresholds_expanded = np.array(
+            [
+                thresholds[0] - threshold_spacing,
+                *thresholds,
+                thresholds[-1] + threshold_spacing,
+            ]
+        )
+        # expand the data to match the newly added thresholds
+        extra_data_shape = list(cube.shape)
+        extra_data_shape[threshold_coord_idx] = 1
+        data_expanded = np.concatenate(
+            [np.zeros(extra_data_shape), cube.data, np.ones(extra_data_shape)],
+            axis=threshold_coord_idx,
+            dtype=np.float32,
+        )
+        data_pdf = np.diff(data_expanded, axis=threshold_coord_idx)
+        del data_expanded
+        # the PDF should always be positive
+        if np.any(data_pdf < 0.0):
+            raise ValueError(
+                "PDF contains negative values - CDF was likely not monotonic increasing"
+            )
+        # use the midpoint of each threshold to weight the PDF
+        threshold_midpoints = thresholds_expanded[:-1] + 0.5 * np.diff(
+            thresholds_expanded
+        )
+        # expand the shape with additional length-1 dimensions so it broadcasts with data_pdf
+        thresh_mid_shape = [
+            len(threshold_midpoints) if i == threshold_coord_idx else 1
+            for i in range(data_pdf.ndim)
+        ]
+        threshold_midpoints = threshold_midpoints.reshape(thresh_mid_shape)
+        # apply threshold weightings to produce a weighed PDF suitable for integration
+        weighted_pdf = data_pdf * threshold_midpoints
+        del data_pdf
+        # numerical integration using trapezoid rule
+        ev_data = np.trapz(
+            weighted_pdf, threshold_midpoints, axis=threshold_coord_idx
+        ).astype(np.float32)
+        del weighted_pdf
+        # set up output cube based on input, with the threshold dimension removed
+        ev_cube = next(cube.slices_over([threshold_coord])).copy()
+        ev_cube.remove_coord(threshold_coord)
+        # name and units come from the threshold coordinate
+        ev_cube.rename(threshold_coord.name())
+        ev_cube.units = threshold_coord.units
+        # replace data with calculated values
+        ev_cube.data = ev_data
+        return ev_cube
 
     def process(self, cube: Cube) -> Cube:
         """Expected value calculation and metadata updates.
@@ -58,17 +137,12 @@ class ExpectedValue(PostProcessingPlugin):
             but with realization/threshold/percentile coordinate removed.
         """
         if is_probability(cube):
-            # TODO: replace this with direct calculation of the integral over
-            # probability thresholds. The current approach works and has the
-            # correct interface, but some accuracy will be lost in the conversion
-            # and memory usage is very high.
-            #
-            # 19 percentiles corresponds to 5, 10, 15...95%.
-            cube = ConvertProbabilitiesToPercentiles().process(
-                cube, no_of_percentiles=19
+            ev_cube = self.integrate_over_thresholds(cube)
+        elif is_percentile(cube):
+            ev_cube = collapse_realizations(
+                RebadgePercentilesAsRealizations().process(cube)
             )
-        if is_percentile(cube):
-            cube = RebadgePercentilesAsRealizations().process(cube)
-        mean_cube = collapse_realizations(cube)
-        mean_cube.add_cell_method(CellMethod("mean", coords="realization"))
-        return mean_cube
+        else:
+            ev_cube = collapse_realizations(cube)
+        ev_cube.add_cell_method(CellMethod("mean", coords="realization"))
+        return ev_cube

--- a/improver_tests/acceptance/test_expected_value.py
+++ b/improver_tests/acceptance/test_expected_value.py
@@ -53,12 +53,8 @@ run_cli = acc.run_cli(CLI)
 def test_probabilistic(tmp_path, input_kind, atol, mae, bias):
     """Test processing of probabilistic data.
 
-    The same KGO is shared across all representations. Processing realizations is
-    straightforward and accurate, so has low error tolerances. Processing percentiles
-    is also straightforward, but with some variation in the result due to representation
-    differences. Processing thresholds is quite rough, due to the currently implemented
-    method of conversion to percentiles. Expect this accuracy to improve if the expected
-    value is directly calculcated from the threshold data.
+    The same KGO is shared across all three representations as percentile and
+    threshold inputs are derived from the realization input.
     """
     kgo_dir = acc.kgo_root() / "expected-value"
     kgo_path = kgo_dir / "kgo.nc"

--- a/improver_tests/acceptance/test_expected_value.py
+++ b/improver_tests/acceptance/test_expected_value.py
@@ -77,7 +77,6 @@ def test_probabilistic(tmp_path, input_kind, atol, mae, bias):
     assert data_mae <= mae
     # custom comparison - bias
     data_bias = np.abs(np.mean(output_data - kgo_data))
-    print(data_bias)
     assert data_bias <= bias
 
 

--- a/improver_tests/acceptance/test_expected_value.py
+++ b/improver_tests/acceptance/test_expected_value.py
@@ -43,10 +43,14 @@ run_cli = acc.run_cli(CLI)
 
 
 @pytest.mark.parametrize(
-    "input_kind,atol,significant_diff_fraction",
-    [("realization", 0.001, 0.0), ("percentile", 0.09, 0.0), ("threshold", 0.18, 0.2)],
+    "input_kind,atol,mae,bias",
+    [
+        ("realization", 0.001, 0.0, 0.0),
+        ("percentile", 0.09, 0.02, 0.011),
+        ("threshold", 0.156, 0.06, 0.007),
+    ],
 )
-def test_probabilistic(tmp_path, input_kind, atol, significant_diff_fraction):
+def test_probabilistic(tmp_path, input_kind, atol, mae, bias):
     """Test processing of probabilistic data.
 
     The same KGO is shared across all representations. Processing realizations is
@@ -63,13 +67,18 @@ def test_probabilistic(tmp_path, input_kind, atol, significant_diff_fraction):
     args = [input_path, "--output", output_path]
     run_cli(args)
     # standard comparison, checking the maximum difference using atol
-    acc.compare(output_path, kgo_path, rtol=0.0, atol=atol)
-    # custom comparison - fraction of the grid with difference more than 0.1 kelvin
+    # KGO comes from realizations, don't recreate if using other kinds of input
+    is_realization = input_kind == "realization"
+    acc.compare(output_path, kgo_path, rtol=0.0, atol=atol, recreate=is_realization)
     kgo_data = iris.load(str(kgo_path))[0].data
     output_data = iris.load(str(output_path))[0].data
-    large_diffs = np.abs(output_data - kgo_data) > 0.1
-    fraction_of_large_diffs = np.mean(large_diffs.astype(np.float32))
-    assert significant_diff_fraction >= fraction_of_large_diffs
+    # custom comparison - mean absolute error
+    data_mae = np.mean(np.abs(output_data - kgo_data))
+    assert data_mae <= mae
+    # custom comparison - bias
+    data_bias = np.abs(np.mean(output_data - kgo_data))
+    print(data_bias)
+    assert data_bias <= bias
 
 
 def test_deterministic(tmp_path):
@@ -79,5 +88,5 @@ def test_deterministic(tmp_path):
     output_path = tmp_path / "output.nc"
     args = [input_path, "--output", output_path]
     # iris CoordinateNotFoundError is a KeyError
-    with pytest.raises(Exception, match="realization"):
+    with pytest.raises(KeyError, match="realization"):
         run_cli(args)

--- a/improver_tests/expected_value/test_expected_value.py
+++ b/improver_tests/expected_value/test_expected_value.py
@@ -99,7 +99,7 @@ def test_process_threshold_basic(threshold_cube):
     expval = ExpectedValue().process(threshold_cube)
     # threshold probablities are asymmetric, so the mean is slightly above the
     # 282 kelvin threshold
-    assert_allclose(expval.data, 282.16, atol=0.01)
+    assert_allclose(expval.data, 282.15, atol=0.0, rtol=0.0)
 
 
 def test_process_non_probabilistic(realizations_cube, percentile_cube):

--- a/improver_tests/expected_value/test_expected_value.py
+++ b/improver_tests/expected_value/test_expected_value.py
@@ -72,6 +72,16 @@ def threshold_cube(request):
     return set_up_probability_cube(data, thresholds=thresholds_interp)
 
 
+@pytest.fixture
+def unequal_threshold_cube():
+    thresholds = np.array([272, 280.75, 281, 282, 282.5, 284, 291])
+    probs = np.array([1.0, 0.99, 0.7, 0.5, 0.45, 0.0, 0.0])
+    data = np.broadcast_to(
+        probs[:, np.newaxis, np.newaxis], [7, 3, 2]
+    ).astype(np.float32)
+    return set_up_probability_cube(data, thresholds=thresholds)
+
+
 def test_process_realizations_basic(realizations_cube):
     """Check that the expected value of realisations calculates the mean and
     appropriately updates metadata."""
@@ -105,6 +115,12 @@ def test_process_threshold_basic(threshold_cube):
     # threshold probablities are asymmetric, so the mean is slightly above the
     # 282 kelvin threshold
     assert_allclose(expval.data, 282.15, atol=1e-6, rtol=0.0)
+
+
+def test_process_threshold_unequal(unequal_threshold_cube):
+    """Check calculation of expected value using unevenly spaced threshold data."""
+    expval = ExpectedValue().process(unequal_threshold_cube)
+    assert_allclose(expval.data, 282.0925, atol=1e-6, rtol=0.0)
 
 
 def test_process_threshold_abovebelow(threshold_cube):

--- a/improver_tests/expected_value/test_expected_value.py
+++ b/improver_tests/expected_value/test_expected_value.py
@@ -143,7 +143,6 @@ def test_process_threshold_abovebelow(threshold_cube):
     # calculate expected value for both, they should be the same
     expval_above = ExpectedValue().process(threshold_cube)
     expval_below = ExpectedValue().process(threshold_below_cube)
-    np.testing.assert_array_equal(expval_above.data, expval_below.data)
     assert expval_above == expval_below
 
 

--- a/improver_tests/expected_value/test_expected_value.py
+++ b/improver_tests/expected_value/test_expected_value.py
@@ -76,9 +76,9 @@ def threshold_cube(request):
 def unequal_threshold_cube():
     thresholds = np.array([272, 280.75, 281, 282, 282.5, 284, 291])
     probs = np.array([1.0, 0.99, 0.7, 0.5, 0.45, 0.0, 0.0])
-    data = np.broadcast_to(
-        probs[:, np.newaxis, np.newaxis], [7, 3, 2]
-    ).astype(np.float32)
+    data = np.broadcast_to(probs[:, np.newaxis, np.newaxis], [7, 3, 2]).astype(
+        np.float32
+    )
     return set_up_probability_cube(data, thresholds=thresholds)
 
 


### PR DESCRIPTION
As a follow up to #1719, implement processing of threshold data by numerical integration over probability thresholds, removing the quick-to-implement but poor performance implementation using ConvertProbabilitiesToPercentiles.

The acceptance test data is unchanged for this PR.
The time to run the acceptance test on threshold data reduced from ~1.5 seconds down to ~0.2 seconds on my workstation. There are significant performance improvements on larger data sets, such as whole-country sized grids.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)