### PR TITLE
Neighbourhood efficiency improvements

### DIFF
--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -356,9 +356,11 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         size = data.size
         extreme = 0
         when_all_extremes = 0
-        half_nb_size = (self.nb_size // 2)
+        half_nb_size = self.nb_size // 2
         for _extreme, _when_all_extremes in ((0, 0), (1, max_extreme)):
-            if _when_all_extremes is None or issubclass(data.dtype.type, np.complexfloating):
+            if _when_all_extremes is None or issubclass(
+                data.dtype.type, np.complexfloating
+            ):
                 # We can't take this shortcut if we don't have either a default value/array,
                 # or the data values are complex, as comparisons with non-complex values are
                 # tricky.

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -320,7 +320,7 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         else:
             area_sum = self._do_nbhood_sum(valid_data_mask)
         # Where data are all ones in nbhood, result will be same as area_sum
-        data = self._do_nbhood_sum(data, max_extreme=area_sum)
+        data = self._do_nbhood_sum(data, max_extreme=area_sum.astype(loc_data_dtype))
 
         if not self.sum_only:
             with np.errstate(divide="ignore", invalid="ignore"):
@@ -353,7 +353,7 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         data_shape = data.shape
         ystart = xstart = 0
         ystop, xstop = data.shape
-        size = data.size + 1
+        size = data.size
         when_all_extremes = 0
         half_nb_size = (self.nb_size // 2) + 1  # rounded up
         for _extreme, _when_all_extremes in ((0, 0), (1, max_extreme)):
@@ -386,9 +386,9 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         if size != data.size:
             # Determine default array for the extremes around the edges, or everywhere
             if isinstance(when_all_extremes, np.ndarray):
-                untrimmed = when_all_extremes.copy()
+                untrimmed = when_all_extremes.astype(data.dtype)
             else:
-                untrimmed = np.full(data_shape, when_all_extremes)
+                untrimmed = np.full(data_shape, when_all_extremes, dtype=data.dtype)
         if size:
             # Trim to the calculated box
             data = data[ystart:ystop, xstart:xstop]

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Module containing neighbourhood processing utilities."""
 
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Union
 
 import iris
 import numpy as np

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -337,9 +337,9 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
     ) -> np.ndarray:
         """Calculate the sum-in-area from an array.
         As this can be expensive, the method first checks for the extreme cases where the data are:
-            - All zeros (result will be all zeros too)
-            - All ones (result will be max_extreme, if supplied)
-            - Contains outer rows / columns that are completely zero or completely one, these
+            All zeros (result will be all zeros too)
+            All ones (result will be max_extreme, if supplied)
+            Contains outer rows / columns that are completely zero or completely one, these
                 rows and columns are trimmed before calculating the area sum and their contents
                 will be as for the appropriate all case above.
 

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -382,7 +382,7 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         if size != data.size:
             # Determine default array for the extremes around the edges, or everywhere
             if isinstance(when_all_extremes, np.ndarray):
-                untrimmed = when_all_extremes
+                untrimmed = when_all_extremes.copy()
             else:
                 untrimmed = np.full(data_shape, when_all_extremes)
         if size:

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -356,10 +356,12 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         size = data.size
         extreme = 0
         when_all_extremes = 0
-        half_nb_size = self.nb_size // 2
+        half_nb_size = (self.nb_size // 2)
         for _extreme, _when_all_extremes in ((0, 0), (1, max_extreme)):
-            if _when_all_extremes is None:
-                # We can't take this shortcut
+            if _when_all_extremes is None or issubclass(data.dtype.type, np.complexfloating):
+                # We can't take this shortcut if we don't have either a default value/array,
+                # or the data values are complex, as comparisons with non-complex values are
+                # tricky.
                 continue
             nonextreme_indices = np.argwhere(data != _extreme)
             if nonextreme_indices.size == 0:
@@ -370,14 +372,6 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
                     nonextreme_indices.min(0),
                     nonextreme_indices.max(0) + 1,
                 )
-                if (
-                    (_ystart - self.nb_size < 0)
-                    or (_ystop + self.nb_size > data_shape[-2])
-                    or (_xstart - self.nb_size < 0)
-                    or (_xstop + self.nb_size > data_shape[-1])
-                ):
-                    #  Cannot safely crop this domain with enough buffer to preserve the result.
-                    continue
                 _ystart = max(0, _ystart - half_nb_size)
                 _ystop = min(data_shape[0], _ystop + half_nb_size)
                 _xstart = max(0, _xstart - half_nb_size)
@@ -393,34 +387,21 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
                     _xstart,
                     _xstop,
                 )
-        square_buffer_kwargs = {"mode": "constant", "constant_value": extreme}
         if size != data.size:
             # Determine default array for the extremes around the edges, or everywhere
             if isinstance(when_all_extremes, np.ndarray):
                 untrimmed = when_all_extremes.astype(data.dtype)
             else:
                 untrimmed = np.full(data_shape, when_all_extremes, dtype=data.dtype)
-            if (
-                self.neighbourhood_method == "square"
-                and min(ystart, xstart, data_shape[-2] - ystop, data_shape[-1] - xstop)
-                >= half_nb_size + 1
-            ):
-                # Trim to the calculated box plus padding
-                # and rely on boxsum to return the right sized array
-                data = data[
-                    ystart - half_nb_size - 1 : ystop + half_nb_size,
-                    xstart - half_nb_size - 1 : xstop + half_nb_size,
-                ]
-                square_buffer_kwargs = {}
-            else:
-                # Trim to the calculated box without padding and let boxsum do its padding.
-                # Circular neighbourhoods will ignore the square_buffer_kwargs.
-                data = data[ystart:ystop, xstart:xstop]
-
         if size:
-            # Calculate neighbourhood totals for input data if it isn't all constant.
+            # Trim to the calculated box
+            data = data[ystart:ystop, xstart:xstop]
+
+            # Calculate neighbourhood totals for input data.
             if self.neighbourhood_method == "square":
-                data = boxsum(data, self.nb_size, **square_buffer_kwargs)
+                data = boxsum(
+                    data, self.nb_size, mode="constant", constant_values=extreme
+                )
             elif self.neighbourhood_method == "circular":
                 data = correlate(data, self.kernel, mode="nearest")
         else:

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -341,12 +341,11 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
     ) -> np.ndarray:
         """Calculate the sum-in-area from an array.
         As this can be expensive, the method first checks for the extreme cases where the data are:
-            All zeros (result will be all zeros too)
-            All ones (result will be max_extreme, if supplied)
-            Contains outer rows / columns that are completely zero or completely one, these
-                rows and columns are trimmed before calculating the area sum and their contents
-                will be as for the appropriate all case above.
-
+        All zeros (result will be all zeros too)
+        All ones (result will be max_extreme, if supplied)
+        Contains outer rows / columns that are completely zero or completely one, these
+        rows and columns are trimmed before calculating the area sum and their contents
+        will be as for the appropriate all case above.
         """
         # Determine the smallest box containing all non-zero or all non-one values with a
         # neighbourhood-sized buffer and quit if there are none.

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -316,11 +316,12 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         data[data_mask] = 0
 
         if self.sum_only:
