### PR TITLE
amend_attributes can now add to an existing value, and add timestamps.

### DIFF
--- a/improver/metadata/amend.py
+++ b/improver/metadata/amend.py
@@ -86,6 +86,11 @@ def amend_attributes(cube: Cube, attributes_dict: Dict[str, Any]) -> None:
     """
     for attribute_name, value in attributes_dict.items():
         re_now = r"({now:.*})"
+        # We use the DOTALL flag below to tell regex that . should match new-line
+        # characters as well as everything else. Therefore, the match below is for
+        # any string that contains the word now inside curly braces, with a colon
+        # and any format specifier. This now section is returned as a group in
+        # position 1 of has_now, which we will use to format the current time.
         has_now = re.match(rf".*{re_now}.*", value, re.DOTALL)
         if has_now:
             now = has_now[1].format(now=datetime.now())

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -211,7 +211,8 @@ class StandardiseMetadata(BasePlugin):
                 Optional list of scalar coordinates to remove from output cube
             attributes_dict:
                 Optional dictionary of required attribute updates. Keys are
-                attribute names, and values are the required value or "remove".
+                attribute names, and values are the required changes.
+                See improver.metadata.amend.amend_attributes for details.
 
         Returns:
             The processed cube

--- a/improver_tests/metadata/test_amend.py
+++ b/improver_tests/metadata/test_amend.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Tests for the improver.metadata.amend module"""
-
+import re
 import unittest
 from datetime import datetime as dt
 
@@ -128,22 +128,28 @@ class Test_amend_attributes(IrisTest):
             attributes={
                 "mosg__grid_version": "1.3.0",
                 "mosg__model_configuration": "uk_det",
+                "history": "20231213T09:04:23Z: StaGE Decoupler",
             },
         )
         self.metadata_dict = {
             "mosg__grid_version": "remove",
             "source": "IMPROVER unit tests",
             "mosg__model_configuration": "other_model",
+            "history": "{}\n{now:%Y%m%dT%H:%M:%SZ}: IMPROVER",
         }
 
     def test_basic(self):
-        """Test function adds, removes and modifies attributes as expected"""
+        """Test function adds, removes, updates and modifies attributes as expected,
+        including the presence of a formatted now string."""
         expected_attributes = {
             "source": "IMPROVER unit tests",
             "mosg__model_configuration": "other_model",
+            "history": "20231213T09:04:23Z: StaGE Decoupler\n.*Z: IMPROVER",
         }
         amend_attributes(self.cube, self.metadata_dict)
-        self.assertDictEqual(self.cube.attributes, expected_attributes)
+        self.assertTrue(self.cube.attributes.keys() == expected_attributes.keys())
+        for k, v in expected_attributes.items():
+            self.assertTrue(re.match(v, self.cube.attributes[k]))
 
 
 class Test_set_history_attribute(IrisTest):


### PR DESCRIPTION
Addresses https://metoffice.atlassian.net/browse/EPPT-650

Updates `amend_attributes` method, used by `standardise` CLI, to allow attributes to be modified in these ways:
- `"{}"` in the new value will be populated with the existing attribute value on the cube.
- `"{now:[date-format]}"` will be populated with the current wall-clock, formatted as specified.

This allows us to update the history attribute of a cube and to append the current date-time and a string describing the process that has been applied.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
