### PR TITLE
Last minute "above_surface_pressure below_surface_pressure" coord removal

### DIFF
--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -57,7 +57,7 @@ class StandardiseMetadata(BasePlugin):
         """
         Remove air_temperature status_flag coord by applying as NaN to cube data.
 
-        See github issue for further details.
+        See https://github.com/metoppv/improver/pull/1839 for further details.
         """
         coord_name = "air_temperature status_flag"
         try:

--- a/improver_tests/standardise/test_StandardiseMetadata.py
+++ b/improver_tests/standardise/test_StandardiseMetadata.py
@@ -181,7 +181,7 @@ class Test_process(IrisTest):
         See https://github.com/metoppv/improver/pull/1839
         """
         cube = set_up_variable_cube(
-            282 * np.ones((3, 3, 5, 5), dtype=np.float32),
+            np.full((3, 3, 5, 5), fill_value=282, dtype=np.float32),
             spatial_grid="latlon",
             standard_grid_metadata="gl_det",
             pressure=True,

--- a/improver_tests/standardise/test_StandardiseMetadata.py
+++ b/improver_tests/standardise/test_StandardiseMetadata.py
@@ -172,6 +172,25 @@ class Test_process(IrisTest):
         self.assertEqual(cube.dtype, np.float32)
         self.assertEqual(result.data.dtype, np.float32)
 
+    def test_air_temperature_status_flag_coord(self):
+        """
+        Ensure we handle cubes which now include a 'air_temperature_status flag'
+        coord to signify points below surface altitude, where previously this
+        was denoted by NaN values in the data
+
+        See https://github.com/metoppv/improver/pull/1839
+        """
+        cube = set_up_variable_cube(
+            282 * np.ones((3, 3, 5, 5), dtype=np.float32),
+            spatial_grid="latlon",
+            standard_grid_metadata="gl_det",
+            pressure=True,
+            height_levels = [100000.,  97500.,  95000.],
+            realizations = [0, 18, 19]
+        )
+        cube.data[:, ]
+        self.cube
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/improver_tests/standardise/test_StandardiseMetadata.py
+++ b/improver_tests/standardise/test_StandardiseMetadata.py
@@ -174,9 +174,9 @@ class Test_process(IrisTest):
 
     def test_air_temperature_status_flag_coord(self):
         """
-        Ensure we handle cubes which now include a 'air_temperature_status flag'
+        Ensure we handle cubes which now include an 'air_temperature_status flag'
         coord to signify points below surface altitude, where previously this
-        was denoted by NaN values in the data
+        was denoted by NaN values in the data.
 
         See https://github.com/metoppv/improver/pull/1839
         """


### PR DESCRIPTION
Removal of "above_surface_pressure below_surface_pressure" coord by re-introducing the original NaN values.  This is done within the standardise plugin.

Closes https://github.com/MetOffice/improver_suite/issues/1523

## Background

`impr_engl_temp_plev_standardise` task is now failing in fpostest (release) with out of memory (OO Killer).  This is due to a change in how the data is now represented via stage.

Below that of the surface altitude we used to set to NaNs in the data.  Now a flag (kind of a mask) is used instead to indicate which values are above/below the surface level pressure.

```
    byte flag(realization, pressure, latitude, longitude) ;
        flag:standard_name = "air_temperature status_flag" ;
        flag:flag_meanings = "above_surface_pressure below_surface_pressure" ;
        flag:flag_values = 0b, 1b ;
```

The file size has then doubled due to this 4D flag coordinate.
At int8 of dimension (18, 33, 960, 1280), that's an extra 730MB

The easiest thing to do last minute might be to reduce the pool size to say half (with data being ~twice the size).
This was attempted in https://github.com/MetOffice/improver_suite/pull/1519

Unfortunately we suspect dask might be at play here as the memory overhead doesn't correspond to what we might expect (doesn't reflect the increase in file size).  This is to be confirmed (in slower, less priority timescales).
Given time constraints, we hope to now instead remove this coordinate by re-applying it to the data as its previous NaN value representation.

Flag values background in cf conventions [here](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#flag-variable-flag-values-ex)