### PR TITLE
Add extract function to facilitate agnostic cube input orders to CLIs

### DIFF
--- a/improver/cli/feels_like_temp.py
+++ b/improver/cli/feels_like_temp.py
@@ -36,14 +36,7 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(
-    temperature: cli.inputcube,
-    wind_speed: cli.inputcube,
-    relative_humidity: cli.inputcube,
-    pressure: cli.inputcube,
-    *,
-    model_id_attr: str = None,
-):
+def process(*cubes: cli.inputcube, model_id_attr: str = None):
     """Calculates the feels like temperature using the data in the input cube.
 
     Calculate the feels like temperature using a combination of the wind chill
@@ -60,17 +53,18 @@ def process(
     order to blend between the wind chill and the apparent temperature.
 
     Args:
-        temperature (iris.cube.Cube):
-            Cube of air temperatures at screen level
-        wind_speed (iris.cube.Cube):
-            Cube of wind speed at 10m
-        relative_humidity (iris.cube.Cube):
-            Cube of relative humidity at screen level
-        pressure (iris.cube.Cube):
-            Cube of surface pressure
+        cubes (iris.cube.CubeList or list of iris.cube.Cube):
+            containing, in any order:
+                temperature (iris.cube.Cube):
+                    Cube of air temperatures at screen level
+                wind_speed (iris.cube.Cube):
+                    Cube of wind speed at 10m
+                relative_humidity (iris.cube.Cube):
+                    Cube of relative humidity at screen level
+                pressure (iris.cube.Cube):
+                    Cube of surface pressure
         model_id_attr (str):
-            Name of the attribute used to identify the source model for
-            blending.
+            Name of the attribute used to identify the source model for blending.
 
     Returns:
         iris.cube.Cube:
@@ -78,7 +72,18 @@ def process(
             will be the same as the units of temperature cube when it is input
             into the function.
     """
+    from iris.cube import CubeList
+
     from improver.feels_like_temperature import calculate_feels_like_temperature
