### PR TITLE
Adds method to check and extract the model id attribute value from a list of input cubes

### DIFF
--- a/improver/metadata/utilities.py
+++ b/improver/metadata/utilities.py
@@ -201,3 +201,38 @@ def create_coordinate_hash(cube: Cube) -> str:
             ]
         )
     return generate_hash(hashable_data)
+
+
+def get_model_id_attr(cubes: List[Cube], model_id_attr: str) -> str:
+    """
+    Gets the specified model ID attribute from a list of input cubes, checking
+    that the value is the same on all those cubes in the process.
+
+    Args:
+        cubes:
+            List of cubes to get the attribute from
+        model_id_attr:
+            Attribute name
+
+    Returns:
+        The unique attribute value
+
+    """
+    try:
+        model_id_value = {cube.attributes[model_id_attr] for cube in cubes}
+    except KeyError as error:
+        failing_cubes = [
+            cube.name()
+            for cube in cubes
+            if not cube.attributes.get(model_id_attr, False)
+        ]
+        raise ValueError(
+            f"Model ID attribute {model_id_attr} not present on {', '.join(failing_cubes)}."
+        ) from error
+    if len(model_id_value) != 1:
+        raise ValueError(
+            f"Attribute {model_id_attr} does not match on input cubes. "
+            f"{' != '.join(model_id_value)}"
+        )
+    (model_id_value,) = model_id_value
+    return model_id_value

--- a/improver/metadata/utilities.py
+++ b/improver/metadata/utilities.py
@@ -227,11 +227,11 @@ def get_model_id_attr(cubes: List[Cube], model_id_attr: str) -> str:
             if not cube.attributes.get(model_id_attr, False)
         ]
         raise ValueError(
-            f"Model ID attribute {model_id_attr} not present on {', '.join(failing_cubes)}."
+            f"Model ID attribute {model_id_attr} not present for {', '.join(failing_cubes)}."
         ) from error
     if len(model_id_value) != 1:
         raise ValueError(
-            f"Attribute {model_id_attr} does not match on input cubes. "
+            f"Attribute {model_id_attr} must be the same on all input cubes. "
             f"{' != '.join(model_id_value)}"
         )
     (model_id_value,) = model_id_value

--- a/improver/metadata/utilities.py
+++ b/improver/metadata/utilities.py
@@ -231,7 +231,7 @@ def get_model_id_attr(cubes: List[Cube], model_id_attr: str) -> str:
         ) from error
     if len(model_id_value) != 1:
         raise ValueError(
-            f"Attribute {model_id_attr} must be the same on all input cubes. "
+            f"Attribute {model_id_attr} must be the same for all input cubes. "
             f"{' != '.join(model_id_value)}"
         )
     (model_id_value,) = model_id_value

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -31,7 +31,7 @@
 """Tests for the improver.metadata.utilities module"""
 
 import unittest
-from typing import List, Callable
+from typing import Callable, List
 
 import iris
 import numpy as np
@@ -357,7 +357,9 @@ def make_cubes() -> List[Cube]:
 @pytest.mark.parametrize(
     "model_id_attr, model_id_value", (("test_attribute", "test_value"), (None, None))
 )
-def test_ok_get_model_id_attr(cubes: List[Cube], input_count, model_id_attr, model_id_value):
+def test_ok_get_model_id_attr(
+    cubes: List[Cube], input_count, model_id_attr, model_id_value
+):
     """Checks that get_model_id_attr gives the right answer when all is well."""
     for cube in cubes:
         cube.attributes[model_id_attr] = model_id_value
@@ -383,9 +385,18 @@ def attribute_not_unique(cubes: List[Cube]):
 @pytest.mark.parametrize(
     "method, message",
     (
-        (attribute_missing_all_cubes, "Model ID attribute test_attribute not present on "),
-        (attribute_missing_one_cube, "Model ID attribute test_attribute not present on "),
-        (attribute_not_unique, "Attribute test_attribute does not match on input cubes. "),
+        (
+            attribute_missing_all_cubes,
+            "Model ID attribute test_attribute not present on ",
+        ),
+        (
+            attribute_missing_one_cube,
+            "Model ID attribute test_attribute not present on ",
+        ),
+        (
+            attribute_not_unique,
+            "Attribute test_attribute does not match on input cubes. ",
+        ),
     ),
 )
 def test_errors_get_model_id_attr(cubes: List[Cube], method: Callable, message):

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -357,10 +357,10 @@ def make_cubes() -> List[Cube]:
 @pytest.mark.parametrize(
     "model_id_attr, model_id_value", (("test_attribute", "test_value"), (None, None))
 )
-def test_ok_get_model_id_attr(
+def test_valid_get_model_id_attr(
     cubes: List[Cube], input_count, model_id_attr, model_id_value
 ):
-    """Checks that get_model_id_attr gives the right answer when all is well."""
+    """Checks that get_model_id_attr gives the expected result when all input cubes match."""
     for cube in cubes:
         cube.attributes[model_id_attr] = model_id_value
     result = get_model_id_attr(cubes[:input_count], model_id_attr)
@@ -378,7 +378,8 @@ def attribute_missing_one_cube(cubes: List[Cube]):
 
 
 def attribute_not_unique(cubes: List[Cube]):
-    """Changes the attribute value on the first cube"""
+    """Changes the attribute value on the first cube so that there is more than one
+    model_id_attr in the cube list."""
     cubes[0].attributes["test_attribute"] = "kittens"
 
 
@@ -387,20 +388,21 @@ def attribute_not_unique(cubes: List[Cube]):
     (
         (
             attribute_missing_all_cubes,
-            "Model ID attribute test_attribute not present on ",
+            "Model ID attribute test_attribute not present for ",
         ),
         (
             attribute_missing_one_cube,
-            "Model ID attribute test_attribute not present on ",
+            "Model ID attribute test_attribute not present for ",
         ),
         (
             attribute_not_unique,
-            "Attribute test_attribute does not match on input cubes. ",
+            "Attribute test_attribute must be the same on all input cubes. ",
         ),
     ),
 )
 def test_errors_get_model_id_attr(cubes: List[Cube], method: Callable, message):
