### PR TITLE
Fix out of bounds expected values for bounded diagnostics

### DIFF
--- a/improver/expected_value.py
+++ b/improver/expected_value.py
@@ -72,7 +72,7 @@ class ExpectedValue(PostProcessingPlugin):
         threshold_coord_idx = cube.dim_coords.index(threshold_coord)
         thresholds = threshold_coord.points
         # check the thresholds are in increasing order
-        if thresholds[0] > thresholds[-1]:
+        if np.any(np.diff(thresholds) <= 0.0):
             raise ValueError("threshold coordinate in decreasing order")
         # add an extra threshold below/above with zero/one probability
         # ensure that the PDF integral covers the full CDF probability range

--- a/improver/expected_value.py
+++ b/improver/expected_value.py
@@ -37,7 +37,6 @@ from iris.cube import Cube
 from improver import PostProcessingPlugin
 from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
     RebadgePercentilesAsRealizations,
-    get_bounds_of_distribution,
 )
 from improver.metadata.probabilistic import (
     find_threshold_coordinate,
@@ -72,24 +71,20 @@ class ExpectedValue(PostProcessingPlugin):
         threshold_coord = find_threshold_coordinate(cube)
         threshold_coord_idx = cube.dim_coords.index(threshold_coord)
         thresholds = threshold_coord.points
+        # check the thresholds are in increasing order
+        if thresholds[0] > thresholds[-1]:
+            raise ValueError("threshold coordinate in decreasing order")
         # add an extra threshold below/above with zero/one probability
         # ensure that the PDF integral covers the full CDF probability range
-        try:
-            ecc_bounds = get_bounds_of_distribution(
-                threshold_coord.name(), threshold_coord.units
-            )
-        except KeyError:
-            # no bound available, this will be skipped below via floating point rules
-            # eg. min(infinty, a) = a and max(-infinity, b) = b
-            ecc_bounds = np.array([np.inf, -np.inf])
-        # expand to the widest of ECC bounds or +/- mean threshold spacing
-        # this will always expand, even if the original data covered the full ECC bounds range
-        threshold_spacing = np.mean(np.diff(thresholds))
+        # thresholds are usually float32 with epsilon of ~= 1.1e-7
+        eps = np.finfo(thresholds.dtype).eps
+        # for small values (especially exactly zero), at least epsilon
+        # for larger values, the next representable float number
         thresholds_expanded = np.array(
             [
-                min(ecc_bounds[0], thresholds[0] - threshold_spacing),
+                thresholds[0] - max(eps, abs(thresholds[0] * eps)),
                 *thresholds,
-                max(ecc_bounds[1], thresholds[-1] + threshold_spacing),
+                thresholds[-1] + max(eps, abs(thresholds[-1] * eps)),
             ]
         )
         # expand the data to match the newly added thresholds

--- a/improver_tests/expected_value/test_expected_value.py
+++ b/improver_tests/expected_value/test_expected_value.py
@@ -179,9 +179,6 @@ def test_process_threshold_doublebounded(double_bounded_threshold_cube):
 
 def test_process_threshold_bounded(single_bounded_threshold_cube):
     """Check expected value of a below bounded distribution eg. precipitation."""
-    thresholds = single_bounded_threshold_cube.coord(
-        "lwe_thickness_of_precipitation_amount"
-    ).points
     expval = ExpectedValue().process(single_bounded_threshold_cube)
     np.testing.assert_allclose(
         expval.data[0], [0.0, 0.01, 3.985], rtol=0, atol=1e-6,


### PR DESCRIPTION
Values outside bounds were found in expected values for diagnostics bounded below (eg. precipitation >= 0 millimetres) and double bounded (eg. cloud cover >= 0% and <= 100%).

These out of bounds values were caused by the addition of extra thresholds to ensure the distribution covers the complete probability range from when converting from CDF to PDF representation. The method in #1734 uses a combination of mean threshold spacing and ECC bounds, which intended to neatly handle the situation where a continuous diagnostic (eg. air temperature) isn't sufficiently represented by a wide enough range of thresholds.

This PR changes the extra thresholds to be tightly constrained by the existing thresholds - a small value near zero and the minimum floating point increment for larger values. This method provides sharp bounds on the thresholds and accurately handles bounded diagnostics, with the tradeoff that there is no tolerance for insufficient thresholds representing continuous diagnostics.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)