### PR TITLE
Fix hail size

### DIFF
--- a/improver/psychrometric_calculations/hail_size.py
+++ b/improver/psychrometric_calculations/hail_size.py
@@ -525,7 +525,9 @@ class HailSize(BasePlugin):
             wet_bulb_zero_height_asl,
             orography,
         )
-        extract_pressure = ExtractPressureLevel(value_of_pressure_level=268.15)
+        extract_pressure = ExtractPressureLevel(
+            value_of_pressure_level=268.15, positive_correlation=True
+        )
         pressure_at_268 = extract_pressure(temperature_on_pressure)
 
         temperature_at_268 = next(temperature_on_pressure.slices_over(["pressure"]))

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -358,8 +358,8 @@ class ExtractPressureLevel(BasePlugin):
 
     def fill_invalid(self, cube: Cube):
         """Populate any invalid values with the neighbouring value in that column plus the median
-        difference. This results in columns that do not have repeated values, which confuses
-        the stratify.interpolate method."""
+        difference. This results in columns that do not have repeated values as repeated values
+        confuses the stratify.interpolate method."""
         if not (
             np.logical_or(np.isnan(cube.data), np.isinf(cube.data)).any()
             or np.ma.is_masked(cube.data)

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -357,9 +357,10 @@ class ExtractPressureLevel(BasePlugin):
         return pressure_array
 
     def fill_invalid(self, cube: Cube):
-        """Populate any invalid values with the neighbouring value in that column plus the median
-        difference. This results in columns that do not have repeated values as repeated values
-        confuses the stratify.interpolate method."""
+        """Populate any invalid values with the neighbouring value in that column plus a small
+        difference (determined by the least_significant_digit attribute, or 10^-2). This results
+        in columns that do not have repeated values as repeated values confuses the
+        stratify.interpolate method."""
         if not (
             np.logical_or(np.isnan(cube.data), np.isinf(cube.data)).any()
             or np.ma.is_masked(cube.data)

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -473,6 +473,8 @@ class ExtractPressureLevel(BasePlugin):
         """Extracts the pressure level where the environment
         variable first intersects self.value_of_pressure_level starting at a pressure value
         near the surface and ascending in altitude from there.
+        Where the pressure surface falls outside the available data, the maximum or minimum
+        pressure will be returned, even if the source data has no value at that point.
 
         Args:
             variable_on_pressure_levels:

--- a/improver_tests/psychrometric_calculations/hail_size/test_hail_size.py
+++ b/improver_tests/psychrometric_calculations/hail_size/test_hail_size.py
@@ -385,32 +385,3 @@ def test_no_realization_coordinate(
         "time",
     ]
     assert result.shape == (3, 2)
-
-
-@pytest.mark.parametrize("missing_value", (np.nan, True, np.inf))
-def test_include_missing_data(
-    missing_value,
-    temperature_on_pressure_levels,
-    ccl_pressure,
-    ccl_temperature,
-    wet_bulb_freezing,
-    orography,
-):
-    """Test plugin if near-surface pressure levels contain missing values"""
-
-    if missing_value is True:
-        temperature_on_pressure_levels.data = np.ma.MaskedArray(temperature_on_pressure_levels.data, mask=False)
-        temperature_on_pressure_levels.data.mask[0, 0, 0, 0] = missing_value
-    else:
-        temperature_on_pressure_levels.data = temperature_on_pressure_levels.data.copy()
-        temperature_on_pressure_levels.data[0, 0, 0, 0] = missing_value
-    result = HailSize()(
-        ccl_temperature,
-        ccl_pressure,
-        temperature_on_pressure_levels,
-        wet_bulb_freezing,
-        orography,
-    )
-    np.testing.assert_array_almost_equal(result.data, 0.1)
-    metadata_check(result)
-    cube_shape_check(result)

--- a/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
@@ -102,6 +102,7 @@ def cube_shape_check_without_realizations(pressure_slice_cube):
     assert pressure_slice_cube.shape == (3, 2)
 
 
