### PR TITLE
Fix stale PR action checkout failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Reference:
+# - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+# - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+    labels:
+      - "bot"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,8 +14,7 @@ jobs:
     if: "github.repository == 'metoppv/improver'"
     runs-on: ubuntu-latest
     steps:
-        # Using actions/stale@v5
-      - uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
+      - uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Stale action failure due to commit SHA no longer existing.
Switch to using tags.  At the same time, use dependabot to automatically open new PRs for updating the tag of action tags (as per `improver_suite`, see https://github.com/MetOffice/improver_suite/pull/1503).

![image](https://user-images.githubusercontent.com/2071643/213382146-dbe5ab58-a322-4b8c-a785-1fb87cf2b5e6.png)
[link to failed action download](https://github.com/metoppv/improver/actions/runs/3954527266)

I'll [enable dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-version-updates-on-forks) on merge of this PR.