### PR TITLE
IM-1933: Remove iteration warning from the recursive filter

### DIFF
--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -48,6 +48,14 @@ def process(
     Gaussian-like kernel or smooth over short distances. The filter uses a
     smoothing_coefficient (between 0 and 1) to control what proportion of the
     probability is passed onto the next grid-square in the x and y directions.
+
+    Each iteration of the recursive filter applies the smoothing coefficients
+    forwards and backwards in both the x and y directions. Applying 1-10
+    iterations of the filter is typical. Each iteration further smooths the
+    data, meaning the user must make a judgement regarding the number of
+    iterations to apply that preserves real detail whilst removing artefacts
+    in their data.
+
     The IMPROVER plugin actually limits the maximum smoothing coefficient to
     a value of 0.5. Above this the smoothing is considered to be too great.
     The smoothing_coefficient can be set on a grid square by grid-square basis

--- a/improver/cli/recursive_filter.py
+++ b/improver/cli/recursive_filter.py
@@ -48,6 +48,8 @@ def process(
     Gaussian-like kernel or smooth over short distances. The filter uses a
     smoothing_coefficient (between 0 and 1) to control what proportion of the
     probability is passed onto the next grid-square in the x and y directions.
+    The IMPROVER plugin actually limits the maximum smoothing coefficient to
+    a value of 0.5. Above this the smoothing is considered to be too great.
     The smoothing_coefficient can be set on a grid square by grid-square basis
     for the x and y directions separately (using two arrays of
     smoothing_coefficients of the same dimensionality as the domain).
@@ -59,9 +61,7 @@ def process(
             CubeList describing the smoothing_coefficients to be used in the x
             and y directions.
         iterations (int):
-            Number of times to apply the filter. (Typically < 3)
-            Number of iterations should be 2 or less, higher values have been
-            shown to lead to poorer conservation.
+            Number of times to apply the filter.
 
     Returns:
         iris.cube.Cube:

--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Module to apply a recursive filter to neighbourhooded data."""
-import warnings
+
 from typing import List, Optional, Tuple
 
 import iris

--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -64,19 +64,11 @@ class RecursiveFilter(PostProcessingPlugin):
         Raises:
             ValueError: If number of iterations is not None and is set such
                         that iterations is less than 1.
-        Warns:
-            UserWarning:
-                If iterations is higher than 2.
         """
         if iterations is not None:
             if iterations < 1:
                 raise ValueError(
                     "Invalid number of iterations: must be >= 1: {}".format(iterations)
-                )
-            if iterations > 2:
-                warnings.warn(
-                    "More than two iterations degrades the conservation"
-                    "of probability assumption."
                 )
         self.iterations = iterations
         self.edge_width = edge_width

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -35,7 +35,6 @@ from datetime import timedelta
 
 import iris
 import numpy as np
-import pytest
 from iris.cube import Cube
 from iris.tests import IrisTest
 

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -428,7 +428,7 @@ class Test__run_recursion(Test_RecursiveFilter):
             edge_width=edge_width
         )._pad_coefficients(*self.smoothing_coefficients)
         padded_cube = pad_cube_with_halo(cube, 2 * edge_width, 2 * edge_width)
-        print(repr(padded_cube.data))
+
         result = RecursiveFilter(edge_width=edge_width)._run_recursion(
             padded_cube, smoothing_coefficients_x, smoothing_coefficients_y, 3,
         )

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -169,16 +169,6 @@ class Test__init__(Test_RecursiveFilter):
                 iterations=iterations, edge_width=1,
             )
 
-    def test_iterations_warn(self):
-        """Test when the iteration value is more than 3 it warns."""
-        iterations = 5
-        warning_msg = (
-            "More than two iterations degrades the conservation"
-            "of probability assumption."
-        )
-        with pytest.warns(UserWarning, match=warning_msg):
-            RecursiveFilter(iterations=iterations)
-
 
 class Test__validate_coefficients(Test_RecursiveFilter):
 
@@ -428,6 +418,22 @@ class Test__run_recursion(Test_RecursiveFilter):
             self.iterations,
         )
         expected_result = 0.12302627
+        self.assertAlmostEqual(result.data[4][4], expected_result)
+
+    def test_result_multiple_iterations(self):
+        """Test that the _run_recursion method returns the expected value after
+        several iterations."""
+        edge_width = 1
+        cube = iris.util.squeeze(self.cube)
+        smoothing_coefficients_x, smoothing_coefficients_y = RecursiveFilter(
+            edge_width=edge_width
+        )._pad_coefficients(*self.smoothing_coefficients)
+        padded_cube = pad_cube_with_halo(cube, 2 * edge_width, 2 * edge_width)
+        print(repr(padded_cube.data))
+        result = RecursiveFilter(edge_width=edge_width)._run_recursion(
+            padded_cube, smoothing_coefficients_x, smoothing_coefficients_y, 3,
+        )
+        expected_result = 0.034629755
         self.assertAlmostEqual(result.data[4][4], expected_result)
 
     def test_different_smoothing_coefficients(self):


### PR DESCRIPTION
This PR removes the warning about using more than 3 iterations with the recursive filter. It also removes the associated brief discussion of conservation of probability as a concept that we should be particularly concerned with when using the recursive filter.

This change will enable more iterations of the recursive filter to be used without clogging the logs with superfluous warnings.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)