### PR TITLE
Updates checksums for WBFL KGO

### DIFF
--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -792,7 +792,7 @@ dc56c3290bae734db3bf479628e5da0b93ccada06a68606b22e25a07a4fc24b5  ./weighted_ble
 dc84cdaafb5a0b8c48e648a6734be019cc4b7b9593c00607667059a71a4c571d  ./weighted_blending/three_models/nc/20190101T0400Z-PT0001H00M-precip_rate.nc
 e535f9b75ca96622b96916bc249a4aa919e5216fcf548a7f6c90748538bfe22a  ./weighted_blending/three_models/ukvx/20190101T0400Z-PT0002H00M-precip_rate.nc
 32042d75b04735b7f4b8db22f793cacb8a71c455f9442dc14c029d78fe59a80c  ./weighted_blending/weights_from_dict/kgo.nc
-2e422d6952a2cef43937ad37137500efefe3ca1e16adfaa3608a0b49f5d482db  ./wet-bulb-freezing-level/kgo.nc
+07398ff72a6a468fd85ecf6442c959f6068664ef8d70ed640421ef1859473f40  ./wet-bulb-freezing-level/kgo.nc
 3d6b8720c087c4ef8daf32ff761695e0f6169104fb134d03c26dd17a5e4d4a02  ./wet-bulb-freezing-level/wet_bulb_temperature.nc
 ef62d78071045163858387292ec56c11aa92e1fa6f5580c1e4ac485cd01979fc  ./wet-bulb-temperature-integral/basic/input.nc
 4143e7583d66c6e776e43e619622eab00fdee3293becadfaaa00ddd72147ac6a  ./wet-bulb-temperature-integral/basic/with_id_attr/kgo.nc


### PR DESCRIPTION
Following #1956

The above PR had an associated change to acceptance test data (https://github.com/metoppv/improver_test_data/pull/35), but the checksums were not updated, and the testing was insufficient (my fault! sorry).

This PR updates the checksum for the modified file.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