-            area_sum = None
+            max_extreme_data = None
         else:
             area_sum = self._do_nbhood_sum(valid_data_mask)
+            max_extreme_data = area_sum.astype(loc_data_dtype)
         # Where data are all ones in nbhood, result will be same as area_sum
-        data = self._do_nbhood_sum(data, max_extreme=area_sum.astype(loc_data_dtype))
+        data = self._do_nbhood_sum(data, max_extreme=max_extreme_data)
 
         if not self.sum_only:
             with np.errstate(divide="ignore", invalid="ignore"):

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -307,7 +307,11 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
 
         # Replace invalid elements with zeros so they don't count towards
         # neighbourhood sum
-        valid_data_mask = np.ones(data.shape, dtype=np.int64)
+        if self.neighbourhood_method == "circular":
+            mask_type = np.float32
+        else:
+            mask_type = np.int64
+        valid_data_mask = np.ones(data.shape, dtype=mask_type)
         valid_data_mask[data_mask] = 0
         data[data_mask] = 0
 

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -354,6 +354,7 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         ystart = xstart = 0
         ystop, xstop = data.shape
         size = data.size
+        extreme = 0
         when_all_extremes = 0
         half_nb_size = self.nb_size // 2
         for _extreme, _when_all_extremes in ((0, 0), (1, max_extreme)):
@@ -383,15 +384,16 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
                 _xstop = min(data_shape[1], _xstop + half_nb_size)
             _size = (_ystop - _ystart) * (_xstop - _xstart)
             if _size < size:
