### PR TITLE
Remove in_vicinity name component from lighting plugin

### DIFF
--- a/improver/lightning.py
+++ b/improver/lightning.py
@@ -157,8 +157,7 @@ class LightningFromCapePrecip(PostProcessingPlugin):
         data = cape_true.data * precip_true.data
 
         cube = create_new_diagnostic_cube(
-            name="probability_of_number_of_lightning_flashes_per_unit_area_in_vicinity"
-            "_above_threshold",
+            name="probability_of_number_of_lightning_flashes_per_unit_area_above_threshold",
             units="1",
             template_cube=precip,
             data=data.astype(FLOAT_DTYPE),

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -319,8 +319,8 @@ a87b4eb0ae9dfac3cdffb75dba94750e047fe618b4bb469f5e2262819bfd2318  ./interpolate-
 2ebd0073a5fd84f989c976229120b60fd720d1c4ed1f2229abaa675fef281c98  ./interpret_metadata/non_compliant_weather_codes.nc
 c45d0da496a7c79052f60ae126cb51cd4a731659cec3470f9005e3996687dc99  ./interpret_metadata/temperature_realizations.nc
 af63974ed9b8370205cb801df8170aaedf43abdc86427b1ea958b9cdd8573cdd  ./lightning-from-cape-and-precip/cape.nc
-6c8bf7f59b9aa72ad987c63c2aadac0ee5bdb7130dab55c7d661f7706b098c84  ./lightning-from-cape-and-precip/kgo.nc
-13d8a4e897818c4c654911b5724ff30d768e7a0d3e46d1e8613c246895f83aff  ./lightning-from-cape-and-precip/kgo_with_model_config.nc
+d2eee2303c30296ec4abf292a01ecb89bfcc4da9f5c4b5b86c10261e19fabff8  ./lightning-from-cape-and-precip/kgo.nc
+833a77d3dcae0f40b890335f15cae018faa78f168c0607378a7897a7fb2ca5ef  ./lightning-from-cape-and-precip/kgo_with_model_config.nc
 11c16c83261ac53d4e8916423810b639716e26c77f983c1c8c8ad0ffb48169be  ./lightning-from-cape-and-precip/precipitation_rate.nc
 814a63cc59ea0c0827cc435c8607891677e2acd234774f6cee721c3afea67548  ./manipulate-reliability-table/basic/kgo_300_min_count.nc
 b99d11406c811e78d690d42e0f46a92280e588a8b0101e8bf2c8fa36f3262860  ./manipulate-reliability-table/basic/kgo_precip.nc

--- a/improver_tests/lightning/test_LightningFromCapePrecip.py
+++ b/improver_tests/lightning/test_LightningFromCapePrecip.py
@@ -101,7 +101,7 @@ def expected_cube_fixture() -> Cube:
     cube = set_up_probability_cube(
         data,
         thresholds=[0.0],
-        variable_name="number_of_lightning_flashes_per_unit_area_in_vicinity",
+        variable_name="number_of_lightning_flashes_per_unit_area",
         threshold_units="m-2",
         time=datetime(2017, 11, 10, 5, 0),
         time_bounds=(datetime(2017, 11, 10, 4, 0), datetime(2017, 11, 10, 5, 0)),


### PR DESCRIPTION
The lightning filter plugin does not inherently create a vicinity diagnostic, this is only applicable when using coarse resolution data. As such this change removes the in_vicinity name component from the plugin output; this should be set specifically for coarse data if so desired using another approach (i.e. renaming in the suite).

Testing:
 - [x] Ran tests and they passed OK