### PR TITLE
Fix pinning to treelite rather than lightgbm.

### DIFF
--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -24,10 +24,10 @@ dependencies:
   # Optional
   - python-stratify
   - statsmodels
-  - lightgbm=2.3.0
+  - lightgbm
   - numba
   - pysteps
-  - treelite
+  - treelite=2.3.0
   # Development
   - astroid
   - bandit


### PR DESCRIPTION
Currently the scheduled tests are failing:
```
improver_tests/calibration/rainforests_calibration/conftest.py:299: ModuleNotFoundError
=========================== short test summary info ============================
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test__check_num_features[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test__empty_config_warning[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test__evaluate_probabilities[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test__calculate_threshold_probabilities[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test__get_ensemble_distributions[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test_lead_time_without_matching_model[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test_process_ensemble_specifying_thresholds[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
ERROR improver_tests/calibration/rainforests_calibration/test_ApplyRainForestsCalibrationLightGBM.py::test_process_deterministic[treelite] - ModuleNotFoundError: No module named 'treelite_runtime'
= 5060 passed, 545 skipped, 1 xfailed, 5601 warnings, 8 errors in 196.43s (0:03:16) =
Error: Process completed with exit code 1.
```
The issue seems to be a change within treelite package. Fix to pin this package with #1966 pinned lightgbm rather than treelite. This PR is to unpin lightgbm and pin treelite.


Testing:
 - [x] Ran tests and they passed OK