### PR TITLE
Remove black strangeness

### DIFF
--- a/improver/between_thresholds.py
+++ b/improver/between_thresholds.py
@@ -216,7 +216,7 @@ class OccurrenceBetweenThresholds(PostProcessingPlugin):
             self.thresh_coord = find_threshold_coordinate(cube)
         except CoordinateNotFoundError:
             raise ValueError(
-                "Input is not a probability cube " "(has no threshold-type coordinate)"
+                "Input is not a probability cube (has no threshold-type coordinate)"
             )
         self.cube = cube.copy()
 

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -419,7 +419,7 @@ class WeightedBlendAcrossWholeDimension(PostProcessingPlugin):
     def __repr__(self) -> str:
         """Represent the configured plugin instance as a string."""
         description = (
-            "<WeightedBlendAcrossWholeDimension: coord = {}, " "timeblending: {}>"
+            "<WeightedBlendAcrossWholeDimension: coord = {}, timeblending: {}>"
         )
         return description.format(self.blend_coord, self.timeblending)
 

--- a/improver/blending/weights.py
+++ b/improver/blending/weights.py
@@ -611,7 +611,7 @@ class ChooseDefaultWeightsLinear(BasePlugin):
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
-        desc = "<ChooseDefaultWeightsLinear y0val=" "{:4.1f}, ynval={:4.1f}>".format(
+        desc = "<ChooseDefaultWeightsLinear y0val={:4.1f}, ynval={:4.1f}>".format(
             self.y0val, self.ynval
         )
         return desc

--- a/improver/blending/weights.py
+++ b/improver/blending/weights.py
@@ -544,7 +544,7 @@ class ChooseDefaultWeightsLinear(BasePlugin):
             )
 
         if y0val < 0.0:
-            msg = "y0val must be a float >= 0.0, " "y0val = {0:s}".format(str(y0val))
+            msg = "y0val must be a float >= 0.0, y0val = {0:s}".format(str(y0val))
             raise ValueError(msg)
 
         self.y0val = float(y0val)
@@ -724,7 +724,7 @@ class ChooseDefaultWeightsNonLinear(BasePlugin):
 
     def __repr__(self):
         """Represent the configured plugin instance as a string."""
-        desc = "<ChooseDefaultWeightsNonLinear " "cval={0:4.1f}>".format(self.cval)
+        desc = "<ChooseDefaultWeightsNonLinear cval={0:4.1f}>".format(self.cval)
         return desc
 
 
@@ -747,7 +747,7 @@ class ChooseDefaultWeightsTriangular(BasePlugin):
 
     def __repr__(self) -> str:
         """Represent the configured plugin instance as a string."""
-        msg = "<ChooseDefaultTriangularWeights " "width={}, parameters_units={}>"
+        msg = "<ChooseDefaultTriangularWeights width={}, parameters_units={}>"
         desc = msg.format(self.width, self.parameters_units)
         return desc
 

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -104,7 +104,7 @@ class ConstructReliabilityCalibrationTables(BasePlugin):
         bin_values = ", ".join(
             ["[{:1.2f} --> {:1.2f}]".format(*item) for item in self.probability_bins]
         )
