### PR TITLE
Fix treelite requirement for string paths

### DIFF
--- a/improver/calibration/rainforest_calibration.py
+++ b/improver/calibration/rainforest_calibration.py
@@ -210,7 +210,7 @@ class ApplyRainForestsCalibrationLightGBM(ApplyRainForestsCalibration):
             for threshold_dict in sorted_model_config_dict.values()
         ]
         self.tree_models = [
-            Booster(model_file=str(file)).reset_parameter({"num_threads": threads})
+            Booster(model_file=file).reset_parameter({"num_threads": threads})
             for file in lightgbm_model_filenames
         ]
 
@@ -772,7 +772,7 @@ class ApplyRainForestsCalibrationTreelite(ApplyRainForestsCalibrationLightGBM):
             for threshold_dict in sorted_model_config_dict.values()
         ]
         self.tree_models = [
-            Predictor(libpath=file, verbose=False, nthread=threads)
+            Predictor(libpath=str(file), verbose=False, nthread=threads)
             for file in treelite_model_filenames
         ]
 

--- a/improver/calibration/rainforest_calibration.py
+++ b/improver/calibration/rainforest_calibration.py
@@ -210,7 +210,7 @@ class ApplyRainForestsCalibrationLightGBM(ApplyRainForestsCalibration):
             for threshold_dict in sorted_model_config_dict.values()
         ]
         self.tree_models = [
-            Booster(model_file=file).reset_parameter({"num_threads": threads})
+            Booster(model_file=str(file)).reset_parameter({"num_threads": threads})
             for file in lightgbm_model_filenames
         ]
 

--- a/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py
+++ b/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py
@@ -29,8 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for the ApplyRainForestsCalibrationLightGBM class."""
-import pathlib
-
 import numpy as np
 import pytest
 from iris import Constraint

--- a/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py
+++ b/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py
@@ -92,8 +92,8 @@ def test__init__(
         assert model.threads == expected_threads
     # Ensure threshold and files match
     for threshold, model in zip(result.error_thresholds, result.tree_models):
-        # LightGBM library handles paths as strings or pathlib Paths
-        assert isinstance(model.model_file, (str, pathlib.Path))
+        # LightGBM library only introduced support for pathlib Paths in 3.3+
+        assert isinstance(model.model_file, str)
         assert f"{threshold:06.4f}" in str(model.model_file)
 
 

--- a/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py
+++ b/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py
@@ -29,6 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for the ApplyRainForestsCalibrationLightGBM class."""
+import pathlib
+
 import numpy as np
 import pytest
 from iris import Constraint
@@ -90,7 +92,9 @@ def test__init__(
         assert model.threads == expected_threads
     # Ensure threshold and files match
     for threshold, model in zip(result.error_thresholds, result.tree_models):
-        assert f"{threshold:06.4f}" in model.model_file
+        # LightGBM library handles paths as strings or pathlib Paths
+        assert isinstance(model.model_file, (str, pathlib.Path))
+        assert f"{threshold:06.4f}" in str(model.model_file)
 
 
 def test__check_num_features(ensemble_features, dummy_lightgbm_models):

--- a/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationTreelite.py
+++ b/improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationTreelite.py
@@ -90,6 +90,8 @@ def test__init__(
         assert model.threads == expected_threads
     # Ensure threshold and files match
     for threshold, model in zip(result.error_thresholds, result.tree_models):
+        # Treelite library requires paths to be passed as strings
+        assert isinstance(model.model_file, str)
         assert f"{threshold:06.4f}" in str(model.model_file)
 
 


### PR DESCRIPTION
A mixup in #1771 resulted in paths being passed to LightGBM as strings and to Treelite as pathlib Paths. However, ~~Treelite is the library~~ both libraries require string paths.

This PR fixes that issue and adds assertions to existing unit tests in order to make sure that this remains correct in the future.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)