### PR TITLE
Speed up ApplyReliabilityCalibration

### DIFF
--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1268,19 +1268,10 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
 
         forecast_probabilities = np.ma.getdata(forecast_threshold).flatten()
 
-        # interpolate using scipy first to get extrapolated values at endpoints
         interpolation_function = scipy.interpolate.interp1d(
             reliability_probabilities, observation_frequencies, fill_value="extrapolate"
         )
-        y_0, y_1 = interpolation_function([0, 1])
-        xp = np.copy(reliability_probabilities)
-        xp[0] = 0
-        xp[-1] = 1
-        fp = np.copy(observation_frequencies)
-        fp[0] = y_0
-        fp[-1] = y_1
-
-        interpolated = np.interp(forecast_probabilities.data, xp, fp)
+        interpolated = interpolation_function(forecast_probabilities.data)
 
         interpolated = interpolated.reshape(shape).astype(np.float32)
 

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1268,12 +1268,19 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
 
         forecast_probabilities = np.ma.getdata(forecast_threshold).flatten()
 
-        # interpolate using scipy first to get extrapolated values at endpoints
+        # Interpolate using scipy first to get extrapolated values at endpoints
+        # since np.interp does not allow extrapolation. We would need to change back
+        # to scipy.interpolate if we want non-linear interpolation in future.
         interpolation_function = scipy.interpolate.interp1d(
             reliability_probabilities, observation_frequencies, fill_value="extrapolate"
         )
         y_0, y_1 = interpolation_function([0, 1])
         xp = np.copy(reliability_probabilities)
+        # Extrapolation preserves the slop of the first and last segments of the piecewise
+        # linear function. Thus the slope betweeen [0, y_0] and [xp[0], fp[0]] is the same as that
+        # between [xp[0], fp[0]] and [xp[1], fp[1]], so we can replace
+        # [xp[0], fp[0]] with [0, y_0] to extend the width of the first segment of the
+        # piecewise linear function. A similar argument applies for the last segment.
         xp[0] = 0
         xp[-1] = 1
         fp = np.copy(observation_frequencies)

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1268,10 +1268,19 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
 
         forecast_probabilities = np.ma.getdata(forecast_threshold).flatten()
 
+        # interpolate using scipy first to get extrapolated values at endpoints
         interpolation_function = scipy.interpolate.interp1d(
             reliability_probabilities, observation_frequencies, fill_value="extrapolate"
         )
-        interpolated = interpolation_function(forecast_probabilities.data)
+        y_0, y_1 = interpolation_function([0, 1])
+        xp = np.copy(reliability_probabilities)
+        xp[0] = 0
+        xp[-1] = 1
+        fp = np.copy(observation_frequencies)
+        fp[0] = y_0
+        fp[-1] = y_1
+
+        interpolated = np.interp(forecast_probabilities.data, xp, fp)
 
         interpolated = interpolated.reshape(shape).astype(np.float32)
 

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1276,7 +1276,7 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
         )
         y_0, y_1 = interpolation_function([0, 1])
         xp = np.copy(reliability_probabilities)
-        # Extrapolation preserves the slop of the first and last segments of the piecewise
+        # Extrapolation preserves the slope of the first and last segments of the piecewise
         # linear function. Thus the slope betweeen [0, y_0] and [xp[0], fp[0]] is the same as that
         # between [xp[0], fp[0]] and [xp[1], fp[1]], so we can replace
         # [xp[0], fp[0]] with [0, y_0] to extend the width of the first segment of the


### PR DESCRIPTION
Speed up ApplyReliabilityCalibration by replacing scipy interpolation with faster numpy version. Gives approximately 25% improvement with 7 reliability bins.

Testing:
 - [X] Ran tests and they passed OK
