### PR TITLE
Change conda dependency solver to libmamba-solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       id: cache
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 3
       with:
         path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
+        key: ${{ format('{0}-conda-improver-{1}-{2}', runner.os, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
     - name: conda env update
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
@@ -75,12 +72,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       id: cache
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 3
       with:
         path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
+        key: ${{ format('{0}-conda-improver-{1}-{2}', runner.os, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
     - name: conda env update
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
@@ -130,12 +124,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       id: cache
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 3
       with:
         path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}-{3}', runner.os, env.CACHE_NUMBER, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
+        key: ${{ format('{0}-conda-improver-{1}-{2}', runner.os, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
     - name: conda env update
       if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,10 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
-        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
-        conda install -c conda-forge mamba
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -86,11 +85,10 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
-        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
-        conda install -c conda-forge mamba
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -142,11 +140,10 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
-        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
-        conda install -c conda-forge mamba
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
+        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
         conda install -c conda-forge mamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
@@ -84,6 +86,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
+        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
         conda install -c conda-forge mamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
@@ -138,6 +142,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
+        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
         conda install -c conda-forge mamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,11 +19,10 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
-        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
-        conda install -c conda-forge mamba
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -70,11 +69,10 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
-        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
-        conda install -c conda-forge mamba
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -103,11 +101,10 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
-        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
-        conda install -c conda-forge mamba
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,6 +19,8 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
+        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
         conda install -c conda-forge mamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
@@ -68,6 +70,8 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
+        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
         conda install -c conda-forge mamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
@@ -99,6 +103,8 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
+        conda config --set allow_conda_downgrades true # workaround for actions/runner-images#6910
+        conda install conda=4.12.0 -y # workaround for actions/runner-images#6910
         conda install -c conda-forge mamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
         mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -20,7 +20,7 @@ dependencies:
   - numpy<1.21
   - scipy<1.7
   - sigtools
-  - sphinx
+  - sphinx=5.3.0
   # Additional libraries to run tests, not included in improver-feedstock
   - bandit
   - filelock


### PR DESCRIPTION
Recent actions using the latest environment have been failing - see [recent example of the scheduled run](https://github.com/metoppv/improver/actions/runs/3927180994/jobs/6713568771).

The CI job actions aren't currently failing on metoppv, but this is because they're [using existing caches](https://github.com/metoppv/improver/actions/runs/3912012569/jobs/6686099418#step:3:14). These CI jobs will also start to fail if the caches become stale and get regenerated. As an example, this happened on my [personal fork](https://github.com/tjtg/improver/actions/runs/3927383494/jobs/6713958567).

This failure seems to be due to the conda version packaged in the current version of the runner VM images from Github Actions not working with mamba. See actions/runner-images#6910 for details.

The proposed solution here is to change over from installing and using the mamba CLI, to installing libmamba-solver and setting it as the dependency solver for conda to use.

**Update:**
I went to bump the cache number and force caches to be regenerated after the changeover to libmamba-solver, but there is now a web interface to do this rather than needing to commit a change in the repository. See https://github.com/metoppv/improver/actions/caches and click on the bin icons.
This change fixes #1339.

Testing:
 - [x] Ran tests and they passed OK