### PR TITLE
Fix cube name in regridding

### DIFF
--- a/improver/regrid/grid.py
+++ b/improver/regrid/grid.py
@@ -379,7 +379,8 @@ def create_regrid_cube(cube_array: ndarray, cube_in: Cube, cube_out: Cube) -> Cu
     """
     # generate a cube based on new data and cube_in
     cube_v = Cube(cube_array, units=cube_in.units, attributes=cube_in.attributes)
-    cube_v.rename(cube_in.var_name or cube_in.standard_name or cube_in.long_name)
+    cube_v.rename(cube_in.standard_name or cube_in.long_name)
+    cube_v.var_name = cube_in.var_name
 
     # use dim_coord from cube_in except lat/lon
     cube_coord_names = get_cube_coord_names(cube_in)

--- a/improver/regrid/grid.py
+++ b/improver/regrid/grid.py
@@ -378,13 +378,8 @@ def create_regrid_cube(cube_array: ndarray, cube_in: Cube, cube_out: Cube) -> Cu
         Regridded result cube
     """
     # generate a cube based on new data and cube_in
-    cube_v = Cube(
-        cube_array,
-        standard_name=cube_in.standard_name,
-        var_name=cube_in.var_name,
-        units=cube_in.units,
-        attributes=cube_in.attributes,
-    )
+    cube_v = Cube(cube_array, units=cube_in.units, attributes=cube_in.attributes)
+    cube_v.rename(cube_in.var_name or cube_in.standard_name or cube_in.long_name)
 
     # use dim_coord from cube_in except lat/lon
     cube_coord_names = get_cube_coord_names(cube_in)

--- a/improver_tests/regrid/test_grid.py
+++ b/improver_tests/regrid/test_grid.py
@@ -199,6 +199,7 @@ def test_create_regrid_cube():
 
     source_cube_latlon = set_up_variable_cube(
         np.ones((2, 5, 5), dtype=np.float32),
+        name="air_temperature",
         time=datetime(2018, 11, 10, 8, 0),
         frt=datetime(2018, 11, 10, 0, 0),
     )
@@ -213,3 +214,29 @@ def test_create_regrid_cube():
     assert cube_v.coord("forecast_reference_time") == source_cube_latlon.coord(
         "forecast_reference_time"
     )
+    assert cube_v.standard_name == "air_temperature"
+    assert cube_v.long_name is None
+
+
+def test_create_regrid_cube_non_standard_name():
+    """Test the create_regrid_cube function with a non-standard name"""
+
+    source_cube_latlon = set_up_variable_cube(
+        np.ones((2, 5, 5), dtype=np.float32),
+        name="not_a_standard_name",
+        time=datetime(2018, 11, 10, 8, 0),
+        frt=datetime(2018, 11, 10, 0, 0),
+    )
+    target_cube_equalarea = set_up_variable_cube(
+        np.ones((10, 10), dtype=np.float32), spatial_grid="equalarea"
+    )
+    data = np.repeat(1.0, 200).reshape(2, 10, 10)
+    cube_v = create_regrid_cube(data, source_cube_latlon, target_cube_equalarea)
+    assert cube_v.shape == (2, 10, 10)
+    assert cube_v.coord(axis="x").standard_name == "projection_x_coordinate"
+    assert cube_v.coord(axis="y").standard_name == "projection_y_coordinate"
+    assert cube_v.coord("forecast_reference_time") == source_cube_latlon.coord(
+        "forecast_reference_time"
+    )
+    assert cube_v.standard_name is None
+    assert cube_v.long_name == "not_a_standard_name"

--- a/improver_tests/regrid/test_grid.py
+++ b/improver_tests/regrid/test_grid.py
@@ -240,3 +240,29 @@ def test_create_regrid_cube_non_standard_name():
     )
     assert cube_v.standard_name is None
     assert cube_v.long_name == "not_a_standard_name"
+
+
+def test_create_regrid_cube_different_var_name():
+    """Test the create_regrid_cube function with a different var_name"""
+
+    source_cube_latlon = set_up_variable_cube(
+        np.ones((2, 5, 5), dtype=np.float32),
+        name="air_temperature",
+        time=datetime(2018, 11, 10, 8, 0),
+        frt=datetime(2018, 11, 10, 0, 0),
+    )
+    source_cube_latlon.var_name = "some_var_name"
+    target_cube_equalarea = set_up_variable_cube(
+        np.ones((10, 10), dtype=np.float32), spatial_grid="equalarea"
+    )
+    data = np.repeat(1.0, 200).reshape(2, 10, 10)
+    cube_v = create_regrid_cube(data, source_cube_latlon, target_cube_equalarea)
+    assert cube_v.shape == (2, 10, 10)
+    assert cube_v.coord(axis="x").standard_name == "projection_x_coordinate"
+    assert cube_v.coord(axis="y").standard_name == "projection_y_coordinate"
+    assert cube_v.coord("forecast_reference_time") == source_cube_latlon.coord(
+        "forecast_reference_time"
+    )
+    assert cube_v.standard_name == "air_temperature"
+    assert cube_v.long_name is None
+    assert cube_v.var_name == "some_var_name"


### PR DESCRIPTION
The regridding code calls `create_regrid_cube` which generates a new cube with regridded data. The way in which it does this results in an "unknown" variable name if the input cube does not have a standard name. The tests added here fail if used with the original code. This PR fixes that bug.

I discovered the issue while testing CAPE processing in improver_suite_bom. The CAPE data from our ingest (stage_suite_bom) does not have a standard name, rather a long name. The regridding code fails to name the variable in the regridded cube correctly leading to "unknown" as the variable name.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for ~the new~ existing feature(s)