-                size, when_all_extremes, ystart, ystop, xstart, xstop = (
+                size, extreme, when_all_extremes, ystart, ystop, xstart, xstop = (
                     _size,
+                    _extreme,
                     _when_all_extremes,
                     _ystart,
                     _ystop,
                     _xstart,
                     _xstop,
                 )
-        square_buffer_kwargs = {"mode": "constant"}
+        square_buffer_kwargs = {"mode": "constant", "constant_value": extreme}
         if size != data.size:
             # Determine default array for the extremes around the edges, or everywhere
             if isinstance(when_all_extremes, np.ndarray):

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -355,7 +355,7 @@ class NeighbourhoodProcessing(BaseNeighbourhoodProcessing):
         ystop, xstop = data.shape
         size = data.size
         when_all_extremes = 0
-        half_nb_size = (self.nb_size // 2) + 1  # rounded up
+        half_nb_size = (self.nb_size // 2) + 2  # rounded up
         for _extreme, _when_all_extremes in ((0, 0), (1, max_extreme)):
             if _when_all_extremes is None:
                 # We can't take this shortcut

--- a/improver/nbhood/use_nbhood.py
+++ b/improver/nbhood/use_nbhood.py
@@ -266,7 +266,7 @@ class ApplyNeighbourhoodProcessingWithAMask(PostProcessingPlugin):
             prev_x_y_slice = x_y_slice
 
             cube_slices = iris.cube.CubeList([])
-            # Apply each mask in in mask_cube to the 2D input slice.
+            # Apply each mask in mask_cube to the 2D input slice.
             for mask_slice in mask_cube.slices_over(self.coord_for_masking):
                 output_cube = plugin(x_y_slice, mask_cube=mask_slice)
                 coord_object = mask_slice.coord(self.coord_for_masking).copy()

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -226,6 +226,38 @@ class Test__calculate_neighbourhood(IrisTest):
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
+    def test_annulus_square(self):
+        """Test the _calculate_neighbourhood method with a square neighbourhood where the data
+        are ones with a central block of zeros, which will trigger the array-shrinking optimisation
+        AND the padding method."""
+        data = np.ones((8, 8), dtype=self.data.dtype)
+        data[3:5, 3:5] = 0
+        expected_array = np.ones((8, 8), dtype=self.data.dtype)
+        expected_array[3:5, 3:5] = 5 / 9  # centre
+        expected_array[2::3, 3:5] = 7 / 9  # edges (y)
+        expected_array[3:5, 2::3] = 7 / 9  # edges (x)
+        expected_array[2::3, 2::3] = 8 / 9  # corners
+        plugin = NeighbourhoodProcessing("square", self.RADIUS)
+        plugin.nb_size = self.nbhood_size
+        result = plugin._calculate_neighbourhood(data)
+        self.assertArrayAlmostEqual(result, expected_array)
+
+    def test_annulus_circular(self):
+        """Test the _calculate_neighbourhood method with a circular neighbourhood where the data
+        are ones with a central block of zeros, which will trigger the array-shrinking optimisation
+        AND the padding method."""
+        data = np.ones((8, 8), dtype=self.data.dtype)
+        data[3:5, 3:5] = 0
+        expected_array = np.ones((8, 8), dtype=self.data.dtype)
+        expected_array[3:5, 3:5] = 0.4  # centre
+        expected_array[2::3, 3:5] = 0.8  # edges (y)
+        expected_array[3:5, 2::3] = 0.8  # edges (x)
+        plugin = NeighbourhoodProcessing("circular", self.RADIUS)
+        plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
+        result = plugin._calculate_neighbourhood(data)
+        self.assertArrayAlmostEqual(result, expected_array)
+
     def test_masked_array_re_mask_true_square(self):
         """Test the _calculate_neighbourhood method when masked data is
         passed in and re-masking is applied."""

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -148,6 +148,7 @@ class Test__calculate_neighbourhood(IrisTest):
         )
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
@@ -165,6 +166,7 @@ class Test__calculate_neighbourhood(IrisTest):
         )
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.weighted_circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
@@ -199,6 +201,7 @@ class Test__calculate_neighbourhood(IrisTest):
         )
         plugin = NeighbourhoodProcessing("circular", self.RADIUS, sum_only=True)
         plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
@@ -229,6 +232,7 @@ class Test__calculate_neighbourhood(IrisTest):
         input_data = np.ma.masked_where(self.mask == 0, self.data_for_masked_tests)
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.circular_kernel
+        plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(input_data)
 
         self.assertArrayAlmostEqual(result.data, expected_array)

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -230,13 +230,13 @@ class Test__calculate_neighbourhood(IrisTest):
         """Test the _calculate_neighbourhood method with a square neighbourhood where the data
         are ones with a central block of zeros, which will trigger the array-shrinking optimisation
         AND the padding method."""
