### PR TITLE
Updates nbhood docstrings

### DIFF
--- a/improver/cli/nbhood.py
+++ b/improver/cli/nbhood.py
@@ -58,7 +58,7 @@ def process(
 
     Args:
         cube (iris.cube.Cube):
-            The Cube to be processed.
+            The Cube to be processed, usually a thresholded data set.
         mask (iris.cube.Cube):
             A cube to mask the input cube. The data should contain 1 for
             usable points and 0 for discarded points.
@@ -69,7 +69,7 @@ def process(
             neighbourhood is calculated. If "percentiles" is selected, then
             the percentiles are calculated with a neighbourhood. Calculating
             percentiles from a neighbourhood is only supported for a circular
-            neighbourhood.
+            neighbourhood, and the input cube should be ensemble realizations.
             Options: "probabilities", "percentiles".
         neighbourhood_shape (str):
             Name of the neighbourhood method to use. Only a "circular"

--- a/improver/cli/nbhood.py
+++ b/improver/cli/nbhood.py
@@ -70,6 +70,8 @@ def process(
             the percentiles are calculated with a neighbourhood. Calculating
             percentiles from a neighbourhood is only supported for a circular
             neighbourhood, and the input cube should be ensemble realizations.
+            The calculation of percentiles from a neighbourhood is notably slower
+            than neighbourhood processing using a thresholded probability field.
             Options: "probabilities", "percentiles".
         neighbourhood_shape (str):
             Name of the neighbourhood method to use. Only a "circular"

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -174,7 +174,7 @@ class BaseNeighbourhoodProcessing(PostProcessingPlugin):
         Supply a cube with a forecast period coordinate in order to set the
         correct radius for use in neighbourhood processing.
 
-        Also checkes there are no unmasked NaNs in the input cube.
+        Also checks there are no unmasked NaNs in the input cube.
 
         Args:
             cube:
@@ -352,14 +352,14 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         point. The neighbourhood mean is then calculated by dividing the
         neighbourhood sum at each grid point by the total number of valid grid
         points that contributed to that sum. If a mask_cube is provided then
-        this is used to mask each x-y-slice prior to the neighburhood sum
+        this is used to mask each x-y-slice prior to the neighbourhood sum
         or mean being calculated.
 
 
         Args:
             cube:
                 Cube containing the array to which the neighbourhood processing
-                will be applied.
+                will be applied. Usually thresholded data.
             mask_cube:
                 Cube containing the array to be used as a mask. Zero values in
                 this array are taken as points to be masked.
@@ -574,7 +574,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
 
         Args:
             cube:
-                Cube containing array to apply processing to.
+                Cube containing array to apply processing to. Usually ensemble realizations.
 
         Returns:
             Cube containing the percentile fields.


### PR DESCRIPTION
Updates nbhood docstrings to specify the different inputs expected for probability and percentile processing.

Addresses #1813

Clarifies the intended input data for probability nbhood and percentile nbhood.

Doc-strings only - no testing needed.
