### PR TITLE
SnowSplitter output cube names are now the same as their StaGE couterparts

### DIFF
--- a/improver/precipitation_type/snow_splitter.py
+++ b/improver/precipitation_type/snow_splitter.py
@@ -127,7 +127,7 @@ class SnowSplitter(BasePlugin):
         Raises:
             ValueError: If, at some grid square, both snow_cube and rain_cube have a probability of
             0
-        """
+        """  # noqa: W605  (flake8 objects to \_ in "lwe\_" that is required for Sphinx)
 
         rain_cube, snow_cube, precip_cube = self.separate_input_cubes(cubes)
 

--- a/improver/precipitation_type/snow_splitter.py
+++ b/improver/precipitation_type/snow_splitter.py
@@ -121,7 +121,7 @@ class SnowSplitter(BasePlugin):
         Returns:
             Cube of rain/snow (depending on self.output_is_rain) rate/accumulation (depending on
             precipitation cube). The name will be an updated version of precip_cube.name().
-            "precipitation" will be replaced with "rainfall" or "snowfall" and "lwe_" will be
+            "precipitation" will be replaced with "rainfall" or "snowfall" and "lwe\_" will be
             removed for rain output.
 
         Raises:

--- a/improver/precipitation_type/snow_splitter.py
+++ b/improver/precipitation_type/snow_splitter.py
@@ -120,7 +120,9 @@ class SnowSplitter(BasePlugin):
 
         Returns:
             Cube of rain/snow (depending on self.output_is_rain) rate/accumulation (depending on
-            precipitation cube)
+            precipitation cube). The name will be an updated version of precip_cube.name().
+            "precipitation" will be replaced with "rainfall" or "snowfall" and "lwe_" will be
+            removed for rain output.
 
         Raises:
             ValueError: If, at some grid square, both snow_cube and rain_cube have a probability of
@@ -140,18 +142,20 @@ class SnowSplitter(BasePlugin):
         if self.output_is_rain:
             required_cube = rain_cube
             other_cube = snow_cube
-            name = "rain"
+            name = "rainfall"
         else:
             required_cube = snow_cube
             other_cube = rain_cube
-            name = "lwe_snow"
+            name = "snowfall"
 
         # arbitrary function that maps combinations of rain and snow probabilities
         # to an appropriate coefficient
         coefficient_cube = (required_cube - other_cube + 1) / 2
         coefficient_cube.data = coefficient_cube.data.astype(np.float32)
 
-        new_name = precip_cube.name().replace("lwe_precipitation", name)
+        new_name = precip_cube.name().replace("precipitation", name)
+        if self.output_is_rain:
+            new_name = new_name.replace("lwe_", "")
         output_cube = Combine(operation="*", new_name=new_name)(
             [precip_cube, coefficient_cube]
         )

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -766,9 +766,9 @@ ef53635982b4269b6292fdc0ea04bee1f64a19304724ef8872bb8e1102a7d3d2  ./snow-fractio
 20b2df1086c9ec6e02b175042b388a8ad76622d5e76860540b28e3b2c482c5fe  ./snow-fraction/basic/snow.nc
 818358071994389472276b451cde63ab8d3da53522ee3a58aa1f375a36babe45  ./snow-splitter/precip_rate.nc
 9931a4fc3fde3daa08137b3f25390837e8ffdd8f8b5052450ed34fb20e217218  ./snow-splitter/rain.nc
-c50cb751a5b99dafc1f524a25e260c4ca200e6e2e4fb933f18329b4e5d23a878  ./snow-splitter/rain_kgo.nc
+11c301c96bd63e43d16826e8dae189f2b7dbbdc30e54fee3dd747ea2746ff54d  ./snow-splitter/rain_kgo.nc
 5bd8889279e32324198c14614173b209bf126a55132c69ff6fa2d706e3dfc529  ./snow-splitter/snow.nc
-84b4d674d7b770f53dfb9f31c025a08921984b7887d2e8ab525211942d091b61  ./snow-splitter/snow_kgo.nc
+56d300196f30b6afd21968ccc70fafcaa096f9a959b19ee42b0e0b4f7c9fce40  ./snow-splitter/snow_kgo.nc
 d7d6ff0436c742449cc95a1ebe6a8298fbda2d01fb8a979f660596ef22a33dbb  ./spot-extract/inputs/all_methods_global.nc
 d4dcdeb1ed121db2c9e96db11283d20a80ab5924ee82b750cab8b02342e16249  ./spot-extract/inputs/all_methods_uk.nc
 5a5e97eeaf2fd457f0e2b655e1b5a0e4befc0176fa1d45d04e7c7439ea9ccedb  ./spot-extract/inputs/all_methods_uk_unique_ids.nc

