### PR TITLE
Add additional checks when rebadging percentiles as realizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-        name: Check CONTRIBUTING.md
-
+      - name: Check CONTRIBUTING.md
         uses: cylc/release-actions/check-shortlog@v1
   Safety-Bandit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
   push:
   workflow_dispatch:
+
+inputs:
+  contributing_file:
+    description: Path to contributing file.
+    default: CONTRIBUTING.md
+    required: false
+
 jobs:
   Sphinx-Pytest-Coverage:
     runs-on: ubuntu-latest
@@ -116,8 +123,40 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 
-      - name: Check CONTRIBUTING.md
-        uses: cylc/release-actions/check-shortlog@v1
+      - name: Get known contributors from contributing file
+        shell: bash
+        run: |
+          sed \
+              -n \
+              -e 's/ - //' \
+              -e 's/ (.*)//' \
+              -e 's/^(//' -e 's/)$//' \
+              -e '/start-shortlog/,${p;/end-shortlog/q}' \
+              "${{ inputs.contributing_file }}" \
+              | head -n -1 \
+              | tail -n +2 \
+              | sort \
+              > contributors
+          cat contributors
+      - name: List commit authors
+        shell: bash
+        run: |
+          git shortlog -s "${{ github.sha }}" \
+              | awk '{$1=""; print substr($0,2) }' \
+              | sort \
+              | grep -v '\[bot\]' \
+              > shortlog
+          git shortlog -se
+      - name: See if they differ
+        shell: bash
+        run: |
+          echo "[command]diff"
+          diff -u shortlog contributors \
+            || (echo '::error::${{ inputs.contributing_file }} or .mailmap needs updating.' \
+            && echo '::warning::If you have not added yourself to this file please do so.' \
+            && echo '::warning::If you need to register a second email address add an entry to the .mailmap file (https://git-scm.com/docs/gitmailmap).' \
+            && echo '::warning::If you want to change the appearence of your name add/edit the entry in the .mailmap file.' \
+            && false)
   Safety-Bandit:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 0 
       - name: Check CONTRIBUTING.md
         uses: cylc/release-actions/check-shortlog@v1
   Safety-Bandit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,6 @@ on:
   pull_request:
   push:
   workflow_dispatch:
-
-inputs:
-  contributing_file:
-    description: Path to contributing file.
-    default: CONTRIBUTING.md
-    required: false
-
 jobs:
   Sphinx-Pytest-Coverage:
     runs-on: ubuntu-latest
@@ -122,41 +115,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0 
-      - name: Get known contributors from contributing file
-        shell: bash
-        run: |
-          sed \
-              -n \
-              -e 's/ - //' \
-              -e 's/ (.*)//' \
-              -e 's/^(//' -e 's/)$//' \
-              -e '/start-shortlog/,${p;/end-shortlog/q}' \
-              "${{ inputs.contributing_file }}" \
-              | head -n -1 \
-              | tail -n +2 \
-              | sort \
-              > contributors
-          cat contributors
-      - name: List commit authors
-        shell: bash
-        run: |
-          git shortlog -s "${{ github.sha }}" \
-              | awk '{$1=""; print substr($0,2) }' \
-              | sort \
-              | grep -v '\[bot\]' \
-              > shortlog
-          git shortlog -se
-      - name: See if they differ
-        shell: bash
-        run: |
-          echo "[command]diff"
-          diff -u shortlog contributors \
-            || (echo '::error::${{ inputs.contributing_file }} or .mailmap needs updating.' \
-            && echo '::warning::If you have not added yourself to this file please do so.' \
-            && echo '::warning::If you need to register a second email address add an entry to the .mailmap file (https://git-scm.com/docs/gitmailmap).' \
-            && echo '::warning::If you want to change the appearence of your name add/edit the entry in the .mailmap file.' \
-            && false)
+          fetch-depth: 0
+        name: Check CONTRIBUTING.md
+
+        uses: cylc/release-actions/check-shortlog@v1
   Safety-Bandit:
     runs-on: ubuntu-latest
     strategy:

--- a/.mailmap
+++ b/.mailmap
@@ -5,6 +5,7 @@ Belinda Trotta <73675905+btrotta-bom@users.noreply.github.com> <73675905+btrotta
 Benjamin Ayliffe <benjamin.ayliffe@metoffice.gov.uk> <benjamin.ayliffe@metoffice.gov.uk>
 Benjamin Owen <benjamin.owen@bom.gov.au> <71359048+benowen-bom@users.noreply.github.com>
 Ben Fitzpatrick <ben.fitzpatrick@metoffice.gov.uk> <ben@seven.powderham>
+Ben Hooper <ben.r.hooper@metoffice.gov.uk> <ben.r.hooper@metoffice.gov.uk>
 Bruno P. Kinoshita <kinow@users.noreply.github.com> <kinow@users.noreply.github.com>
 Caroline Jones <caroline.jones@metoffice.gov.uk> <caroline.jones@metoffice.gov.uk>
 Caroline Sandford <caroline.sandford@metoffice.gov.uk> <csand@localhost.localdomain>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ below:
  - Zhiliang Fan (Bureau of Meteorology, Australia)
  - Ben Fitzpatrick (Met Office, UK)
  - Tom Gale (Bureau of Meteorology, Australia)
