### PR TITLE
Fix flake8 long lines E501 error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       id: cache
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 2
+        CACHE_NUMBER: 3
       with:
         path: /usr/share/miniconda/envs/im${{ matrix.env }}
         key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
@@ -76,7 +76,7 @@ jobs:
       id: cache
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 2
+        CACHE_NUMBER: 3
       with:
         path: /usr/share/miniconda/envs/im${{ matrix.env }}
         key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
@@ -130,7 +130,7 @@ jobs:
       id: cache
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 2
+        CACHE_NUMBER: 3
       with:
         path: /usr/share/miniconda/envs/im${{ matrix.env }}
         key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -97,8 +97,8 @@ class Test_construct_yx_coords(IrisTest):
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
 
     def test_lat_lon_domain_corner(self):
-        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
-        not provided"""
+        """Test grid points generated with default grid spacing if domain corner
+        provided and grid spacing not provided"""
         y_coord, x_coord = construct_yx_coords(3, 3, "latlon", domain_corner=(0, 0))
         self.assertArrayEqual(x_coord.points, [0.0, 10.0, 20.0])
         self.assertArrayEqual(y_coord.points, [0.0, 10.0, 20.0])
@@ -116,8 +116,8 @@ class Test_construct_yx_coords(IrisTest):
         self.assertEqual(len(x_coord.points), 3)
 
     def test_equal_area_grid_spacing(self):
-        """Test projection_y_coordinate and projection_x_coordinate point values created around 0,0 with
-        provided grid spacing"""
+        """Test projection_y_coordinate and projection_x_coordinate point
+        values created around 0,0 with provided grid spacing"""
         y_coord, x_coord = construct_yx_coords(3, 3, "equalarea", grid_spacing=1)
         self.assertArrayEqual(x_coord.points, [-1.0, 0.0, 1.0])
         self.assertArrayEqual(y_coord.points, [-1.0, 0.0, 1.0])
@@ -127,8 +127,8 @@ class Test_construct_yx_coords(IrisTest):
         self.assertArrayEqual(y_coord.points, [-1.5, -0.5, 0.5, 1.5])
 
     def test_equal_area_grid_spacing_domain_corner(self):
-        """Test projection_y_coordinate and projection_x_coordinate point values start at domain corner
-        with provided grid spacing"""
+        """Test projection_y_coordinate and projection_x_coordinate point values
+        start at domain corner with provided grid spacing"""
         y_coord, x_coord = construct_yx_coords(
             3, 3, "equalarea", grid_spacing=2, domain_corner=(15, 12)
         )
@@ -136,8 +136,8 @@ class Test_construct_yx_coords(IrisTest):
         self.assertArrayEqual(y_coord.points, [15.0, 17.0, 19.0])
 
     def test_equal_area_domain_corner(self):
-        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
-        not provided"""
+        """Test grid points generated with default grid spacing if domain
+        corner provided and grid spacing not provided"""
         y_coord, x_coord = construct_yx_coords(3, 3, "equalarea", domain_corner=(0, 0))
         self.assertArrayEqual(x_coord.points, [0.0, 2000.0, 4000.0])
         self.assertArrayEqual(y_coord.points, [0.0, 2000.0, 4000.0])
@@ -568,8 +568,8 @@ class Test_set_up_variable_cube(IrisTest):
         )
 
     def test_latlon_domain_corner(self):
-        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
-        not provided"""
+        """Test grid points generated with default grid spacing if domain
+        corner provided and grid spacing not provided"""
         domain_corner = (-17, -10)
         result = set_up_variable_cube(
             self.data, spatial_grid="latlon", domain_corner=domain_corner
@@ -580,8 +580,8 @@ class Test_set_up_variable_cube(IrisTest):
         )
 
     def test_equalarea_domain_corner(self):
-        """Test grid points generated with default grid spacing if domain corner provided and grid spacing
-        not provided"""
+        """Test grid points generated with default grid spacing if domain
+        corner provided and grid spacing not provided"""
         domain_corner = (1100, 300)
         result = set_up_variable_cube(
             self.data, spatial_grid="equalarea", domain_corner=domain_corner


### PR DESCRIPTION
Fix long lines causing warnings in flake8 version 5.

Flake8 version 5.0.0 was released a few weeks ago and includes changes which check line length inside triple-quoted strings (usually docstrings). See "Fix physical line plugins not receiving all lines in the case of triple-quoted strings" in the [release notes](https://flake8.pycqa.org/en/latest/release-notes/5.0.0.html).
This didn't cause any errors on metoppv/improver due to the actions cache, but I encountered it on my personal fork - see [logs of failing job](https://github.com/tjtg/improver/actions/runs/3081134398/jobs/4979327949#step:8:7).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
