### PR TITLE
Optionally set a new name in max_in_height

### DIFF
--- a/improver/cli/max_in_height.py
+++ b/improver/cli/max_in_height.py
@@ -41,6 +41,7 @@ def process(
     *,
     lower_height_bound: float = None,
     upper_height_bound: float = None,
+    new_name: str =None,
 ):
     """Calculate the maximum value over the height coordinate of a cube. If height bounds are
     specified then the maximum value between these height levels is calculated.
@@ -56,6 +57,9 @@ def process(
             The upper bound for the height coordinate. This is either a float or None if no upper
             bound is desired. Any specified bounds should have the same units as the height
             coordinate of cube.
+        new_name (str):
+            The new name to be assigned to the output cube. If unspecified the name of the original
+            cube is used.
     Returns:
         A cube of the maximum value over the height coordinate or maximum value between the provided
         height bounds."""
@@ -66,4 +70,5 @@ def process(
         cube,
         lower_height_bound=lower_height_bound,
         upper_height_bound=upper_height_bound,
+        new_name=new_name,
     )

--- a/improver/cli/max_in_height.py
+++ b/improver/cli/max_in_height.py
@@ -41,7 +41,7 @@ def process(
     *,
     lower_height_bound: float = None,
     upper_height_bound: float = None,
-    new_name: str =None,
+    new_name: str = None,
 ):
     """Calculate the maximum value over the height coordinate of a cube. If height bounds are
     specified then the maximum value between these height levels is calculated.

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -734,7 +734,10 @@ def add_coordinate_to_cube(
 
 
 def maximum_in_height(
-    cube: Cube, lower_height_bound: float = None, upper_height_bound: float = None, new_name: str =None
+    cube: Cube,
+    lower_height_bound: float = None,
+    upper_height_bound: float = None,
+    new_name: str = None,
 ) -> Cube:
     """Calculate the maximum value over the height coordinate. If bounds are specified
     then the maximum value between the lower_height_bound and upper_height_bound is calculated.

