### PR TITLE
Add CLI for clipping cubes

### DIFF
--- a/improver/cli/clip.py
+++ b/improver/cli/clip.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to clip the input cube's data to be between the specified values"""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(
+    cube: cli.inputcube, *, min_value: float = None, max_value: float = None,
+):
+    """Clip the data in the input cube to be below max_value and higher than min_value.
+
+    Args:
+        cube (iris.cube.Cube):
+            A Cube whose data will be clipped
+        max_value (float):
+            If specified any data in cube that is above max_value will be set equal to
+            max_value.
+        min_value (float):
+            If specified any data in cube that is below min_value will be set equal to
+            min_value.
+    Returns:
+        iris.cube.Cube:
+            A cube with the same metadata as the input cube but with the data clipped to be
+            higher than min_value and lower than max_value
+    """
+    from improver.utilities.cube_manipulation import clip_cube_data
+
+    return clip_cube_data(cube, min_value, max_value)

--- a/improver/cli/clip.py
+++ b/improver/cli/clip.py
@@ -59,10 +59,6 @@ def process(
     """
     from numpy import clip
 
-    from improver.utilities.cube_manipulation import clip_cube_data, get_coord_names
+    cube.data = clip(cube.data, min_value, max_value)
 
-    if "spot_index" in get_coord_names(cube):
-        cube.data = clip(cube.data, min_value, max_value)
-    else:
-        cube = clip_cube_data(cube, min_value, max_value)
     return cube

--- a/improver/cli/clip.py
+++ b/improver/cli/clip.py
@@ -43,7 +43,7 @@ def process(
 
     Args:
         cube (iris.cube.Cube):
-            A Cube whose data will be clipped
+            A Cube whose data will be clipped. This can be a cube of spot or gridded data.
         max_value (float):
             If specified any data in cube that is above max_value will be set equal to
             max_value.
@@ -55,6 +55,12 @@ def process(
             A cube with the same metadata as the input cube but with the data clipped to be
             higher than min_value and lower than max_value
     """
-    from improver.utilities.cube_manipulation import clip_cube_data
+    from numpy import clip
 
-    return clip_cube_data(cube, min_value, max_value)
+    from improver.utilities.cube_manipulation import clip_cube_data, get_coord_names
+
+    if "spot_index" in get_coord_names(cube):
+        cube.data = clip(cube.data, min_value, max_value)
+    else:
+        cube = clip_cube_data(cube, min_value, max_value)
+    return cube

--- a/improver/cli/clip.py
+++ b/improver/cli/clip.py
@@ -39,7 +39,8 @@ from improver import cli
 def process(
     cube: cli.inputcube, *, min_value: float = None, max_value: float = None,
 ):
-    """Clip the data in the input cube to be below max_value and higher than min_value.
+    """Clip the data in the input cube such that any data above max_value is set equal to
+     max_value and any data below min_value is set equal to min_value.
 
     Args:
         cube (iris.cube.Cube):
@@ -52,8 +53,9 @@ def process(
             min_value.
     Returns:
         iris.cube.Cube:
-            A cube with the same metadata as the input cube but with the data clipped to be
-            higher than min_value and lower than max_value
+            A cube with the same metadata as the input cube but with the data clipped such
+            that any data above max_value is set equal to max_value and any data below
+            min_value is set equal to min_value.
     """
     from numpy import clip
 

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -124,6 +124,10 @@ a37a4829a3d45295e38d454c9983f499cca11f14b21707e4f36f1bb3da32de63  ./calculate-fo
 be26d2ea432284b08ef68a2764f7b18463840d57b9dc495961c1bd90c1bf73c5  ./calculate-forecast-bias/inputs/20220813T0300Z-PT0003H00M-wind_speed_at_10m.nc
 3220caf063928ee4ff7905c0d30cdb48a856a5e513e8d7f5cfd6cd162dbf170d  ./calculate-forecast-bias/multiple_frt/kgo.nc
 ec49997369aab4bb84049efcbf7720d15ca7a371d366bfcb707a2ca5a0473cfd  ./calculate-forecast-bias/single_frt/kgo.nc
+90f170375e1f7673bf271ee00d35f5a6ffaf81338f708092cfb4c49d79a45a7d  ./clip/input.nc
+71dd5f9e58e286e627ccf6c90df0a29487dad6641def4fbb89edc4e33ead0b49  ./clip/kgo_(0, 4000).nc
+e1a002ee954978e9ab5830320f700a05f3f067c39bba9853587d79cd047564b8  ./clip/kgo_(1000, None).nc
+17034578353d6b7c59963c5bb2904141fc9eadf8642f18546ef8cb9efb429f86  ./clip/kgo_(None, 6000).nc
 9ae995a600331cf97ca5c64be4dd9a34adc9be7c5b5f987d3735af0d7973d7c3  ./cloud-condensation-level/pressure_at_surface.nc
 5d964d04169737f4116505c6b4ad5e2a894592c789303460f9d292fa204b3775  ./cloud-condensation-level/relative_humidity.nc
 0425846305d3e15ef78f303855254f902c6a06d33caa38ac1d12540da88e4a7d  ./cloud-condensation-level/temperature.nc

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -125,13 +125,13 @@ be26d2ea432284b08ef68a2764f7b18463840d57b9dc495961c1bd90c1bf73c5  ./calculate-fo
 3220caf063928ee4ff7905c0d30cdb48a856a5e513e8d7f5cfd6cd162dbf170d  ./calculate-forecast-bias/multiple_frt/kgo.nc
 ec49997369aab4bb84049efcbf7720d15ca7a371d366bfcb707a2ca5a0473cfd  ./calculate-forecast-bias/single_frt/kgo.nc
 90f170375e1f7673bf271ee00d35f5a6ffaf81338f708092cfb4c49d79a45a7d  ./clip/gridded_data/input.nc
-71dd5f9e58e286e627ccf6c90df0a29487dad6641def4fbb89edc4e33ead0b49  ./clip/gridded_data/kgo_(0, 4000).nc
-e1a002ee954978e9ab5830320f700a05f3f067c39bba9853587d79cd047564b8  ./clip/gridded_data/kgo_(1000, None).nc
-17034578353d6b7c59963c5bb2904141fc9eadf8642f18546ef8cb9efb429f86  ./clip/gridded_data/kgo_(None, 6000).nc
+71dd5f9e58e286e627ccf6c90df0a29487dad6641def4fbb89edc4e33ead0b49  ./clip/gridded_data/kgo_0_4000.nc
+e1a002ee954978e9ab5830320f700a05f3f067c39bba9853587d79cd047564b8  ./clip/gridded_data/kgo_1000_None.nc
+17034578353d6b7c59963c5bb2904141fc9eadf8642f18546ef8cb9efb429f86  ./clip/gridded_data/kgo_None_6000.nc
 235f266aef201f71ee3526885c3c90e5f782c90025a1f8c5a5d1f006683b1a7d  ./clip/spot_data/input.nc
-04370f3a0302194ab328eee7436382a24d53b112d0749988b422d943a57f3b33  ./clip/spot_data/kgo_(0, 4000).nc
-268b04ef0bd6a5c0d9c1237b87f044e28e7e2c35835ba573c5498644de8b45be  ./clip/spot_data/kgo_(1000, None).nc
-2d97cf98701e7bcf560289b1c14e4ddffd4599645ca5219022ed63b96a69f46e  ./clip/spot_data/kgo_(None, 6000).nc
+04370f3a0302194ab328eee7436382a24d53b112d0749988b422d943a57f3b33  ./clip/spot_data/kgo_0_4000.nc
+268b04ef0bd6a5c0d9c1237b87f044e28e7e2c35835ba573c5498644de8b45be  ./clip/spot_data/kgo_1000_None.nc
+2d97cf98701e7bcf560289b1c14e4ddffd4599645ca5219022ed63b96a69f46e  ./clip/spot_data/kgo_None_6000.nc
 9ae995a600331cf97ca5c64be4dd9a34adc9be7c5b5f987d3735af0d7973d7c3  ./cloud-condensation-level/pressure_at_surface.nc
 5d964d04169737f4116505c6b4ad5e2a894592c789303460f9d292fa204b3775  ./cloud-condensation-level/relative_humidity.nc
 0425846305d3e15ef78f303855254f902c6a06d33caa38ac1d12540da88e4a7d  ./cloud-condensation-level/temperature.nc

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -124,10 +124,14 @@ a37a4829a3d45295e38d454c9983f499cca11f14b21707e4f36f1bb3da32de63  ./calculate-fo
 be26d2ea432284b08ef68a2764f7b18463840d57b9dc495961c1bd90c1bf73c5  ./calculate-forecast-bias/inputs/20220813T0300Z-PT0003H00M-wind_speed_at_10m.nc
 3220caf063928ee4ff7905c0d30cdb48a856a5e513e8d7f5cfd6cd162dbf170d  ./calculate-forecast-bias/multiple_frt/kgo.nc
 ec49997369aab4bb84049efcbf7720d15ca7a371d366bfcb707a2ca5a0473cfd  ./calculate-forecast-bias/single_frt/kgo.nc
-90f170375e1f7673bf271ee00d35f5a6ffaf81338f708092cfb4c49d79a45a7d  ./clip/input.nc
-71dd5f9e58e286e627ccf6c90df0a29487dad6641def4fbb89edc4e33ead0b49  ./clip/kgo_(0, 4000).nc
-e1a002ee954978e9ab5830320f700a05f3f067c39bba9853587d79cd047564b8  ./clip/kgo_(1000, None).nc
-17034578353d6b7c59963c5bb2904141fc9eadf8642f18546ef8cb9efb429f86  ./clip/kgo_(None, 6000).nc
+90f170375e1f7673bf271ee00d35f5a6ffaf81338f708092cfb4c49d79a45a7d  ./clip/gridded_data/input.nc
+71dd5f9e58e286e627ccf6c90df0a29487dad6641def4fbb89edc4e33ead0b49  ./clip/gridded_data/kgo_(0, 4000).nc
+e1a002ee954978e9ab5830320f700a05f3f067c39bba9853587d79cd047564b8  ./clip/gridded_data/kgo_(1000, None).nc
+17034578353d6b7c59963c5bb2904141fc9eadf8642f18546ef8cb9efb429f86  ./clip/gridded_data/kgo_(None, 6000).nc
+235f266aef201f71ee3526885c3c90e5f782c90025a1f8c5a5d1f006683b1a7d  ./clip/spot_data/input.nc
+04370f3a0302194ab328eee7436382a24d53b112d0749988b422d943a57f3b33  ./clip/spot_data/kgo_(0, 4000).nc
+268b04ef0bd6a5c0d9c1237b87f044e28e7e2c35835ba573c5498644de8b45be  ./clip/spot_data/kgo_(1000, None).nc
+2d97cf98701e7bcf560289b1c14e4ddffd4599645ca5219022ed63b96a69f46e  ./clip/spot_data/kgo_(None, 6000).nc
 9ae995a600331cf97ca5c64be4dd9a34adc9be7c5b5f987d3735af0d7973d7c3  ./cloud-condensation-level/pressure_at_surface.nc
 5d964d04169737f4116505c6b4ad5e2a894592c789303460f9d292fa204b3775  ./cloud-condensation-level/relative_humidity.nc
 0425846305d3e15ef78f303855254f902c6a06d33caa38ac1d12540da88e4a7d  ./cloud-condensation-level/temperature.nc

--- a/improver_tests/acceptance/test_clip.py
+++ b/improver_tests/acceptance/test_clip.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests for the clip CLI"""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+@pytest.mark.parametrize("min_value,max_value", ((0, 4000), (None, 6000), (1000, None)))
+def test_basic(tmp_path, min_value, max_value):
+    """Test clip functionality with different combinations of min and max values """
+    kgo_dir = acc.kgo_root() / "clip"
+    kgo_path = kgo_dir / f"kgo_{min_value,max_value}.nc"
+    output_path = tmp_path / "output.nc"
+
+    args = [kgo_dir / "input.nc", "--output", output_path]
+    if min_value is not None:
+        args.append(f"--min-value={min_value}")
+    if max_value is not None:
+        args.append(f"--max-value={max_value}")
+
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_clip.py
+++ b/improver_tests/acceptance/test_clip.py
@@ -39,10 +39,11 @@ CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 
 
+@pytest.mark.parametrize("cube_type", ("spot_data", "gridded_data"))
 @pytest.mark.parametrize("min_value,max_value", ((0, 4000), (None, 6000), (1000, None)))
-def test_basic(tmp_path, min_value, max_value):
+def test_basic(tmp_path, min_value, max_value, cube_type):
     """Test clip functionality with different combinations of min and max values """
-    kgo_dir = acc.kgo_root() / "clip"
+    kgo_dir = acc.kgo_root() / "clip" / cube_type
     kgo_path = kgo_dir / f"kgo_{min_value,max_value}.nc"
     output_path = tmp_path / "output.nc"
 

--- a/improver_tests/acceptance/test_clip.py
+++ b/improver_tests/acceptance/test_clip.py
@@ -44,7 +44,7 @@ run_cli = acc.run_cli(CLI)
 def test_basic(tmp_path, min_value, max_value, cube_type):
     """Test clip functionality with different combinations of min and max values """
     kgo_dir = acc.kgo_root() / "clip" / cube_type
-    kgo_path = kgo_dir / f"kgo_{min_value,max_value}.nc"
+    kgo_path = kgo_dir / f"kgo_{min_value}_{max_value}.nc"
     output_path = tmp_path / "output.nc"
 
     args = [kgo_dir / "input.nc", "--output", output_path]


### PR DESCRIPTION
Required for metoppv/mo-blue-team#516
Acceptance_test_PR: metoppv/improver_test_data#17

Adds in a CLI calling a pre-existing function in IMPROVER to clip data in a cube between an upper and lower bound. This is required to be able to clip cloud bases to 0m in the suite. This PR also includes some acceptance tests for the new CLI. 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
