### PR TITLE
MOBT-272: Reduce memory usages in freezing-rain calculation

### DIFF
--- a/improver/cli/freezing_rain.py
+++ b/improver/cli/freezing_rain.py
@@ -44,6 +44,10 @@ def process(*cubes: cli.inputcube, model_id_attr: str = None):
         (P(rain rate or accumulation >  threshold) +
          P(sleet rate or accumulation >  threshold)) * P(temperature < 0C)
 
+    If the input data is multi-realization, the realization coordinate is
+    collapsed as part of this calculation to yield an ensemble average
+    probability of freezing rain.
+
     Args:
         cubes (iris.cube.CubeList or list):
             Contains cubes of rain, sleet, and temperature probabilities. The

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -218,11 +218,11 @@ c2abfc4f83d4a918dd2d80f20b7746e5ae19d809d21df9715bd8ed5011d38ed2  ./extract/site
 f3516e5b36fa637151c4c7306e08d348fdc04aa24dec07e2bcd333248f4010cc  ./field-texture/basic/kgo.nc
 3379e6f19083154ebea42a32d9b48e0bae442243833aed23e45dea61b24d7739  ./fill-radar-holes/basic/201811271330_remasked_rainrate_composite.nc
 b25a397ac5ecac536f43c553f17b0bd6b5d2587d4eda8559bf5709e25f2c237b  ./fill-radar-holes/basic/kgo.nc
-3152c466221b6ed4fa696aa85436cbd09a8494ea10786e62e0eec7a7ae883173  ./freezing-rain/one_hour/kgo.nc
+744fd5c1fbd0fea2959e2bdbffebd6c82f96266ee723ed215cbe6c449f8d1899  ./freezing-rain/one_hour/kgo.nc
 0ddfec929063042e7dc47d0ef154f539a1d7418f74a724343ae42651e714d6b2  ./freezing-rain/one_hour/rain_acc.nc
 c7258e05788b7605524be7f0074c81a71ebd98683dc5b24e5bad0ac1703e74b9  ./freezing-rain/one_hour/sleet_acc.nc
 e8af9f50f7caa1d385daecbeeb7bc53a13cd4638b1f13ae9c0e173fd23ccb1f5  ./freezing-rain/one_hour/temperature_min.nc
-038852df5847c092aa32dfeb87092546c8fee3a9f8413019beef80157d770b3f  ./freezing-rain/three_hour/kgo.nc
+0c49dc02f3c22835e0f50bebedac9c8954a44e96270ec30d034ce58c3c81768f  ./freezing-rain/three_hour/kgo.nc
 ecd65249d525dec4662e6047363423646f59bad26aa3b13e068f1d94c028bcfe  ./freezing-rain/three_hour/rain_acc.nc
 e326b32d7382c9a2244feaae19025234bd080ec3252888adfe1c83d217703ab2  ./freezing-rain/three_hour/sleet_acc.nc
 335ce8b8cca70570f1f339f53f1337e9fa195027b6b4f3275ccc08ea1da028ea  ./freezing-rain/three_hour/temperature_min.nc

--- a/improver_tests/precipitation_type/freezing_rain/conftest.py
+++ b/improver_tests/precipitation_type/freezing_rain/conftest.py
@@ -144,6 +144,10 @@ def precipitation_multi_realization(period):
     rain, sleet = precipitation_cubes(period)
     rain = add_coordinate(rain, [0, 1], "realization", coord_units=1, dtype=np.int32)
     sleet = add_coordinate(sleet, [0, 1], "realization", coord_units=1, dtype=np.int32)
+    # Modify one realization to demonstrate that the implicit realization collapse
+    # within the plugin is giving the expected results; these are provided by the
+    # expected_probabilities_multi_realization fixture below.
+    rain.data[1, 1] = np.full_like(rain.data[1, 1], 0.6)
     return rain, sleet
 
 
@@ -162,7 +166,7 @@ def temperature_multi_realization(period):
     and period air temperature as an input."""
     temperature = temperature_cube(period)
     temperature = add_coordinate(
-        temperature, [1, 2, 3], "realization", coord_units=1, dtype=np.int32
+        temperature, [0, 1, 2], "realization", coord_units=1, dtype=np.int32
     )
     return temperature
 
@@ -181,6 +185,15 @@ def expected_probabilities():
     """Return the expected freezing rain probabilities."""
     return np.array(
         [[[0.0, 0.05], [0.14, 0.27]], [[0.0, 0.03], [0.1, 0.21]]], dtype=np.float32
+    )
+
+
+@pytest.fixture
+def expected_probabilities_multi_realization():
+    """Return the expected freezing rain probabilities when using multi-realization
+    data. The realization coordinate is collapsed in the calculation."""
+    return np.array(
+        [[[0.0, 0.05], [0.14, 0.27]], [[0.0, 0.055], [0.14, 0.255]]], dtype=np.float32
     )
 
 


### PR DESCRIPTION
Modifies calculation of freezing-rain such that realization collapse occurs within the plugin.

The realization collapse is now performed (assuming an equal weight for each realization) by summing the freezing rain probability from each realization slice weighted by 1/n_realizations. This removes the need to hold all of the realizations in memory at the same time to perform the averaging calculation. It also removes the need for a realization_collapse step in the suite.

Memory usage is reduced by a factor of ~8 and the need for a separate realization collapse step is removed.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
 - [x] There is demonstration of the memory improvements on the [associated ticket](https://github.com/metoppv/mo-blue-team/issues/272) and testing that results remain unchanged using real-data.
