### PR TITLE
Pin sphinx to version 5.3.0

### DIFF
--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - iris=3.0
   - cf_units
   - python-stratify
-  - sphinx
+  - sphinx=5.3.0
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - pip


### PR DESCRIPTION
Sphinx must be pinned to enable the docs to built using python 3.7 following changes in sphinx release 6.
https://www.sphinx-doc.org/en/master/changes.html#release-6-0-0-released-dec-29-2022

This PR pins the version in the read-the-docs environment.

Successful read-the-docs build with this change: https://readthedocs.org/projects/bens-improver-fork/builds/19074227/

Testing:
 - [ ] Ran tests and they passed OK
 - [ ] Added new tests for the new feature(s)
