### PR TITLE
Account for orography when vertically interpolating falling-levels at sea points

### DIFF
--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -692,7 +692,7 @@ class PhaseChangeLevel(BasePlugin):
                 The vertical height levels above orography, matching the
                 leading dimension of the wet_bulb_temperature.
             orography:
-                Cube of orography (m).
+                Orography heights
         """
         sea_points = (
             np.isnan(phase_change_level_data)

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -656,6 +656,7 @@ class PhaseChangeLevel(BasePlugin):
         max_wb_integral: ndarray,
         wet_bulb_temperature: ndarray,
         heights: ndarray,
+        orography: ndarray,
     ) -> None:
         """
         Fill in any sea points where we have not found a phase change level
@@ -686,6 +687,8 @@ class PhaseChangeLevel(BasePlugin):
             heights:
                 The vertical height levels above orography, matching the
                 leading dimension of the wet_bulb_temperature.
+            orography:
+                Cube of orography (m).
         """
         sea_points = (
             np.isnan(phase_change_level_data)
@@ -702,6 +705,8 @@ class PhaseChangeLevel(BasePlugin):
         self.find_extrapolated_falling_level(
             max_wb_integral, gradient, intercept, phase_change_level_data, sea_points
         )
+
+        phase_change_level_data[sea_points] += orography[sea_points]
 
     def find_max_in_nbhood_orography(self, orography_cube: Cube) -> Cube:
         """
@@ -781,6 +786,7 @@ class PhaseChangeLevel(BasePlugin):
             wb_integral.max(axis=0),
             wet_bulb_temp,
             heights,
+            orography,
         )
 
         # Any unset points at this stage are set to np.nan; these will be

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -669,6 +669,10 @@ class PhaseChangeLevel(BasePlugin):
         phase change levels below sea level for points where we have applied
         the extrapolation.
 
+        The linear fit assumes that all sea points have an orography altitude of zero,
+        however this is not always the case. The orography altitude is  added to phase
+        change levels calculated from the linear fit to account for this.
+
         Assumes that height is the first axis in the wet_bulb_integral array.
 
         Args:

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -670,7 +670,7 @@ class PhaseChangeLevel(BasePlugin):
         the extrapolation.
 
         The linear fit assumes that all sea points have an orography altitude of zero,
-        however this is not always the case. The orography altitude is  added to phase
+        however this is not always the case. The orography altitude is added to phase
         change levels calculated from the linear fit to account for this.
 
         Assumes that height is the first axis in the wet_bulb_integral array.

--- a/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
+++ b/improver_tests/psychrometric_calculations/test_PhaseChangeLevel.py
@@ -315,6 +315,7 @@ class Test_fill_sea_points(IrisTest):
         data[:, :, 0] = data[:, :, 0] - 10
         data[:, :, 2] = data[:, :, 2] + 20
         self.wet_bulb_temperature = data
+        self.orography = np.zeros((3, 3))
         self.expected_phase_change_level = np.array(
             [
                 [-27.5, -15.0, -4.154759],
@@ -332,6 +333,7 @@ class Test_fill_sea_points(IrisTest):
             self.max_wb_integral,
             self.wet_bulb_temperature,
             self.heights,
+            self.orography,
         )
         self.assertArrayAlmostEqual(
             self.phase_change_level.data, self.expected_phase_change_level
@@ -348,6 +350,7 @@ class Test_fill_sea_points(IrisTest):
             self.max_wb_integral,
             self.wet_bulb_temperature,
             self.heights,
+            self.orography,
         )
         self.assertArrayAlmostEqual(self.phase_change_level.data, expected)
 
@@ -363,6 +366,24 @@ class Test_fill_sea_points(IrisTest):
             self.max_wb_integral,
             self.wet_bulb_temperature,
             self.heights,
+            self.orography,
+        )
+        self.assertArrayAlmostEqual(
+            self.phase_change_level.data, self.expected_phase_change_level
+        )
+
+    def test_non_zero_orography(self):
+        """Test that points with non-zero orography are updated correctly"""
+        plugin = PhaseChangeLevel(phase_change="snow-sleet")
+        orography = np.array([[-5, 0, 5], [-5, 0, 5], [-5, 0, 5]])
+        self.expected_phase_change_level += orography
+        plugin.fill_in_sea_points(
+            self.phase_change_level,
+            self.land_sea,
+            self.max_wb_integral,
+            self.wet_bulb_temperature,
+            self.heights,
+            orography,
         )
         self.assertArrayAlmostEqual(
             self.phase_change_level.data, self.expected_phase_change_level


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/558
Notebook: https://github.com/MetOffice/improver_aux/pull/399

Description
Updates vertical interpolation of precipitation falling-levels for sea points to account for orography. 
Adds test for new functionality.

The notebook linked above demonstrates how the negative sleet probabilities arise and also shows that this change does actually fix the problem.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
