### PR TITLE
MOBT-572: Loosen dz-scaling usage restriction.

### DIFF
--- a/improver/calibration/dz_rescaling.py
+++ b/improver/calibration/dz_rescaling.py
@@ -374,7 +374,7 @@ class ApplyDzRescaling(PostProcessingPlugin):
         forecast period from the scaled_dz to extract. The most appropriate scaled dz
         is selected by choosing the nearest forecast period that is greater than or
         equal to the forecast period of the forecast. If no forecast periods in the
-        scaled fz cube are greater than the forecast period of the forecast, the
+        scaled dz cube are greater than the forecast period of the forecast, the
         longest available forecast period is used.
 
         Args:

--- a/improver/cli/apply_dz_rescaling.py
+++ b/improver/cli/apply_dz_rescaling.py
@@ -56,8 +56,10 @@ def process(
             forecast period and forecast reference_time_hour pair within the
             rescaling cube are chosen using the forecast reference time hour from
             the forecast and the nearest forecast period that is greater than or
-            equal to the forecast period of the forecast. This cube is generated
-            using the estimate_dz_rescaling CLI.
+            equal to the forecast period of the forecast. However, if the forecast
+            period of the forecast exceeds all forecast periods within the rescaling
+            cube, the scaling factor from the maximum forecast period is used.
+            This cube is generated using the estimate_dz_rescaling CLI.
         site_id_coord (str):
             The name of the site ID coordinate. This defaults to 'wmo_id'.
 

--- a/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
@@ -177,7 +177,9 @@ def test_apply_dz_rescaling(
     contains the scaling_factor value.
     forecast_period_offset (hours) adjusts the forecast period coord on the forecast
     cube to ensure the plugin always snaps to the next largest forecast_time when the
-    precise point is not available.
+    precise point is not available except when the forecast period of the forecast
+    exceeds all forecast periods within the scaling factor cube. In this case, the
+    last forecast period within the scaling factor cube will be used.
     frt_hour_offset (hours) alters the forecast reference time hour within the forecast
     whilst the forecast reference time hour of the scaling factor remains the same.
     This checks that the a mismatch in the forecast reference time hour can still
@@ -200,7 +202,8 @@ def test_apply_dz_rescaling(
         forecast,
     )
     # Use min(fp, 24) here to ensure that the scaling cube contains
-    # the scaling factor for the last forecast_period if nowhere else.
+    # the scaling factor for the last forecast_period if the specified
+    # forecast period is beyond the T+24 limit of the scaling cube.
     scaling_factor = _create_scaling_factor_cube(
         frt_hour, min(forecast_period, 24), scaling_factor
     )

--- a/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
@@ -158,7 +158,7 @@ def _create_scaling_factor_cube(
 
 
 @pytest.mark.parametrize("wmo_id", [True, False])
-@pytest.mark.parametrize("forecast_period", [6, 18])
+@pytest.mark.parametrize("forecast_period", [6, 18, 30])
 @pytest.mark.parametrize("frt_hour", [3, 12])
 @pytest.mark.parametrize("scaling_factor", [0.99, 1.01])
 @pytest.mark.parametrize("forecast_period_offset", [0, -1, -5])
@@ -179,7 +179,7 @@ def test_apply_dz_rescaling(
     cube to ensure the plugin always snaps to the next largest forecast_time when the
     precise point is not available.
     frt_hour_offset (hours) alters the forecast reference time hour within the forecast
-    whilst the forececast reference time hour of the scaling factor remains the same.
+    whilst the forecast reference time hour of the scaling factor remains the same.
     This checks that the a mismatch in the forecast reference time hour can still
     result in a match, if a leniency is specified.
     """
@@ -199,8 +199,10 @@ def test_apply_dz_rescaling(
         forecast_period + forecast_period_offset,
         forecast,
     )
+    # Use min(fp, 24) here to ensure that the scaling cube contains
+    # the scaling factor for the last forecast_period if nowhere else.
     scaling_factor = _create_scaling_factor_cube(
-        frt_hour, forecast_period, scaling_factor
+        frt_hour, min(forecast_period, 24), scaling_factor
     )
 
     kwargs = {}
@@ -275,10 +277,7 @@ def test_mismatching_sites():
 
 @pytest.mark.parametrize(
     "forecast_period,frt_hour,exception",
-    [
-        (25, 3, "forecast period greater than or equal to 25"),
-        (7, 1, "forecast reference time hour equal to 1"),
-    ],
+    [(7, 1, "forecast reference time hour equal to 1")],
 )
 def test_no_appropriate_scaled_dz(forecast_period, frt_hour, exception):
     """Test an exception is raised if no appropriate scaled version of the difference


### PR DESCRIPTION
Loosen dz scaling application to use the longest forecast period scaling coefficient available if no scaling coefficient has a forecast period that is longer than the forecast itself.

This will enable us to e.g. use a T+7 day scaling coefficient when calibrating a T+8 days forecast.
It also means we have no warning that such use if going on. So for example, once we implement 14-day forecasts if we fail to update this ancillary with a greater range of forecast periods it will silently use the longest available.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)