-        result = "<ConstructReliabilityCalibrationTables: " "probability_bins: {}>"
+        result = "<ConstructReliabilityCalibrationTables: probability_bins: {}>"
         return result.format(bin_values)
 
     def _define_probability_bins(

--- a/improver/cli/nbhood.py
+++ b/improver/cli/nbhood.py
@@ -136,7 +136,7 @@ def process(
                 "weighted_mode cannot be used with" 'neighbourhood_output="percentiles"'
             )
         if degrees_as_complex:
-            raise RuntimeError("Cannot generate percentiles from complex " "numbers")
+            raise RuntimeError("Cannot generate percentiles from complex numbers")
 
     if neighbourhood_shape == "circular":
         if degrees_as_complex:

--- a/improver/cli/nbhood_land_and_sea.py
+++ b/improver/cli/nbhood_land_and_sea.py
@@ -150,7 +150,7 @@ def process(
 
     else:
         if weights is not None:
-            raise TypeError("A weights cube has been provided but will not be " "used")
+            raise TypeError("A weights cube has been provided but will not be used")
         land_sea_mask = mask
         # In this case the land is set to 1 and the sea is set to 0 in the
         # input mask.

--- a/improver/cli/time_lagged_ensembles.py
+++ b/improver/cli/time_lagged_ensembles.py
@@ -59,9 +59,7 @@ def process(*cubes: cli.inputcube):
     from improver.utilities.time_lagging import GenerateTimeLaggedEnsemble
 
     if len(cubes) == 1:
-        warnings.warn(
-            "Only a single cube input, so time lagging will have " "no effect."
-        )
+        warnings.warn("Only a single cube input, so time lagging will have no effect.")
         return cubes[0]
 
     # raise error if validity times are not all equal

--- a/improver/cli/weighted_blending.py
+++ b/improver/cli/weighted_blending.py
@@ -146,7 +146,7 @@ def process(
         raise RuntimeError("Method: linear does not accept arguments: cval")
     if (weighting_method == "nonlinear") and any([y0val, ynval]):
         raise RuntimeError(
-            "Method: non-linear does not accept arguments:" " y0val, ynval"
+            "Method: non-linear does not accept arguments: y0val, ynval"
         )
     if (weighting_method == "dict") and weighting_config is None:
         raise RuntimeError('Dictionary is required if wts_calc_method="dict"')

--- a/improver/cli/weighted_blending.py
+++ b/improver/cli/weighted_blending.py
@@ -145,9 +145,7 @@ def process(
     if (weighting_method == "linear") and cval:
         raise RuntimeError("Method: linear does not accept arguments: cval")
     if (weighting_method == "nonlinear") and any([y0val, ynval]):
-        raise RuntimeError(
-            "Method: non-linear does not accept arguments: y0val, ynval"
-        )
+        raise RuntimeError("Method: non-linear does not accept arguments: y0val, ynval")
     if (weighting_method == "dict") and weighting_config is None:
         raise RuntimeError('Dictionary is required if wts_calc_method="dict"')
     if "model" in coordinate and model_id_attr is None:

--- a/improver/lapse_rate.py
+++ b/improver/lapse_rate.py
@@ -192,7 +192,7 @@ class ApplyGriddedLapseRate(PostProcessingPlugin):
 
         if not spatial_coords_match([temperature, source_orog]):
             raise ValueError(
-                "Source orography spatial coordinates do not match " "temperature grid"
+                "Source orography spatial coordinates do not match temperature grid"
             )
 
         if not spatial_coords_match([temperature, dest_orog]):

--- a/improver/nbhood/__init__.py
+++ b/improver/nbhood/__init__.py
@@ -60,7 +60,7 @@ def radius_by_lead_time(
     if lead_times is None:
         if not len(radii) == 1:
             raise ValueError(
-                "Multiple radii have been supplied but no " "associated lead times."
+                "Multiple radii have been supplied but no associated lead times."
             )
         radius_or_radii = float(radii[0])
     else:

--- a/improver/nowcasting/forecasting.py
+++ b/improver/nowcasting/forecasting.py
@@ -111,7 +111,7 @@ class AdvectField(BasePlugin):
 
     def __repr__(self) -> str:
         """Represent the plugin instance as a string."""
-        result = "<AdvectField: vel_x={}, vel_y={}, " "attributes_dict={}>".format(
+        result = "<AdvectField: vel_x={}, vel_y={}, attributes_dict={}>".format(
             repr(self.vel_x), repr(self.vel_y), self.attributes_dict
         )
         return result
@@ -364,7 +364,7 @@ class AdvectField(BasePlugin):
         # check spatial coordinates match those of plugin velocities
         if cube.coord(axis="x") != self.x_coord or cube.coord(axis="y") != self.y_coord:
             raise InvalidCubeError(
-                "Input data grid does not match advection " "velocities"
+                "Input data grid does not match advection velocities"
             )
 
         # derive velocities in "grid squares per second"

--- a/improver/psychrometric_calculations/wet_bulb_temperature.py
+++ b/improver/psychrometric_calculations/wet_bulb_temperature.py
@@ -103,7 +103,7 @@ class WetBulbTemperature(BasePlugin):
         else:
             if len(set(vertical_coords)) > 1 or len(vertical_coords) != 3:
                 raise ValueError(
-                    "WetBulbTemperature: Cubes have differing " "vertical coordinates."
+                    "WetBulbTemperature: Cubes have differing vertical coordinates."
                 )
             (level_coord,) = set(vertical_coords)
             temperature_over_levels = temperature.slices_over(level_coord)

--- a/improver/spotdata/apply_lapse_rate.py
+++ b/improver/spotdata/apply_lapse_rate.py
@@ -86,7 +86,7 @@ class SpotLapseRateAdjust(PostProcessingPlugin):
 
     def __repr__(self) -> str:
         """Represent the configured plugin instance as a string."""
-        return "<SpotLapseRateAdjust: neighbour_selection_method: {}" ">".format(
+        return "<SpotLapseRateAdjust: neighbour_selection_method: {}>".format(
             self.neighbour_selection_method
         )
 

--- a/improver/spotdata/neighbour_finding.py
+++ b/improver/spotdata/neighbour_finding.py
@@ -503,7 +503,7 @@ class NeighbourSelection(BasePlugin):
 
         # Ensure land_mask and orography are on the same grid.
         if not orography.dim_coords == land_mask.dim_coords:
-            msg = "Orography and land_mask cubes are not on the same " "grid."
+            msg = "Orography and land_mask cubes are not on the same grid."
             raise ValueError(msg)
 
         # Enforce x-y coordinate order for input cubes.

--- a/improver/utilities/interpolation.py
+++ b/improver/utilities/interpolation.py
@@ -192,7 +192,7 @@ class InterpolateUsingDifference(BasePlugin):
         """
         if not np.ma.is_masked(cube.data):
             warnings.warn(
-                "Input cube unmasked, no data to fill in, returning " "unchanged."
+                "Input cube unmasked, no data to fill in, returning unchanged."
             )
             return cube
 

--- a/improver/utilities/pad_spatial.py
+++ b/improver/utilities/pad_spatial.py
@@ -77,7 +77,7 @@ def pad_coord(coord: Coord, width: int, method: str) -> Coord:
     if np.isclose(np.sum(np.diff(increment)), 0):
         increment = increment[0]
     else:
-        msg = "Non-uniform increments between grid points: " "{}.".format(increment)
+        msg = "Non-uniform increments between grid points: {}.".format(increment)
         raise ValueError(msg)
 
     if method == "add":

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -131,7 +131,7 @@ def save_netcdf(
             xy_chunksizes = [cube.shape[-2], cube.shape[-1]]
             chunksizes = tuple([1] * (cube.ndim - 2) + xy_chunksizes)
     else:
-        msg = "Chunksize not set as cubelist " "contains cubes of varying dimensions"
+        msg = "Chunksize not set as cubelist contains cubes of varying dimensions"
         warnings.warn(msg)
 
     global_keys = [

--- a/improver/utilities/solar.py
+++ b/improver/utilities/solar.py
@@ -290,7 +290,7 @@ class DayNightMask(BasePlugin):
 
     def __repr__(self) -> str:
         """Represent the configured plugin instance as a string."""
-        result = "<DayNightMask : " "Day = {}, Night = {}>".format(self.day, self.night)
+        result = "<DayNightMask : Day = {}, Night = {}>".format(self.day, self.night)
         return result
 
     def _create_daynight_mask(self, cube: Cube) -> Cube:

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -112,7 +112,7 @@ class TemporalInterpolation(BasePlugin):
     def __repr__(self) -> str:
         """Represent the configured plugin instance as a string."""
         result = (
-            "<TemporalInterpolation: interval_in_minutes: {}, " "times: {}, method: {}>"
+            "<TemporalInterpolation: interval_in_minutes: {}, times: {}, method: {}>"
         )
         return result.format(
             self.interval_in_minutes, self.times, self.interpolation_method
@@ -393,7 +393,7 @@ class TemporalInterpolation(BasePlugin):
             (final_time,) = iris_time_to_datetime(cube_t1.coord("time"))
         except CoordinateNotFoundError:
             msg = (
-                "Cube provided to TemporalInterpolation contains no time " "coordinate."
+                "Cube provided to TemporalInterpolation contains no time coordinate."
             )
             raise CoordinateNotFoundError(msg)
         except ValueError:

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -392,9 +392,7 @@ class TemporalInterpolation(BasePlugin):
             (initial_time,) = iris_time_to_datetime(cube_t0.coord("time"))
             (final_time,) = iris_time_to_datetime(cube_t1.coord("time"))
         except CoordinateNotFoundError:
-            msg = (
-                "Cube provided to TemporalInterpolation contains no time coordinate."
-            )
+            msg = "Cube provided to TemporalInterpolation contains no time coordinate."
             raise CoordinateNotFoundError(msg)
         except ValueError:
             msg = (

--- a/improver/wind_calculations/wind_direction.py
+++ b/improver/wind_calculations/wind_direction.py
@@ -97,7 +97,7 @@ class WindDirection(PostProcessingPlugin):
         self.backup_methods = ["first_realization", "neighbourhood"]
         self.backup_method = backup_method
         if self.backup_method not in self.backup_methods:
-            msg = "Invalid option for keyword backup_method " "({})".format(
+            msg = "Invalid option for keyword backup_method ({})".format(
                 self.backup_method
             )
             raise ValueError(msg)

--- a/improver/wind_calculations/wind_downscaling.py
+++ b/improver/wind_calculations/wind_downscaling.py
@@ -95,7 +95,7 @@ class FrictionVelocity(BasePlugin):
         array_sizes = [np.size(u_href), np.size(h_ref), np.size(z_0), np.size(mask)]
 
         if not all(x == array_sizes[0] for x in array_sizes):
-            raise ValueError("Different size input arrays u_href, h_ref, z_0, " "mask")
+            raise ValueError("Different size input arrays u_href, h_ref, z_0, mask")
 
     def process(self) -> ndarray:
         """Function to calculate the friction velocity.
@@ -823,7 +823,7 @@ class RoughnessCorrection(PostProcessingPlugin):
                 except CoordinateNotFoundError:
                     pass
             if z0_cube.units != Unit("m"):
-                msg = "z0 ancil has unexpected unit: should be {} " "is {}"
+                msg = "z0 ancil has unexpected unit: should be {} is {}"
                 raise ValueError(msg.format(Unit("m"), z0_cube.units))
         permutated_ancil_list = list(itertools.permutations(ancil_list, 2))
         oklist = []

--- a/improver/wind_calculations/wind_gust_diagnostic.py
+++ b/improver/wind_calculations/wind_gust_diagnostic.py
@@ -146,7 +146,7 @@ class WindGustDiagnostic(PostProcessingPlugin):
         constraint = iris.Constraint(coord_values={perc_coord.name(): req_percentile})
         result = cube.extract(constraint)
         if result is None:
-            msg = "Could not find required percentile " "{0:3.1f} in cube".format(
+            msg = "Could not find required percentile {0:3.1f} in cube".format(
                 req_percentile
             )
             raise ValueError(msg)

--- a/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
+++ b/improver_tests/blending/weighted_blend/test_WeightedBlendAcrossWholeDimension.py
@@ -104,9 +104,7 @@ class Test__repr__(IrisTest):
     def test_basic(self):
         """Test that the __repr__ returns the expected string."""
         result = str(WeightedBlendAcrossWholeDimension("time"))
-        msg = (
-            "<WeightedBlendAcrossWholeDimension: coord = time, " "timeblending: False>"
-        )
+        msg = "<WeightedBlendAcrossWholeDimension: coord = time, timeblending: False>"
         self.assertEqual(result, msg)
 
 
@@ -210,7 +208,7 @@ class Test_check_percentile_coord(Test_weighted_blend):
         """Test it raises a Value Error if percentile coord not a dim."""
         new_cube = self.cube.copy()
         new_cube.add_aux_coord(AuxCoord([10.0], long_name="percentile"))
-        msg = "The percentile coord must be a dimension " "of the cube."
+        msg = "The percentile coord must be a dimension of the cube."
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin.check_percentile_coord(new_cube)
 

--- a/improver_tests/blending/weights/test_ChooseDefaultWeightsLinear.py
+++ b/improver_tests/blending/weights/test_ChooseDefaultWeightsLinear.py
@@ -133,7 +133,7 @@ class Test_process(IrisTest):
         """Test it raises a Value Error if not supplied with a cube. """
         plugin = LinearWeights(y0val=20.0, ynval=2.0)
         notacube = 0.0
-        msg = "The first argument must be an instance of " "iris.cube.Cube"
+        msg = "The first argument must be an instance of iris.cube.Cube"
         with self.assertRaisesRegex(TypeError, msg):
             plugin.process(notacube, self.coord_name)
 

--- a/improver_tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
+++ b/improver_tests/blending/weights/test_ChooseDefaultWeightsNonLinear.py
@@ -122,7 +122,7 @@ class Test_process(IrisTest):
         """Test it raises a Value Error if not supplied with a cube. """
         plugin = NonLinearWeights(0.85)
         notacube = 0.0
-        msg = "The first argument must be an instance of " "iris.cube.Cube"
+        msg = "The first argument must be an instance of iris.cube.Cube"
         with self.assertRaisesRegex(TypeError, msg):
             plugin.process(notacube, self.coord_name)
 

--- a/improver_tests/blending/weights/test_ChooseDefaultWeightsTriangular.py
+++ b/improver_tests/blending/weights/test_ChooseDefaultWeightsTriangular.py
@@ -55,9 +55,7 @@ class Test___repr__(IrisTest):
             width, units="hours"
         )
         result = str(triangular_weights_instance)
-        expected = (
-            "<ChooseDefaultTriangularWeights " "width=3.0, parameters_units=hours>"
-        )
+        expected = "<ChooseDefaultTriangularWeights width=3.0, parameters_units=hours>"
         self.assertEqual(result, expected)
 
     def test_basic_no_units(self):
@@ -66,7 +64,7 @@ class Test___repr__(IrisTest):
         triangular_weights_instance = ChooseDefaultWeightsTriangular(width)
         result = str(triangular_weights_instance)
         expected = (
-            "<ChooseDefaultTriangularWeights " "width=3.0, parameters_units=no_unit>"
+            "<ChooseDefaultTriangularWeights width=3.0, parameters_units=no_unit>"
         )
         self.assertEqual(result, expected)
 

--- a/improver_tests/blending/weights/test_WeightsUtilities.py
+++ b/improver_tests/blending/weights/test_WeightsUtilities.py
@@ -192,9 +192,7 @@ class Test_build_weights_cube(IrisTest):
 
         weights = np.array([0.4, 0.4, 0.2])
         blending_coord = "time"
-        msg = (
-            "Weights array provided is not the same size as the " "blending coordinate"
-        )
+        msg = "Weights array provided is not the same size as the blending coordinate"
         plugin = WeightsUtilities.build_weights_cube
         with self.assertRaisesRegex(ValueError, msg):
             plugin(self.cube, weights, blending_coord)

--- a/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
+++ b/improver_tests/calibration/ensemble_calibration/test_CalibratedForecastDistributionParameters.py
@@ -238,13 +238,13 @@ class Test__repr__(IrisTest):
     def test_basic(self):
         """Test without the predictor."""
         result = str(Plugin())
-        msg = "<CalibratedForecastDistributionParameters: " "predictor: mean>"
+        msg = "<CalibratedForecastDistributionParameters: predictor: mean>"
         self.assertEqual(result, msg)
 
     def test_with_predictor(self):
         """Test specifying the predictor."""
         result = str(Plugin(predictor="realizations"))
-        msg = "<CalibratedForecastDistributionParameters: " "predictor: realizations>"
+        msg = "<CalibratedForecastDistributionParameters: predictor: realizations>"
         self.assertEqual(result, msg)
 
 

--- a/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParametersToProbabilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertLocationAndScaleParametersToProbabilities.py
@@ -92,7 +92,7 @@ class Test__check_template_cube(IrisTest):
         """Pass in a cube with an additional dimensional coordinate. This will
         raise an exception."""
         cube = iris.util.new_axis(self.cube, "time")
-        msg = "ConvertLocationAndScaleParametersToProbabilities expects a " "cube with"
+        msg = "ConvertLocationAndScaleParametersToProbabilities expects a cube with"
         with self.assertRaisesRegex(ValueError, msg):
             Plugin()._check_template_cube(cube)
 

--- a/improver_tests/metadata/test_check_datatypes.py
+++ b/improver_tests/metadata/test_check_datatypes.py
@@ -121,7 +121,7 @@ class Test_check_mandatory_standards(IrisTest):
     def test_float64_cube_data(self):
         """Test a failure of a cube with 64-bit float data."""
         self.cube.data = self.cube.data.astype(np.float64)
-        msg = "does not have required dtype.\n" "Expected: float32, Actual: float64"
+        msg = "does not have required dtype.\nExpected: float32, Actual: float64"
         with self.assertRaisesRegex(ValueError, msg):
             check_mandatory_standards(self.cube)
 

--- a/improver_tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/improver_tests/nowcasting/lightning/test_NowcastLightning.py
@@ -328,7 +328,7 @@ class Test__modify_first_guess(IrisTest):
         """Test that the method raises an error if the first-guess cube doesn't
         match the meta-data cube time coordinate."""
         self.fg_cube.coord("time").points = [1.0]
-        msg = "is not available within the input cube within the " "allowed difference"
+        msg = "is not available within the input cube within the allowed difference"
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin._modify_first_guess(
                 self.cube, self.fg_cube, self.ltng_cube, self.precip_cube, None

--- a/improver_tests/threshold/test_Threshold.py
+++ b/improver_tests/threshold/test_Threshold.py
@@ -675,7 +675,7 @@ class Test__init__(IrisTest):
         """Test when fuzzy_bounds contains one value (invalid)."""
         threshold_config = {"0.6": [0.4]}
         # Regexp matches .* with any string.
-        msg = "Invalid bounds for one threshold: .*. " "Expected 2 floats."
+        msg = "Invalid bounds for one threshold: .*. Expected 2 floats."
         with self.assertRaisesRegex(ValueError, msg):
             Threshold(threshold_config=threshold_config)
 
@@ -683,7 +683,7 @@ class Test__init__(IrisTest):
         """Test when fuzzy_bounds contains three values (invalid)."""
         threshold_config = {"0.6": [0.4, 0.8, 1.2]}
         # Regexp matches .* with any string.
-        msg = "Invalid bounds for one threshold: .*. " "Expected 2 floats."
+        msg = "Invalid bounds for one threshold: .*. Expected 2 floats."
         with self.assertRaisesRegex(ValueError, msg):
             Threshold(threshold_config=threshold_config)
 

--- a/improver_tests/utilities/temporal/test_temporal.py
+++ b/improver_tests/utilities/temporal/test_temporal.py
@@ -421,7 +421,7 @@ class Test_extract_nearest_time_point(IrisTest):
         """Test that an exception is raised, if an invalid time name
         is specified."""
         time_point = datetime(2017, 11, 23, 6, 0)
-        msg = "The time_name must be either " "'time' or 'forecast_reference_time'"
+        msg = "The time_name must be either 'time' or 'forecast_reference_time'"
         with self.assertRaisesRegex(ValueError, msg):
             extract_nearest_time_point(
                 self.cube, time_point, time_name="forecast_period"

--- a/improver_tests/utilities/test_TemporalInterpolation.py
+++ b/improver_tests/utilities/test_TemporalInterpolation.py
@@ -856,7 +856,7 @@ class Test_process(IrisTest):
 
         self.cube_time_0.remove_coord("time")
 
-        msg = "Cube provided to TemporalInterpolation " "contains no time coordinate"
+        msg = "Cube provided to TemporalInterpolation contains no time coordinate"
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             TemporalInterpolation(interval_in_minutes=180).process(
                 self.cube_time_0, self.cube_time_1

--- a/improver_tests/wind_calculations/wind_direction/test_WindDirection.py
+++ b/improver_tests/wind_calculations/wind_direction/test_WindDirection.py
@@ -238,7 +238,7 @@ class Test_complex_to_deg(IrisTest):
     def test_fails_if_data_is_not_array(self):
         """Test code raises a Type Error if input data not an array."""
         input_data = 0 - 1j
-        msg = "Input data is not a numpy array, but" " {}".format(type(input_data))
+        msg = "Input data is not a numpy array, but {}".format(type(input_data))
         with self.assertRaisesRegex(TypeError, msg):
             WindDirection().complex_to_deg(input_data)
 
@@ -449,7 +449,7 @@ class Test_process(IrisTest):
     def test_fails_if_data_is_not_cube(self):
         """Test code raises a Type Error if input cube is not a cube."""
         input_data = 50.0
-        msg = "Wind direction input is not a cube, but" " {0}".format(type(input_data))
+        msg = "Wind direction input is not a cube, but {0}".format(type(input_data))
         with self.assertRaisesRegex(TypeError, msg):
             WindDirection().process(input_data)
 

--- a/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
+++ b/improver_tests/wind_calculations/wind_downscaling/test_RoughnessCorrection.py
@@ -730,7 +730,7 @@ class Test2D(IrisTest):
         """
         landpointtests_rc = TestSinglePoint(z_0=0.2, pporog=250.0, modelorog=250.0)
         landpointtests_rc.z0_cube.units = Unit("s")
-        msg = "z0 ancil has unexpected unit: should be {} " "is {}"
+        msg = "z0 ancil has unexpected unit: should be {} is {}"
         with self.assertRaisesRegex(
             ValueError, msg.format(Unit("m"), landpointtests_rc.z0_cube.units)
         ):

--- a/improver_tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
+++ b/improver_tests/wind_calculations/wind_gust_diagnostic/test_WindGustDiagnostic.py
@@ -86,7 +86,7 @@ class Test__repr__(IrisTest):
     def test_basic(self):
         """Test that the __repr__ returns the expected string."""
         result = str(WindGustDiagnostic(50.0, 95.0))
-        msg = "<WindGustDiagnostic: wind-gust perc=50.0, " "wind-speed perc=95.0>"
+        msg = "<WindGustDiagnostic: wind-gust perc=50.0, wind-speed perc=95.0>"
         self.assertEqual(result, msg)
 
 
@@ -109,7 +109,7 @@ class Test_add_metadata(IrisTest):
         plugin = WindGustDiagnostic(50.0, 80.0)
         result = plugin.add_metadata(self.cube_wg)
         self.assertEqual(result.standard_name, "wind_speed_of_gust")
-        msg = "<WindGustDiagnostic: wind-gust perc=50.0, " "wind-speed perc=80.0>"
+        msg = "<WindGustDiagnostic: wind-gust perc=50.0, wind-speed perc=80.0>"
         self.assertEqual(result.attributes["wind_gust_diagnostic"], msg)
 
     def test_diagnostic_typical_txt(self):


### PR DESCRIPTION
Remove all the strange same line divided string definitions with extraneous quotation marks. These result from black making split strings into single lines without removing the extra quotes.

Testing:
 - [x] Ran tests and they passed OK
