### PR TITLE
Enforce percentile consistency

### DIFF
--- a/improver/cli/enforce_consistent_percentiles.py
+++ b/improver/cli/enforce_consistent_percentiles.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""CLI to enforce consistent percentiles between two forecasts."""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(
+    *cubes: cli.inputcubelist,
+    ref_name: str = None,
+    min_percentage_exceedance: float = 0.0,
+):
+    """Enforce consistent percentiles between two forecasts by assuming that the
+    reference forecast is equal to, or provides a lower bound, for the percentiles
+    within the accompanying forecast.
+
+    Args:
+        cubes (iris.cube.CubeList or list of iris.cube.Cube):
+            containing:
+                ref_forecast (iris.cube.Cube)
+                    Cube with percentiles that are equal to, or provide a lower bound,
+                    for the accompanying forecast. The reference forecast is expected
+                    to be the same shape as forecast_cube but have a different name.
+                forecast_cube (iris.cube.Cube):
+                    Cube with percentiles that will have consistency enforced.
+
+        ref_name (str):
+            Name of ref_forecast cube.
+        min_percentage_exceedance (float):
+            The minimum percentage by which the reference forecast must be exceeded by
+            the accompanying forecast. The reference forecast therefore provides a
+            lower bound for the accompanying forecast with this forecast limited to
+            a minimum of the reference forecast plus the min_percentage_exceedance
+            multiplied by the reference forecast. The percentage is expected as a
+            value between 0 and 100.
+
+    Returns:
+        iris.cube.Cube:
+            Cube with identical metadata to forecast_cube but with
+            percentiles that are equal to or exceed the reference forecast.
+    """
+    from iris.cube import CubeList
+
+    from improver.utilities.enforce_consistency import EnforceConsistentPercentiles
+    from improver.utilities.flatten import flatten
+
+    cubes = flatten(cubes)
+
+    if len(cubes) != 2:
+        raise ValueError(
+            f"Exactly two cubes should be provided but received {len(cubes)}"
+        )
+
+    ref_forecast_cube = CubeList(cubes).extract_cube(ref_name)
+    cubes.remove(ref_forecast_cube)
+
+    (forecast_cube,) = cubes
+
+    plugin = EnforceConsistentPercentiles(
+        min_percentage_exceedance=min_percentage_exceedance
+    )
+
+    return plugin(ref_forecast_cube, forecast_cube)

--- a/improver/utilities/enforce_consistency.py
+++ b/improver/utilities/enforce_consistency.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Provides utilities for enforcing consistency between forecasts."""
+from iris.cube import Cube
+
+from improver import PostProcessingPlugin
+
+
+class EnforceConsistentPercentiles(PostProcessingPlugin):
+    """Enforce that the percentiles of the forecast provided are equal to, or exceed,
+    the reference forecast by a minimum percentage exceedance. For example, wind speed
+    forecasts may be provided as the reference forecast for wind gust forecasts with
+    a minimum percentage exceedance of 10%. Wind speed forecasts of 10 m/s will mean
+    that the resulting wind gust forecast will be at least 11 m/s.
+    """
+
+    def __init__(self, min_percentage_exceedance: float = 0.0) -> None:
+        """Initialise class.
+
+        Args:
+            min_percentage_exceedance: The minimum percentage by which the reference
+                forecast must be exceeded by the accompanying forecast. The reference
+                forecast therefore provides a lower bound for the accompanying forecast
+                with this forecast limited to a minimum of the reference forecast plus
+                the min_percentage_exceedance multiplied by the reference forecast.
+                The percentage is expected as a value between 0 and 100.
+
+        """
+        if min_percentage_exceedance < 0 or min_percentage_exceedance > 100:
+            msg = (
+                "The percentage representing the minimum that the reference "
+                "forecast must be exceeded by is outside the range 0 to 100. "
+                f"The value provided is {min_percentage_exceedance}."
+            )
+            raise ValueError(msg)
+
+        self.min_percentage_exceedance = min_percentage_exceedance
+
+    def process(self, ref_forecast_cube: Cube, forecast_cube: Cube) -> Cube:
+        """Enforce a lower bound for the forecast cube using the reference forecast
+        cube plus a minimum percentage exceedance.
+
+        Args:
+            ref_forecast (iris.cube.Cube)
+                Cube with percentiles that are equal to, or provide a lower bound,
+                for the accompanying forecast. The reference forecast is expected
+                to be the same shape as forecast_cube but have a different name.
+            forecast_cube (iris.cube.Cube):
+                Cube with percentiles that will have consistency enforced.
+
+        Returns:
+            Cube with percentiles that has had consistency enforced.
+        """
+        updated_forecast_cube = forecast_cube.copy()
+        lower_bound = (
+            ref_forecast_cube.data
+            + ref_forecast_cube.data * self.min_percentage_exceedance / 100
+        )
+        condition1 = updated_forecast_cube.data < lower_bound
+        updated_forecast_cube.data[condition1] = lower_bound[condition1]
+        return updated_forecast_cube

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -170,6 +170,9 @@ b946c7687cb9ed02a12a934429a31306004ad45214cf4b451468b077018c0911  ./convection-r
 d3efbc6014743793fafed512a8017a7b75e4f0ffa7fd202cd4f1b4a1086b2583  ./create-grid-with-halo/basic/kgo.nc
 fee00437131d2367dc317e5b0fff44e65e03371b8f096bf1ac0d4cc7253693c9  ./create-grid-with-halo/basic/source_grid.nc
 bf7e42be7897606682c3ecdaeb27bf3d3b6ab13a9a88b46c88ae6e92801c6245  ./create-grid-with-halo/halo_size/kgo.nc
