### PR TITLE
Adds CLI to copy attributes from one NetCDF file to another.

### DIFF
--- a/improver/cli/copy_attributes.py
+++ b/improver/cli/copy_attributes.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Script to copy attributes from template_cube to cube"""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(
+    cube: cli.inputcube,
+    template_cube: cli.inputcube,
+    *,
+    attributes: cli.comma_separated_list,
+):
+    """
+    Copy attribute values from template_cube to cube, overwriting any existing values.
+
+    Args:
+        cube (iris.cube.Cube):
+            Source cube to be updated.
+        template_cube (iris.cube.Cube):
+            Source cube to get attribute values from.
+        attributes (list):
+            List of names of attributes to copy. If any are not present on template_cube, a
+            KeyError will be raised.
+
+    Returns:
+        iris.cube.Cube
+    """
+    from improver.metadata.amend import amend_attributes
+
+    new_attributes = {k: template_cube.attributes[k] for k in attributes}
+    amend_attributes(cube, new_attributes)
+    return cube

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -320,6 +320,9 @@ fbc14286b4ce41e2e60df0870ae4911c1b00a38ec96912f43c6187fcaf7d02f6  ./construct-re
 9795b9758a88e2c4d4171c8b08304f7f0711e03acda66a7394333f8b919ccf50  ./convection-ratio/basic/kgo.nc
 74f850942572aa99de807396d48bd80dd96088c638a9d5fa379b95f7c5ad8614  ./convection-ratio/basic/lwe_convective_precipitation_rate.nc
 b946c7687cb9ed02a12a934429a31306004ad45214cf4b451468b077018c0911  ./convection-ratio/basic/lwe_stratiform_precipitation_rate.nc
+0f196f264fa1102089623eb5b1e683c9d1595b2331ed4bcac42eab2654d7f830  ./copy-attributes/input.nc
+ae2f673bf29b926cac46c3a578a8e1842cce19881f8fe479cba3f51f0d474951  ./copy-attributes/kgo.nc
+1c126e24fcda3ac584b4712b5938d90abf8bf369315f7ef5c87f47a13613845d  ./copy-attributes/stage_input.nc
 d3efbc6014743793fafed512a8017a7b75e4f0ffa7fd202cd4f1b4a1086b2583  ./create-grid-with-halo/basic/kgo.nc
 fee00437131d2367dc317e5b0fff44e65e03371b8f096bf1ac0d4cc7253693c9  ./create-grid-with-halo/basic/source_grid.nc
 bf7e42be7897606682c3ecdaeb27bf3d3b6ab13a9a88b46c88ae6e92801c6245  ./create-grid-with-halo/halo_size/kgo.nc

--- a/improver_tests/acceptance/test_copy_attributes.py
+++ b/improver_tests/acceptance/test_copy_attributes.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown copyright. The Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Tests for the copy-attributes CLI
+"""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+ATTRIBUTES_PATH = acc.kgo_root() / "standardise/metadata/metadata.json"
+
+
+def test_change_metadata(tmp_path):
+    """Test copying attribute values from a template file"""
+    kgo_dir = acc.kgo_root() / "copy-attributes"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "input.nc"
+    template_path = kgo_dir / "stage_input.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        template_path,
+        "--attributes",
+        "mosg__forecast_run_duration,mosg__grid_version",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_copy_attributes.py
+++ b/improver_tests/acceptance/test_copy_attributes.py
@@ -41,9 +41,6 @@ CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 
 
-ATTRIBUTES_PATH = acc.kgo_root() / "standardise/metadata/metadata.json"
-
-
 def test_change_metadata(tmp_path):
     """Test copying attribute values from a template file"""
     kgo_dir = acc.kgo_root() / "copy-attributes"


### PR DESCRIPTION
Adds CLI to copy attributes from one NetCDF file to another. Includes acceptance test.

Addresses https://github.com/MetOffice/epp_workflows/pull/24

For the EPP Precipitation Type workflow, we need a new CLI to copy attribute values from one cube to another so that the precipitation type output can contain StaGE attribute values inherited from a precipitation rate cube.

Acceptance test data can be found in https://github.com/metoppv/improver_test_data/pull/41

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
