### PR TITLE
Add CLI to perform blending with mismatching vicinities and the option to rename the cube

### DIFF
--- a/improver/cli/blend_with_vicinity_and_rename.py
+++ b/improver/cli/blend_with_vicinity_and_rename.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Script to run weighted blending, with mismatched vicinity coord and new output cube name."""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(
+    *cubes: cli.inputcube,
+    coordinate,
+    new_name: str = None,
+    vicinity_radius: float = None,
+    weighting_method="linear",
+    weighting_coord="forecast_period",
+    weighting_config: cli.inputjson = None,
+    attributes_config: cli.inputjson = None,
+    cycletime: str = None,
+    y0val: float = None,
+    ynval: float = None,
+    cval: float = None,
+    model_id_attr: str = None,
+    record_run_attr: str = None,
+    spatial_weights_from_mask=False,
+    fuzzy_length=20000.0,
+):
+    """Runs weighted blending, with additional options to handle mismatched in_vicinity coords
+    and to apply a new name to the output cube.
+
+    Check for inconsistent arguments, then calculate a weighted blend
+    of input cube data using the options specified.
+
+    Args:
+        cubes (iris.cube.CubeList):
+            Cubelist of cubes to be blended.
+        coordinate (str):
+            The coordinate over which the blending will be applied.
+        new_name (str):
+            Replaces cube.name() on the output cube.
+        vicinity_radius (float):
+            The data value associated with the vicinity coord on the output cube.
+            Assumes same units as the x and y spatial coordinates.
+        weighting_method (str):
+            Method to use to calculate weights used in blending.
+            "linear" (default): calculate linearly varying blending weights.
+            "nonlinear": calculate blending weights that decrease
+            exponentially with increasing blending coordinates.
+            "dict": calculate weights using a dictionary passed in.
+        weighting_coord (str):
+            Name of coordinate over which linear weights should be scaled.
+            This coordinate must be available in the weights dictionary.
+        weighting_config (dict or None):
+            Dictionary from which to calculate blending weights. Dictionary
+            format is as specified in
+            improver.blending.weights.ChoosingWeightsLinear
+        attributes_config (dict):
+            Dictionary describing required changes to attributes after blending
+        cycletime (str):
+            The forecast reference time to be used after blending has been
+            applied, in the format YYYYMMDDTHHMMZ. If not provided, the
+            blended file takes the latest available forecast reference time
+            from the input datasets supplied.
+        y0val (float):
+            The relative value of the weighting start point (lowest value of
+            blend coord) for choosing default linear weights.
+            If used this must be a positive float or 0.
+        ynval (float):
+            The relative value of the weighting end point (highest value of
+            blend coord) for choosing default linear weights. This must be a
+            positive float or 0.
+            Note that if blending over forecast reference time, ynval >= y0val
+            would normally be expected (to give greater weight to the more
+            recent forecast).
+        cval (float):
+            Factor used to determine how skewed the non-linear weights will be.
+            A value of 1 implies equal weighting.
+        model_id_attr (str):
+            The name of the dataset attribute to be used to identify the source
+            model when blending data from different models.
+        record_run_attr:
+            The name of the dataset attribute to be used to store model and
+            cycle sources in metadata, e.g. when blending data from different
+            models. Requires model_id_attr.
+        spatial_weights_from_mask (bool):
+            If True, this option will result in the generation of spatially
+            varying weights based on the masks of the data we are blending.
+            The one dimensional weights are first calculated using the chosen
+            weights calculation method, but the weights will then be adjusted
+            spatially based on where there is masked data in the data we are
+            blending. The spatial weights are calculated using the
+            SpatiallyVaryingWeightsFromMask plugin.
+        fuzzy_length (float):
+            When calculating spatially varying weights we can smooth the
+            weights so that areas close to areas that are masked have lower
+            weights than those further away. This fuzzy length controls the
+            scale over which the weights are smoothed. The fuzzy length is in
+            terms of m, the default is 20km. This distance is then converted
+            into a number of grid squares, which does not have to be an
+            integer. Assumes the grid spacing is the same in the x and y
+            directions and raises an error if this is not true. See
+            SpatiallyVaryingWeightsFromMask for more details.
+
+    Returns:
+        iris.cube.Cube:
+            Merged and blended Cube.
+
+    Raises:
+        RuntimeError:
+            If calc_method is linear and cval is not None.
+        RuntimeError:
+            If calc_method is nonlinear and either y0val and ynval is not None.
+        RuntimeError:
+            If calc_method is dict and weights_dict is None.
+    """
+    from improver.cli import weighted_blending
+    from improver.utilities.spatial import update_name_and_vicinity_coord
+
+    if not new_name and not vicinity_radius:
+        raise ValueError(
+            "Neither new_name nor vicinity_radius have been specified. Use weighted-blending "
+            "instead."
+        )
+
+    result_cube = weighted_blending.process(
+        *cubes,
+        coordinate=coordinate,
+        weighting_method=weighting_method,
+        weighting_coord=weighting_coord,
+        weighting_config=weighting_config,
+        attributes_config=attributes_config,
+        cycletime=cycletime,
+        y0val=y0val,
+        ynval=ynval,
+        cval=cval,
+        model_id_attr=model_id_attr,
+        record_run_attr=record_run_attr,
+        spatial_weights_from_mask=spatial_weights_from_mask,
+        fuzzy_length=fuzzy_length,
+    )
+    update_name_and_vicinity_coord(result_cube, new_name, vicinity_radius)
+    return result_cube

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -31,7 +31,7 @@
 """Module containing plugins for combining cubes"""
 
 from operator import eq
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Union
 
 import iris
 import numpy as np
@@ -40,13 +40,10 @@ from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
+from improver.metadata.amend import update_diagnostic_name
 from improver.metadata.check_datatypes import enforce_dtype
 from improver.metadata.constants.time_types import TIME_COORDS
-from improver.metadata.probabilistic import (
-    find_threshold_coordinate,
-    get_diagnostic_cube_name_from_probability_name,
-    get_threshold_coord_name_from_probability_name,
-)
+from improver.metadata.probabilistic import find_threshold_coordinate
 from improver.utilities.cube_manipulation import (
     enforce_coordinate_ordering,
     expand_bounds,
@@ -439,56 +436,6 @@ class CubeMultiplier(CubeCombiner):
             (len(coord1.points) == 1) or (len(coord2.points) == 1)
         )
 
-    @staticmethod
-    def _update_cell_methods(
-        cell_methods: Tuple[CellMethod], original_name: str, new_diagnostic_name: str,
-    ) -> List[CellMethod]:
-        """
-        Update any cell methods that include a comment that refers to the
-        diagnostic name to refer instead to the new diagnostic name. Those cell
-        methods that do not include the diagnostic name are passed through
-        unmodified.
-
-        Args:
-            cell_methods:
-                The cell methods found on the cube that is being used as the
-                metadata template.
-            original_name:
-                The full name of the metadata template cube.
-            new_diagnostic_name:
-                The new diagnostic name to use in the modified cell methods.
-
-        Returns:
-            A list of modified cell methods to replace the originals.
-        """
-        try:
-            # strip probability and vicinity components to provide the diagnostic name
-            diagnostic_name = get_threshold_coord_name_from_probability_name(
-                original_name
-            )
-        except ValueError:
-            diagnostic_name = original_name
-
-        new_cell_methods = []
-        for cell_method in cell_methods:
-            try:
-                (cell_comment,) = cell_method.comments
-            except ValueError:
-                new_cell_methods.append(cell_method)
-            else:
-                if diagnostic_name in cell_comment:
-                    new_cell_methods.append(
-                        CellMethod(
-                            cell_method.method,
-                            coords=cell_method.coord_names,
-                            intervals=cell_method.intervals,
-                            comments=f"of {new_diagnostic_name}",
-                        )
-                    )
-                else:
-                    new_cell_methods.append(cell_method)
-        return new_cell_methods
-
     def process(
         self, cube_list: Union[List[Cube], CubeList], new_diagnostic_name: str
     ) -> Cube:
@@ -524,34 +471,9 @@ class CubeMultiplier(CubeCombiner):
 
         result = self._combine_cube_data(cube_list)
 
-        # Used for renaming the threshold coordinate and modifying cell methods
-        # where necessary; excludes the in_vicinity component.
-        new_base_name = new_diagnostic_name.replace("_in_vicinity", "")
-
-        original_name = cube_list[0].name()
-
-        if self.broadcast_to_threshold:
-            diagnostic_name = get_diagnostic_cube_name_from_probability_name(
-                original_name
-            )
-            # Rename the threshold coordinate to match the name of the diagnostic
-            # that results from the combine operation.
-            result.coord(var_name="threshold").rename(new_base_name)
-            result.coord(new_base_name).var_name = "threshold"
-
-            new_diagnostic_name = original_name.replace(
-                diagnostic_name, new_diagnostic_name
-            )
-
-        # Modify cell methods that include the variable name to match the new
-        # name.
-        cell_methods = cube_list[0].cell_methods
-        if cell_methods:
-            result.cell_methods = self._update_cell_methods(
-                cell_methods, original_name, new_base_name
-            )
-
-        result.rename(new_diagnostic_name)
+        update_diagnostic_name(
+            cube_list[0], new_diagnostic_name, result, self.broadcast_to_threshold
+        )
 
         return result
 

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -471,9 +471,7 @@ class CubeMultiplier(CubeCombiner):
 
         result = self._combine_cube_data(cube_list)
 
-        update_diagnostic_name(
-            cube_list[0], new_diagnostic_name, result, self.broadcast_to_threshold
-        )
+        update_diagnostic_name(cube_list[0], new_diagnostic_name, result)
 
         return result
 

--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -67,6 +67,7 @@ BOUNDS_FOR_ECDF = {
     "lwe_thickness_of_graupel_and_hail_fall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_precipitation_amount_in_vicinity": Bounds((0, 0.5), "m"),
+    "lwe_thickness_of_precipitation_amount_in_variable_vicinity": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_sleetfall_amount": Bounds((0, 0.5), "m"),
     "lwe_thickness_of_snowfall_amount": Bounds((0, 0.5), "m"),
     "thickness_of_rainfall_amount": Bounds((0, 0.5), "m"),

--- a/improver/metadata/amend.py
+++ b/improver/metadata/amend.py
@@ -30,13 +30,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing utilities for modifying cube metadata"""
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
+from iris.coords import CellMethod
 from iris.cube import Cube, CubeList
 
 from improver.metadata.constants.mo_attributes import (
     GRID_ID_LOOKUP,
     MOSG_GRID_DEFINITION,
+)
+from improver.metadata.probabilistic import (
+    get_diagnostic_cube_name_from_probability_name,
+    get_threshold_coord_name_from_probability_name,
 )
 
 
