### PR TITLE
Add hail accumulation to list of ECC constants.

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -64,6 +64,7 @@ BOUNDS_FOR_ECDF = {
     "medium_type_cloud_area_fraction": Bounds((0, 1.0), "1"),
     # Precipitation amount
     "lwe_thickness_of_freezing_rainfall_amount": Bounds((0, 0.5), "m"),
+    "lwe_thickness_of_graupel_and_hail_fall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),


### PR DESCRIPTION
Related to [MOBT-398](https://github.com/metoppv/mo-blue-team/issues/398) 
Suite ticket: [Suite-496](https://github.com/MetOffice/improver_suite/pull/1496)

Description:

This PR is a sister to this suite PR: 
It adds lwe_thickness_of_graupel_and_hail_fall_amount to the list of ECC constants so that percentile send tasks can added to the hailacc1/3h chains.