-    """Checks that get_model_id_attr raises useful errors when all is not well."""
+    """Checks that get_model_id_attr raises useful errors when the required conditions are not met.
+    """
     model_id_attr = "test_attribute"
     model_id_value = "test_value"
     for cube in cubes:

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -368,17 +368,17 @@ def test_valid_get_model_id_attr(
 
 
 def attribute_missing_all_cubes(cubes: List[Cube]):
-    """Removes the attribute value on all cubes"""
+    """Removes the attribute value from all cubes"""
     [cube.attributes.pop("test_attribute") for cube in cubes]
 
 
 def attribute_missing_one_cube(cubes: List[Cube]):
-    """Removes the attribute value on the first cube"""
+    """Removes the attribute value from the first cube"""
     cubes[0].attributes.pop("test_attribute")
 
 
 def attribute_not_unique(cubes: List[Cube]):
-    """Changes the attribute value on the first cube so that there is more than one
+    """Changes the attribute value for the first cube so that there is more than one
     model_id_attr in the cube list."""
     cubes[0].attributes["test_attribute"] = "kittens"
 
@@ -396,7 +396,7 @@ def attribute_not_unique(cubes: List[Cube]):
         ),
         (
             attribute_not_unique,
-            "Attribute test_attribute must be the same on all input cubes. ",
+            "Attribute test_attribute must be the same for all input cubes. ",
         ),
     ),
 )

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -353,14 +353,15 @@ def make_cubes() -> List[Cube]:
     return cubes
 
 
+@pytest.mark.parametrize("input_count", (1, 3))
 @pytest.mark.parametrize(
     "model_id_attr, model_id_value", (("test_attribute", "test_value"), (None, None))
 )
-def test_ok_get_model_id_attr(cubes: List[Cube], model_id_attr, model_id_value):
+def test_ok_get_model_id_attr(cubes: List[Cube], input_count, model_id_attr, model_id_value):
     """Checks that get_model_id_attr gives the right answer when all is well."""
     for cube in cubes:
         cube.attributes[model_id_attr] = model_id_value
-    result = get_model_id_attr(cubes, model_id_attr)
+    result = get_model_id_attr(cubes[:input_count], model_id_attr)
     assert result == model_id_value
 
 

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -31,9 +31,12 @@
 """Tests for the improver.metadata.utilities module"""
 
 import unittest
+from typing import List, Callable
 
 import iris
 import numpy as np
+import pytest
+from iris.cube import Cube
 
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
 from improver.metadata.utilities import (
@@ -41,6 +44,7 @@ from improver.metadata.utilities import (
     create_new_diagnostic_cube,
     generate_hash,
     generate_mandatory_attributes,
+    get_model_id_attr,
 )
 from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
 
@@ -335,6 +339,63 @@ class Test_create_coordinate_hash(unittest.TestCase):
         result1 = create_coordinate_hash(hash_input1)
         result2 = create_coordinate_hash(hash_input2)
         self.assertNotEqual(result1, result2)
+
+
+@pytest.fixture(name="cubes")
+def make_cubes() -> List[Cube]:
+    """Generates a list of three cubes"""
+    cubes = []
+    master_cube = set_up_variable_cube(np.zeros((2, 2), dtype=np.float32))
+    for name in "temperature", "pressure", "humidity":
+        cube = master_cube.copy()
+        cube.rename(name)
+        cubes.append(cube)
+    return cubes
+
+
+@pytest.mark.parametrize(
+    "model_id_attr, model_id_value", (("test_attribute", "test_value"), (None, None))
+)
+def test_ok_get_model_id_attr(cubes: List[Cube], model_id_attr, model_id_value):
+    """Checks that get_model_id_attr gives the right answer when all is well."""
+    for cube in cubes:
+        cube.attributes[model_id_attr] = model_id_value
+    result = get_model_id_attr(cubes, model_id_attr)
+    assert result == model_id_value
+
+
+def attribute_missing_all_cubes(cubes: List[Cube]):
+    """Removes the attribute value on all cubes"""
+    [cube.attributes.pop("test_attribute") for cube in cubes]
+
+
+def attribute_missing_one_cube(cubes: List[Cube]):
+    """Removes the attribute value on the first cube"""
+    cubes[0].attributes.pop("test_attribute")
+
+
+def attribute_not_unique(cubes: List[Cube]):
+    """Changes the attribute value on the first cube"""
+    cubes[0].attributes["test_attribute"] = "kittens"
+
+
+@pytest.mark.parametrize(
+    "method, message",
+    (
+        (attribute_missing_all_cubes, "Model ID attribute test_attribute not present on "),
+        (attribute_missing_one_cube, "Model ID attribute test_attribute not present on "),
+        (attribute_not_unique, "Attribute test_attribute does not match on input cubes. "),
+    ),
+)
+def test_errors_get_model_id_attr(cubes: List[Cube], method: Callable, message):
+    """Checks that get_model_id_attr raises useful errors when all is not well."""
+    model_id_attr = "test_attribute"
+    model_id_value = "test_value"
+    for cube in cubes:
+        cube.attributes[model_id_attr] = model_id_value
+    method(cubes)
+    with pytest.raises(ValueError, match=message):
+        get_model_id_attr(cubes, model_id_attr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses #1770 

Adds a metadata utility method that checks that for all input cubes, the specified model ID attribute is present and has one unique value.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

