### PR TITLE
Evenly space percentiles check function

### DIFF
--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -46,6 +46,7 @@ import improver.ensemble_copula_coupling._scipy_continuous_distns as scipy_cont_
 from improver import BasePlugin
 from improver.calibration.utilities import convert_cube_data_to_2d
 from improver.ensemble_copula_coupling.utilities import (
+    check_evenly_spaced_percentiles,
     choose_set_of_percentiles,
     concatenate_2d_array_with_2d_array_endpoints,
     create_cube_with_percentiles,
@@ -176,25 +177,7 @@ class RebadgePercentilesAsRealizations(BasePlugin):
         """
         percentile_coord_name = find_percentile_coordinate(cube).name()
 
-        # create array of percentiles from cube metadata, add in fake
-        # 0th and 100th percentiles if not already included
-        percentile_coords = np.sort(
-            np.unique(np.append(cube.coord(percentile_coord_name).points, [0, 100]))
-        )
-        percentile_diffs = np.diff(percentile_coords)
-
-        # percentiles cannot be rebadged unless they are evenly spaced,
-        # centred on 50th percentile, and equally partition percentile
-        # space
-        if not np.isclose(np.max(percentile_diffs), np.min(percentile_diffs)):
-            msg = (
-                "The percentile cube provided cannot be rebadged as ensemble "
-                "realizations. The input percentiles need to be equally spaced, "
-                "be centred on the 50th percentile, and to equally partition percentile "
-                "space. The percentiles provided were "
-                f"{cube.coord(percentile_coord_name).points}"
-            )
-            raise ValueError(msg)
+        check_evenly_spaced_percentiles(cube)
 
         if ensemble_realization_numbers is None:
             ensemble_realization_numbers = np.arange(

--- a/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
+++ b/improver_tests/ensemble_copula_coupling/test_RebadgePercentilesAsRealizations.py
@@ -93,39 +93,6 @@ class Test_process(IrisTest):
         with self.assertRaisesRegex(InvalidCubeError, msg):
             Plugin().process(self.cube)
 
-    def test_raises_exception_if_percentiles_unevenly_spaced(self):
-        """Check that an exception is raised if the input percentiles
-        are not evenly spaced."""
-        cube = set_up_percentile_cube(
-            np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
-            np.array([25, 50, 90], dtype=np.float32),
-        )
-        msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
-        with self.assertRaisesRegex(ValueError, msg):
-            Plugin().process(cube)
-
-    def test_raises_exception_if_percentiles_not_centred(self):
-        """Check that an exception is raised if the input percentiles
-        are not centred on 50th percentile."""
-        cube = set_up_percentile_cube(
-            np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
-            np.array([30, 60, 90], dtype=np.float32),
-        )
-        msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
-        with self.assertRaisesRegex(ValueError, msg):
-            Plugin().process(cube)
-
-    def test_raises_exception_if_percentiles_unequal_partition_percentile_space(self):
-        """Check that an exception is raised if the input percentiles
-        don't evenly partition percentile space."""
-        cube = set_up_percentile_cube(
-            np.sort(ECC_TEMPERATURE_REALIZATIONS.copy(), axis=0),
-            np.array([10, 50, 90], dtype=np.float32),
-        )
-        msg = r"The percentile cube provided cannot be rebadged as ensemble realizations.*"
-        with self.assertRaisesRegex(ValueError, msg):
-            Plugin().process(cube)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Factors out the checking of percentile spacing from `RebadgePercentilesAsRealizations` into a stand along utility. This will be needed within the threshold plugin when collapsing percentiles to ensure that treating the percentiles like realizations is acceptable.

Part of https://github.com/metoppv/improver/issues/1787

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)