### PR TITLE
Reduces size of data array handled in nbhood

### DIFF
--- a/improver/nbhood/use_nbhood.py
+++ b/improver/nbhood/use_nbhood.py
@@ -266,7 +266,7 @@ class ApplyNeighbourhoodProcessingWithAMask(PostProcessingPlugin):
             prev_x_y_slice = x_y_slice
 
             cube_slices = iris.cube.CubeList([])
-            # Apply each mask in in mask_cube to the 2D input slice.
+            # Apply each mask in mask_cube to the 2D input slice.
             for mask_slice in mask_cube.slices_over(self.coord_for_masking):
                 output_cube = plugin(x_y_slice, mask_cube=mask_slice)
                 coord_object = mask_slice.coord(self.coord_for_masking).copy()

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -148,6 +148,7 @@ class Test__calculate_neighbourhood(IrisTest):
         )
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
@@ -165,6 +166,7 @@ class Test__calculate_neighbourhood(IrisTest):
         )
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.weighted_circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
@@ -199,6 +201,7 @@ class Test__calculate_neighbourhood(IrisTest):
         )
         plugin = NeighbourhoodProcessing("circular", self.RADIUS, sum_only=True)
         plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
@@ -229,6 +232,7 @@ class Test__calculate_neighbourhood(IrisTest):
         input_data = np.ma.masked_where(self.mask == 0, self.data_for_masked_tests)
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(input_data)
 
         self.assertArrayAlmostEqual(result.data, expected_array)


### PR DESCRIPTION
Reduces size of data array handled in nbhood to exclude rows and columns of zeros.

Addresses https://github.com/metoppv/mo-blue-team/issues/556

Topographic neighbourhooding is mostly processing masked data. One of the steps sets masked points to zero. This PR takes advantage of this and crops those arrays so that areas of excluded data don't require huge amounts of compute time. Where no unmasked data exist, the calculations are bypassed entirely.

I believe it is possible to generalise this further so that unmasked, unvarying data can be processed much more quickly, but I do not have time to pursue this right now.

Testing:
 - [x] Ran tests and they passed OK
 - No new features and existing tests cover the cases I am trying to optimise.
 - The linked ticket shows how this reduces the computation time of the most expensive method in topographic neighbourhooding.
