### PR TITLE
MOBT-350: Increasing ECC upper bound for precipitation rate in line with thresholds

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -72,14 +72,14 @@ BOUNDS_FOR_ECDF = {
     # Forecast error: precipitation_amount
     "forecast_error_of_lwe_thickness_of_precipitation_amount": Bounds((-0.3, 0.3), "m"),
     # Precipitation rate
-    "lwe_precipitation_rate": Bounds((0, 128.0), "mm h-1"),
-    "lwe_precipitation_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
-    "lwe_precipitation_rate_max": Bounds((0, 128.0), "mm h-1"),
-    "lwe_sleetfall_rate": Bounds((0, 128.0), "mm h-1"),
-    "lwe_snowfall_rate": Bounds((0, 128.0), "mm h-1"),
-    "lwe_snowfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
-    "rainfall_rate": Bounds((0, 128.0), "mm h-1"),
-    "rainfall_rate_in_vicinity": Bounds((0, 128.0), "mm h-1"),
+    "lwe_precipitation_rate": Bounds((0, 400.0), "mm h-1"),
+    "lwe_precipitation_rate_in_vicinity": Bounds((0, 400.0), "mm h-1"),
+    "lwe_precipitation_rate_max": Bounds((0, 400.0), "mm h-1"),
+    "lwe_sleetfall_rate": Bounds((0, 400.0), "mm h-1"),
+    "lwe_snowfall_rate": Bounds((0, 400.0), "mm h-1"),
+    "lwe_snowfall_rate_in_vicinity": Bounds((0, 400.0), "mm h-1"),
+    "rainfall_rate": Bounds((0, 400.0), "mm h-1"),
+    "rainfall_rate_in_vicinity": Bounds((0, 400.0), "mm h-1"),
     # Temperature
     "air_temperature": (Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")),
     "feels_like_temperature": (


### PR DESCRIPTION
This PR is associated with [MOBT-350](https://github.com/metoppv/mo-blue-team/issues/350) which increases the thresholds in temperature, precipitation rate and visibility diagnostics.

### Description

One aspect of MOBT-350 is increasing the precipitation rate threshold upper bound from 128mm to 400mm in order to better capture global precipitation rate events. This PR increases the ECC bounds in line with the these changes.   
The related suite PR testing this change is found here: [Suite-1404](https://github.com/MetOffice/improver_suite/pull/1404)

Testing:
 - [X] Ran tests and they passed OK