### PR TITLE
Shrink acceptance test data - PR15

### DIFF
--- a/improver_tests/acceptance/test_nbhood.py
+++ b/improver_tests/acceptance/test_nbhood.py
@@ -45,7 +45,7 @@ def test_basic_circular(tmp_path):
     """Test basic circular neighbourhooding"""
     kgo_dir = acc.kgo_root() / "nbhood/basic"
     kgo_path = kgo_dir / "kgo_circular.nc"
-    input_path = kgo_dir / "input_circular.nc"
+    input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,
@@ -67,7 +67,7 @@ def test_basic_square(tmp_path):
     """Test basic square neighbourhooding"""
     kgo_dir = acc.kgo_root() / "nbhood/basic"
     kgo_path = kgo_dir / "kgo_square.nc"
-    input_path = kgo_dir / "input_square.nc"
+    input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [
         input_path,


### PR DESCRIPTION
#A component of https://github.com/metoppv/improver/issues/1804

To reduce the data volume of the acceptance test data repository, work has been done to coarsen the resolution of test data relating to the following CLIs:

- nbhood

This PR updates the checksums. It also unifies the input data for the nbhood/basic acceptance tests.
Most KGO are very similar to the originals, but by the nature of neighbourhooding they tend to be modified towards the edges of the domain where the data available within a neighbourhood has changed.

## nbhood/basic
I unified the inputs for these tests. The circular originally took in a 3-threshold input and the square a single threshold input (which was the first threshold of the data used for the circular test). I've made the input a shared 2-threshold file which retains the originally shared threshold. Differences are confined to the edges of the domain as expected.

![nbhood_basic_kgo_circular](https://user-images.githubusercontent.com/28042362/223396333-00fa7f4f-a37d-4ee7-8899-0549c7cd1ba1.png)
![nbhood_basic_kgo_square](https://user-images.githubusercontent.com/28042362/223396326-d7c13047-0f85-45ca-bfcb-d1cdf3a5a2aa.png)


The relevant acceptance test data can be found in branch shrink_atd_15
Plotting of the original and modified data [can be seen here](https://github.com/MetOffice/improver_aux/blob/acceptance_test_data_shrinking/notebooks/acceptance_test_data/shrink_atd_15.ipynb).