+1de3227751ff46a7cf39a0b7bcd4156717814809c3a02153fcd35ee4adfb5668  ./enforce-consistent-percentiles/kgo.nc
+f5085e98e23fc903395372f2e0e6a2bc028f7fa44cc212d49690782cd2dd275a  ./enforce-consistent-percentiles/wind_gust.nc
+3876dcc20a45fdc6d6c775d6970903f06b1f75e6bcbdfb7436acd4d383aa816a  ./enforce-consistent-percentiles/wind_speed.nc
 5474c4c2309dcc0991355007f20869eb6d1d234d721bdf37542cddb0570d7217  ./enforce-consistent-probabilities/hybrid_total_cloud.nc
 7e435c2db5e792b71bb5170140fbe1e37cc03d96bd88f73ce7196f9469ba3e13  ./enforce-consistent-probabilities/kgo.nc
 764833f16f1ed5939ba82130fa73961fdecacceebcf2b4cdb2970cb670e2ee3e  ./enforce-consistent-probabilities/total_cloud.nc

--- a/improver_tests/acceptance/test_enforce_consistent_percentiles.py
+++ b/improver_tests/acceptance/test_enforce_consistent_percentiles.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests for the enforce-consistent-percentiles CLI."""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+def test_enforce_consistent_percentiles(tmp_path):
+    """Test enforcing percentile consistency between inconsistent cubes."""
+    kgo_dir = acc.kgo_root() / "enforce-consistent-percentiles"
+    kgo_path = kgo_dir / "kgo.nc"
+
+    wind_speed = kgo_dir / "wind_speed.nc"
+    wind_gust = kgo_dir / "wind_gust.nc"
+    output_path = tmp_path / "output.nc"
+
+    args = [
+        wind_speed,
+        wind_gust,
+        "--ref-name",
+        "wind_speed",
+        "--min-percentage-exceedance",
+        "10",
+        "--output",
+        output_path,
+    ]
+
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_too_many_cubes(tmp_path):
+    """Test an error is raised if too many cubes are provided."""
+    kgo_dir = acc.kgo_root() / "enforce-consistent-percentiles"
+
+    wind_speed = kgo_dir / "wind_speed.nc"
+    wind_gust = kgo_dir / "wind_gust.nc"
+    output_path = tmp_path / "output.nc"
+
+    args = [
+        wind_speed,
+        wind_gust,
+        wind_gust,
+        "--ref-name",
+        "wind_speed",
+        "--min-percentage-exceedance",
+        "10",
+        "--output",
+        output_path,
+    ]
+    with pytest.raises(ValueError, match="Exactly two cubes"):
+        run_cli(args)

--- a/improver_tests/utilities/test_enforce_consistency.py
+++ b/improver_tests/utilities/test_enforce_consistency.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for enforce_consistency utilities."""
+
+import numpy as np
+import pytest
+from iris.cube import Cube
+
+from improver.synthetic_data.set_up_test_cubes import set_up_percentile_cube
+from improver.utilities.enforce_consistency import EnforceConsistentPercentiles
+
+
+def get_percs(value, shape):
+    """Correctly shape the value provided into the desired shape. The value is
+    used as the middle of three percentiles. The value is subtracted by 10 or added by
+    10 to create the bounding percentiles. These values are clipped to ensure that
+    the values are positive."""
+    return np.broadcast_to(
+        np.expand_dims(np.clip([value - 10, value, value + 10], 0, None), axis=(1, 2),),
+        shape,
+    )
+
+
+def get_wind_speed_cube(wind_speed, shape):
+    """Create a wind speed percentile cube."""
+    wind_speed_percs = get_percs(wind_speed, shape)
+    wind_speed_cube = set_up_percentile_cube(
+        np.full(shape, wind_speed_percs, dtype=np.float32),
+        [10, 50, 90],
+        name="wind_speed_at_10m",
+        units="m s-1",
+    )
+    return wind_speed_cube
+
+
+def get_wind_gust_cube(wind_gust, shape):
+    """Create a wind gust percentile cube."""
+    wind_gust_percs = get_percs(wind_gust, shape)
+    wind_gust_cube = set_up_percentile_cube(
+        np.full(shape, wind_gust_percs, dtype=np.float32),
+        [10, 50, 90],
+        name="wind_gust_at_10m_max-PT01H",
+        units="m s-1",
+    )
+    return wind_gust_cube
+
+
+@pytest.mark.parametrize(
+    "min_percentage_exceedance,wind_speed,wind_gust,expected_values",
+    (
+        (0, 10, 10, [0.0, 10, 20]),  # Values unchanged. 0 percentage.
+        (10, 10, 10, [0.0, 11, 22]),  # 10% increase.
+        (10, 10, 20, [10, 20, 30],),  # Percentage exceedance has no effect.
+        (10, 20, 10, [11, 22, 33],),  # Gust speed 10% greater than wind speed.
+        (20, 10, 10, [0.0, 12, 24]),  # 20% increase.
+        (100, 10, 10, [0.0, 20, 40]),  # 100% increase.
+    ),
+)
+def test_basic(min_percentage_exceedance, wind_speed, wind_gust, expected_values):
+    """Test that consistency between percentiles is enforced for a variety of
+    percentages, wind speeds and wind gusts."""
+    shape = (3, 2, 2)
+    wind_speed_cube = get_wind_speed_cube(wind_speed, shape)
+    wind_gust_cube = get_wind_gust_cube(wind_gust, shape)
+
+    result = EnforceConsistentPercentiles(
+        min_percentage_exceedance=min_percentage_exceedance
+    )(wind_speed_cube, wind_gust_cube.copy())
+
+    expected = wind_gust_cube.copy()
+    expected.data = np.broadcast_to(np.expand_dims(expected_values, axis=(1, 2)), shape)
+
+    assert isinstance(result, Cube)
+    assert result.name() == wind_gust_cube.name()
+    np.testing.assert_array_almost_equal(result.data, expected.data)
+
+
+@pytest.mark.parametrize(
+    "min_percentage_exceedance", ((-10, 110)),
+)
+def test_exception(min_percentage_exceedance):
+    """Test that an exception is raised if the percentage representing the
+    minimum that the reference forecast must be exceeded by is outside the
+    range 0 to 100"""
+    msg = "The percentage representing the minimum"
+    with pytest.raises(ValueError, match=msg):
+        EnforceConsistentPercentiles(
+            min_percentage_exceedance=min_percentage_exceedance
+        )


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/492

Description
Add a plugin and CLI for ensuring consistency between two diagnostics in percentile format. This has been created with wind speed and wind gust in mind, where different processing may result in wind speed and wind gust percentiles that are inconsistent i.e. where the wind gust is lower than the wind speed.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)