### PR TITLE
DEBUG: Using mamba tool once more

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,11 +19,9 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda install -n base conda-libmamba-solver
-        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        conda config --show-sources
-        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }} --solver=libmamba
+        conda install -c conda-forge mamba
+        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -70,11 +68,9 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda install -n base conda-libmamba-solver
-        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        conda config --show-sources
-        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }} --solver=libmamba
+        conda install -c conda-forge mamba
+        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
@@ -103,11 +99,9 @@ jobs:
     - name: conda env update
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda install -n base conda-libmamba-solver
-        conda config --set solver libmamba
         rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        conda config --show-sources
-        conda env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }} --solver=libmamba
+        conda install -c conda-forge mamba
+        mamba env update -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
     - name: conda info
       run: |
         source '/usr/share/miniconda/etc/profile.d/conda.sh'


### PR DESCRIPTION
Looks like the [switch](https://github.com/metoppv/improver/pull/1850) to conda-libmamba brought with it a new set of problems.  The environment resolving within minutes at times, while at other times, timing out after over an hour. Let's see whether conda provided with the ubuntu image works with the mamba tool once more and what difference that makes on resolving the environment.

Note how the change to libmamba solver ran fine for 1 day then produced inconsistent results thereafter (sometimes failing and sometimes succeeding).
![image](https://user-images.githubusercontent.com/2071643/228230481-47c5e767-40c8-48e8-8acb-cd5e881cd0ce.png)

Previous attempt to fixing/debugging the issue:
https://github.com/metoppv/improver/pull/1888