+ - Ben Hooper (Met Office, UK)
  - Aaron Hopkinson (Met Office, UK)
  - Kathryn Howard (Met Office, UK)
  - Tim Hume (Bureau of Meteorology, Australia)

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -111,6 +111,24 @@ class RebadgePercentilesAsRealizations(BasePlugin):
         """
         percentile_coord_name = find_percentile_coordinate(cube).name()
 
+        # create array of percentiles from cube metadata, add in fake
+        # 0th and 100th percentiles if not already included
+        percentile_coords = np.sort(
+            np.unique(np.append(cube.coord(percentile_coord_name).points, [0, 100]))
+        )
+        percentile_diffs = np.diff(percentile_coords)
+
+        # we can't rebadge as percentiles unless the percentiles
+        # are evenly spaced and centred on 50
+        if not np.isclose(np.max(percentile_diffs), np.min(percentile_diffs)):
+            msg = (
+                "The percentile cube provided cannot be rebadged as ensemble realizations. "
+                "The input percentiles need to be equally spaced, centred on the 50th percentile, "
+                "and to equally partition percentile space. The percentiles provided were "
+                f"{cube.coord(percentile_coord_name).points}"
+            )
+            raise ValueError(msg)
+
         if ensemble_realization_numbers is None:
             ensemble_realization_numbers = np.arange(
                 len(cube.coord(percentile_coord_name).points), dtype=np.int32

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -122,9 +122,10 @@ class RebadgePercentilesAsRealizations(BasePlugin):
         # are evenly spaced and centred on 50
         if not np.isclose(np.max(percentile_diffs), np.min(percentile_diffs)):
             msg = (
-                "The percentile cube provided cannot be rebadged as ensemble realizations. "
-                "The input percentiles need to be equally spaced, centred on the 50th percentile, "
-                "and to equally partition percentile space. The percentiles provided were "
+                "The percentile cube provided cannot be rebadged as ensemble "
+                "realizations. The input percentiles need to be equally spaced, "
+                "centred on the 50th percentile, and to equally partition percentile "
+                "space. The percentiles provided were "
                 f"{cube.coord(percentile_coord_name).points}"
             )
             raise ValueError(msg)

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -118,13 +118,14 @@ class RebadgePercentilesAsRealizations(BasePlugin):
         )
         percentile_diffs = np.diff(percentile_coords)
 
-        # we can't rebadge as percentiles unless the percentiles
-        # are evenly spaced and centred on 50
+        # percentiles cannot be rabadged unless they are evenly spaced,
+        # centred on 50th percentile, and equally partition percentile
+        # space
         if not np.isclose(np.max(percentile_diffs), np.min(percentile_diffs)):
             msg = (
                 "The percentile cube provided cannot be rebadged as ensemble "
                 "realizations. The input percentiles need to be equally spaced, "
-                "centred on the 50th percentile, and to equally partition percentile "
+                "be centred on the 50th percentile, and to equally partition percentile "
                 "space. The percentiles provided were "
                 f"{cube.coord(percentile_coord_name).points}"
             )

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -118,7 +118,7 @@ class RebadgePercentilesAsRealizations(BasePlugin):
         )
         percentile_diffs = np.diff(percentile_coords)
 
-        # percentiles cannot be rabadged unless they are evenly spaced,
+        # percentiles cannot be rebadged unless they are evenly spaced,
         # centred on 50th percentile, and equally partition percentile
         # space
         if not np.isclose(np.max(percentile_diffs), np.min(percentile_diffs)):

--- a/improver_tests/ensemble_copula_coupling/test_EnsembleReordering.py
+++ b/improver_tests/ensemble_copula_coupling/test_EnsembleReordering.py
@@ -395,7 +395,7 @@ class Test__check_input_cube_masks(IrisTest):
         )
         self.post_processed_percentiles = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
-            np.array([10, 50, 90], dtype=np.float32),
+            np.array([25, 50, 75], dtype=np.float32),
         )
 
     def test_unmasked_data(self):
@@ -495,7 +495,7 @@ class Test_process(IrisTest):
         )
         self.post_processed_percentiles = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
-            np.array([10, 50, 90], dtype=np.float32),
+            np.array([25, 50, 75], dtype=np.float32),
         )
 
     @ManageWarnings(ignored_messages=["Only a single cube so no differences"])

--- a/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -96,35 +96,35 @@ class Test_process(IrisTest):
     def test_raises_exception_if_percentiles_unevenly_spaced(self):
         """Check that we raise an exception if the input percentiles are not
         evenly spaced."""
-        self.cube = set_up_percentile_cube(
+        cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([25, 50, 90], dtype=np.float32),
         )
         msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
         with self.assertRaisesRegex(ValueError, msg):
-            Plugin().process(self.cube)
+            Plugin().process(cube)
 
     def test_raises_exception_if_percentiles_not_centred(self):
         """Check that we raise an exception if the input percentiles are not
         not centred on 50th percentile."""
-        self.cube = set_up_percentile_cube(
+        cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([30, 60, 90], dtype=np.float32),
         )
         msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
         with self.assertRaisesRegex(ValueError, msg):
-            Plugin().process(self.cube)
+            Plugin().process(cube)
 
     def test_raises_exception_if_percentiles_unequal_partition_percentile_space(self):
         """Check that we raise an exception if the input percentiles don't
         evenly partition percentile space"""
-        self.cube = set_up_percentile_cube(
+        cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([10, 50, 90], dtype=np.float32),
         )
         msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
         with self.assertRaisesRegex(ValueError, msg):
-            Plugin().process(self.cube)
+            Plugin().process(cube)
 
 
 if __name__ == "__main__":

--- a/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -86,8 +86,8 @@ class Test_process(IrisTest):
         )
 
     def test_raises_exception_if_realization_already_exists(self):
-        """Check that we raise an exception if a realization coordinate already
-        exists."""
+        """Check that an exception is raised if a realization
+        coordinate already exists."""
         self.cube.add_aux_coord(AuxCoord(0, "realization"))
         msg = r"Cannot rebadge percentile coordinate to realization.*"
         with self.assertRaisesRegex(InvalidCubeError, msg):
@@ -116,8 +116,8 @@ class Test_process(IrisTest):
             Plugin().process(cube)
 
     def test_raises_exception_if_percentiles_unequal_partition_percentile_space(self):
-        """Check that we an exception is raised if the input percentiles
-        don't evenly partition percentile space"""
+        """Check that an exception is raised if the input percentiles
+        don't evenly partition percentile space."""
         cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([10, 50, 90], dtype=np.float32),

