### PR TITLE
Rainforests: fix for deterministic usage

### DIFF
--- a/improver/calibration/rainforest_calibration.py
+++ b/improver/calibration/rainforest_calibration.py
@@ -44,6 +44,7 @@ import numpy as np
 import pandas as pd
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
+from iris.util import new_axis
 from numpy import ndarray
 from pandas import DataFrame
 
@@ -451,6 +452,8 @@ class ApplyRainForestsCalibrationLightGBM(ApplyRainForestsCalibration):
         error_percentiles_cube = ConvertProbabilitiesToPercentiles().process(
             error_probability_cube, percentiles=error_percentiles
         )
+        if len(error_percentiles_cube.coord_dims("realization")) == 0:
+            error_percentiles_cube = new_axis(error_percentiles_cube, "realization")
 
         return error_percentiles_cube
 


### PR DESCRIPTION
An error was encountered using `apply_rainforests_calibration` on deterministic models. The source of the error was that the realization dimension was dropped when converting `error_probability_cube` into `error_percentiles_cube` using `ConvertProbabilitiesToPercentiles`. This PR adds a small fix to ensure the realization dim coord is restored after being demoted in the convserion.

Tests are also added to test this case and use of the process function using deterministic inputs.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
