### PR TITLE
Filter validity times when apply EMOS and update metadata

### DIFF
--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -209,14 +209,14 @@ def split_forecasts_and_coeffs(
     )
 
 
-def validity_time_check(forecast: Cube, validity_times) -> bool:
+def validity_time_check(forecast: Cube, validity_times: List[str]) -> bool:
     """Check the validity time of the forecast matches the accepted validity times
     within the validity times list.
 
     Args:
         forecast:
             Cube containing the forecast to be calibrated.
-        validity_times (List[str]):
+        validity_times:
             Times at which the forecast must be valid. This must be provided
             as a four digit string (HHMM) where the first two digits represent the hour
             and the last two digits represent the minutes e.g. 0300 or 0315. If the
@@ -242,8 +242,14 @@ def add_warning_comment(forecast: Cube) -> Cube:
     Returns:
         Forecast with an additional comment.
     """
-    forecast.attributes["comment"] = (
-        "Warning: Calibration of this forecast has been attempted, "
-        "however, no calibration has been applied."
-    )
+    if forecast.attributes.get("comment", None):
+        forecast.attributes["comment"] = forecast.attributes["comment"] + (
+            "\nWarning: Calibration of this forecast has been attempted, "
+            "however, no calibration has been applied."
+        )
+    else:
+        forecast.attributes["comment"] = (
+            "Warning: Calibration of this forecast has been attempted, "
+            "however, no calibration has been applied."
+        )
     return forecast

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -209,6 +209,30 @@ def split_forecasts_and_coeffs(
     )
 
 
+def validity_time_check(forecast: Cube, validity_times) -> bool:
+    """Check the validity time of the forecast matches the accepted validity times
+    within the validity times list.
+
+    Args:
+        forecast:
+            Cube containing the forecast to be calibrated.
+        validity_times (List[str]):
+            Times at which the forecast must be valid at. This must be provided
+            as a four digit string (HHMM) where the first two digits represent the hour
+            and the last two digits represent the minutes e.g. 0300 or 0315. If the
+            forecast provided is at a different validity time then no coefficients
+            will be applied.
+
+    Returns:
+        If the validity time within the cube matches a validity time within the
+        validity time list, then True is returned. Otherwise, False is returned.
+    """
+    point = forecast.coord("time").cell(0).point
+    if f"{point.hour:02}{point.minute:02}" not in validity_times:
+        return False
+    return True
+
+
 def add_warning_comment(forecast: Cube) -> Cube:
     """Add a comment to warn that calibration has not been applied.
 

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -207,3 +207,18 @@ def split_forecasts_and_coeffs(
         land_sea_mask,
         prob_template,
     )
+
+
+def add_warning_comment(forecast: Cube) -> Cube:
+    """Add a comment to warn that calibration has not been applied.
+
+    Args:
+        forecast: The forecast to which a comment will be added.
+    """
+    import pdb
+    pdb.set_trace()
+    forecast.attributes["comment"] = (
+        "Warning: Calibration of this forecast has been attempted, "
+        "however, no calibration has been applied."
+    )
+    return forecast

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -217,7 +217,7 @@ def validity_time_check(forecast: Cube, validity_times) -> bool:
         forecast:
             Cube containing the forecast to be calibrated.
         validity_times (List[str]):
-            Times at which the forecast must be valid at. This must be provided
+            Times at which the forecast must be valid. This must be provided
             as a four digit string (HHMM) where the first two digits represent the hour
             and the last two digits represent the minutes e.g. 0300 or 0315. If the
             forecast provided is at a different validity time then no coefficients

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -214,9 +214,10 @@ def add_warning_comment(forecast: Cube) -> Cube:
 
     Args:
         forecast: The forecast to which a comment will be added.
+
+    Returns:
+        Forecast with an additional comment.
     """