-        data = np.ones((8, 8), dtype=self.data.dtype)
-        data[3:5, 3:5] = 0
-        expected_array = np.ones((8, 8), dtype=self.data.dtype)
-        expected_array[3:5, 3:5] = 5 / 9  # centre
-        expected_array[2::3, 3:5] = 7 / 9  # edges (y)
-        expected_array[3:5, 2::3] = 7 / 9  # edges (x)
-        expected_array[2::3, 2::3] = 8 / 9  # corners
+        data = np.ones((10, 10), dtype=self.data.dtype)
+        data[4:6, 4:6] = 0
+        expected_array = np.ones_like(data, dtype=self.data.dtype)
+        expected_array[4:6, 4:6] = 5 / 9  # centre
+        expected_array[3:7:3, 4:6] = 7 / 9  # edges (y)
+        expected_array[4:6, 3:7:3] = 7 / 9  # edges (x)
+        expected_array[3:7:3, 3:7:3] = 8 / 9  # corners
         plugin = NeighbourhoodProcessing("square", self.RADIUS)
         plugin.nb_size = self.nbhood_size
         result = plugin._calculate_neighbourhood(data)
@@ -246,12 +246,12 @@ class Test__calculate_neighbourhood(IrisTest):
         """Test the _calculate_neighbourhood method with a circular neighbourhood where the data
         are ones with a central block of zeros, which will trigger the array-shrinking optimisation
         AND the padding method."""
-        data = np.ones((8, 8), dtype=self.data.dtype)
-        data[3:5, 3:5] = 0
-        expected_array = np.ones((8, 8), dtype=self.data.dtype)
-        expected_array[3:5, 3:5] = 0.4  # centre
-        expected_array[2::3, 3:5] = 0.8  # edges (y)
-        expected_array[3:5, 2::3] = 0.8  # edges (x)
+        data = np.ones((10, 10), dtype=self.data.dtype)
+        data[4:6, 4:6] = 0
+        expected_array = np.ones_like(data, dtype=self.data.dtype)
+        expected_array[4:6, 4:6] = 0.4  # centre
+        expected_array[3:7:3, 4:6] = 0.8  # edges (y)
+        expected_array[4:6, 3:7:3] = 0.8  # edges (x)
         plugin = NeighbourhoodProcessing("circular", self.RADIUS)
         plugin.kernel = self.circular_kernel
         plugin.nb_size = self.nbhood_size

--- a/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_NeighbourhoodProcessing.py
@@ -152,6 +152,27 @@ class Test__calculate_neighbourhood(IrisTest):
         result = plugin._calculate_neighbourhood(self.data)
         self.assertArrayAlmostEqual(result.data, expected_array)
 
+    def test_edge_circular(self):
+        """Test the _calculate_neighbourhood method with a circular neighbourhood that crosses the
+        edge. The zero is now in the left column and the "nearest" method means that this zero
+        is repeated in the sum, so the final calculation is 3 / 5 instead of 4 / 5."""
+        data = np.ones_like(self.data)
+        data[:, :3] = self.data[:, 2:]
+        expected_array = np.array(
+            [
+                [1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.8, 1.0, 1.0, 1.0, 1.0],
+                [0.6, 0.8, 1.0, 1.0, 1.0],
+                [0.8, 1.0, 1.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        )
+        plugin = NeighbourhoodProcessing("circular", self.RADIUS)
+        plugin.kernel = self.circular_kernel
+        plugin.nb_size = max(plugin.kernel.shape)
+        result = plugin._calculate_neighbourhood(data)
+        self.assertArrayAlmostEqual(result.data, expected_array)
+
     def test_basic_weighted_circular(self):
         """Test the _calculate_neighbourhood method with a
         weighted circular neighbourhood."""

--- a/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
+++ b/improver_tests/nbhood/use_nbhood/test_ApplyNeighbourhoodProcessingWithAMask.py
@@ -325,7 +325,9 @@ class Test_process(unittest.TestCase):
             "topographic_zone", "square", 2000
         )
         result = plugin(cube, mask_cube)
-        assert_allclose(result.data[...,3:6,3:6], self.expected_uncollapsed_result, equal_nan=True)
+        assert_allclose(
+            result.data[..., 3:6, 3:6], self.expected_uncollapsed_result, equal_nan=True
+        )
         expected_coords = cube.coords()
         expected_coords.insert(0, mask_cube.coord("topographic_zone"))
         self.assertEqual(result.coords(), expected_coords)


### PR DESCRIPTION
Reduces size of data array handled in nbhood to exclude rows and columns of only zeros or only ones.

Replaces https://github.com/metoppv/improver/pull/1936

Addresses https://github.com/metoppv/mo-blue-team/issues/556

Topographic neighbourhooding is mostly processing masked data and lots of other nbhood calls contain complete arrays of zeros or ones. This PR takes advantage of this and crops those arrays so that areas of excluded data don't require huge amounts of compute time. Where no unmasked data exist, the calculations are bypassed entirely.

The result is that ALL neighbourhood processing benefits from this method when the non-extreme values (points that are not 1 or 0) are sparse or non-existent.

Testing:
 - [x] Ran tests and they passed OK
 - The linked ticket shows how this reduces the computation time of the most expensive method in topographic neighbourhooding.
