### PR TITLE
MOBT-417: Error handling for old record_run attributes

### DIFF
--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -439,7 +439,19 @@ def update_record_run_weights(cube: Cube, weights: Cube, blend_coord: str) -> Cu
         for run_record in run_records:
             components = run_record.rsplit(":", 1)
             model_cycle = components[0]
-            value = float(components[-1]) * weight.data
+            try:
+                value = float(components[-1]) * weight.data
+            except ValueError as err:
+                msg = (
+                    "record_run attributes are expected to be of the form "
+                    "'model_id:model_cycle:blending weight'. The weight is "
+                    f"absent in this case: {run_record}. This suggests one "
+                    "of the sources of data is using an older version of "
+                    "IMPROVER that did not include the weights in this "
+                    "attribute."
+                )
+                raise ValueError(msg) from err
+
             updated_records.append(f"{model_cycle}:{value:{WEIGHT_FORMAT}}")
         cslice.coord(RECORD_COORD).points = "\n".join(sorted(updated_records))
         cubes.append(cslice)

--- a/improver_tests/blending/test_utilities.py
+++ b/improver_tests/blending/test_utilities.py
@@ -538,3 +538,31 @@ def test_update_record_run_weights_model(
         if coord.name() == RECORD_COORD:
             continue
         assert coord == model_cube_with_blend_record.coord(coord.name())
+
+
+@pytest.mark.parametrize("weights", [[0.5, 0.5]])
+def test_update_record_run_weights_old_inputs(
+    model_cube_with_blend_record, model_blending_weights
+):
+    """Test that an exception is raised if older inputs without a weight
+    recorded in the record_run attribute are passed in. This might happen
+    if a source model has been processed with an older version of IMPROVER,
+    the output of which is then included in a model blend with the model
+    blending suite using a version of IMPROVER that includes the weight
+    recording."""
+
+    attributes = []
+    attribute_entries = model_blend_record_template()
+    attributes.append(attribute_entries[0].format(uk_det_weight="", WEIGHT_FORMAT=""))
+    attributes.append(
+        attribute_entries[1].format(uk_ens_weight=1 / 3, WEIGHT_FORMAT=WEIGHT_FORMAT)
+    )
+
+    model_cube_with_blend_record.coord(RECORD_COORD).points = attributes
+
+    with pytest.raises(
+        ValueError, match="record_run attributes are expected to be of the form"
+    ):
+        update_record_run_weights(
+            model_cube_with_blend_record, model_blending_weights, MODEL_BLEND_COORD
+        )


### PR DESCRIPTION
Add explicit error handling for instances where old record_run attributes are encountered by the new code. These lack weights and this needs to be flagged to the user to make the failure easy to understand.

This is being seen in the recently stood up operational mix suite into which is being fed data from model suites that are using an older version of IMPROVER.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)