### PR TITLE
github actions for marking issues and PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,10 +20,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
           # Idle number of days before marking issues/prs stale.
-          days-before-stale: 60
+          days-before-issue-stale: -1
+          days-before-pr-stale: 60
 
           # Idle number of days before closing stale issues/prs.
-          days-before-close: 30
+          days-before-issue-close: -1
+          days-before-pr-close: 30
 
           # Comment on the staled issues.
           stale-issue-message: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,14 +27,6 @@ jobs:
           days-before-issue-close: -1
           days-before-pr-close: 30
 
-          # Comment on the staled issues.
-          stale-issue-message: |
-            In order to maintain a backlog of relevant issues, we automatically label them as stale after 60 days of inactivity.
-
-            If this issue is still important to you, then please comment on this issue and the stale label will be removed.
-
-            Otherwise this issue will be automatically closed in 30 days time.
-
           # Comment on the staled prs.
           stale-pr-message: |
             In order to maintain a backlog of relevant PRs, we automatically label them as stale after 60 days of inactivity.
@@ -43,27 +35,14 @@ jobs:
 
             Otherwise this PR will be automatically closed in 30 days time.
 
-          # Comment on the staled issues while closed.
-          close-issue-message: |
-            This stale issue has been automatically closed due to a lack of activity.
-
-            If you still care about this issue, then please re-open this issue.
-
           # Comment on the staled prs while closed.
           close-pr-message: |
             This stale PR has been automatically closed due to a lack of activity.
 
             If you still care about this PR, then please re-open this PR.
 
-          # Label to apply on staled issues.
-          stale-issue-label: Stale
-
           # Label to apply on staled prs.
           stale-pr-label: Stale
-
-          # Labels on issues exempted from stale.
-          exempt-issue-labels:
-            "good first issue"
 
           # Labels on prs exempted from stale.
           exempt-pr-labels:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,81 @@
+# See https://github.com/actions/stale
+
+name: Stale issues and pull-requests
+
+on:
+  schedule:
+    # Run once a day
+    # N.B. "should" be quoted, according to
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    if: "github.repository == 'metoppv/improver'"
+    runs-on: ubuntu-latest
+    steps:
+        # Using actions/stale@v5
+      - uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Idle number of days before marking issues/prs stale.
+          days-before-stale: 60
+
+          # Idle number of days before closing stale issues/prs.
+          days-before-close: 30
+
+          # Comment on the staled issues.
+          stale-issue-message: |
+            In order to maintain a backlog of relevant issues, we automatically label them as stale after 60 days of inactivity.
+
+            If this issue is still important to you, then please comment on this issue and the stale label will be removed.
+
+            Otherwise this issue will be automatically closed in 30 days time.
+
+          # Comment on the staled prs.
+          stale-pr-message: |
+            In order to maintain a backlog of relevant PRs, we automatically label them as stale after 60 days of inactivity.
+
+            If this PR is still important to you, then please comment on this PR and the stale label will be removed.
+
+            Otherwise this PR will be automatically closed in 30 days time.
+
+          # Comment on the staled issues while closed.
+          close-issue-message: |
+            This stale issue has been automatically closed due to a lack of activity.
+
+            If you still care about this issue, then please re-open this issue.
+
+          # Comment on the staled prs while closed.
+          close-pr-message: |
+            This stale PR has been automatically closed due to a lack of activity.
+
+            If you still care about this PR, then please re-open this PR.
+
+          # Label to apply on staled issues.
+          stale-issue-label: Stale
+
+          # Label to apply on staled prs.
+          stale-pr-label: Stale
+
+          # Labels on issues exempted from stale.
+          exempt-issue-labels:
+            "good first issue"
+
+          # Labels on prs exempted from stale.
+          exempt-pr-labels:
+            "good first issue"
+
+          # Max number of operations per run.
+          operations-per-run: 300
+
+          # Remove stale label from issues/prs on updates/comments.
+          remove-stale-when-updated: true
+
+          # Order to get issues/PRs.
+          ascending: true
+
+          # Exempt all issues/prs with milestones from stale.
+          exempt-all-milestones: true
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # See https://github.com/actions/stale
 
-name: Stale issues and pull-requests
+name: Stale pull-requests
 
 on:
   schedule:


### PR DESCRIPTION
Modified version of the configuration for `actions/stale` from `SciTools/iris`
More info on the action here: https://github.com/actions/stale

To be discussed:
- Choosing a suitable number of days before the action will assign the "Stale" label to a issue/PR (60 days right now).
- Choosing a suitable number of days **after** issue/PR being marked as stale before issue/PR is actually closed (30 days right now).
- Any further label exclusions?

Hopefully will work (permissions on improver repo. setup to allow).