### PR TITLE
Mobt411 sphinx

### DIFF
--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - python-stratify
   - sphinx
   - sphinx-autodoc-typehints
+  - sphinx_rtd_theme
   - pip
   - pip:
     - clize

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,6 +74,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
     "sphinx_autodoc_typehints",
+    "sphinx_rtd_theme",
 ]
 
 autodoc_default_flags = ["members", "private-members"]
@@ -130,7 +131,6 @@ language = "en"
 exclude_patterns = ["modules.rst", "extended_documentation"]
 
 autodoc_mock_imports = ["numba"]
-
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 #
@@ -168,7 +168,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -394,13 +394,13 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
-    "https://scitools-iris.readthedocs.io/en/latest/": None,
-    "https://scitools.org.uk/cartopy/docs/latest/": None,
-    "https://cf-units.readthedocs.io/en/stable/": None,
-    "https://numpy.org/doc/stable/": None,
-    "https://docs.scipy.org/doc/scipy-1.6.2/reference/": None,
-    "https://pandas.pydata.org/pandas-docs/dev/": None,
+    'python': ("https://docs.python.org/3/", None),
+    'iris': ("https://scitools-iris.readthedocs.io/en/latest/", None),
+    'cartophy': ("https://scitools.org.uk/cartopy/docs/latest/", None),
+    'cf_units': ("https://cf-units.readthedocs.io/en/stable/", None),
+    'numpy': ("https://numpy.org/doc/stable/", None),
+    'scipy': ("https://docs.scipy.org/doc/scipy-1.6.2/reference/", None),
+    'pandas': ("https://pandas.pydata.org/pandas-docs/dev/", None),
 }
 
 # Get napoleon to document constructor methods.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -395,13 +395,13 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ("https://docs.python.org/3/", None),
-    'iris': ("https://scitools-iris.readthedocs.io/en/latest/", None),
-    'cartophy': ("https://scitools.org.uk/cartopy/docs/latest/", None),
-    'cf_units': ("https://cf-units.readthedocs.io/en/stable/", None),
-    'numpy': ("https://numpy.org/doc/stable/", None),
-    'scipy': ("https://docs.scipy.org/doc/scipy-1.6.2/reference/", None),
-    'pandas': ("https://pandas.pydata.org/pandas-docs/dev/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "iris": ("https://scitools-iris.readthedocs.io/en/latest/", None),
+    "cartophy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
+    "cf_units": ("https://cf-units.readthedocs.io/en/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy-1.6.2/reference/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/dev/", None),
 }
 
 # Get napoleon to document constructor methods.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -131,6 +131,7 @@ language = "en"
 exclude_patterns = ["modules.rst", "extended_documentation"]
 
 autodoc_mock_imports = ["numba"]
+
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 #

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -26,4 +26,5 @@ dependencies:
   - filelock
   - pytest
   - sphinx-autodoc-typehints
+  - sphinx_rtd_theme
   - threadpoolctl

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -41,4 +41,5 @@ dependencies:
   - pytest-xdist
   - safety
   - sphinx-autodoc-typehints
+  - sphinx_rtd_theme
   - threadpoolctl

--- a/envs/environment_b.yml
+++ b/envs/environment_b.yml
@@ -42,4 +42,5 @@ dependencies:
   - pytest-xdist
   - safety
   - sphinx-autodoc-typehints
+  - sphinx_rtd_theme
   - threadpoolctl

--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -44,4 +44,5 @@ dependencies:
   - pytest-xdist
   - safety
   - sphinx-autodoc-typehints
+  - sphinx_rtd_theme
   - threadpoolctl


### PR DESCRIPTION
Addresses metoppv/mo-blue-team#411

Updates the doc/conf.py file to use the sphinx_rtd_theme docs template making a local build appear like the readthedocs page. Updates the environments to include spinx_rtd_theme. 

Also updates the intersphinx mapping to use a more up-to-date format.

Testing:
 - [x] Ran tests and they passed OK