@@ -131,3 +136,92 @@ def update_model_id_attr_attribute(
 
     attr_list = [a for c in cubes for a in c.attributes[model_id_attr].split(" ")]
     return {model_id_attr: " ".join(sorted(set(attr_list)))}
+
+
+def update_diagnostic_name(
+    source_cube: Cube,
+    new_diagnostic_name: str,
+    result: Cube,
+    rename_threshold_coord: bool = True,
+):
+    """
+    Used for renaming the threshold coordinate and modifying cell methods
+    where necessary; excludes the in_vicinity component.
+
+    Args:
+        source_cube: An original cube before any processing took place. Can be the same cube as
+            result.
+        new_diagnostic_name: The new diagnostic name to apply to result.
+        result: The cube that needs to be modified in place.
+        rename_threshold_coord: If True (default), the threshold coord is modified to match the
+            diagnostic name.
+
+    """
+    new_base_name = new_diagnostic_name.replace("_in_vicinity", "")
+    original_name = source_cube.name()
+    if rename_threshold_coord:
+        diagnostic_name = get_diagnostic_cube_name_from_probability_name(original_name)
+        # Rename the threshold coordinate to match the name of the diagnostic
+        # that results from the combine operation.
+        result.coord(var_name="threshold").rename(new_base_name)
+        result.coord(new_base_name).var_name = "threshold"
+
+        new_diagnostic_name = original_name.replace(
+            diagnostic_name, new_diagnostic_name
+        )
+    # Modify cell methods that include the variable name to match the new
+    # name.
+    cell_methods = source_cube.cell_methods
+    if cell_methods:
+        result.cell_methods = _update_cell_methods(
+            cell_methods, original_name, new_base_name
+        )
+    result.rename(new_diagnostic_name)
+
+
+def _update_cell_methods(
+    cell_methods: Tuple[CellMethod], original_name: str, new_diagnostic_name: str,
+) -> List[CellMethod]:
+    """
+    Update any cell methods that include a comment that refers to the
+    diagnostic name to refer instead to the new diagnostic name. Those cell
+    methods that do not include the diagnostic name are passed through
+    unmodified.
+
+    Args:
+        cell_methods:
+            The cell methods found on the cube that is being used as the
+            metadata template.
+        original_name:
+            The full name of the metadata template cube.
+        new_diagnostic_name:
+            The new diagnostic name to use in the modified cell methods.
+
+    Returns:
+        A list of modified cell methods to replace the originals.
+    """
+    try:
+        # strip probability and vicinity components to provide the diagnostic name
+        diagnostic_name = get_threshold_coord_name_from_probability_name(original_name)
+    except ValueError:
+        diagnostic_name = original_name
+
+    new_cell_methods = []
+    for cell_method in cell_methods:
+        try:
+            (cell_comment,) = cell_method.comments
+        except ValueError:
+            new_cell_methods.append(cell_method)
+        else:
+            if diagnostic_name in cell_comment:
+                new_cell_methods.append(
+                    CellMethod(
+                        cell_method.method,
+                        coords=cell_method.coord_names,
+                        intervals=cell_method.intervals,
+                        comments=f"of {new_diagnostic_name}",
+                    )
+                )
+            else:
+                new_cell_methods.append(cell_method)
+    return new_cell_methods

--- a/improver/metadata/amend.py
+++ b/improver/metadata/amend.py
@@ -42,6 +42,7 @@ from improver.metadata.constants.mo_attributes import (
 from improver.metadata.probabilistic import (
     get_diagnostic_cube_name_from_probability_name,
     get_threshold_coord_name_from_probability_name,
+    is_probability,
 )
 
 
@@ -138,12 +139,7 @@ def update_model_id_attr_attribute(
     return {model_id_attr: " ".join(sorted(set(attr_list)))}
 
 
-def update_diagnostic_name(
-    source_cube: Cube,
-    new_diagnostic_name: str,
-    result: Cube,
-    rename_threshold_coord: bool = True,
-):
+def update_diagnostic_name(source_cube: Cube, new_diagnostic_name: str, result: Cube):
     """
     Used for renaming the threshold coordinate and modifying cell methods
     where necessary; excludes the in_vicinity component.
@@ -153,13 +149,13 @@ def update_diagnostic_name(
             result.
         new_diagnostic_name: The new diagnostic name to apply to result.
         result: The cube that needs to be modified in place.
-        rename_threshold_coord: If True (default), the threshold coord is modified to match the
-            diagnostic name.
 
     """
-    new_base_name = new_diagnostic_name.replace("_in_vicinity", "")
+    new_base_name = new_diagnostic_name.replace("_in_variable_vicinity", "")
+    new_base_name = new_base_name.replace("_in_vicinity", "")
     original_name = source_cube.name()
-    if rename_threshold_coord:
+
+    if is_probability(source_cube):
         diagnostic_name = get_diagnostic_cube_name_from_probability_name(original_name)
         # Rename the threshold coordinate to match the name of the diagnostic
         # that results from the combine operation.

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -75,7 +75,7 @@ def in_vicinity_name_format(cube_name: str) -> str:
         'probability_of_X_in_vicinity_above_threshold'.
     """
     regex = probability_cube_name_regex(cube_name)
-    new_cube_name = "probability_of_{diag}{vicinity}{thresh}".format(
+    new_cube_name = "probability_of_{diag}_in_vicinity{thresh}".format(
         **regex.groupdict()
     )
     return new_cube_name

--- a/improver/metadata/probabilistic.py
+++ b/improver/metadata/probabilistic.py
@@ -55,7 +55,7 @@ def probability_cube_name_regex(cube_name: str) -> Optional[Match]:
     regex = re.compile(
         "(probability_of_)"  # always starts this way
         "(?P<diag>.*?)"  # named group for the diagnostic name
-        "(_in_vicinity|)"  # optional group, may be empty
+        "(?P<vicinity>_in_vicinity|_in_variable_vicinity)?"  # optional group, may be empty
         "(?P<thresh>_above_threshold|_below_threshold|_between_thresholds|$)"
     )
     return regex.match(cube_name)
@@ -75,7 +75,7 @@ def in_vicinity_name_format(cube_name: str) -> str:
         'probability_of_X_in_vicinity_above_threshold'.
     """
     regex = probability_cube_name_regex(cube_name)
-    new_cube_name = "probability_of_{diag}_in_vicinity{thresh}".format(
+    new_cube_name = "probability_of_{diag}{vicinity}{thresh}".format(
         **regex.groupdict()
     )
     return new_cube_name
@@ -108,7 +108,7 @@ def _extract_diagnostic_name(cube_name: str, check_vicinity: bool = False) -> st
             If False the function will return X as described above, which matches
             the name of the threshold-type coordinate on the cube.  If True, the
             cube name is checked to see whether it is a vicinity diagnostic, and
-            if so the function returns "X_in_vicinity".  This is the name of the
+            if so the function returns "X_in.*_vicinity".  This is the name of the
             equivalent diagnostic in percentile or realization space.
 
     Returns:
@@ -118,15 +118,17 @@ def _extract_diagnostic_name(cube_name: str, check_vicinity: bool = False) -> st
         ValueError: If the input name does not match the expected regular
             expression (ie if cube_name_regex(cube_name) returns None).
     """
+    cube_name_parts = probability_cube_name_regex(cube_name)
     try:
-        diagnostic_name = probability_cube_name_regex(cube_name).group("diag")
+        diagnostic_name = cube_name_parts.group("diag")
     except AttributeError:
         raise ValueError(
             "Input {} is not a valid probability cube name".format(cube_name)
         )
 
-    if check_vicinity and "_in_vicinity" in cube_name:
-        diagnostic_name += "_in_vicinity"
+    vicinity_match = cube_name_parts.group("vicinity")
+    if check_vicinity and vicinity_match:
+        diagnostic_name += vicinity_match
 
     return diagnostic_name
 

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -47,10 +47,7 @@ from scipy.ndimage.filters import maximum_filter
 from improver import BasePlugin, PostProcessingPlugin
 from improver.metadata.amend import update_diagnostic_name
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
-from improver.metadata.probabilistic import (
-    in_vicinity_name_format,
-    is_probability,
-)
+from improver.metadata.probabilistic import in_vicinity_name_format, is_probability
 from improver.metadata.utilities import create_new_diagnostic_cube
 from improver.utilities.cube_checker import check_cube_coordinates, spatial_coords_match
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
@@ -717,7 +714,7 @@ def update_name_and_vicinity_coord(cube: Cube, new_name: str, vicinity_radius: f
         if vicinities_matched:
             cube.remove_coord("radius_of_vicinity")
         add_vicinity_coordinate(
-            cube, vicinity_radius, radius_is_max=~vicinities_matched
+            cube, vicinity_radius, radius_is_max=not vicinities_matched
         )
 
 

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -45,8 +45,12 @@ from numpy import ndarray
 from scipy.ndimage.filters import maximum_filter
 
 from improver import BasePlugin, PostProcessingPlugin
+from improver.metadata.amend import update_diagnostic_name
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
-from improver.metadata.probabilistic import in_vicinity_name_format, is_probability
+from improver.metadata.probabilistic import (
+    in_vicinity_name_format,
+    is_probability,
+)
 from improver.metadata.utilities import create_new_diagnostic_cube
 from improver.utilities.cube_checker import check_cube_coordinates, spatial_coords_match
 from improver.utilities.cube_manipulation import enforce_coordinate_ordering
@@ -518,35 +522,6 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
             max_cube.data = max_data
         return max_cube
 
-    def _add_vicinity_coordinate(self, cube: Cube, radius: Union[float, int]) -> None:
-        """
-        Add a coordinate to the cube that records the vicinity radius that
-        has been applied to the data.
-
-        Args:
-            cube:
-                Vicinity processed cube.
-            radius:
-                The radius as a physical distance or number of grid points, the
-                value of which is recorded in the coordinate.
-        """
-        if self.native_grid_point_radius:
-            point = np.array(radius, dtype=np.float32)
-            units = "1"
-            attributes = {
-                "comment": "Units of 1 indicate radius of vicinity is defined "
-                "in grid points rather than physical distance"
-            }
-        else:
-            point = np.array(radius, dtype=np.float32)
-            units = "m"
-            attributes = {}
-
-        coord = AuxCoord(
-            point, units=units, long_name="radius_of_vicinity", attributes=attributes
-        )
-        cube.add_aux_coord(coord)
-
     def process(self, cube: Cube) -> Cube:
         """
         Produces the vicinity processed data. The input data is sliced to
@@ -604,7 +579,7 @@ class OccurrenceWithinVicinity(PostProcessingPlugin):
             result_cube = check_cube_coordinates(cube, result_cube)
 
             # Add a coordinate recording the vicinity radius applied to the data.
-            self._add_vicinity_coordinate(result_cube, radius)
+            add_vicinity_coordinate(result_cube, radius, self.native_grid_point_radius)
 
             radii_cubes.append(result_cube)
 
@@ -716,3 +691,58 @@ def transform_grid_to_lat_lon(cube: Cube) -> Tuple[ndarray, ndarray]:
     lats = points[..., 1]
 
     return lats, lons
+
+
+def update_name_and_vicinity_coord(cube: Cube, new_name: str, vicinity_radius: float):
+    """
+    Updates a cube with a new probabilistic-style name and replaces or adds a radius_of_vicinity
+    coord with the specified radius.
+
+    Args:
+        cube: Cube to be updated in-place
+        new_name: The new name to be applied to the Cube, the threshold coord and any related
+            cell methods.
+        vicinity_radius: The point value for the radius_of_vicinity coord. The units are assumed
+            to be the same as the x and y spatial coords of the Cube
+
+    """
+    if new_name:
+        update_diagnostic_name(cube, new_name, cube)
+    if vicinity_radius:
+        if "radius_of_vicinity" in [coord.name() for coord in cube.coords()]:
+            cube.remove_coord("radius_of_vicinity")
+        add_vicinity_coordinate(cube, vicinity_radius)
+
+
+def add_vicinity_coordinate(
+    cube: Cube, radius: Union[float, int], native_grid_point_radius: bool = False
+) -> None:
+    """
+    Add a coordinate to the cube that records the vicinity radius that
+    has been applied to the data.
+
+    Args:
+        cube:
+            Vicinity processed cube.
+        radius:
+            The radius as a physical distance (m) or number of grid points, the
+            value of which is recorded in the coordinate.
+        native_grid_point_radius:
+            True if radius is "number of grid points", else False
+    """
+    if native_grid_point_radius:
+        point = np.array(radius, dtype=np.float32)
+        units = "1"
+        attributes = {
+            "comment": "Units of 1 indicate radius of vicinity is defined "
+            "in grid points rather than physical distance"
+        }
+    else:
+        point = np.array(radius, dtype=np.float32)
+        units = "m"
+        attributes = {}
+
+    coord = AuxCoord(
+        point, units=units, long_name="radius_of_vicinity", attributes=attributes
+    )
+    cube.add_aux_coord(coord)

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -110,6 +110,12 @@ f274cbc5a3b076a477a152d74a6ddac09a133f87619915a8d1a40c08f5d9d85b  ./blend-adjace
 3d84f229a2b9203ac5b685036d0a42b170075dfea1789fcb8e823cb82acdefdc  ./blend-cycles-and-realizations/basic/0900Z_precip_rate.nc
 cebf5785b5d98d11ab091f6e870b69a71ee95db4390fb7d509072006abb25543  ./blend-cycles-and-realizations/basic/1000Z_precip_rate.nc
 b082744bc817a37dfef5a165e52c71d3db5037342785db94393903323adc7346  ./blend-cycles-and-realizations/basic/kgo.nc
+c163c7abc3cfca24c9509b9f461da8e6defc2af6a33f26b52dc52d066389c265  ./blend-with-vicinity-and-rename/attributes.json
+67dbf1a0e1725cd4fe77dc2c2c422fb379edd59262cc6aaa2e0f40b207db8cf9  ./blend-with-vicinity-and-rename/blending_weights.json
+a7aec5f0b80d6f7ac6f71fea1c9bf15b76b92572509b5e550e7151bfd005777b  ./blend-with-vicinity-and-rename/enukx.nc
+6c498befd962f286dedc8041ea8981007474f32995ee5dba0b6fbf6629ae47ad  ./blend-with-vicinity-and-rename/ncuk.nc
+00afa510d2b1f088f14cf75dd8aad80c2c9be3a53fb39d180e0621ea0ac4d235  ./blend-with-vicinity-and-rename/ukvx.nc
+9fee5756f45af01b54b8c608b60e7e564d5dfa447bc731a8f505fe0c84c69389  ./blend-with-vicinity-and-rename/with_nowcast/kgo.nc
 0fc03589a5a17536a16805a76208a12eabceb6a9fb0042842dbd42aa05c26acb  ./calculate-forecast-bias/inputs/20220811T0300Z-PT0000H00M-wind_speed_at_10m.nc
 a86344226370885ca6062200ddda5db1fab629d398c5af0678254c1d9960d272  ./calculate-forecast-bias/inputs/20220811T0300Z-PT0003H00M-wind_speed_at_10m.nc
 ac609404e0083db721ded42d983f3a616f8ce7ca220ef3bbfc2af9ccfd83c02f  ./calculate-forecast-bias/inputs/20220812T0300Z-PT0000H00M-wind_speed_at_10m.nc

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -116,6 +116,7 @@ a7aec5f0b80d6f7ac6f71fea1c9bf15b76b92572509b5e550e7151bfd005777b  ./blend-with-v
 6c498befd962f286dedc8041ea8981007474f32995ee5dba0b6fbf6629ae47ad  ./blend-with-vicinity-and-rename/ncuk.nc
 00afa510d2b1f088f14cf75dd8aad80c2c9be3a53fb39d180e0621ea0ac4d235  ./blend-with-vicinity-and-rename/ukvx.nc
 9fee5756f45af01b54b8c608b60e7e564d5dfa447bc731a8f505fe0c84c69389  ./blend-with-vicinity-and-rename/with_nowcast/kgo.nc
+1f0d55b15c75f04e8cea2aed7fc87e93fd8051ad40592e8c16622b2d72bcbadf  ./blend-with-vicinity-and-rename/without_nowcast/kgo.nc
 0fc03589a5a17536a16805a76208a12eabceb6a9fb0042842dbd42aa05c26acb  ./calculate-forecast-bias/inputs/20220811T0300Z-PT0000H00M-wind_speed_at_10m.nc
 a86344226370885ca6062200ddda5db1fab629d398c5af0678254c1d9960d272  ./calculate-forecast-bias/inputs/20220811T0300Z-PT0003H00M-wind_speed_at_10m.nc
 ac609404e0083db721ded42d983f3a616f8ce7ca220ef3bbfc2af9ccfd83c02f  ./calculate-forecast-bias/inputs/20220812T0300Z-PT0000H00M-wind_speed_at_10m.nc

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -115,8 +115,8 @@ c163c7abc3cfca24c9509b9f461da8e6defc2af6a33f26b52dc52d066389c265  ./blend-with-v
 a7aec5f0b80d6f7ac6f71fea1c9bf15b76b92572509b5e550e7151bfd005777b  ./blend-with-vicinity-and-rename/enukx.nc
 6c498befd962f286dedc8041ea8981007474f32995ee5dba0b6fbf6629ae47ad  ./blend-with-vicinity-and-rename/ncuk.nc
 00afa510d2b1f088f14cf75dd8aad80c2c9be3a53fb39d180e0621ea0ac4d235  ./blend-with-vicinity-and-rename/ukvx.nc
-9fee5756f45af01b54b8c608b60e7e564d5dfa447bc731a8f505fe0c84c69389  ./blend-with-vicinity-and-rename/with_nowcast/kgo.nc
-1f0d55b15c75f04e8cea2aed7fc87e93fd8051ad40592e8c16622b2d72bcbadf  ./blend-with-vicinity-and-rename/without_nowcast/kgo.nc
+8f0576ad7074d1fba5ddc83fad01b087007e20392c9e83900362d1a357f21622  ./blend-with-vicinity-and-rename/with_nowcast/kgo.nc
+4b29aed468b770d45ba47af4602eed6b5c09a9df11d84876ce3820d312ee7968  ./blend-with-vicinity-and-rename/without_nowcast/kgo.nc
 0fc03589a5a17536a16805a76208a12eabceb6a9fb0042842dbd42aa05c26acb  ./calculate-forecast-bias/inputs/20220811T0300Z-PT0000H00M-wind_speed_at_10m.nc
 a86344226370885ca6062200ddda5db1fab629d398c5af0678254c1d9960d272  ./calculate-forecast-bias/inputs/20220811T0300Z-PT0003H00M-wind_speed_at_10m.nc
 ac609404e0083db721ded42d983f3a616f8ce7ca220ef3bbfc2af9ccfd83c02f  ./calculate-forecast-bias/inputs/20220812T0300Z-PT0000H00M-wind_speed_at_10m.nc

--- a/improver_tests/acceptance/test_blend_with_vicinity_and_rename.py
+++ b/improver_tests/acceptance/test_blend_with_vicinity_and_rename.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Tests for the weighted-blending CLI
+"""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+PRECIP = "lwe_precipitation_rate"
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+ATTRIBUTES_PATH = acc.kgo_root() / "blend-with-vicinity-and-rename/attributes.json"
+BLEND_WEIGHTS_PATH = (
+    acc.kgo_root() / "blend-with-vicinity-and-rename/blending_weights.json"
+)
+SOURCE_FILES = ["ncuk.nc", "ukvx.nc", "enukx.nc"]
+SOURCE_DIR = acc.kgo_root() / "blend-with-vicinity-and-rename"
+
+
+def test_nowcast_cycle_blending(tmp_path):
+    """Test blending nowcast cycles"""
+    kgo_dir = acc.kgo_root() / "blend-with-vicinity-and-rename/with_nowcast"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_files = [f"{SOURCE_DIR / f}" for f in SOURCE_FILES]
+    output_path = tmp_path / "output.nc"
+    args = [
+        "--new-name",
+        "lwe_thickness_of_precipitation_amount_in_variable_vicinity",
+        "--vicinity-radius",
+        "10000",
+        "--coordinate",
+        "model_configuration",
+        "--cycletime",
+        "20230405T1100Z",
+        "--spatial-weights-from-mask",
+        "--model-id-attr",
+        "mosg__model_configuration",
+        "--record-run-attr",
+        "mosg__model_run",
+        "--weighting-coord",
+        "forecast_period",
+        "--weighting-config",
+        BLEND_WEIGHTS_PATH,
+        "--weighting-method",
+        "dict",
+        "--attributes-config",
+        ATTRIBUTES_PATH,
+        "--least-significant-digit",
+        "3",
+        *input_files,
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_blend_with_vicinity_and_rename.py
+++ b/improver_tests/acceptance/test_blend_with_vicinity_and_rename.py
@@ -50,11 +50,15 @@ SOURCE_FILES = ["ncuk.nc", "ukvx.nc", "enukx.nc"]
 SOURCE_DIR = acc.kgo_root() / "blend-with-vicinity-and-rename"
 
 
-def test_nowcast_cycle_blending(tmp_path):
+@pytest.mark.parametrize(
+    "input_files,kgo_path",
+    ((SOURCE_FILES, "with_nowcast"), (SOURCE_FILES[1:], "without_nowcast")),
+)
+def test_nowcast_cycle_blending(tmp_path, input_files, kgo_path):
     """Test blending nowcast cycles"""
-    kgo_dir = acc.kgo_root() / "blend-with-vicinity-and-rename/with_nowcast"
+    kgo_dir = acc.kgo_root() / "blend-with-vicinity-and-rename" / kgo_path
     kgo_path = kgo_dir / "kgo.nc"
-    input_files = [f"{SOURCE_DIR / f}" for f in SOURCE_FILES]
+    source_files = [f"{SOURCE_DIR / f}" for f in input_files]
     output_path = tmp_path / "output.nc"
     args = [
         "--new-name",
@@ -80,7 +84,7 @@ def test_nowcast_cycle_blending(tmp_path):
         ATTRIBUTES_PATH,
         "--least-significant-digit",
         "3",
-        *input_files,
+        *source_files,
         "--output",
         output_path,
     ]

--- a/improver_tests/acceptance/test_blend_with_vicinity_and_rename.py
+++ b/improver_tests/acceptance/test_blend_with_vicinity_and_rename.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """
-Tests for the weighted-blending CLI
+Tests for the blend-with-vicinity-and-rename CLI
 """
 
 import pytest
@@ -54,11 +54,12 @@ SOURCE_DIR = acc.kgo_root() / "blend-with-vicinity-and-rename"
     "input_files,kgo_path",
     ((SOURCE_FILES, "with_nowcast"), (SOURCE_FILES[1:], "without_nowcast")),
 )
-def test_nowcast_cycle_blending(tmp_path, input_files, kgo_path):
-    """Test blending nowcast cycles"""
+def test_basic(tmp_path, input_files, kgo_path):
+    """Test blend-with-vicinity-and-rename for the case where the vicinity on the
+    input cubes matches (without_nowcast) and where it doesn't (with nowcast)"""
     kgo_dir = acc.kgo_root() / "blend-with-vicinity-and-rename" / kgo_path
     kgo_path = kgo_dir / "kgo.nc"
-    source_files = [f"{SOURCE_DIR / f}" for f in input_files]
+    source_files = [SOURCE_DIR / f for f in input_files]
     output_path = tmp_path / "output.nc"
     args = [
         "--new-name",

--- a/improver_tests/metadata/test_amend.py
+++ b/improver_tests/metadata/test_amend.py
@@ -36,21 +36,21 @@ from datetime import datetime as dt
 import iris
 import numpy as np
 import pytest
-from iris.coords import CellMethod, DimCoord
+from iris.coords import CellMethod
 from iris.tests import IrisTest
 
 from improver.metadata.amend import (
     amend_attributes,
     set_history_attribute,
+    update_diagnostic_name,
     update_model_id_attr_attribute,
     update_stage_v110_metadata,
-    update_diagnostic_name,
 )
 from improver.synthetic_data.set_up_test_cubes import (
     add_coordinate,
+    set_up_percentile_cube,
     set_up_probability_cube,
     set_up_variable_cube,
-    set_up_percentile_cube,
 )
 
 
@@ -258,7 +258,7 @@ def test_update_diagnostic_name(cell_method, in_vicinity, probability_data):
     input_name_suffix = ""
     if in_vicinity:
         input_name_suffix = "_in_vicinity"
-    source_name = f"lwe_thickness_of_precipitation_amount"
+    source_name = "lwe_thickness_of_precipitation_amount"
     if probability_data:
         cube = set_up_probability_cube(
             np.zeros((2, 2, 2), dtype=np.float32),

--- a/improver_tests/metadata/test_amend.py
+++ b/improver_tests/metadata/test_amend.py
@@ -35,6 +35,8 @@ from datetime import datetime as dt
 
 import iris
 import numpy as np
+import pytest
+from iris.coords import CellMethod, DimCoord
 from iris.tests import IrisTest
 
 from improver.metadata.amend import (
@@ -42,11 +44,13 @@ from improver.metadata.amend import (
     set_history_attribute,
     update_model_id_attr_attribute,
     update_stage_v110_metadata,
+    update_diagnostic_name,
 )
 from improver.synthetic_data.set_up_test_cubes import (
     add_coordinate,
     set_up_probability_cube,
     set_up_variable_cube,
+    set_up_percentile_cube,
 )
 
 
@@ -241,6 +245,53 @@ class Test_update_model_id_attr_attribute(IrisTest):
         msg = "Expected to find mosg__model_configuration attribute on all cubes"
         with self.assertRaisesRegex(AttributeError, msg):
             update_model_id_attr_attribute([self.cube1, self.cube2], self.model_id_attr)
+
+
+@pytest.mark.parametrize("cell_method", (True, False))
+@pytest.mark.parametrize("probability_data", (True, False))
+@pytest.mark.parametrize("in_vicinity", (True, False))
+def test_update_diagnostic_name(cell_method, in_vicinity, probability_data):
+    """Make sure that the update_diagnostic_name method makes the expected changes in the expected
+    situations. Checks that cell_method comments are updated to match the cube name, if present;
+    that "in_vicinity" can be present on the cube name but not the threshold coord name;
+    that both probabilistic and non-probabilistic meta-data are handled correctly."""
+    input_name_suffix = ""
+    if in_vicinity:
+        input_name_suffix = "_in_vicinity"
+    source_name = f"lwe_thickness_of_precipitation_amount"
+    if probability_data:
+        cube = set_up_probability_cube(
+            np.zeros((2, 2, 2), dtype=np.float32),
+            [0, 1],
+            f"{source_name}{input_name_suffix}",
+            "mm",
+        )
+    else:
+        cube = set_up_percentile_cube(
+            np.zeros((2, 2, 2), dtype=np.float32),
+            [40, 60],
+            name=f"{source_name}{input_name_suffix}",
+            units="mm",
+        )
+    if cell_method:
+        cube.add_cell_method(CellMethod("mean", "time", comments=f"of {source_name}"))
+    new_base_name = "lwe_thickness_of_precipitation_amount"
+    new_name = f"{new_base_name}_in_variable_vicinity"
+    if probability_data:
+        expected_long_name = f"probability_of_{new_name}_above_threshold"
+        expected_name = new_base_name
+    else:
+        expected_long_name = new_name
+        expected_name = source_name
+    expected_cm_comment = f"of {new_base_name}"
+    update_diagnostic_name(cube, new_name, cube)
+    assert cube.long_name == expected_long_name
+    if probability_data:
+        assert cube.coord(var_name="threshold").name() == expected_name
+    else:
+        assert "threshold" not in [coord.var_name for coord in cube.coords()]
+    if cell_method:
+        assert expected_cm_comment in cube.cell_methods[0].comments
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of https://github.com/MetOffice/improver_suite/issues/1610

To achieve the meta-data changes requested here (https://github.com/MetOffice/improver_suite/pull/1611#discussion_r1165375538), I have created a new CLI to call `weighted-blending`, then modify the meta-data of the resulting cube before it is returned.

The metadata changes are:
- File name: `f"precipitation_accumulation_in_variable_vicinity-PT{period:02d}H"`
- Cube name: `probability_of_lwe_thickness_of_precipitation_amount_in_variable_vicinity_above_threshold`
- Cube coordinate: `radius_of_vicinity`, Value: 10000 m, With the addition of this comment attribute in the nowcast period only: `comment: "Maximum"`

Implementing this required these changes to allow me to reuse existing code:
- Refactors `update_diagnostic_name` and `_update_cell_methods` from `cube_combiner.CubeMultiplier` to `metadata.amend.py`
- Refactors `add_vicinity_coordinate` from `spatial.OccurrenceWithinVicinity` plugin to `spatial.py`
- New unit tests for these refactored methods.
- Modification to allow the `interpret-metadata` CLI to accept the new metadata.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
