### PR TITLE
Ensure comment present if EMOS calibration is not applied

### DIFF
--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -65,7 +65,6 @@ def process(
             - A Cube containing the forecast to be calibrated. The input format
             could be either realizations, probabilities or percentiles.
             - A cubelist containing the coefficients used for calibration or None.
-            - A cubelist containing the coefficients used for calibration or None.
             If none then the input, or probability template if provided,
             is returned unchanged.
             - Optionally, cubes representing static additional predictors.

--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -177,6 +177,7 @@ def process(
                 "forecast."
             )
             warnings.warn(msg)
+            prob_template = add_warning_comment(prob_template)
             return prob_template
 
         if percentiles:

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -23,6 +23,7 @@ bd56f09033f7a37323e04be7b509e8e363eb2474c04fb8aa4fb5e3769acb81f7  ./apply-emos-c
 e2551504357f9c8e98e569ff7fa3ba1d7f1c8ca02354d1045defa171b8bf00ff  ./apply-emos-coefficients/sites/additional_predictor/percentile_kgo.nc
 cba168f494f2fd91b6a6dc5a0844c03e9573747e91960eef33706fcdc7f30961  ./apply-emos-coefficients/sites/additional_predictor/probability_kgo.nc
 ad84567485d14563d243cbef40a576488c074533978d94b4075d00950b7b8273  ./apply-emos-coefficients/sites/additional_predictor/probability_template.nc
+66052676e8266c29fef7f3a1d5a1cedaa997f41ff0108b2aff33c71617d1bbed  ./apply-emos-coefficients/sites/additional_predictor/probability_template_kgo.nc
 a0112b5a48ba99a1a4a345d43b0c453caaf25181504fb9a13786b5722f84cc10  ./apply-emos-coefficients/sites/offset/coefficients.nc
 22d950494dc9d76d642b0ecc75414e95bfb78fa693e5701fe7cd2fc462a0c6a7  ./apply-emos-coefficients/sites/offset/kgo.nc
 2722b1d08a87cebf1f36ac914d5badb9af38859b2150da83311dc202ce9be4dd  ./apply-emos-coefficients/sites/offset/offset_input.nc

--- a/improver_tests/acceptance/test_apply_emos_coefficients.py
+++ b/improver_tests/acceptance/test_apply_emos_coefficients.py
@@ -478,6 +478,7 @@ def test_no_coefficients_with_prob_template(tmp_path):
     kgo_dir = acc.kgo_root() / "apply-emos-coefficients/sites/additional_predictor"
     input_path = kgo_dir / ".." / "percentile_input.nc"
     prob_template = kgo_dir / "probability_template.nc"
+    kgo_path = kgo_dir / "probability_template_kgo.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -493,12 +494,18 @@ def test_no_coefficients_with_prob_template(tmp_path):
         UserWarning, match=".*no coefficients provided.*probability template.*"
     ):
         run_cli(args)
+    # Check output matches the probability template excluding the comment attribute.
     acc.compare(
         output_path,
         prob_template,
         recreate=False,
         atol=LOOSE_TOLERANCE,
         rtol=LOOSE_TOLERANCE,
+        exclude_attributes="comment",
+    )
+    # Check output matches kgo.
+    acc.compare(
+        output_path, kgo_path, atol=LOOSE_TOLERANCE, rtol=LOOSE_TOLERANCE,
     )
 
 


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/416

Description
If no coefficients are provided to the apply EMOS CLI and a probability template is provided, the probability template is returned as the uncalibrated forecast. This probability template is, however, not currently updated with a comment to indicate that this is not calibrated. This PR ensures that the probability template cube is updated with a comment.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
