### PR TITLE
Modify __init__ presence test

### DIFF
--- a/improver_tests/test_source_code.py
+++ b/improver_tests/test_source_code.py
@@ -71,6 +71,9 @@ def test_init_files_exist():
         for path in directory.glob("**"):
             if not path.is_dir():
                 continue
+            # ignore hidden directories and their sub-directories
+            if any([part.startswith(".") for part in path.parts]):
+                continue
             # in-place running will produce pycache directories, these should be ignored
             if path.name == "__pycache__":
                 continue


### PR DESCRIPTION
This change excludes hidden directories and their sub-directories from the init check test. This accommodates IDEs that store information in hidden directories, i.e. vscode, without attempting to maintain an explicit list of directories to be excluded.

Testing:
 - [x] Ran tests and they passed OK
