### PR TITLE
Change to nbhood plugin to satisfy Numpy warning and future Numpy error.

### DIFF
--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -99,7 +99,7 @@ def circular_kernel(ranges: int, weighted_mode: bool) -> ndarray:
     # contained within the desired radius.
     kernel = np.ones((int(1 + ranges * 2), (int(1 + ranges * 2))))
     # Create an open multi-dimensional meshgrid.
-    open_grid = np.array(np.ogrid[[slice(-x, x + 1) for x in (ranges, ranges)]])
+    open_grid = np.array(np.ogrid[[slice(-x, x + 1) for x in (ranges, ranges)]], dtype=object)
     if weighted_mode:
         # Create a kernel, such that the central grid point has the
         # highest weighting, with the weighting decreasing with distance


### PR DESCRIPTION
### Description:

During the investigation work into IMPROVER wind gusts I noticed an error in our nbhood plugin when using a more up to date environment than we use for production:

`ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.`

It tripped me up a bit trying to work out what the problem was.
This error is a `VisibleDeprecationWarning` in our current environment which explains things better: 
 
```
/improver/nbhood/nbhood.py:102: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  open_grid = np.array(np.ogrid[[slice(-x, x + 1) for x in (ranges, ranges)]])
```
  
To avoid tripping up on this again in the future this PR suggests we implement the change it requires now.

Testing:
 - [X] Ran tests and they passed OK