### PR TITLE
Correct handling of reference time in weather_code plugin

### DIFF
--- a/improver/metadata/constants/time_types.py
+++ b/improver/metadata/constants/time_types.py
@@ -45,6 +45,7 @@ _TIME_INTERVAL_SPEC = TimeSpec(calendar=None, dtype=np.int32, units="seconds")
 TIME_COORDS = {
     "time": _TIME_REFERENCE_SPEC,
     "forecast_reference_time": _TIME_REFERENCE_SPEC,
+    "blend_time": _TIME_REFERENCE_SPEC,
     "forecast_period": _TIME_INTERVAL_SPEC,
     "UTC_offset": _TIME_INTERVAL_SPEC,
 }

--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -54,14 +54,14 @@ def forecast_period_coord(
     """
     Return the lead time coordinate (forecast_period) from a cube, either by
     reading an existing forecast_period coordinate, or by calculating the
-    difference between time and forecast_reference_time.
+    difference between time and forecast_reference_time or blend_time.
 
     Args:
         cube:
             Cube from which the lead times will be determined.
         force_lead_time_calculation:
             Force the lead time to be calculated from the
-            forecast_reference_time and the time coordinate, even if
+            reference time and the time coordinates, even if
             the forecast_period coordinate exists. Default is False.
 
     Returns:
@@ -72,6 +72,16 @@ def forecast_period_coord(
     """
     create_dim_coord = False
     coord_attributes = {}
+    frt_coord = cube.coords("forecast_reference_time")
+    blend_time_coord = cube.coords("blend_time")
+    reference_coord = frt_coord if frt_coord else blend_time_coord
+    if frt_coord and blend_time_coord:
+        if not frt_coord[0].points == blend_time_coord[0].points:
+            raise ValueError(
+                "Reference time coords do not match. forecast_reference_time is "
+                f"{frt_coord[0].cell(0).point}; blend_time is {blend_time_coord[0].cell(0).point}"
+            )
+
     if cube.coords("forecast_period"):
         coord_attributes = cube.coord("forecast_period").attributes
         if isinstance(cube.coord("forecast_period"), DimCoord):
@@ -80,14 +90,14 @@ def forecast_period_coord(
     if cube.coords("forecast_period") and not force_lead_time_calculation:
         result_coord = cube.coord("forecast_period").copy()
 
-    elif cube.coords("time") and cube.coords("forecast_reference_time"):
+    elif cube.coords("time") and reference_coord:
         # Cube must adhere to mandatory standards for safe time calculations
         check_mandatory_standards(cube)
         # Try to calculate forecast period from forecast reference time and
         # time coordinates
         result_coord = _calculate_forecast_period(
             cube.coord("time"),
-            cube.coord("forecast_reference_time"),
+            cube.coord(reference_coord[0]),
             dim_coord=create_dim_coord,
         )
         result_coord.attributes.update(coord_attributes)
@@ -95,7 +105,7 @@ def forecast_period_coord(
     else:
         msg = (
             "The forecast period coordinate is not available within {}."
-            "The time coordinate and forecast_reference_time "
+            "The time coordinate and (forecast_reference_time or blend_time) "
             "coordinate were also not available for calculating "
             "the forecast_period.".format(cube)
         )

--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -71,7 +71,9 @@ def forecast_period_coord(
         it will be an AuxCoord.
     """
     create_dim_coord = False
+    coord_attributes = {}
     if cube.coords("forecast_period"):
+        coord_attributes = cube.coord("forecast_period").attributes
         if isinstance(cube.coord("forecast_period"), DimCoord):
             create_dim_coord = True
 
@@ -88,6 +90,7 @@ def forecast_period_coord(
             cube.coord("forecast_reference_time"),
             dim_coord=create_dim_coord,
         )
+        result_coord.attributes.update(coord_attributes)
 
     else:
         msg = (

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -408,10 +408,9 @@ def set_up_variable_cube(
         time_bounds:
             Lower and upper bound on time point, if required
         frt:
-            Single cube forecast reference time - providing a blend_time will mean the cube has no
-            frt. Default value is datetime(2017, 11, 10, 0, 0).
+            Single cube forecast reference time. Default value is datetime(2017, 11, 10, 0, 0).
         blend_time:
-            Single cube blend time - if supplied, frt is not applied.
+            Single cube blend time
         realizations:
             List of forecast realizations.  If not present, taken from the
             leading dimension of the input data array (if 3D).
@@ -437,9 +436,11 @@ def set_up_variable_cube(
         Cube containing a single variable field
     """
     if blend_time and frt:
-        raise ValueError(
-            "Refusing to create cube with both forecast_reference_time and blend_time"
-        )
+        if blend_time != frt:
+            raise ValueError(
+                "Refusing to create cube with different values for forecast_reference_time and "
+                "blend_time"
+            )
     if not frt and not blend_time:
         frt = datetime(2017, 11, 10, 0, 0)
     # construct spatial dimension coordinates

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -179,7 +179,7 @@ def _create_time_point(time: datetime) -> int:
 
 def construct_scalar_time_coords(
     time: datetime,
-    time_bounds: Optional[List[datetime]],
+    time_bounds: Optional[List[datetime]] = None,
     frt: Optional[datetime] = None,
     blend_time: Optional[datetime] = None,
 ) -> List[Tuple[DimCoord, None]]:
@@ -194,12 +194,21 @@ def construct_scalar_time_coords(
         frt:
             Single forecast reference time point. Either this or blend_time is required.
         blend_time:
-            Single blend time point. Either this or frt is required. Both may be supplied.
+            Single blend time point. Either this or frt is required. Both may not be supplied.
 
     Returns:
         List of iris.coords.DimCoord instances with the associated "None"
         dimension (format required by iris.cube.Cube initialisation).
+
+    Raises:
+        ValueError: if differing frt and blend_time are supplied
     """
+    if blend_time and frt:
+        if blend_time != frt:
+            raise ValueError(
+                "Refusing to create cube with different values for forecast_reference_time and "
+                "blend_time"
+            )
     # generate time coordinate points
     time_point_seconds = _create_time_point(time)
     if frt:
@@ -435,12 +444,6 @@ def set_up_variable_cube(
     Returns:
         Cube containing a single variable field
     """
-    if blend_time and frt:
-        if blend_time != frt:
-            raise ValueError(
-                "Refusing to create cube with different values for forecast_reference_time and "
-                "blend_time"
-            )
     if not frt and not blend_time:
         frt = datetime(2017, 11, 10, 0, 0)
     # construct spatial dimension coordinates

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -583,8 +583,16 @@ class WeatherSymbols(BasePlugin):
             record_run_coord_to_attr(
                 symbols, set(cubes), self.record_run_attr, discard_weights=True
             )
+        self._set_blend_time(symbols, cubes)
 
         return symbols
+
+    @staticmethod
+    def _set_blend_time(cube: Cube, cubes: CubeList):
+        """Replace the blend_time coord point on cube with the latest blend_time from cubes"""
+        reference_time = max([c.coord("blend_time").points[0] for c in cubes])
+        new_coord = cube.coord("blend_time").copy(reference_time)
+        cube.replace_coord(new_coord)
 
     @staticmethod
     def compare_array_to_threshold(

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -49,6 +49,7 @@ from improver.blending.utilities import (
     store_record_run_as_coord,
 )
 from improver.metadata.amend import update_model_id_attr_attribute
+from improver.metadata.forecast_times import forecast_period_coord
 from improver.metadata.probabilistic import (
     find_threshold_coordinate,
     get_threshold_coord_name_from_probability_name,
@@ -590,16 +591,22 @@ class WeatherSymbols(BasePlugin):
 
     @staticmethod
     def _set_reference_time(cube: Cube, cubes: CubeList):
-        """Replace the blend_time or forecast_reference_time coord point on cube with the
-        latest value from cubes. Mixed, or missing cubes will raise an error."""
-        try:
-            coord_name = "blend_time"
-            reference_time = max([c.coord(coord_name).points[0] for c in cubes])
-        except CoordinateNotFoundError:
-            coord_name = "forecast_reference_time"
-            reference_time = max([c.coord(coord_name).points[0] for c in cubes])
-        new_coord = cube.coord(coord_name).copy(reference_time)
-        cube.replace_coord(new_coord)
+        """Replace the forecast_reference_time and/or blend_time if present coord point on cube
+        with the latest value from cubes. Forecast_period is also updated."""
+        coord_names = ["forecast_reference_time", "blend_time"]
+        coords_found = []
+        for coord_name in coord_names:
+            try:
+                reference_time = max([c.coord(coord_name).points[0] for c in cubes])
+            except CoordinateNotFoundError:
+                continue
+            coords_found.append(coord_name)
+        if not coords_found:
+            raise CoordinateNotFoundError(f"Could not find {'or '.join(coord_names)} on all input cubes")
+        for coord_name in coords_found:
+            new_coord = cube.coord(coord_name).copy(reference_time)
+            cube.replace_coord(new_coord)
+        cube.replace_coord(forecast_period_coord(cube, force_lead_time_calculation=True))
 
     @staticmethod
     def compare_array_to_threshold(

--- a/improver/wxcode/weather_symbols.py
+++ b/improver/wxcode/weather_symbols.py
@@ -602,11 +602,15 @@ class WeatherSymbols(BasePlugin):
                 continue
             coords_found.append(coord_name)
         if not coords_found:
-            raise CoordinateNotFoundError(f"Could not find {'or '.join(coord_names)} on all input cubes")
+            raise CoordinateNotFoundError(
+                f"Could not find {'or '.join(coord_names)} on all input cubes"
+            )
         for coord_name in coords_found:
             new_coord = cube.coord(coord_name).copy(reference_time)
             cube.replace_coord(new_coord)
-        cube.replace_coord(forecast_period_coord(cube, force_lead_time_calculation=True))
+        cube.replace_coord(
+            forecast_period_coord(cube, force_lead_time_calculation=True)
+        )
 
     @staticmethod
     def compare_array_to_threshold(

--- a/improver_tests/metadata/test_forecast_times.py
+++ b/improver_tests/metadata/test_forecast_times.py
@@ -85,8 +85,9 @@ class Test_forecast_period_coord(IrisTest):
 
     def test_values_force_lead_time_calculation(self):
         """Test that the data within the coord is as expected with the
-        expected units, when the input cube has a forecast_period coordinate.
+        expected units and copied attributes, when the input cube has a forecast_period coordinate.
         """
+        self.cube.coord("forecast_period").attributes["message"] = "may include kittens"
         fp_coord = self.cube.coord("forecast_period").copy()
         # put incorrect data into the existing coordinate so we can test it is
         # correctly recalculated
@@ -95,6 +96,7 @@ class Test_forecast_period_coord(IrisTest):
         self.assertArrayEqual(result.points, fp_coord.points)
         self.assertEqual(result.units, fp_coord.units)
         self.assertEqual(result.dtype, fp_coord.dtype)
+        self.assertEqual(result.attributes, fp_coord.attributes)
 
     def test_exception_insufficient_data(self):
         """Test that a CoordinateNotFoundError exception is raised if forecast

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -232,6 +232,14 @@ class Test_construct_scalar_time_coords(IrisTest):
                 datetime(2017, 12, 1, 14, 0), None, datetime(2017, 12, 1, 16, 0)
             )
 
+    def test_error_no_reference_time(self):
+        """Test an error is raised if neither a forecast reference time nor blend time are supplied
+        """
+        msg = "Cannot create forecast_period without either a forecast reference time " \
+              "or a blend time."
+        with self.assertRaisesRegex(ValueError, msg):
+            construct_scalar_time_coords(datetime(2017, 12, 1, 14, 0), None)
+
     def test_time_bounds(self):
         """Test creation of time coordinate with bounds"""
         coord_dims = construct_scalar_time_coords(

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -358,14 +358,14 @@ class Test_set_up_variable_cube(IrisTest):
     def test_blend_time(self):
         """Test use of blend_time instead of forecast reference time"""
         expected_time = datetime(2018, 3, 1, 12, 0)
-        expected_frt = datetime(2018, 3, 1, 9, 0)
+        expected_reference_time = datetime(2018, 3, 1, 9, 0)
         result = set_up_variable_cube(
-            self.data, time=expected_time, blend_time=expected_frt
+            self.data, time=expected_time, blend_time=expected_reference_time
         )
         time_point = iris_time_to_datetime(result.coord("time"))[0]
         self.assertEqual(time_point, expected_time)
-        frt_point = iris_time_to_datetime(result.coord("blend_time"))[0]
-        self.assertEqual(frt_point, expected_frt)
+        reference_point = iris_time_to_datetime(result.coord("blend_time"))[0]
+        self.assertEqual(reference_point, expected_reference_time)
         self.assertEqual(result.coord("forecast_period").points[0], 10800)
         self.assertFalse(result.coords("time", dim_coords=True))
 

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -235,8 +235,10 @@ class Test_construct_scalar_time_coords(IrisTest):
     def test_error_no_reference_time(self):
         """Test an error is raised if neither a forecast reference time nor blend time are supplied
         """
-        msg = "Cannot create forecast_period without either a forecast reference time " \
-              "or a blend time."
+        msg = (
+            "Cannot create forecast_period without either a forecast reference time "
+            "or a blend time."
+        )
         with self.assertRaisesRegex(ValueError, msg):
             construct_scalar_time_coords(datetime(2017, 12, 1, 14, 0), None)
 

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -423,16 +423,18 @@ class Test_set_up_variable_cube(IrisTest):
         result = set_up_variable_cube(self.data_3d, realizations=np.array([0, 3, 4]))
         self.assertArrayEqual(result.coord("realization").points, np.array([0, 3, 4]))
 
-    def test_error_frt_and_blend_time(self):
-        """Test error is raised if both frt and blend_time are supplied"""
-        ref_time = datetime(2018, 3, 1, 9, 0)
-        msg = "Refusing to create cube with both forecast_reference_time and blend_time"
+    def test_error_frt_and_blend_time_differ(self):
+        """Test error is raised if both frt and blend_time are supplied but with different values"""
+        msg = (
+            "Refusing to create cube with different values for forecast_reference_time and "
+            "blend_time"
+        )
         with self.assertRaisesRegex(ValueError, msg):
             set_up_variable_cube(
                 self.data,
                 time=datetime(2018, 3, 1, 12, 0),
-                frt=ref_time,
-                blend_time=ref_time,
+                frt=datetime(2018, 3, 1, 9, 0),
+                blend_time=datetime(2018, 3, 1, 8, 0),
             )
 
     def test_error_unmatched_realizations(self):

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -59,7 +59,7 @@ class Test_WXCode(IrisTest):
         """Set up cubes and constraints required for Weather Symbols."""
 
         time = dt(2017, 10, 10, 12, 0)
-        blend_time = dt(2017, 10, 10, 6, 0)
+        blend_times = (dt(2017, 10, 9, h, 0) for h in range(12))
 
         thresholds = np.array(
             [8.33333333e-09, 2.77777778e-08, 2.77777778e-07], dtype=np.float32
@@ -71,7 +71,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_snowfall_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         data_sleet = np.zeros((3, 3, 3), dtype=np.float32)
@@ -82,7 +82,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_sleetfall_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         data_rain = np.array(
@@ -100,7 +100,7 @@ class Test_WXCode(IrisTest):
             variable_name="rainfall_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         data_precip = np.maximum.reduce([data_snow, data_sleet, data_rain])
@@ -111,7 +111,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_precipitation_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         precip_vicinity = set_up_probability_cube(
@@ -120,7 +120,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_precipitation_rate_in_vicinity",
             threshold_units="m s-1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         thresholds = np.array([0.1875, 0.8125], dtype=np.float32)
@@ -138,7 +138,7 @@ class Test_WXCode(IrisTest):
             variable_name="low_and_medium_type_cloud_area_fraction",
             threshold_units="1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         thresholds = np.array([0.85], dtype=np.float32)
@@ -151,7 +151,7 @@ class Test_WXCode(IrisTest):
             variable_name="low_type_cloud_area_fraction",
             threshold_units="1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         thresholds = np.array([1000.0, 5000.0], dtype=np.float32)
@@ -169,7 +169,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m",
             spp__relative_to_threshold="below",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         thresholds = np.array([0.0], dtype=np.float32)
@@ -184,7 +184,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m-2",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         hail = set_up_probability_cube(
@@ -194,7 +194,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         thresholds = np.array([2.77777778e-07], dtype=np.float32)
@@ -205,7 +205,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         thresholds = np.array([1.0], dtype=np.float32)
@@ -219,7 +219,7 @@ class Test_WXCode(IrisTest):
             variable_name="shower_condition",
             threshold_units="1",
             time=time,
-            blend_time=blend_time,
+            blend_time=next(blend_times),
         )
 
         self.cubes = iris.cube.CubeList(

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -1424,9 +1424,9 @@ class Test_create_symbol_cube(IrisTest):
         result = plugin.create_symbol_cube([self.cube])
         self.assertEqual(result.attributes["title"], target_title)
 
-    def test_blend_time_multiple_inputs(self):
-        """Test cube is constructed with appropriate blend_time with multiple
-        source cubes. Newest blend_time should be used."""
+    def test_reference_time_multiple_inputs(self):
+        """Test cube is constructed with appropriate reference times with multiple
+        source cubes. Newest reference time should be used."""
         self.plugin.template_cube = self.cube
         cube1 = self.cube.copy()
         for coord_name in ["blend_time", "forecast_reference_time"]:
@@ -1436,10 +1436,15 @@ class Test_create_symbol_cube(IrisTest):
 
         result = self.plugin.create_symbol_cube([self.cube, cube1])
 
+        for coord_name in ["blend_time", "forecast_reference_time"]:
+            self.assertEqual(
+                result.coord(coord_name).cell(0).point, dt(2017, 11, 9, 2, 0),
+            )
+            self.assertEqual(len(result.coord(coord_name).points), 1)
         self.assertEqual(
-            result.coord("blend_time").cell(0).point, dt(2017, 11, 9, 2, 0),
+            result.coord("forecast_period").points[0], 26 * 3600,
         )
-        self.assertEqual(len(result.coord("blend_time").points), 1)
+        self.assertEqual(len(result.coord("forecast_period").points), 1)
 
     def test_error_blend_and_frt_inputs(self):
         """Test an error is raised if input cubes have a mix of blend_time or

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -59,7 +59,7 @@ class Test_WXCode(IrisTest):
         """Set up cubes and constraints required for Weather Symbols."""
 
         time = dt(2017, 10, 10, 12, 0)
-        frt = dt(2017, 10, 10, 6, 0)
+        blend_time = dt(2017, 10, 10, 6, 0)
 
         thresholds = np.array(
             [8.33333333e-09, 2.77777778e-08, 2.77777778e-07], dtype=np.float32
@@ -71,7 +71,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_snowfall_rate",
             threshold_units="m s-1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         data_sleet = np.zeros((3, 3, 3), dtype=np.float32)
@@ -82,7 +82,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_sleetfall_rate",
             threshold_units="m s-1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         data_rain = np.array(
@@ -100,7 +100,7 @@ class Test_WXCode(IrisTest):
             variable_name="rainfall_rate",
             threshold_units="m s-1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         data_precip = np.maximum.reduce([data_snow, data_sleet, data_rain])
@@ -111,7 +111,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_precipitation_rate",
             threshold_units="m s-1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         precip_vicinity = set_up_probability_cube(
@@ -120,7 +120,7 @@ class Test_WXCode(IrisTest):
             variable_name="lwe_precipitation_rate_in_vicinity",
             threshold_units="m s-1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         thresholds = np.array([0.1875, 0.8125], dtype=np.float32)
@@ -138,7 +138,7 @@ class Test_WXCode(IrisTest):
             variable_name="low_and_medium_type_cloud_area_fraction",
             threshold_units="1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         thresholds = np.array([0.85], dtype=np.float32)
@@ -151,7 +151,7 @@ class Test_WXCode(IrisTest):
             variable_name="low_type_cloud_area_fraction",
             threshold_units="1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         thresholds = np.array([1000.0, 5000.0], dtype=np.float32)
@@ -169,7 +169,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m",
             spp__relative_to_threshold="below",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         thresholds = np.array([0.0], dtype=np.float32)
@@ -184,7 +184,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m-2",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            frt=frt,
+            blend_time=blend_time,
         )
 
         hail = set_up_probability_cube(
@@ -194,7 +194,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            frt=frt,
+            blend_time=blend_time,
         )
 
         thresholds = np.array([2.77777778e-07], dtype=np.float32)
@@ -205,7 +205,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            frt=frt,
+            blend_time=blend_time,
         )
 
         thresholds = np.array([1.0], dtype=np.float32)
@@ -219,7 +219,7 @@ class Test_WXCode(IrisTest):
             variable_name="shower_condition",
             threshold_units="1",
             time=time,
-            frt=frt,
+            blend_time=blend_time,
         )
 
         self.cubes = iris.cube.CubeList(

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -1302,8 +1302,8 @@ class Test_create_symbol_cube(IrisTest):
         cube = set_up_probability_cube(
             data,
             np.array([288, 290, 292], dtype=np.float32),
-            frt=dt(2017, 10, 9, 1, 0),
-            blend_time=dt(2017, 10, 9, 1, 0),
+            frt=dt(2017, 11, 9, 1, 0),
+            blend_time=dt(2017, 11, 9, 1, 0),
         )
         cube.attributes["mosg__model_configuration"] = "uk_det uk_ens"
         cube.attributes[

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -74,7 +74,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         data_sleet = np.zeros((3, 3, 3), dtype=np.float32)
@@ -86,7 +86,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         data_rain = np.array(
@@ -105,7 +105,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         data_precip = np.maximum.reduce([data_snow, data_sleet, data_rain])
@@ -117,7 +117,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         blend_time = next(blend_times)
@@ -128,7 +128,7 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         thresholds = np.array([0.1875, 0.8125], dtype=np.float32)
@@ -147,7 +147,7 @@ class Test_WXCode(IrisTest):
             threshold_units="1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         thresholds = np.array([0.85], dtype=np.float32)
@@ -162,7 +162,7 @@ class Test_WXCode(IrisTest):
             threshold_units="1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         thresholds = np.array([1000.0, 5000.0], dtype=np.float32)
@@ -182,7 +182,7 @@ class Test_WXCode(IrisTest):
             spp__relative_to_threshold="below",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         thresholds = np.array([0.0], dtype=np.float32)
@@ -198,7 +198,7 @@ class Test_WXCode(IrisTest):
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         hail = set_up_probability_cube(
@@ -209,7 +209,7 @@ class Test_WXCode(IrisTest):
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
         blend_time = next(blend_times)
         thresholds = np.array([2.77777778e-07], dtype=np.float32)
@@ -221,7 +221,7 @@ class Test_WXCode(IrisTest):
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         thresholds = np.array([1.0], dtype=np.float32)
@@ -236,7 +236,7 @@ class Test_WXCode(IrisTest):
             threshold_units="1",
             time=time,
             blend_time=blend_time,
-            frt=blend_time
+            frt=blend_time,
         )
 
         self.cubes = iris.cube.CubeList(

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -1460,6 +1460,7 @@ class Test_process(Test_WXCode):
         self.assertEqual(result.attributes["weather_code_meaning"], self.wxmeaning)
         self.assertArrayAndMaskEqual(result.data, self.expected_wxcode)
         self.assertEqual(result.dtype, np.int32)
+        self.assertEqual(result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 11, 0))
 
     def test_day_night(self):
         """Test codes for night-time weather symbols are returned."""

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -1437,7 +1437,7 @@ class Test_create_symbol_cube(IrisTest):
         result = self.plugin.create_symbol_cube([self.cube, cube1])
 
         self.assertEqual(
-            result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 2, 0),
+            result.coord("blend_time").cell(0).point, dt(2017, 11, 9, 2, 0),
         )
         self.assertEqual(len(result.coord("blend_time").points), 1)
 

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -60,7 +60,7 @@ class Test_WXCode(IrisTest):
         """Set up cubes and constraints required for Weather Symbols."""
 
         time = dt(2017, 10, 10, 12, 0)
-        blend_times = (dt(2017, 10, 9, h, 0) for h in range(12))
+        blend_times = (dt(2017, 10, 9, h, 0) for h in range(12, 0, -1))
 
         thresholds = np.array(
             [8.33333333e-09, 2.77777778e-08, 2.77777778e-07], dtype=np.float32
@@ -1511,7 +1511,7 @@ class Test_process(Test_WXCode):
         self.assertArrayAndMaskEqual(result.data, self.expected_wxcode)
         self.assertEqual(result.dtype, np.int32)
         self.assertEqual(
-            result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 11, 0)
+            result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 12, 0)
         )
 
     def test_day_night(self):

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -1283,7 +1283,9 @@ class Test_create_symbol_cube(IrisTest):
             dtype=np.float32,
         )
         self.cube = set_up_probability_cube(
-            data, np.array([288, 290, 292], dtype=np.float32)
+            data,
+            np.array([288, 290, 292], dtype=np.float32),
+            blend_time=dt(2017, 10, 9, 1, 0),
         )
         self.cube.attributes["mosg__model_configuration"] = "uk_det uk_ens"
         self.cube.attributes[
@@ -1460,7 +1462,9 @@ class Test_process(Test_WXCode):
         self.assertEqual(result.attributes["weather_code_meaning"], self.wxmeaning)
         self.assertArrayAndMaskEqual(result.data, self.expected_wxcode)
         self.assertEqual(result.dtype, np.int32)
-        self.assertEqual(result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 11, 0))
+        self.assertEqual(
+            result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 11, 0)
+        )
 
     def test_day_night(self):
         """Test codes for night-time weather symbols are returned."""

--- a/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
+++ b/improver_tests/wxcode/wxcode/test_WeatherSymbols.py
@@ -66,24 +66,27 @@ class Test_WXCode(IrisTest):
             [8.33333333e-09, 2.77777778e-08, 2.77777778e-07], dtype=np.float32
         )
         data_snow = np.zeros((3, 3, 3), dtype=np.float32)
+        blend_time = next(blend_times)
         snowfall_rate = set_up_probability_cube(
             data_snow,
             thresholds,
             variable_name="lwe_snowfall_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         data_sleet = np.zeros((3, 3, 3), dtype=np.float32)
-
+        blend_time = next(blend_times)
         sleetfall_rate = set_up_probability_cube(
             data_sleet,
             thresholds,
             variable_name="lwe_sleetfall_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         data_rain = np.array(
@@ -94,34 +97,38 @@ class Test_WXCode(IrisTest):
             ],
             dtype=np.float32,
         )
-
+        blend_time = next(blend_times)
         rainfall_rate = set_up_probability_cube(
             data_rain,
             thresholds,
             variable_name="rainfall_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         data_precip = np.maximum.reduce([data_snow, data_sleet, data_rain])
-
+        blend_time = next(blend_times)
         precip_rate = set_up_probability_cube(
             data_precip,
             thresholds,
             variable_name="lwe_precipitation_rate",
             threshold_units="m s-1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
+        blend_time = next(blend_times)
         precip_vicinity = set_up_probability_cube(
             data_precip,
             thresholds,
             variable_name="lwe_precipitation_rate_in_vicinity",
             threshold_units="m s-1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         thresholds = np.array([0.1875, 0.8125], dtype=np.float32)
@@ -132,27 +139,30 @@ class Test_WXCode(IrisTest):
             ],
             dtype=np.float32,
         )
-
+        blend_time = next(blend_times)
         cloud = set_up_probability_cube(
             data_cloud,
             thresholds,
             variable_name="low_and_medium_type_cloud_area_fraction",
             threshold_units="1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         thresholds = np.array([0.85], dtype=np.float32)
         data_cld_low = np.array(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]], dtype=np.float32
         ).reshape((1, 3, 3))
+        blend_time = next(blend_times)
         cloud_low = set_up_probability_cube(
             data_cld_low,
             thresholds,
             variable_name="low_type_cloud_area_fraction",
             threshold_units="1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         thresholds = np.array([1000.0, 5000.0], dtype=np.float32)
@@ -163,6 +173,7 @@ class Test_WXCode(IrisTest):
             ],
             dtype=np.float32,
         )
+        blend_time = next(blend_times)
         visibility = set_up_probability_cube(
             data_vis,
             thresholds,
@@ -170,14 +181,15 @@ class Test_WXCode(IrisTest):
             threshold_units="m",
             spp__relative_to_threshold="below",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         thresholds = np.array([0.0], dtype=np.float32)
         data_lightning = np.zeros((1, 3, 3), dtype=np.float32)
         data_lightning[0, 0, 0] = 0.25
         data_lightning[0, 0, 1] = 0.30
-
+        blend_time = next(blend_times)
         lightning = set_up_probability_cube(
             data_lightning,
             thresholds,
@@ -185,7 +197,8 @@ class Test_WXCode(IrisTest):
             threshold_units="m-2",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         hail = set_up_probability_cube(
@@ -195,9 +208,10 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
-
+        blend_time = next(blend_times)
         thresholds = np.array([2.77777778e-07], dtype=np.float32)
         precipmaxrate = set_up_probability_cube(
             np.zeros((1, 3, 3), dtype=np.float32),
@@ -206,21 +220,23 @@ class Test_WXCode(IrisTest):
             threshold_units="m s-1",
             time=time,
             time_bounds=[time - timedelta(hours=1), time],
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         thresholds = np.array([1.0], dtype=np.float32)
         data_shower_condition = np.array(
             [[[0.0, 1.0, 0.0], [0.0, 1.0, 1.0], [1.0, 0.0, 0.0]]], dtype=np.float32,
         )
-
+        blend_time = next(blend_times)
         shower_condition = set_up_probability_cube(
             data_shower_condition,
             thresholds,
             variable_name="shower_condition",
             threshold_units="1",
             time=time,
-            blend_time=next(blend_times),
+            blend_time=blend_time,
+            frt=blend_time
         )
 
         self.cubes = iris.cube.CubeList(
@@ -1283,19 +1299,17 @@ class Test_create_symbol_cube(IrisTest):
             ],
             dtype=np.float32,
         )
-        cubes = []
-        for key in ("frt", "blend_time"):
-            cube = set_up_probability_cube(
-                data,
-                np.array([288, 290, 292], dtype=np.float32),
-                **{key: dt(2017, 10, 9, 1, 0)},
-            )
-            cube.attributes["mosg__model_configuration"] = "uk_det uk_ens"
-            cube.attributes[
-                "mosg__model_run"
-            ] = "uk_det:20171109T2300Z:0.500\nuk_ens:20171109T2100Z:0.500"
-            cubes.append(cube)
-        self.cube_frt, self.cube = cubes
+        cube = set_up_probability_cube(
+            data,
+            np.array([288, 290, 292], dtype=np.float32),
+            frt=dt(2017, 10, 9, 1, 0),
+            blend_time=dt(2017, 10, 9, 1, 0),
+        )
+        cube.attributes["mosg__model_configuration"] = "uk_det uk_ens"
+        cube.attributes[
+            "mosg__model_run"
+        ] = "uk_det:20171109T2300Z:0.500\nuk_ens:20171109T2100Z:0.500"
+        self.cube = cube
         self.wxcode = np.array(list(WX_DICT.keys()))
         self.wxmeaning = " ".join(WX_DICT.values())
         self.plugin = WeatherSymbols(wxtree=wxcode_decision_tree())
@@ -1415,9 +1429,10 @@ class Test_create_symbol_cube(IrisTest):
         source cubes. Newest blend_time should be used."""
         self.plugin.template_cube = self.cube
         cube1 = self.cube.copy()
-        new_coord = cube1.coord("blend_time")
-        new_coord = new_coord.copy(new_coord.points + 3600)
-        cube1.replace_coord(new_coord)
+        for coord_name in ["blend_time", "forecast_reference_time"]:
+            new_coord = cube1.coord(coord_name)
+            new_coord = new_coord.copy(new_coord.points + 3600)
+            cube1.replace_coord(new_coord)
 
         result = self.plugin.create_symbol_cube([self.cube, cube1])
 
@@ -1426,32 +1441,17 @@ class Test_create_symbol_cube(IrisTest):
         )
         self.assertEqual(len(result.coord("blend_time").points), 1)
 
-    def test_frt_multiple_inputs(self):
-        """Test cube is constructed with appropriate forecast_reference_time with multiple
-        source cubes. Newest forecast_reference_time should be used."""
-        self.plugin.template_cube = self.cube_frt
-        cube1 = self.cube_frt.copy()
-        new_coord = cube1.coord("forecast_reference_time")
-        new_coord = new_coord.copy(new_coord.points + 3600)
-        cube1.replace_coord(new_coord)
-
-        result = self.plugin.create_symbol_cube([self.cube_frt, cube1])
-
-        self.assertEqual(
-            result.coord("forecast_reference_time").cell(0).point,
-            dt(2017, 10, 9, 2, 0),
-        )
-        self.assertEqual(len(result.coord("forecast_reference_time").points), 1)
-
     def test_error_blend_and_frt_inputs(self):
-        """Test cube is constructed with appropriate forecast_reference_time with multiple
-        source cubes. Newest forecast_reference_time should be used."""
+        """Test an error is raised if input cubes have a mix of blend_time or
+        forecast_reference_time"""
+        cube1 = self.cube.copy()
+        self.cube.remove_coord("forecast_reference_time")
+        cube1.remove_coord("blend_time")
         self.plugin.template_cube = self.cube
 
-        msg = "Expected to find exactly 1 forecast_reference_time coordinate, but found none."
-
+        msg = "Could not find"
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
-            self.plugin.create_symbol_cube([self.cube_frt, self.cube])
+            self.plugin.create_symbol_cube([self.cube, cube1])
 
 
 class Test_compare_to_threshold(IrisTest):


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/521

The output cube from the weather code plugin will contain either a forecast_reference_time coord or a blend_time coord, but the value of this auxiliary coordinate will be taken from either the last supplied cube that has time bounds, or the first cube if none have time bounds. (This becomes `self.template_cube`).

In practise, the weather code plugin receives data from different models and the blended data have different update frequencies. This can mean that the reference time on the output cube can be several hours older than the newest reference time passed in. Given that we update the weather code when any of the input data changes, this is not appropriate.

This PR adds handling of the reference time and selects the newest (largest) reference time point from all the input cubes and applies it to the output cube. The reference time can be either `blend_time` or `forecast_reference_time` or both, but all input cubes must be consistent. The `forecast_period` coord is also updated to be consistent with the output reference time while preserving any attributes that may be present on this coord.

To facilitate testing, the `set_up_variable_cube` and sub-methods have been modified to accept a `blend_time` argument and tests are added for these changes too.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
