### PR TITLE
Remove system_packages option

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,3 @@ build:
 
 conda:
   environment: doc/rtd_environment.yml
-
-python:
-    system_packages: true


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/542

Description
ReadTheDocs are making some deprecations: https://github.com/readthedocs/readthedocs.org/issues/10587, in particular removing the system_packages option. [We specify this option in IMPROVER](https://github.com/metoppv/improver/blob/master/.readthedocs.yml#L12), however, I don't think that this option is actually used because [the documentation](https://docs.readthedocs.io/en/stable/config-file/v2.html#python-system-packages) says that this option isn't used if a Conda environment is specified.

Testing:
 - [x] Ran tests and they passed OK