--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -734,7 +734,7 @@ def add_coordinate_to_cube(
 
 
 def maximum_in_height(
-    cube: Cube, lower_height_bound: float = None, upper_height_bound: float = None
+    cube: Cube, lower_height_bound: float = None, upper_height_bound: float = None, new_name: str =None
 ) -> Cube:
     """Calculate the maximum value over the height coordinate. If bounds are specified
     then the maximum value between the lower_height_bound and upper_height_bound is calculated.
@@ -754,6 +754,9 @@ def maximum_in_height(
             The upper bound for the height coordinate. This is either a float or None if no
             upper bound is desired. Any specified bounds should have the same units as the
             height coordinate of cube.
+        new_name:
+            The new name to be assigned to the output cube. If unspecified the name of the original
+            cube is used.
     Returns:
         A cube of the maximum value over the height coordinate or maximum value between the desired
         height values. This cube inherits Iris' meta-data updates to the height coordinate and to
@@ -787,5 +790,8 @@ def maximum_in_height(
         max_cube = cube_subsetted.collapsed("height", iris.analysis.MAX)
     else:
         max_cube = cube_subsetted
+
+    if new_name:
+        max_cube.rename(new_name)
 
     return max_cube

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -550,6 +550,7 @@ a162ff6c31dd3f0d84e1633c0cca28083e731876a69d40b7f14c6ff4a3431f25  ./manipulate-r
 0f35c52998ea93be4d8ed08f0ed1164b68bd6a197557afb95ae466fbec81c22e  ./max-in-height/input.nc
 2856432e02159afc04dadf37a0f8033cba25a9b29dfd73baea10369ccadfb645  ./max-in-height/kgo_with_bounds.nc
 823232b882186fd7b7bd6172f5cedcaf5fb980b86a271553d2e4313e5e9b2b4b  ./max-in-height/kgo_without_bounds.nc
+19df0025503f5c42e07db9a104a14f9cff8d98006b58e5c6ba7bb4a59c9f7f7d  ./max-in-height/kgo_without_bounds_new_name.nc
 a2de3ea5608d30d4ac2759e9ff4c4a6573e2c0e8e655595682a2ec2691c2de74  ./max-in-time-window/input_PT0029H00M.nc
 ac81531fa507a2a3a12d4adb542ed014594eff4a38137f947d3a68a2063fab49  ./max-in-time-window/input_PT0032H00M.nc
 fb02306f960fa36cf9a86921ec6599541e0a0823dfa546856000f810cdd96d73  ./max-in-time-window/kgo.nc

--- a/improver_tests/acceptance/test_max_in_height.py
+++ b/improver_tests/acceptance/test_max_in_height.py
@@ -59,15 +59,18 @@ def test_with_bounds(tmp_path):
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
-
-def test_without_bounds(tmp_path):
+@pytest.mark.parametrize("new_name",(None,"max_relative_humidity"))
+def test_without_bounds(tmp_path, new_name):
     """Test max_in_height computation without bounds."""
 
     kgo_dir = acc.kgo_root() / "max-in-height"
     input_path = kgo_dir / "input.nc"
     output_path = tmp_path / "output.nc"
     args = [input_path, "--output", f"{output_path}"]
-
-    kgo_path = kgo_dir / "kgo_without_bounds.nc"
+    if new_name:
+        kgo_path = kgo_dir / f"kgo_without_bounds_new_name.nc"
+        args.extend(["--new-name", f"{new_name}"])
+    else:
+        kgo_path = kgo_dir / f"kgo_without_bounds.nc"
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_max_in_height.py
+++ b/improver_tests/acceptance/test_max_in_height.py
@@ -59,7 +59,8 @@ def test_with_bounds(tmp_path):
     run_cli(args)
     acc.compare(output_path, kgo_path)
 
-@pytest.mark.parametrize("new_name",(None,"max_relative_humidity"))
+
+@pytest.mark.parametrize("new_name", (None, "max_relative_humidity"))
 def test_without_bounds(tmp_path, new_name):
     """Test max_in_height computation without bounds."""
 
@@ -68,9 +69,9 @@ def test_without_bounds(tmp_path, new_name):
     output_path = tmp_path / "output.nc"
     args = [input_path, "--output", f"{output_path}"]
     if new_name:
-        kgo_path = kgo_dir / f"kgo_without_bounds_new_name.nc"
+        kgo_path = kgo_dir / "kgo_without_bounds_new_name.nc"
         args.extend(["--new-name", f"{new_name}"])
     else:
-        kgo_path = kgo_dir / f"kgo_without_bounds.nc"
+        kgo_path = kgo_dir / "kgo_without_bounds.nc"
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/improver_tests/utilities/cube_manipulation/test_maximum_in_height.py
+++ b/improver_tests/utilities/cube_manipulation/test_maximum_in_height.py
@@ -56,6 +56,7 @@ def wet_bulb_temperature() -> Cube:
     return cube
 
 
+@pytest.mark.parametrize("new_name", (None, "max_wet_bulb_temperature"))
 @pytest.mark.parametrize(
     "lower_bound,upper_bound,expected",
     (
@@ -65,18 +66,24 @@ def wet_bulb_temperature() -> Cube:
         (50, 1000, [300, 400, 300]),
     ),
 )
-def test_maximum_in_height(lower_bound, upper_bound, expected, wet_bulb_temperature):
+def test_maximum_in_height(
+    lower_bound, upper_bound, expected, wet_bulb_temperature, new_name
+):
     """Test that the maximum over the height coordinate is correctly calculated for
-    different combinations of upper and lower bounds."""
+    different combinations of upper and lower bounds. Also checks the name of the
+    cube is correctly updated."""
 
-    result = maximum_in_height(
-        wet_bulb_temperature,
-        lower_height_bound=lower_bound,
-        upper_height_bound=upper_bound,
-    )
+    if new_name:
+        expected_name = new_name
+        result = maximum_in_height(
+            wet_bulb_temperature, lower_bound, upper_bound, new_name
+        )
+    else:
+        expected_name = "wet_bulb_temperature"
+        result = maximum_in_height(wet_bulb_temperature, lower_bound, upper_bound)
 
     assert np.allclose(result.data, [expected] * 2)
-    assert "wet_bulb_temperature" == result.name()
+    assert expected_name == result.name()
 
 
 def test_height_bounds_error(wet_bulb_temperature):

--- a/improver_tests/utilities/cube_manipulation/test_maximum_in_height.py
+++ b/improver_tests/utilities/cube_manipulation/test_maximum_in_height.py
@@ -73,14 +73,11 @@ def test_maximum_in_height(
     different combinations of upper and lower bounds. Also checks the name of the
     cube is correctly updated."""
 
+    expected_name = "wet_bulb_temperature"
     if new_name:
         expected_name = new_name
-        result = maximum_in_height(
-            wet_bulb_temperature, lower_bound, upper_bound, new_name
-        )
-    else:
-        expected_name = "wet_bulb_temperature"
-        result = maximum_in_height(wet_bulb_temperature, lower_bound, upper_bound)
+
+    result = maximum_in_height(wet_bulb_temperature, lower_bound, upper_bound, new_name)
 
     assert np.allclose(result.data, [expected] * 2)
     assert expected_name == result.name()


### PR DESCRIPTION
Adds in the ability to update the name of a cube when calculating the maximum over a vertical coordinate. This is required for the EPP PR: https://github.com/MetOffice/epp_workflows/pull/17

Acceptance test data: https://github.com/metoppv/improver_test_data/pull/37

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)