### PR TITLE
Debug scheduled action

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,7 +22,8 @@ jobs:
         conda install -n base conda-libmamba-solver
         conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda config --show-sources
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }} --solver=libmamba
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -72,7 +73,8 @@ jobs:
         conda install -n base conda-libmamba-solver
         conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda config --show-sources
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }} --solver=libmamba
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -104,7 +106,8 @@ jobs:
         conda install -n base conda-libmamba-solver
         conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
+        conda config --show-sources
+        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }} --solver=libmamba
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'


### PR DESCRIPTION
To hopefully address the failing [scheduled actions](https://github.com/metoppv/improver/actions/workflows/scheduled.yml).

Recently we switched (https://github.com/metoppv/improver/pull/1850) to using the libmamba solver as per [docs](https://conda.github.io/conda-libmamba-solver/getting-started/#set-as-default).
For some reason, the conda env update is sometimes taking 2m while at other times tasking an hour.  More recently, taking more consistently taking long enough to timeout.

This proposed change is to understand whether the solver is actually being changed via the documented means and also whether specifying the solver for the update makes the difference.

At some point it might be preferable to move back to mamba the tool as that provides parallel resolution (as I recall anyway - dunno on the fence).