### PR TITLE
Add function and test for flattening an arbitrarily nested iterable

### DIFF
--- a/improver/utilities/flatten.py
+++ b/improver/utilities/flatten.py
@@ -31,21 +31,23 @@
 """ Provides support utilities for flattening."""
 
 from collections.abc import Iterable
-from typing import Iterator
+from typing import List
 
 
-def flatten(an_iterable: Iterable) -> Iterator:
+def flatten(an_iterable: Iterable) -> List:
     """Flatten an arbitrarily nested iterable.
 
     Args:
         an_iterable:
             An arbitrarily nested iterable to be flattened.
 
-    Yields:
-        An iterator to generate a flattened version of the arbitrarily nested input.
+    Returns:
+        A list containing a flattened version of the arbitrarily nested input.
     """
+    alist = []
     for item in an_iterable:
         if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
-            yield from flatten(item)
+            alist.extend(flatten(item))
         else:
-            yield item
+            alist.append(item)
+    return alist

--- a/improver/utilities/flatten.py
+++ b/improver/utilities/flatten.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+""" Provides support utilities for flattening."""
+
+from collections.abc import Iterable
+from typing import Iterator
+
+
+def flatten(an_iterable: Iterable) -> Iterator:
+    """Flatten an arbitrarily nested iterable.
+
+    Args:
+        an_iterable:
+            An arbitrarily nested iterable to be flattened.
+
+    Yields:
+        An iterator to generate a flattened version of the arbitrarily nested input.
+    """
+    for item in an_iterable:
+        if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+            yield from flatten(item)
+        else:
+            yield item

--- a/improver/utilities/flatten.py
+++ b/improver/utilities/flatten.py
@@ -30,24 +30,27 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """ Provides support utilities for flattening."""
 
-from collections.abc import Iterable
-from typing import List
+from typing import List, Tuple, Union
 
 
-def flatten(an_iterable: Iterable) -> List:
+def flatten(nested_list: Union[List, Tuple]) -> List:
     """Flatten an arbitrarily nested iterable.
 
     Args:
-        an_iterable:
+        nested_list:
             An arbitrarily nested iterable to be flattened.
 
     Returns:
         A list containing a flattened version of the arbitrarily nested input.
     """
-    alist = []
-    for item in an_iterable:
-        if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
-            alist.extend(flatten(item))
+    flat_list = []
+    if not isinstance(nested_list, (list, tuple)):
+        raise ValueError(
+            f"Expected object of type list or tuple, not {type(nested_list)}"
+        )
+    for item in nested_list:
+        if isinstance(item, (list, tuple)):
+            flat_list.extend(flatten(item))
         else:
-            alist.append(item)
-    return alist
+            flat_list.append(item)
+    return flat_list

--- a/improver_tests/utilities/test_flatten.py
+++ b/improver_tests/utilities/test_flatten.py
@@ -32,7 +32,7 @@
 
 import numpy as np
 import pytest
-from iris.cube import Cube
+from iris.cube import Cube, CubeList
 
 from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
 from improver.utilities.flatten import flatten
@@ -56,12 +56,11 @@ def cube() -> Cube:
             [np.array([0]), np.array([1]), np.array([2]), np.array([2])],
         ),
         ([cube, cube, [cube, cube]], [cube, cube, cube, cube]),
+        (CubeList([cube, cube, CubeList([cube, cube])]), [cube, cube, cube, cube]),
         ([0, [1, [2, [3]]]], [0, 1, 2, 3]),
         ([0, [1, 2], [3]], [0, 1, 2, 3]),
-        ("cat", ["c", "a", "t"]),
         (["cat"], ["cat"]),
         ((0, 1, (2, 3)), [0, 1, 2, 3]),
-        ({0: {1: "cat"}, 1: {2: "dog"}}, [0, 1]),
     ),
 )
 def test_basic(nested, expected):
@@ -69,3 +68,14 @@ def test_basic(nested, expected):
     result = flatten(nested)
     assert result == expected
     assert isinstance(result, list)
+
+
+@pytest.mark.parametrize(
+    "nested", ((0), ("cat"), ({0: {1: "cat"}, 1: {2: "dog"}}),),
+)
+def test_exception(nested):
+    """Test an exception is raised if inappropriate types
+    are provided for flattening."""
+    msg = "Expected object of type list or tuple"
+    with pytest.raises(ValueError, match=msg):
+        flatten(nested)

--- a/improver_tests/utilities/test_flatten.py
+++ b/improver_tests/utilities/test_flatten.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for flattening an arbitrarily nested iterable."""
+
+import numpy as np
+import pytest
+from iris.cube import Cube
+
+from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
+from improver.utilities.flatten import flatten
+
+
+@pytest.fixture
+def cube() -> Cube:
+    """Sets up a cube for testing"""
+    return set_up_variable_cube(np.zeros((2, 2), dtype=np.float32),)
+
+
+@pytest.mark.parametrize(
+    "nested,expected",
+    (
+        ([0, 1, 2], [0, 1, 2]),
+        ([0, 1, [2, 3]], [0, 1, 2, 3]),
+        (["a", "b", "c"], ["a", "b", "c"]),
+        (["a", "b", ["c", "d"]], ["a", "b", "c", "d"]),
+        (
+            [np.array([0]), np.array([1]), [np.array([2]), np.array([2])]],
+            [np.array([0]), np.array([1]), np.array([2]), np.array([2])],
+        ),
+        ([cube, cube, [cube, cube]], [cube, cube, cube, cube]),
+        ([0, [1, [2, [3]]]], [0, 1, 2, 3]),
+        ([0, [1, 2], [3]], [0, 1, 2, 3]),
+        ("cat", ["c", "a", "t"]),
+        (["cat"], ["cat"]),
+        ((0, 1, (2, 3)), [0, 1, 2, 3]),
+        ({0: {1: "cat"}, 1: {2: "dog"}}, [0, 1]),
+    ),
+)
+def test_basic(nested, expected):
+    """Test flattening an arbitrarily nested iterable."""
+    result = list(flatten(nested))
+    assert result == expected

--- a/improver_tests/utilities/test_flatten.py
+++ b/improver_tests/utilities/test_flatten.py
@@ -66,5 +66,6 @@ def cube() -> Cube:
 )
 def test_basic(nested, expected):
     """Test flattening an arbitrarily nested iterable."""
-    result = list(flatten(nested))
+    result = flatten(nested)
     assert result == expected
+    assert isinstance(result, list)


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/354

Description
This PR adds a function with tests for flattening an arbitrarily nested list. This is intended to help when the argument to a CLI is provided as a list, which is a mixture of individual cubes and cubelists, such as in #1792. The `flatten` function in this PR would help with flattening this nested list.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)