-    import pdb
-    pdb.set_trace()
     forecast.attributes["comment"] = (
         "Warning: Calibration of this forecast has been attempted, "
         "however, no calibration has been applied."

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -40,6 +40,7 @@ from improver import cli
 @cli.with_output
 def process(
     *cubes: cli.inputcubelist,
+    validity_times: cli.comma_separated_list = None,
     realizations_count: int = None,
     randomise=False,
     random_seed: int = None,
@@ -83,6 +84,12 @@ def process(
             or percentiles. If no coefficients are provided and a probability
             template is provided, the probability template forecast will be
             returned as the uncalibrated probability forecast.
+        validity_times (List[str]):
+            Times at which the forecast must be valid at. This must be provided
+            as a four digit string (HHMM) where the first two digits represent the hour
+            and the last two digits represent the minutes e.g. 0300 or 0315. If the
+            forecast provided is at a different validity time then no coefficients
+            will be applied.
         realizations_count (int):
             Option to specify the number of ensemble realizations that will be
             created from probabilities or percentiles when applying the EMOS
@@ -131,7 +138,11 @@ def process(
 
     import numpy as np
 
-    from improver.calibration import add_warning_comment, split_forecasts_and_coeffs
+    from improver.calibration import (
+        add_warning_comment,
+        split_forecasts_and_coeffs,
+        validity_time_check,
+    )
     from improver.calibration.ensemble_calibration import ApplyEMOS
     from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
         ResamplePercentiles,
@@ -144,6 +155,16 @@ def process(
         land_sea_mask,
         prob_template,
     ) = split_forecasts_and_coeffs(cubes, land_sea_mask_name)
+
+    if not validity_time_check(forecast, validity_times):
+        msg = (
+            "The forecast provided is not at an accepted validity time. The "
+            f"forecast provided has a validity time of {forecast.coord('time').cell(0)}."
+            f"The validity times provided were {validity_times}."
+        )
+        warnings.warn(msg)
+        forecast = add_warning_comment(forecast)
+        return forecast
 
     if coefficients is None:
         if prob_template:

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -156,9 +156,7 @@ def process(
         prob_template,
     ) = split_forecasts_and_coeffs(cubes, land_sea_mask_name)
 
-    if validity_times is not None and not validity_time_check(
-        forecast, validity_times
-    ):
+    if validity_times is not None and not validity_time_check(forecast, validity_times):
         forecast = add_warning_comment(forecast)
         return forecast
 

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -85,7 +85,7 @@ def process(
             template is provided, the probability template forecast will be
             returned as the uncalibrated probability forecast.
         validity_times (List[str]):
-            Times at which the forecast must be valid at. This must be provided
+            Times at which the forecast must be valid. This must be provided
             as a four digit string (HHMM) where the first two digits represent the hour
             and the last two digits represent the minutes e.g. 0300 or 0315. If the
             forecast provided is at a different validity time then no coefficients
@@ -156,13 +156,9 @@ def process(
         prob_template,
     ) = split_forecasts_and_coeffs(cubes, land_sea_mask_name)
 
-    if not validity_time_check(forecast, validity_times):
-        msg = (
-            "The forecast provided is not at an accepted validity time. The "
-            f"forecast provided has a validity time of {forecast.coord('time').cell(0)}."
-            f"The validity times provided were {validity_times}."
-        )
-        warnings.warn(msg)
+    if validity_times is not None and not validity_time_check(
+        forecast, validity_times
+    ):
         forecast = add_warning_comment(forecast)
         return forecast
 

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -131,7 +131,7 @@ def process(
 
     import numpy as np
 
-    from improver.calibration import split_forecasts_and_coeffs
+    from improver.calibration import add_warning_comment, split_forecasts_and_coeffs
     from improver.calibration.ensemble_calibration import ApplyEMOS
     from improver.ensemble_copula_coupling.ensemble_copula_coupling import (
         ResamplePercentiles,
@@ -168,6 +168,8 @@ def process(
             "uncalibrated forecast will be returned."
         )
         warnings.warn(msg)
+
+        forecast = add_warning_comment(forecast)
         return forecast
 
     calibration_plugin = ApplyEMOS(percentiles=percentiles)

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -9,6 +9,7 @@ bee125371a9db4c80fb7f8d1b0644a2710903aad27023b5939331f7ec5f3b617  ./apply-emos-c
 fa8efb4b54430cf6f5e4782b9ec1a0c49dd4102d228dae04bd250ec7b0b9b481  ./apply-emos-coefficients/land_sea/realizations_kgo.nc
 4eaedd69b7d0bbc4b99fa598ffffdb39454962d8e9c33c3d75f58d1de9f25313  ./apply-emos-coefficients/normal/input.nc
 0c5839e3f3a9d557a24757c292099af859ff7ce27c75de7ba8b98a46828b3912  ./apply-emos-coefficients/normal/kgo.nc
+99cfb7112cfd01f45bc65db0e492e6eb7017064bddab9b390cc1043796c26cf7  ./apply-emos-coefficients/normal/kgo_with_comment.nc
 7c4033340c89788ba3e55f560fbe2f47ed8bac14c7b47cdf71312e115caf7cfc  ./apply-emos-coefficients/normal/normal_coefficients.nc
 d51fde4566a4d9695a3ba26622ef8505a879131e10f438ab19d4594a57997ad7  ./apply-emos-coefficients/percentiles/input.nc
 7e673a16dd80edb42f890771184a4ad8592a53bd0d0d18d7cd316c489c9b4d7d  ./apply-emos-coefficients/percentiles/kgo.nc
@@ -30,7 +31,7 @@ a0112b5a48ba99a1a4a345d43b0c453caaf25181504fb9a13786b5722f84cc10  ./apply-emos-c
 833a703e14a02999a7d70e9a37ce199ab36a09b13b96f87295a0fb91739658ce  ./apply-emos-coefficients/sites/point_by_point/kgo.nc
 0bc91af1e7003d696aa440a07d79e653bca566733cdf9bf525ca92cff821548f  ./apply-emos-coefficients/sites/realization_input.nc
 8085cb7a0e88266fedba841be50621fd6af3d6a669f045fcc0fae8e14f9ff9fe  ./apply-emos-coefficients/subsetted_percentiles/input.nc
-8c4f92060a9dde860214b93be95651c36060732f8d63f35dcb43b01b4543890a  ./apply-emos-coefficients/subsetted_percentiles/kgo.nc
+50593394ae576f40d9af12058497ccb1780e77fb957d26b55ee5ce4b923e624d  ./apply-emos-coefficients/subsetted_percentiles/kgo.nc
 965a1f0565f9192d95eb01d0a61dc7bede6902f5e1a0481d92611e677841a139  ./apply-emos-coefficients/truncated_normal/input.nc
 feb2d93cf96b05889571bcb348dfbb4d60cfc1f3d9b7343dcf7d85cf34339746  ./apply-emos-coefficients/truncated_normal/kgo.nc
 d2cab1d3d8aa588be08a3d7d65e95e859fed37daa767e8d4a2bdaae25702b9a8  ./apply-emos-coefficients/truncated_normal/truncated_normal_coefficients.nc

--- a/improver_tests/acceptance/acceptance.py
+++ b/improver_tests/acceptance/acceptance.py
@@ -331,6 +331,7 @@ def compare(
     atol=DEFAULT_TOLERANCE,
     rtol=DEFAULT_TOLERANCE,
     exclude_vars=None,
+    exclude_attributes=None,
 ):
     """
     Compare output against expected using KGO file with absolute and
@@ -343,6 +344,7 @@ def compare(
         atol (float): Absolute tolerance
         rtol (float): Relative tolerance
         exclude_vars (Iterable[str]): Variables to exclude from comparison
+        exclude_attributes (Iterable[str]): Attributes to exclude from comparison
 
     Returns:
         None
@@ -365,6 +367,13 @@ def compare(
         difference_found = True
         message = exception_message
 
+    if exclude_attributes:
+        if isinstance(exclude_attributes, str):
+            exclude_attributes = [exclude_attributes]
+        exclude_attributes.extend(IGNORED_ATTRIBUTES)
+    else:
+        exclude_attributes = IGNORED_ATTRIBUTES
+
     compare_netcdfs(
         output_path,
         kgo_path,
@@ -372,7 +381,7 @@ def compare(
         rtol=rtol,
         exclude_vars=exclude_vars,
         reporter=message_recorder,
-        ignored_attributes=IGNORED_ATTRIBUTES,
+        ignored_attributes=exclude_attributes,
     )
     if difference_found:
         if recreate:

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -406,6 +406,7 @@ def test_perc_in_prob_out_sites_additional_predictor(tmp_path):
 def test_no_coefficients(tmp_path):
     """Test no coefficients provided"""
     kgo_dir = acc.kgo_root() / "apply-emos-coefficients/normal"
+    kgo_path = kgo_dir / "kgo_with_comment.nc"
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [
@@ -417,12 +418,18 @@ def test_no_coefficients(tmp_path):
     ]
     with pytest.warns(UserWarning, match=".*no coefficients provided.*"):
         run_cli(args)
+    # Check output matches input excluding the comment attribute.
     acc.compare(
         output_path,
         input_path,
         recreate=False,
         atol=LOOSE_TOLERANCE,
         rtol=LOOSE_TOLERANCE,
+        exclude_attributes="comment",
+    )
+    # Check output matches kgo.
+    acc.compare(
+        output_path, kgo_path, atol=LOOSE_TOLERANCE,
     )
 
 

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -537,10 +537,7 @@ def test_mismatching_validity_times(tmp_path):
         "--output",
         output_path,
     ]
-    with pytest.warns(
-        UserWarning, match="The forecast provided is not at an accepted validity time.*"
-    ):
-        run_cli(args)
+    run_cli(args)
     # Check output matches input excluding the comment attribute.
     acc.compare(
         output_path,

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -428,9 +428,7 @@ def test_no_coefficients(tmp_path):
         exclude_attributes="comment",
     )
     # Check output matches kgo.
-    acc.compare(
-        output_path, kgo_path, atol=LOOSE_TOLERANCE,
-    )
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
 
 
 def test_no_coefficients_percentiles(tmp_path):
@@ -497,3 +495,57 @@ def test_wrong_coefficients(tmp_path):
     ]
     with pytest.raises(ValueError, match="Multiple items have been provided.*"):
         run_cli(args)
+
+
+def test_matching_validity_times(tmp_path):
+    """Test passing validity times when the forecast validity time matches
+    one of the validity times within the list."""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/normal"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "input.nc"
+    emos_est_path = kgo_dir / "normal_coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        emos_est_path,
+        "--validity-times",
+        "1500,1800,2100",
+        "--random-seed",
+        "0",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
+
+
+def test_mismatching_validity_times(tmp_path):
+    """Test passing validity times when the forecast validity time does not match
+    any of the validity times within the list."""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/normal"
+    kgo_path = kgo_dir / "kgo_with_comment.nc"
+    input_path = kgo_dir / "input.nc"
+    emos_est_path = kgo_dir / "normal_coefficients.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        emos_est_path,
+        "--validity-times",
+        "0600,0900,1200",
+        "--random-seed",
+        "0",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    # Check output matches input excluding the comment attribute.
+    acc.compare(
+        output_path,
+        input_path,
+        recreate=False,
+        atol=LOOSE_TOLERANCE,
+        rtol=LOOSE_TOLERANCE,
+        exclude_attributes="comment",
+    )
+    # Check output matches kgo.
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -537,7 +537,10 @@ def test_mismatching_validity_times(tmp_path):
         "--output",
         output_path,
     ]
-    run_cli(args)
+    with pytest.warns(
+        UserWarning, match="The forecast provided is not at an accepted validity time.*"
+    ):
+        run_cli(args)
     # Check output matches input excluding the comment attribute.
     acc.compare(
         output_path,

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -35,7 +35,6 @@ from datetime import datetime
 
 import iris
 import numpy as np
-import pytest
 from iris.cube import CubeList
 
 from improver.calibration import (
@@ -542,6 +541,8 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
 
 
 def test_add_warning_to_comment():
+    """Test the addition of a warning comment if calibration has been attempted
+    but not applied successfully."""
     expected = (
         "Warning: Calibration of this forecast has been attempted, "
         "however, no calibration has been applied."

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -35,9 +35,14 @@ from datetime import datetime
 
 import iris
 import numpy as np
+import pytest
 from iris.cube import CubeList
 
-from improver.calibration import split_forecasts_and_coeffs, split_forecasts_and_truth
+from improver.calibration import (
+    add_warning_comment,
+    split_forecasts_and_coeffs,
+    split_forecasts_and_truth,
+)
 from improver.synthetic_data.set_up_test_cubes import (
     set_up_percentile_cube,
     set_up_probability_cube,
@@ -534,6 +539,17 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
                 ),
                 self.land_sea_mask_name,
             )
+
+
+def test_add_warning_to_comment():
+    expected = (
+        "Warning: Calibration of this forecast has been attempted, "
+        "however, no calibration has been applied."
+    )
+    data = np.zeros((2, 2), dtype=np.float32)
+    cube = set_up_variable_cube(data)
+    result = add_warning_comment(cube)
+    assert result.attributes["comment"] == expected
 
 
 if __name__ == "__main__":

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -560,7 +560,10 @@ def test_matching_validity_times(time, validity_times, expected):
     assert result is expected
 
 
-def test_add_warning_to_comment():
+@pytest.mark.parametrize(
+    "comment", [(None), ("Example comment")],
+)
+def test_add_warning_to_comment(comment):
     """Test the addition of a warning comment if calibration has been attempted
     but not applied successfully."""
     expected = (
@@ -569,6 +572,9 @@ def test_add_warning_to_comment():
     )
     data = np.zeros((2, 2), dtype=np.float32)
     cube = set_up_variable_cube(data)
+    if comment:
+        cube.attributes["comment"] = comment
+        expected = "\n".join([comment, expected])
     result = add_warning_comment(cube)
     assert result.attributes["comment"] == expected
 


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/376, https://github.com/metoppv/mo-blue-team/issues/380

Description
This PR adds the capability to filter by validity time when applying EMOS. This helps ensure that forecasts will only be calibrated, if they match the desired validity times. This PR also adds a comment to the file to indicate that EMOS has not been applied successfully, either because the validity time of the forecast does not match the desired list of validity times, or because no coefficients have been supplied. This is aimed at helping to make it clear within the output files whether calibration has been applied or not.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

