### PR TITLE
Fix to the wind vertical displacement adjustment implementation

### DIFF
--- a/improver/calibration/dz_rescaling.py
+++ b/improver/calibration/dz_rescaling.py
@@ -407,7 +407,7 @@ class ApplyDzRescaling(PostProcessingPlugin):
         """
         # Define forecast_reference_time constraint
         frt_hour_in_seconds = (
-            forecast.coord("forecast_reference_time").cell(0).point.hour + leniency
+            (forecast.coord("forecast_reference_time").cell(0).point.hour + leniency) % 24
         ) * SECONDS_IN_HOUR
         return iris.Constraint(forecast_reference_time_hour=frt_hour_in_seconds)
 

--- a/improver/calibration/dz_rescaling.py
+++ b/improver/calibration/dz_rescaling.py
@@ -407,7 +407,8 @@ class ApplyDzRescaling(PostProcessingPlugin):
         """
         # Define forecast_reference_time constraint
         frt_hour_in_seconds = (
-            (forecast.coord("forecast_reference_time").cell(0).point.hour + leniency) % 24
+            (forecast.coord("forecast_reference_time").cell(0).point.hour + leniency)
+            % 24
         ) * SECONDS_IN_HOUR
         return iris.Constraint(forecast_reference_time_hour=frt_hour_in_seconds)
 

--- a/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
@@ -121,7 +121,7 @@ def _create_scaling_factor_cube(
         Scaling factor cube.
     """
     cubelist = iris.cube.CubeList()
-    for ref_hour in [3, 9]:
+    for ref_hour in [3, 12]:
         for forecast_period in [6, 12, 18, 24]:
             if ref_hour == frt_hour and forecast_period == forecast_period_hour:
                 data = np.array((scaling_factor, 1), dtype=np.float32)
@@ -159,10 +159,10 @@ def _create_scaling_factor_cube(
 
 @pytest.mark.parametrize("wmo_id", [True, False])
 @pytest.mark.parametrize("forecast_period", [6, 18])
-@pytest.mark.parametrize("frt_hour", [3, 9])
+@pytest.mark.parametrize("frt_hour", [3, 12])
 @pytest.mark.parametrize("scaling_factor", [0.99, 1.01])
 @pytest.mark.parametrize("forecast_period_offset", [0, -1, -5])
-@pytest.mark.parametrize("frt_hour_offset", [0, 1, 2])
+@pytest.mark.parametrize("frt_hour_offset", [0, 1, 4])
 def test_apply_dz_rescaling(
     wmo_id,
     forecast_period,
@@ -183,7 +183,7 @@ def test_apply_dz_rescaling(
     This checks that the a mismatch in the forecast reference time hour can still
     result in a match, if a leniency is specified.
     """
-    forecast_reference_time = f"20170101T{frt_hour-frt_hour_offset:02d}00Z"
+    forecast_reference_time = f"20170101T{(frt_hour-frt_hour_offset) % 24:02d}00Z"
     forecast = [10.0, 20.0, 30.0]
     expected_data = np.array(forecast).repeat(2).reshape(3, 2)
     expected_data[:, 0] *= scaling_factor

--- a/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
@@ -112,7 +112,7 @@ def _create_forecasts(
 def _create_scaling_factor_cube(
     frt_hour: int, forecast_period_hour: int, scaling_factor: float
 ) -> Cube:
-    """Create a scaling factor cube containing forecast_reference_time_hours of 3 and 9 and
+    """Create a scaling factor cube containing forecast_reference_time_hours of 3 and 12 and
     forecast_period_hours of 6, 12, 18 and 24 and two sites.
     All scaling factors are 1 except at the specified [frt_hour, forecast_period_hour], where
     scaling_factor is used for the first site only.


### PR DESCRIPTION
This change addresses an issue in the dz adjustment of wind speeds. The leniency applied for finding a dz adjustment match in the ancillary did not span across midnight, meaning a 23Z forecast reference time was unable to use a 00Z forecast reference time with a leniency of +- 1 hour. This change simply adds a modulus about 24 hours to ensure the looping around to 00Z occurs as required.

The unit tests have been modified to span the midnight line to check that this works as expected.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)