### PR TITLE
Ensure consistent percentiles from EMOS

### DIFF
--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -157,6 +157,13 @@ def process(
     ) = split_forecasts_and_coeffs(cubes, land_sea_mask_name)
 
     if validity_times is not None and not validity_time_check(forecast, validity_times):
+        if percentiles:
+            # Ensure that a consistent set of percentiles are returned,
+            # regardless of whether EMOS is successfully applied.
+            percentiles = [np.float32(p) for p in percentiles]
+            forecast = ResamplePercentiles(ecc_bounds_warning=ignore_ecc_bounds)(
+                forecast, percentiles=percentiles
+            )
         forecast = add_warning_comment(forecast)
         return forecast
 
@@ -173,6 +180,8 @@ def process(
             return prob_template
 
         if percentiles:
+            # Ensure that a consistent set of percentiles are returned,
+            # regardless of whether EMOS is successfully applied.
             percentiles = [np.float32(p) for p in percentiles]
             forecast = ResamplePercentiles(ecc_bounds_warning=ignore_ecc_bounds)(
                 forecast, percentiles=percentiles

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -571,3 +571,30 @@ def test_mismatching_validity_times(tmp_path):
     )
     # Check output matches kgo.
     acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)
+
+
+def test_mismatching_validity_times_percentiles(tmp_path):
+    """Test passing validity times when the forecast validity time does not match
+    any of the validity times within the list. The desired percentiles are supplied."""
+    kgo_dir = acc.kgo_root() / "apply-emos-coefficients/subsetted_percentiles"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "input.nc"
+    emos_est_path = (
+        acc.kgo_root() / "apply-emos-coefficients/normal/normal_coefficients.nc"
+    )
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        emos_est_path,
+        "--validity-times",
+        "1200,1500,1800",
+        "--random-seed",
+        "0",
+        "--percentiles",
+        "25,50,75",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    # Check output matches kgo.
+    acc.compare(output_path, kgo_path, atol=LOOSE_TOLERANCE)


### PR DESCRIPTION
Related to: https://github.com/metoppv/improver/pull/1820

Description
This PR ensures that a consistent set of percentiles are able to be returned when EMOS is not applied successfully due to the application of validity time filtering (#1820).

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

