### PR TITLE
Add ~ home directory path handling to RainForests JSON configuration

### DIFF
--- a/improver/calibration/rainforest_calibration.py
+++ b/improver/calibration/rainforest_calibration.py
@@ -38,6 +38,7 @@
 
 import warnings
 from collections import OrderedDict
+from os.path import expanduser
 from typing import Optional, Tuple
 
 import numpy as np
@@ -208,7 +209,9 @@ class ApplyRainForestsCalibrationLightGBM(ApplyRainForestsCalibration):
             for threshold_dict in sorted_model_config_dict.values()
         ]
         self.tree_models = [
-            Booster(model_file=file).reset_parameter({"num_threads": threads})
+            Booster(model_file=expanduser(file)).reset_parameter(
+                {"num_threads": threads}
+            )
             for file in lightgbm_model_filenames
         ]
 
@@ -768,7 +771,7 @@ class ApplyRainForestsCalibrationTreelite(ApplyRainForestsCalibrationLightGBM):
             for threshold_dict in sorted_model_config_dict.values()
         ]
         self.tree_models = [
-            Predictor(libpath=file, verbose=False, nthread=threads)
+            Predictor(libpath=expanduser(file), verbose=False, nthread=threads)
             for file in treelite_model_filenames
         ]
 


### PR DESCRIPTION
While running suites containing RainForests calibration, we have found it useful to use home-directory-based paths in the configuration, rather than absolute or relative (to the current working directory) paths. This reduces the need to edit configuration files when sharing between users and systems.

This PR adds expansion of `~` into the user's home directory path using python standard library functionality.

Testing:
 - [x] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)