--- a/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -58,7 +58,7 @@ class Test_process(IrisTest):
         """Set up temperature percentile cube for testing"""
         self.cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
-            np.array([10, 50, 90], dtype=np.float32),
+            np.array([25, 50, 75], dtype=np.float32),
         )
 
     def test_basic(self):
@@ -91,6 +91,39 @@ class Test_process(IrisTest):
         self.cube.add_aux_coord(AuxCoord(0, "realization"))
         msg = r"Cannot rebadge percentile coordinate to realization.*"
         with self.assertRaisesRegex(InvalidCubeError, msg):
+            Plugin().process(self.cube)
+
+    def test_raises_exception_if_percentiles_unevenly_spaced(self):
+        """Check that we raise an exception if the input percentiles are not
+        evenly spaced."""
+        self.cube = set_up_percentile_cube(
+            np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
+            np.array([25, 50, 90], dtype=np.float32),
+        )
+        msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
+        with self.assertRaisesRegex(ValueError, msg):
+            Plugin().process(self.cube)
+
+    def test_raises_exception_if_percentiles_not_centred(self):
+        """Check that we raise an exception if the input percentiles are not
+        not centred on 50th percentile."""
+        self.cube = set_up_percentile_cube(
+            np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
+            np.array([30, 60, 90], dtype=np.float32),
+        )
+        msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
+        with self.assertRaisesRegex(ValueError, msg):
+            Plugin().process(self.cube)
+
+    def test_raises_exception_if_percentiles_unequal_partition_percentile_space(self):
+        """Check that we raise an exception if the input percentiles don't
+        evenly partition percentile space"""
+        self.cube = set_up_percentile_cube(
+            np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
+            np.array([10, 50, 90], dtype=np.float32),
+        )
+        msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
+        with self.assertRaisesRegex(ValueError, msg):
             Plugin().process(self.cube)
 
 

--- a/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -94,8 +94,8 @@ class Test_process(IrisTest):
             Plugin().process(self.cube)
 
     def test_raises_exception_if_percentiles_unevenly_spaced(self):
-        """Check that we raise an exception if the input percentiles are not
-        evenly spaced."""
+        """Check that an exception is raised if the input percentiles
+        are not evenly spaced."""
         cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([25, 50, 90], dtype=np.float32),
@@ -105,8 +105,8 @@ class Test_process(IrisTest):
             Plugin().process(cube)
 
     def test_raises_exception_if_percentiles_not_centred(self):
-        """Check that we raise an exception if the input percentiles are not
-        not centred on 50th percentile."""
+        """Check that an exception is raised if the input percentiles
+        are not centred on 50th percentile."""
         cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([30, 60, 90], dtype=np.float32),
@@ -116,8 +116,8 @@ class Test_process(IrisTest):
             Plugin().process(cube)
 
     def test_raises_exception_if_percentiles_unequal_partition_percentile_space(self):
-        """Check that we raise an exception if the input percentiles don't
-        evenly partition percentile space"""
+        """Check that we an exception is raised if the input percentiles
+        don't evenly partition percentile space"""
         cube = set_up_percentile_cube(
             np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
             np.array([10, 50, 90], dtype=np.float32),


### PR DESCRIPTION
Addresses #1724 

Description
Percentiles should be evenly spaced, centered on 50, and evenly partition percentile space. Added unit tests for new features. Changed some existing unit tests to adhere to new requirements when rebadging percentiles as realizations.


Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

CLA
 - [x] If a new developer, signed up to CLA
