### PR TITLE
Update wet bulb freezing level cube name

### DIFF
--- a/improver/cli/wet_bulb_freezing_level.py
+++ b/improver/cli/wet_bulb_freezing_level.py
@@ -61,6 +61,6 @@ def process(wet_bulb_temperature: cli.inputcube):
     wet_bulb_freezing_level = ExtractLevel(
         positive_correlation=False, value_of_level=273.15
     )(wet_bulb_temperature)
-    wet_bulb_freezing_level.rename("wet_bulb_freezing_level")
+    wet_bulb_freezing_level.rename("wet_bulb_freezing_level_altitude")
 
     return wet_bulb_freezing_level


### PR DESCRIPTION
Currently the wet bulb freezing level cube is called "wet_bulb_freezing_level". However the hail size cli requires the name the be "wet_bulb_freezing_level_altitude" to extract it from a cubelist.

This PR updates the cube name so it can be used with the hail size plugin.

Updated acceptance test data:  https://github.com/metoppv/improver_test_data/pull/35

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)