### PR TITLE
Handling of missing data in IMPROVER

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ below:
  - Aaron Hopkinson (Met Office, UK)
  - Kathryn Howard (Met Office, UK)
  - Tim Hume (Bureau of Meteorology, Australia)
+ - Timothy Hume (Bureau of Meteorology, Australia)
  - Katharine Hurst (Met Office, UK)
  - Simon Jackson (Met Office, UK)
  - Caroline Jones (Met Office, UK)

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -670,7 +670,9 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
         )
 
         result_slices = iris.cube.CubeList(
-            collapsed(c_slice, self.blend_coord, iris.analysis.MEAN, weights=w_slice)
+            collapsed(
+                c_slice, self.blend_coord, iris.analysis.MEAN, mdtol=0, weights=w_slice
+            )
             for c_slice, w_slice in zip(cube_slices, weights_slices)
         )
 

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -205,8 +205,10 @@ def process(
     # Section for combining land and sea points following land and sea points
     # being neighbourhood processed individually.
     if sea_only.data.max() > 0.0 and land_only.data.max() > 0.0:
-        # Recombine cubes to be a single output.
+        # Recombine cubes to be a single output, and burn back in the
+        # missing data mask from the original cube.
         combined_data = result_land.data.filled(0) + result_sea.data.filled(0)
+        combined_data = np.ma.masked_array(combined_data, cube.data.mask, copy=False)
         result = result_land.copy(data=combined_data)
 
     return result


### PR DESCRIPTION
Addresses #1931 

Description

There seem to be inconsistencies in how certain functions in IMPROVER handle missing data. We encountered this in the Bureau when we were running hindcasts with some input data fields full of missing values.

To date I have found two small areas of code where this can be fixed.

1. In the land and sea neighbourhood code missing data from the input files is lost unless it is explicitly "burned" back into the final output data.

2. In the probablility blending code, the computations allow some input data to be missing, and consequently we were getting blended probabilities we didn't quite understand. The solution is that if any of the input data are missing value, then we set the blended value to be missing. This is handled by an option already in IRIS (mdtol=0).

I am suspicious that there are more areas in the code where we will need to make some changes to handling of missing data, but it is slow to identify the exact causes of the issues, and then fix them. It will no doubt be work that will gradually be done as people find and fix any issues.

Testing:
 - [x] Ran tests and they passed OK