+
+    temperature, wind_speed, relative_humidity, pressure = CubeList(cubes).extract(
+        [
+            "air_temperature",
+            "wind_speed",
+            "relative_humidity",
+            "air_pressure_at_sea_level",
+        ]
+    )
 
     return calculate_feels_like_temperature(
         temperature,

--- a/improver/cli/resolve_wind_components.py
+++ b/improver/cli/resolve_wind_components.py
@@ -36,14 +36,16 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(wind_speed: cli.inputcube, wind_direction: cli.inputcube):
+def process(*cubes: cli.inputcube):
     """Converts speed and direction into individual velocity components.
 
     Args:
-        wind_speed (iris.cube.Cube):
-            A cube of wind speed.
-        wind_direction (iris.cube.Cube):
-            A cube of wind from direction.
+        cubes (iris.cube.CubeList or list of iris.cube.Cube):
+            containing, in any order:
+                wind_speed (iris.cube.Cube):
+                    A cube of wind speed.
+                wind_direction (iris.cube.Cube):
+                    A cube of wind from direction.
 
     Returns:
         iris.cube.Cubelist:
@@ -53,8 +55,9 @@ def process(wind_speed: cli.inputcube, wind_direction: cli.inputcube):
 
     from improver.wind_calculations.wind_components import ResolveWindComponents
 
-    if not (wind_speed and wind_direction):
-        raise TypeError("Neither wind_speed or wind_direction can be none")
+    wind_speed, wind_direction = CubeList(cubes).extract(
+        ["wind_speed", "wind_from_direction"]
+    )
 
     u_cube, v_cube = ResolveWindComponents()(wind_speed, wind_direction)
     return CubeList([u_cube, v_cube])

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -61,10 +61,7 @@ def process(*cubes: cli.inputcube):
     )
 
     snow, rain = CubeList(cubes).extract(
-        [
-            "probability_of_snow_at_surface",
-            "probability_of_rain_at_surface",
-        ]
+        ["probability_of_snow_at_surface", "probability_of_rain_at_surface"]
     )
 
     return calculate_sleet_probability(snow, rain)

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -36,26 +36,35 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(snow: cli.inputcube, rain: cli.inputcube):
+def process(*cubes: cli.inputcube):
     """Calculate sleet probability.
 
     Calculates the sleet probability using the
     calculate_sleet_probability plugin.
 
     Args:
-        snow (iris.cube.Cube):
-            An iris Cube of the probability of snow.
-        rain (iris.cube.Cube):
-            An iris Cube of the probability of rain.
+        cubes (iris.cube.CubeList or list of iris.cube.Cube):
+            containing, in any order:
+                 snow (iris.cube.Cube):
+                    An iris Cube of the probability of snow.
+                rain (iris.cube.Cube):
+                    An iris Cube of the probability of rain.
 
     Returns:
         iris.cube.Cube:
             Returns a cube with the probability of sleet.
     """
+    from iris.cube import CubeList
 
     from improver.precipitation_type.calculate_sleet_prob import (
         calculate_sleet_probability,
     )
 
-    result = calculate_sleet_probability(snow, rain)
-    return result
+    snow, rain = CubeList(cubes).extract(
+        [
+            "probability_of_snow_at_surface",
+            "probability_of_rain_at_surface",
+        ]
+    )
+
+    return calculate_sleet_probability(snow, rain)

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -54,6 +54,7 @@ def process(*cubes: cli.inputcube):
         iris.cube.Cube:
             Returns a cube with the probability of sleet.
     """
+
     from iris.cube import CubeList
 
     from improver.precipitation_type.calculate_sleet_prob import (

--- a/improver/cli/sleet_probability.py
+++ b/improver/cli/sleet_probability.py
@@ -45,7 +45,7 @@ def process(*cubes: cli.inputcube):
     Args:
         cubes (iris.cube.CubeList or list of iris.cube.Cube):
             containing, in any order:
-                 snow (iris.cube.Cube):
+                snow (iris.cube.Cube):
                     An iris Cube of the probability of snow.
                 rain (iris.cube.Cube):
                     An iris Cube of the probability of rain.

--- a/improver/cli/wind_gust_diagnostic.py
+++ b/improver/cli/wind_gust_diagnostic.py
@@ -37,9 +37,7 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(
-    wind_gust: cli.inputcube,
-    wind_speed: cli.inputcube,
-    *,
+    *cubes: cli.inputcube,
     wind_gust_percentile: float = 50.0,
     wind_speed_percentile: float = 95.0,
 ):
@@ -51,10 +49,12 @@ def process(
     specified percentile data.
 
     Args:
-        wind_gust (iris.cube.Cube):
-            Cube containing one or more percentiles of wind_gust data.
-        wind_speed (iris.cube.Cube):
-            Cube containing one or more percentiles of wind_speed data.
+        cubes (iris.cube.CubeList or list of iris.cube.Cube):
+            containing, in any order:
+                wind_gust (iris.cube.Cube):
+                    Cube containing one or more percentiles of wind_gust data.
+                wind_speed (iris.cube.Cube):
+                    Cube containing one or more percentiles of wind_speed data.
         wind_gust_percentile (float):
             Percentile value required from wind-gust cube.
         wind_speed_percentile (float):
@@ -64,9 +64,12 @@ def process(
         iris.cube.Cube:
             Cube containing the wind-gust diagnostic data.
     """
+    from iris.cube import CubeList
+
     from improver.wind_calculations.wind_gust_diagnostic import WindGustDiagnostic
 
-    result = WindGustDiagnostic(wind_gust_percentile, wind_speed_percentile)(
+    wind_gust, wind_speed = CubeList(cubes).extract(["wind_speed_of_gust", "wind_speed"])
+
+    return WindGustDiagnostic(wind_gust_percentile, wind_speed_percentile)(
         wind_gust, wind_speed
     )
-    return result

--- a/improver/cli/wind_gust_diagnostic.py
+++ b/improver/cli/wind_gust_diagnostic.py
@@ -68,7 +68,9 @@ def process(
 
     from improver.wind_calculations.wind_gust_diagnostic import WindGustDiagnostic
 
-    wind_gust, wind_speed = CubeList(cubes).extract(["wind_speed_of_gust", "wind_speed"])
+    wind_gust, wind_speed = CubeList(cubes).extract(
+        ["wind_speed_of_gust", "wind_speed"]
+    )
 
     return WindGustDiagnostic(wind_gust_percentile, wind_speed_percentile)(
         wind_gust, wind_speed

--- a/improver/feels_like_temperature.py
+++ b/improver/feels_like_temperature.py
@@ -43,6 +43,10 @@ from improver.metadata.utilities import (
 from improver.psychrometric_calculations.psychrometric_calculations import (
     calculate_svp_in_air,
 )
+from improver.utilities.cube_checker import (
+    assert_spatial_coords_match,
+    assert_time_coords_valid,
+)
 
 
 def _calculate_wind_chill(temperature: ndarray, wind_speed: ndarray) -> ndarray:
@@ -218,6 +222,13 @@ def calculate_feels_like_temperature(
         Cube of feels like temperatures in the same units as the input
         temperature cube.
     """
+
+    # Implement cube check functions
+    assert_spatial_coords_match([temperature, wind_speed, relative_humidity, pressure])
+    assert_time_coords_valid(
+        [temperature, wind_speed, relative_humidity, pressure], False
+    )
+
     t_cube = temperature.copy()
     t_cube.convert_units("degC")
     t_celsius = t_cube.data

--- a/improver/precipitation_type/calculate_sleet_prob.py
+++ b/improver/precipitation_type/calculate_sleet_prob.py
@@ -37,6 +37,10 @@ from improver.metadata.utilities import (
     create_new_diagnostic_cube,
     generate_mandatory_attributes,
 )
+from improver.utilities.cube_checker import (
+    assert_spatial_coords_match,
+    assert_time_coords_valid,
+)
 
 
 def calculate_sleet_probability(prob_of_snow: Cube, prob_of_rain: Cube) -> Cube:
@@ -60,6 +64,11 @@ def calculate_sleet_probability(prob_of_snow: Cube, prob_of_rain: Cube) -> Cube:
         ValueError: If the cube contains negative values for the the
                     probability of sleet.
     """
+
+    # Implement cube check functions
+    assert_spatial_coords_match([prob_of_snow, prob_of_rain])
+    assert_time_coords_valid([prob_of_snow, prob_of_rain], False)
+
     sleet_prob = 1 - (prob_of_snow.data + prob_of_rain.data)
     if np.any(sleet_prob < 0):
         msg = "Negative values of sleet probability have been calculated."

--- a/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/improver/wind_calculations/wind_gust_diagnostic.py
@@ -38,6 +38,10 @@ import numpy as np
 from iris.coords import Coord
 from iris.cube import Cube
 
+from improver.utilities.cube_checker import (
+    assert_spatial_coords_match,
+)
+
 from improver import PostProcessingPlugin
 from improver.metadata.probabilistic import find_percentile_coordinate
 
@@ -158,13 +162,16 @@ class WindGustDiagnostic(PostProcessingPlugin):
 
         Args:
             cube_gust:
-                Cube contain one or more percentiles of wind_gust data.
+                Cube containing one or more percentiles of wind_gust data.
             cube_ws:
-                Cube contain one or more percentiles of wind_speed data.
+                Cube containing one or more percentiles of wind_speed data.
 
         Returns:
             Cube containing the wind-gust diagnostic data.
         """
+
+        # Implement cube check functions
+        assert_spatial_coords_match([cube_gust, cube_ws])
 
         # Extract wind-gust data
         (req_cube_gust, perc_coord_gust) = self.extract_percentile_data(

--- a/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/improver/wind_calculations/wind_gust_diagnostic.py
@@ -38,12 +38,9 @@ import numpy as np
 from iris.coords import Coord
 from iris.cube import Cube
 
-from improver.utilities.cube_checker import (
-    assert_spatial_coords_match,
-)
-
 from improver import PostProcessingPlugin
 from improver.metadata.probabilistic import find_percentile_coordinate
+from improver.utilities.cube_checker import assert_spatial_coords_match
 
 
 class WindGustDiagnostic(PostProcessingPlugin):

--- a/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/improver/wind_calculations/wind_gust_diagnostic.py
@@ -41,6 +41,7 @@ from iris.cube import Cube
 from improver import PostProcessingPlugin
 from improver.metadata.probabilistic import find_percentile_coordinate
 
+
 class WindGustDiagnostic(PostProcessingPlugin):
 
     """Plugin for calculating wind-gust diagnostic.

--- a/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/improver/wind_calculations/wind_gust_diagnostic.py
@@ -41,7 +41,6 @@ from iris.cube import Cube
 from improver import PostProcessingPlugin
 from improver.metadata.probabilistic import find_percentile_coordinate
 
-
 class WindGustDiagnostic(PostProcessingPlugin):
 
     """Plugin for calculating wind-gust diagnostic.

--- a/improver_tests/wind_calculations/wind_components/test_ResolveWindComponents.py
+++ b/improver_tests/wind_calculations/wind_components/test_ResolveWindComponents.py
@@ -231,7 +231,7 @@ class Test_process(IrisTest):
         """Test an error is raised if coordinate values are different for wind
         speed and direction cubes"""
         self.wind_direction_cube.coord(axis="y").convert_units("km")
-        msg = "Wind speed and direction cubes have unmatched coordinates"
+        msg = "Mismatched spatial coords for wind_speed, wind_to_direction"
         with self.assertRaisesRegex(ValueError, msg):
             _, _ = self.plugin.process(self.wind_speed_cube, self.wind_direction_cube)
 
@@ -240,7 +240,7 @@ class Test_process(IrisTest):
         speed and direction cubes"""
         self.wind_speed_cube.coord(axis="x").rename("longitude")
         self.wind_speed_cube.coord(axis="y").rename("latitude")
-        msg = "Wind speed and direction cubes have unmatched coordinates"
+        msg = "Mismatched spatial coords for wind_speed, wind_to_direction"
         with self.assertRaisesRegex(ValueError, msg):
             _, _ = self.plugin.process(self.wind_speed_cube, self.wind_direction_cube)
 


### PR DESCRIPTION
This PR adds functionality to simple order specific CLI's to be able to pass input cubes agnostically.
It also adds input cube functions to the corresponding plugins where necessary.

This PR acts as a first step toward a bigger issue: #1770 and more PR's will be put up as plugins/CLI's are changed.

Addresses #GitHubissuenum

Description

Testing:
 - [X] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)

CLA
 - [ ] If a new developer, signed up to CLA