+@pytest.mark.parametrize("least_significant_digit", (0, None))
 @pytest.mark.parametrize("reverse_pressure", (False, True))
 @pytest.mark.parametrize(
     "special_value", (None, np.nan, True, np.inf, (np.nan, np.nan))
@@ -123,6 +124,7 @@ def test_basic(
     with_realization,
     special_value,
     reverse_pressure,
+    least_significant_digit,
 ):
     """Tests the ExtractPressureLevel plugin with values for temperature and
     temperature on pressure levels to check for expected result.
@@ -175,6 +177,12 @@ def test_basic(
     if not with_realization:
         temperature_on_pressure_levels = temperature_on_pressure_levels[0]
         expected_data = expected_data[0]
+
+    if least_significant_digit:
+        temperature_on_pressure_levels.attributes[
+            "least_significant_digit"
+        ] = least_significant_digit
+
     result = ExtractPressureLevel(
         value_of_pressure_level=temperature, positive_correlation=positive_correlation
     )(temperature_on_pressure_levels)
@@ -185,3 +193,46 @@ def test_basic(
         cube_shape_check_with_realizations(result)
     else:
         cube_shape_check_without_realizations(result)
+
+
+@pytest.mark.parametrize(
+    "index, expected",
+    (
+        (0, 30000),
+        (1, 30000),
+        (2, 80000),
+        (3, 100000),
+        (4, 100000),
+        (5, 100000),
+        (6, 100000),
+    ),
+)
+@pytest.mark.parametrize("special_value", (np.nan, True, np.inf))
+def test_only_one_point(
+    temperature_on_pressure_levels, index, expected, special_value,
+):
+    """Tests the ExtractPressureLevel plugin with the unusual case that only one layer has
+    a valid value.
+    """
+    temperature_on_pressure_levels = temperature_on_pressure_levels[0]
+
+    if special_value is True:
+        # This is a proxy for setting a mask=True entry
+        temperature_on_pressure_levels.data = np.ma.MaskedArray(
+            temperature_on_pressure_levels.data, mask=False
+        )
+        temperature_on_pressure_levels.data.mask[:index, 0, 0] = special_value
+        temperature_on_pressure_levels.data.mask[index + 1 :, 0, 0] = special_value
+    else:
+        temperature_on_pressure_levels.data = temperature_on_pressure_levels.data.copy()
+        temperature_on_pressure_levels.data[:index, 0, 0] = special_value
+        temperature_on_pressure_levels.data[index + 1 :, 0, 0] = special_value
+
+    expected_data = np.full_like(temperature_on_pressure_levels.data[0, ...], 80000)
+    expected_data[0, 0] = expected
+
+    result = ExtractPressureLevel(
+        value_of_pressure_level=280, positive_correlation=True
+    )(temperature_on_pressure_levels)
+    assert not np.ma.is_masked(result.data)
+    np.testing.assert_array_almost_equal(result.data, expected_data)

--- a/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
@@ -103,7 +103,9 @@ def cube_shape_check_without_realizations(pressure_slice_cube):
 
 
 @pytest.mark.parametrize("reverse_pressure", (False, True))
-@pytest.mark.parametrize("special_value", (np.nan, True, np.inf, (np.nan, np.nan)))
+@pytest.mark.parametrize(
+    "special_value", (None, np.nan, True, np.inf, (np.nan, np.nan))
+)
 @pytest.mark.parametrize("with_realization", (True, False))
 @pytest.mark.parametrize(
     "temperature,expected_p_index",
@@ -154,6 +156,8 @@ def test_basic(
         temperature_on_pressure_levels.data.mask[
             0, special_value_index, 0, 0
         ] = special_value
+    elif special_value is None:
+        pass
     else:
         temperature_on_pressure_levels.data = temperature_on_pressure_levels.data.copy()
         if isinstance(special_value, float):

--- a/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
@@ -29,6 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for the ExtractPressureLevel plugin"""
+from collections.abc import Iterable
 
 import numpy as np
 import pytest
@@ -164,15 +165,16 @@ def test_basic(
         pass
     else:
         temperature_on_pressure_levels.data = temperature_on_pressure_levels.data.copy()
-        if isinstance(special_value, float):
-            temperature_on_pressure_levels.data[
-                0, special_value_index, 0, 0
-            ] = special_value
-        else:
+        if isinstance(special_value, Iterable):
+            # This catches the test case where two consecutive special values are to be used
             if special_value_index < 0:
                 temperature_on_pressure_levels.data[0, -2:, 0, 0] = special_value
             else:
                 temperature_on_pressure_levels.data[0, 0:2, 0, 0] = special_value
+        else:
+            temperature_on_pressure_levels.data[
+                0, special_value_index, 0, 0
+            ] = special_value
 
     if not with_realization:
         temperature_on_pressure_levels = temperature_on_pressure_levels[0]

--- a/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
@@ -151,11 +151,15 @@ def test_basic(
         temperature_on_pressure_levels.data = np.ma.MaskedArray(
             temperature_on_pressure_levels.data, mask=False
         )
-        temperature_on_pressure_levels.data.mask[0, special_value_index, 0, 0] = special_value
+        temperature_on_pressure_levels.data.mask[
+            0, special_value_index, 0, 0
+        ] = special_value
     else:
         temperature_on_pressure_levels.data = temperature_on_pressure_levels.data.copy()
         if isinstance(special_value, float):
-            temperature_on_pressure_levels.data[0, special_value_index, 0, 0] = special_value
+            temperature_on_pressure_levels.data[
+                0, special_value_index, 0, 0
+            ] = special_value
         else:
             if special_value_index < 0:
                 temperature_on_pressure_levels.data[0, -2:, 0, 0] = special_value

--- a/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractPressureLevel.py
@@ -132,6 +132,7 @@ def test_basic(
     Tests behaviour with and without a realization coordinate.
     Also checks the metadata of the output cube"""
     special_value_index = 0
+    positive_correlation = True
     if reverse_pressure:
         # Flip the pressure coordinate for this test. We also swap which end the
         # special value goes, so we can test _one_way_fill in both modes.
@@ -139,6 +140,7 @@ def test_basic(
             "pressure"
         ).points = temperature_on_pressure_levels.coord("pressure").points[::-1]
         special_value_index = -1
+        positive_correlation = False
     expected = np.interp(
         expected_p_index,
         range(len(temperature_on_pressure_levels.coord("pressure").points)),
@@ -173,9 +175,9 @@ def test_basic(
     if not with_realization:
         temperature_on_pressure_levels = temperature_on_pressure_levels[0]
         expected_data = expected_data[0]
-    result = ExtractPressureLevel(value_of_pressure_level=temperature)(
-        temperature_on_pressure_levels
-    )
+    result = ExtractPressureLevel(
+        value_of_pressure_level=temperature, positive_correlation=positive_correlation
+    )(temperature_on_pressure_levels)
     assert not np.ma.is_masked(result.data)
     np.testing.assert_array_almost_equal(result.data, expected_data)
     metadata_check(result, temperature, temperature_on_pressure_levels.units)


### PR DESCRIPTION
Closes #1832

An investigation into the behaviour of the hail size plugin found that it wasn't generating a 268K isotherm pressure correctly. This is within the `ExtractPressureLevel` plugin and additional unit tests showed that the presence of `np.nan` values, where the source variable-on-pressure-levels fell below the NWP model surface, was causing the issue. The existing `fill_invalid` method was working, but if more than one level were missing, both received the same infill value which caused the `stratify.interpolate` method to fail (I didn't dig deeply, but I think it couldn't determine the direction of change in the column)

While playing with unit tests, it became apparent that the code was not robust to data ordered differently. It is reasonable to define a pressure coordinate that increases, rather than decreases, and it is reasonable to provide a variable that reduces with altitude, rather than increases. It is also reasonable for the missing values to be at either end, and to be represented by a mask rather than a `nan`. All of these cases are now handled and tested. There is only one test, but it has several levels of parametrization resulting in 64 individual tests.

Once done, I tested the code with some global-domain data, but found that it still failed because I had made an assumption that the zeroth spatial grid point would represent the temperature changes in the whole domain. As this point is high up over Antarctica, this is not true and that column is dominated by the stratosphere where temperatures **increase** with altitude which completely ruined the entire domain. The solution I've implemented is to pick a column near the centre of the domain for determining the direction of the variable. And now it works.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
