### PR TITLE
Recreate tests badge based on scheduled tests of master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IMPROVER
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Tests](https://github.com/metoppv/improver/workflows/Tests/badge.svg)](https://github.com/metoppv/improver/actions?query=branch%3Amaster)
+[![Tests](https://github.com/metoppv/improver/actions/workflows/scheduled.yml/badge.svg)](https://github.com/metoppv/improver/actions/workflows/scheduled.yml)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f7dcb46e8e1b4110b3d194dba03fe526)](https://www.codacy.com/app/metoppv_tech/improver?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=metoppv/improver&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/f7dcb46e8e1b4110b3d194dba03fe526)](https://www.codacy.com/app/metoppv_tech/improver?utm_source=github.com&utm_medium=referral&utm_content=metoppv/improver&utm_campaign=Badge_Coverage)
 [![codecov](https://codecov.io/gh/metoppv/improver/branch/master/graph/badge.svg)](https://codecov.io/gh/metoppv/improver)


### PR DESCRIPTION
The tests badge was showing as failed. This was pointing at an old automated test that has not been running for sometime. I deleted the old test run, and thus fully broke the tests badge. This PR replaces it with a badge pointing at the current scheduled tests of the master branch.