--- a/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
+++ b/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
@@ -91,7 +91,7 @@ def precip_acc_cube() -> Cube:
     precip_cube = set_up_variable_cube(
         data,
         name="lwe_thickness_of_precipitation_amount",
-        units="m/s",
+        units="m",
         time_bounds=(datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0)),
         attributes=LOCAL_MANDATORY_ATTRIBUTES,
     )
@@ -120,7 +120,7 @@ def run_test(
         expected = rain_value if output_is_rain else snow_value
     assert np.isclose(result.data, expected).all()
     assert result.name() == cube_name
-    assert result.units == "m/s"
+    assert result.units == precip_cube.units
     assert result.attributes == LOCAL_MANDATORY_ATTRIBUTES
 
 

--- a/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
+++ b/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
@@ -108,6 +108,9 @@ def run_test(
     snow_cube,
     snow_value,
 ):
+    """Used in two tests, this method applies the rain_value and snow_value to the relevant data,
+    runs the SnowSplitter plugin and checks the results are as expected, including data, name,
+    units and attributes."""
     rain_cube.data = np.full_like(rain_cube.data, rain_value)
     snow_cube.data = np.full_like(snow_cube.data, snow_value)
     result = SnowSplitter(output_is_rain=output_is_rain)(
@@ -176,7 +179,7 @@ def test_accumulations(
     expected,
 ):
     """Check that for all possible combinations of rain and snow probabilities the correct
-    rain/snow rate is returned. The correct output will sometimes depend on whether the
+    rain/snow accumulation is returned. The correct output will sometimes depend on whether the
     output_is_rain is True or False. Also check the name of the returned cube has been
     updated correctly"""
     run_test(

--- a/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
+++ b/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
@@ -29,6 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Tests for the SnowSplitter plugin"""
+from datetime import datetime
+
 import numpy as np
 import pytest
 from iris.cube import Cube, CubeList
@@ -82,14 +84,51 @@ def precip_rate_cube() -> Cube:
     return precip_cube
 
 
+@pytest.fixture()
+def precip_acc_cube() -> Cube:
+    """Set up a r, y, x cube of precipitation accumulation"""
+    data = np.full((2, 2, 2), fill_value=1, dtype=np.float32)
+    precip_cube = set_up_variable_cube(
+        data,
+        name="lwe_thickness_of_precipitation_amount",
+        units="m/s",
+        time_bounds=(datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0)),
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
+    )
+    return precip_cube
+
+
+def run_test(
+    cube_name,
+    expected,
+    output_is_rain,
+    precip_cube,
+    rain_cube,
+    rain_value,
+    snow_cube,
+    snow_value,
+):
+    rain_cube.data = np.full_like(rain_cube.data, rain_value)
+    snow_cube.data = np.full_like(snow_cube.data, snow_value)
+    result = SnowSplitter(output_is_rain=output_is_rain)(
+        CubeList([snow_cube, rain_cube, precip_cube])
+    )
+    if expected == "dependent":
+        expected = rain_value if output_is_rain else snow_value
+    assert np.isclose(result.data, expected).all()
+    assert result.name() == cube_name
+    assert result.units == "m/s"
+    assert result.attributes == LOCAL_MANDATORY_ATTRIBUTES
+
+
 @pytest.mark.parametrize(
-    "output_is_rain,cube_name", ((True, "rain_rate"), (False, "lwe_snow_rate"))
+    "output_is_rain,cube_name", ((True, "rainfall_rate"), (False, "lwe_snowfall_rate"))
 )
 @pytest.mark.parametrize(
     "rain_value,snow_value,expected",
     ((0, 0, 0.5), (0, 1, "dependent"), (1, 0, "dependent")),
 )
-def test_basic(
+def test_rates(
     snow_cube,
     rain_cube,
     precip_rate_cube,
@@ -103,23 +142,56 @@ def test_basic(
     rain/snow rate is returned. The correct output will sometimes depend on whether the
     output_is_rain is True or False. Also check the name of the returned cube has been
     updated correctly"""
-    rain_cube.data = np.full_like(rain_cube.data, rain_value)
-    snow_cube.data = np.full_like(snow_cube.data, snow_value)
-
-    result = SnowSplitter(output_is_rain=output_is_rain)(
-        CubeList([snow_cube, rain_cube, precip_rate_cube])
+    run_test(
+        cube_name,
+        expected,
+        output_is_rain,
+        precip_rate_cube,
+        rain_cube,
+        rain_value,
+        snow_cube,
+        snow_value,
     )
 
-    if expected == "dependent":
-        expected = rain_value if output_is_rain else snow_value
 
-    assert np.isclose(result.data, expected).all()
-    assert result.name() == cube_name
-    assert result.units == "m/s"
-    assert result.attributes == LOCAL_MANDATORY_ATTRIBUTES
+@pytest.mark.parametrize(
+    "output_is_rain,cube_name",
+    (
+        (True, "thickness_of_rainfall_amount"),
+        (False, "lwe_thickness_of_snowfall_amount"),
+    ),
+)
+@pytest.mark.parametrize(
+    "rain_value,snow_value,expected",
+    ((0, 0, 0.5), (0, 1, "dependent"), (1, 0, "dependent")),
+)
+def test_accumulations(
+    snow_cube,
+    rain_cube,
+    precip_acc_cube,
+    snow_value,
+    rain_value,
+    output_is_rain,
+    cube_name,
+    expected,
+):
+    """Check that for all possible combinations of rain and snow probabilities the correct
+    rain/snow rate is returned. The correct output will sometimes depend on whether the
+    output_is_rain is True or False. Also check the name of the returned cube has been
+    updated correctly"""
+    run_test(
+        cube_name,
+        expected,
+        output_is_rain,
+        precip_acc_cube,
+        rain_cube,
+        rain_value,
+        snow_cube,
+        snow_value,
+    )
 
 
-def test_both_phases_1(snow_cube, rain_cube, precip_rate_cube):
+def test_both_phases_1(snow_cube, rain_cube, precip_cube):
     """Test an error is raised if both snow and rain_cube have a probability of
     1"""
 
@@ -127,5 +199,5 @@ def test_both_phases_1(snow_cube, rain_cube, precip_rate_cube):
     snow_cube.data = np.full_like(snow_cube.data, 1)
     with pytest.raises(ValueError, match="1 grid square where the probability of snow"):
         SnowSplitter(output_is_rain=False)(
-            CubeList([snow_cube, rain_cube, precip_rate_cube])
+            CubeList([snow_cube, rain_cube, precip_cube])
         )

--- a/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
+++ b/improver_tests/precipitation_type/snow_splitter/test_snow_splitter.py
@@ -191,7 +191,7 @@ def test_accumulations(
     )
 
 
-def test_both_phases_1(snow_cube, rain_cube, precip_cube):
+def test_both_phases_1(snow_cube, rain_cube, precip_rate_cube):
     """Test an error is raised if both snow and rain_cube have a probability of
     1"""
 
@@ -199,5 +199,5 @@ def test_both_phases_1(snow_cube, rain_cube, precip_cube):
     snow_cube.data = np.full_like(snow_cube.data, 1)
     with pytest.raises(ValueError, match="1 grid square where the probability of snow"):
         SnowSplitter(output_is_rain=False)(
-            CubeList([snow_cube, rain_cube, precip_cube])
+            CubeList([snow_cube, rain_cube, precip_rate_cube])
         )


### PR DESCRIPTION
Addresses https://metoffice.atlassian.net/browse/EPPT-650

While testing the EPP Precipitation Type workflows, I have found that the output cube names for rain/snow rate/accum data are not the same as the same data found on StaGE. For accumulation data, the rain and snow outputs had the names of the precipitation cube. This PR modifies the new cube name generation, which is generated from a precipitation cube name, so that:
 - "precipitation" is replaced with either "rainfall" or "snowfall" (not "rain" or "snow")
 - "lwe_", which means liquid water equivalent, is removed if the output is rain.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Updated KGOs: https://github.com/metoppv/improver_test_data/pull/42
 - [x] Added new tests for the new feature(s)
