### PR TITLE
MOBT-345: Remove expectation of forecast_period coordinate when blending

### DIFF
--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -174,6 +174,7 @@ def update_blended_metadata(
 def _set_blended_time_coords(blended_cube: Cube, cycletime: Optional[str]) -> None:
     """
     For cycle and model blending:
+
     - Add a "blend_time" coordinate equal to the current cycletime
     - Update the forecast reference time to reflect the current cycle time
       (behaviour is DEPRECATED)

--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -175,10 +175,12 @@ def _set_blended_time_coords(blended_cube: Cube, cycletime: Optional[str]) -> No
     """
     For cycle and model blending:
     - Add a "blend_time" coordinate equal to the current cycletime
-    - Update the forecast reference time and forecast period coordinate points
-    to reflect the current cycle time (behaviour is DEPRECATED)
+    - Update the forecast reference time to reflect the current cycle time
+      (behaviour is DEPRECATED)
+    - If a forecast period coordinate is present this will be updated relative
+      to the current cycle time (behaviour is DEPRECATED)
     - Remove any bounds from the forecast reference time (behaviour is DEPRECATED)
-    - Mark the forecast reference time and forecast period as DEPRECATED
+    - Mark any forecast reference time and forecast period coordinates as DEPRECATED
 
     Modifies cube in place.
 

--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -35,6 +35,7 @@ from typing import Dict, List, Optional
 
 import numpy as np
 from iris.cube import Cube, CubeList
+from iris.exceptions import CoordinateNotFoundError
 from numpy import int64
 
 from improver.blending import MODEL_BLEND_COORD, MODEL_NAME_COORD
@@ -196,12 +197,15 @@ def _set_blended_time_coords(blended_cube: Cube, cycletime: Optional[str]) -> No
     blended_cube.coord("forecast_reference_time").bounds = None
     if blended_cube.coords("forecast_period"):
         blended_cube.remove_coord("forecast_period")
-    new_forecast_period = forecast_period_coord(blended_cube)
-    time_dim = blended_cube.coord_dims("time")
-    blended_cube.add_aux_coord(new_forecast_period, data_dims=time_dim)
+        new_forecast_period = forecast_period_coord(blended_cube)
+        time_dim = blended_cube.coord_dims("time")
+        blended_cube.add_aux_coord(new_forecast_period, data_dims=time_dim)
     for coord in ["forecast_period", "forecast_reference_time"]:
         msg = f"{coord} will be removed in future and should not be used"
-        blended_cube.coord(coord).attributes.update({"deprecation_message": msg})
+        try:
+            blended_cube.coord(coord).attributes.update({"deprecation_message": msg})
+        except CoordinateNotFoundError:
+            pass
 
 
 def _get_cycletime_point(cube: Cube, cycletime: str) -> int64:

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -169,7 +169,10 @@ class MergeCubesForWeightedBlending(BasePlugin):
         """Remove deprecation warnings from forecast period and forecast reference
         time coordinates so that these can be merged before blending"""
         for coord in ["forecast_period", "forecast_reference_time"]:
-            cube.coord(coord).attributes.pop("deprecation_message", None)
+            try:
+                cube.coord(coord).attributes.pop("deprecation_message", None)
+            except CoordinateNotFoundError:
+                pass
         return cube
 
     def process(
@@ -472,7 +475,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
             ValueError : If blending over forecast reference time on a cube
                          with multiple times.
         """
-        if self.timeblending:
+        if self.timeblending or cube.coord("time").ndim > 1:
             return
 
         time_points = cube.coord("time").points

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -466,6 +466,16 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         timeblending flag should be true and this function will not raise an
         exception.
 
+        In cases where local-time-zone products are being blended, the time
+        coordinate will be two dimensional. Each point in the two dimensional
+        coordinate must match in order that the cubes to be blended can be
+        combined into a single cube. As such an Iris error will have been
+        raised earlier in the processing if this is not the case. Here we
+        ensure that the "time_in_local_timezone" coordinate matches between
+        cubes. This describes the time the diagnostic is valid in local time
+        which should match between input cubes or else they are describing
+        fundamentally different things.
+
         Args:
             cube:
                 The cube upon which the compatibility of the time coords is

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -475,10 +475,14 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
             ValueError : If blending over forecast reference time on a cube
                          with multiple times.
         """
-        if self.timeblending or cube.coord("time").ndim > 1:
+        if self.timeblending:
             return
 
-        time_points = cube.coord("time").points
+        try:
+            time_points = cube.coord("time_in_local_timezone").points
+        except CoordinateNotFoundError:
+            time_points = cube.coord("time").points
+
         if len(set(time_points)) > 1:
             msg = (
                 "Attempting to blend data for different validity times. The"

--- a/improver_tests/blending/weighted_blend/test_MergeCubesForWeightedBlending.py
+++ b/improver_tests/blending/weighted_blend/test_MergeCubesForWeightedBlending.py
@@ -441,6 +441,23 @@ class Test_process(IrisTest):
         for coord in ["forecast_period", "forecast_reference_time"]:
             self.assertNotIn("deprecation_message", result.coord(coord).attributes)
 
+    def test_forecast_coord_deprecation_missing_coords(self):
+        """Test removing deprecation warning raises no error if the coordinate
+        on which it is expected is missing."""
+        for cube in [self.cube_ukv, self.cube_enuk]:
+            cube.remove_coord("forecast_period")
+            cube.coord("forecast_reference_time").attributes.update(
+                {"deprecation_message": "blah"}
+            )
+
+        plugin = MergeCubesForWeightedBlending(
+            "model_id", model_id_attr="mosg__model_configuration"
+        )
+        result = plugin([self.cube_ukv, self.cube_enuk])
+        self.assertNotIn(
+            "deprecation_message", result.coord("forecast_reference_time").attributes
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -260,11 +260,14 @@ class Test_check_compatible_time_points(Test_weighted_blend):
         plugin = WeightedBlendAcrossWholeDimension(self.coord, timeblending=True)
         plugin.check_compatible_time_points(self.cube)
 
-    def test_multi_dimensional_time_exemption(self):
-        """Test that no ValueError is raised if the time coordinate is multi-
-        dimensional. A cube with a multi-dimensional time coordinate must have
-        already checked that the times match at each point to be blended into a
-        single cube by iris."""
+    def test_local_timezone_coordinate(self):
+        """Test that if a time_in_local_timezone coordinate is present the
+        check is conducted using it instead of the time coordinate. In these
+        cases the time coordinate itself will be two dimensional and will have been
+        implicitly checked when the cubes for blending were combined into a single
+        cube. Cubes with multi-dimensional time coordinates can only be merged into
+        a single cube by iris if the time coordinate on each input cube is
+        identical."""
         yxshape = next(self.cube.slices(["latitude", "longitude"])).shape
         yxdims = [*self.cube.coord_dims("latitude"), *self.cube.coord_dims("longitude")]
 
@@ -273,9 +276,10 @@ class Test_check_compatible_time_points(Test_weighted_blend):
         new_time_coord = iris.coords.AuxCoord(time_points, "time")
 
         self.cube.remove_coord("time")
+        time_coord.rename("time_in_local_timezone")
         self.cube.add_aux_coord(new_time_coord, data_dims=yxdims)
-        print(self.cube)
-        plugin = WeightedBlendAcrossWholeDimension(self.coord, timeblending=True)
+        self.cube.add_aux_coord(time_coord)
+        plugin = WeightedBlendAcrossWholeDimension(self.coord)
         plugin.check_compatible_time_points(self.cube)
 
 

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -260,6 +260,24 @@ class Test_check_compatible_time_points(Test_weighted_blend):
         plugin = WeightedBlendAcrossWholeDimension(self.coord, timeblending=True)
         plugin.check_compatible_time_points(self.cube)
 
+    def test_multi_dimensional_time_exemption(self):
+        """Test that no ValueError is raised if the time coordinate is multi-
+        dimensional. A cube with a multi-dimensional time coordinate must have
+        already checked that the times match at each point to be blended into a
+        single cube by iris."""
+        yxshape = next(self.cube.slices(["latitude", "longitude"])).shape
+        yxdims = [*self.cube.coord_dims("latitude"), *self.cube.coord_dims("longitude")]
+
+        time_coord = self.cube.coord("time")
+        time_points = np.full(yxshape, time_coord.points[0])
+        new_time_coord = iris.coords.AuxCoord(time_points, "time")
+
+        self.cube.remove_coord("time")
+        self.cube.add_aux_coord(new_time_coord, data_dims=yxdims)
+        print(self.cube)
+        plugin = WeightedBlendAcrossWholeDimension(self.coord, timeblending=True)
+        plugin.check_compatible_time_points(self.cube)
+
 
 class Test_shape_weights(Test_weighted_blend):
 


### PR DESCRIPTION
The weighted blending plugins at the moment presume a `forecast_period` coordinate exists, even when it is not being used for blending. This presumption is not necessary, it largely relates to appending comments (stating that `forecast_period` is deprecated!) and recalculating the value of the forecast period. This change ensures that if the `forecast_period` is not present on the input, and is not being used in the blending, it is not required.

The motivation for this change is the blending of local-timezone products on the UK domain for which there is no `forecast_period` as it has no meaning for the data contained within the cube which is an amalgam of data from different forecast periods.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)