### PR TITLE
Licensee match

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 BSD 3-Clause License
 
-British Crown copyright. The Met Office.
-All rights reserved.
+(c) British Crown copyright. The Met Office.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Addresses #1776

## Description
- Github uses licensee to identify licensee to identify which license is used indicate on the right hand panel for the repo.
- Updated our license as per https://choosealicense.com/licenses/bsd-3-clause/ so that it can be correctly identified.
- From experimentation, the substitute copyright symbol `(c)` is used to identify the copyright line (to exclude it) and so allow an exact match on the license.

## Testing
I ran licensee locally on my own machine using this updated license file and got a 100% match.

## CLA
N/A