### PR TITLE
Add medium and high type cloud to ECC bounds

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -58,8 +58,10 @@ BOUNDS_FOR_ECDF = {
     "cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_2p5_oktas": Bounds(
         (-300, 20000), "m"
     ),
+    "high_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
     "low_and_medium_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
     "low_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
+    "medium_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
     # Precipitation amount
     "lwe_thickness_of_freezing_rainfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),


### PR DESCRIPTION
ECC bounds are missing for medium and high type cloud which BOM would like to process. This leads to the same error as discussed in #1756. I have chosen the lower and upper bounds to be the same as the existing low and total cloud bounds, i.e. zero to unity (as expected for a cloud fraction).

Testing:
 - [x] Ran tests and they passed OK
