### PR TITLE
MOBT-430: Synthetic data utilities for creating spot-cubes

### DIFF
--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -51,7 +51,7 @@ from improver.metadata.constants.attributes import (
     MANDATORY_ATTRIBUTE_DEFAULTS,
     MANDATORY_ATTRIBUTES,
 )
-from improver.metadata.constants.time_types import TIME_COORDS
+from improver.metadata.constants.time_types import DT_FORMAT, TIME_COORDS
 from improver.metadata.forecast_times import add_blend_time, forecast_period_coord
 from improver.utilities.round import round_close
 from improver.utilities.temporal import cycletime_to_number
@@ -334,7 +334,7 @@ def store_record_run_as_coord(
         cycle = datetime.utcfromtimestamp(
             cube.coord("forecast_reference_time").points[0]
         )
-        cycle_str = cycle.strftime("%Y%m%dT%H%MZ")
+        cycle_str = cycle.strftime(DT_FORMAT)
 
         blending_weight = 1
         run_attr = (

--- a/improver/metadata/constants/time_types.py
+++ b/improver/metadata/constants/time_types.py
@@ -36,6 +36,8 @@ import numpy as np
 
 TimeSpec = namedtuple("TimeSpec", ("calendar", "dtype", "units"))
 
+DT_FORMAT = "%Y%m%dT%H%MZ"
+
 _TIME_REFERENCE_SPEC = TimeSpec(
     calendar="gregorian", dtype=np.int64, units="seconds since 1970-01-01 00:00:00"
 )

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -442,6 +442,7 @@ def set_up_spot_variable_cube(
 ):
     """
     Set up a spot cube containing a single variable field with:
+
     - latitude, longitude, altitude, WMO ID and unique site ID coordinates
       associated with the sites.
     - optional leading realization coordinate.
@@ -560,6 +561,7 @@ def set_up_variable_cube(
 ):
     """
     Set up a gridded cube containing a single variable field with:
+
     - a lat/lon or equal areas projection.
     - optional leading realization coordinate.
     - optional height or pressure levels.

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -335,8 +335,16 @@ def _construct_dimension_coords(
     height_levels: Optional[Union[List[float], ndarray]] = None,
     pressure: bool = False,
 ) -> DimCoord:
-    """ Create array of all dimension coordinates. These dimensions will be ordered:
-    realization, height/pressure, y, x. """
+    """Create array of all dimension coordinates. The expected dimension order
+    for gridded cubes is realization, height/pressure, y, x or realization,
+    height/pressure, spot_index for site cubes. The returned coordinates will
+    reflect this ordering.
+
+    A realization coordinate will be created if the cube is
+    (n_spatial_dims + 1) or (n_spatial_dims + 2), even if no values for values
+    for the realizations argument are provided. To create a height coordinate,
+    the height_levels must be provided.
+    """
 
     data_shape = data.shape
     ndims = data.ndim
@@ -464,10 +472,10 @@ def set_up_spot_variable_cube(
             Optional list of altitude values of the same length as the number
             of sites.
         wmo_ids:
-            Optional list of WMO IDs that identify the sites, these stored as
-            padded 5-digit strings. Same length as the number of sites.
+            Optional list of WMO IDs that identify the sites, these are stored
+            as padded 5-digit strings. Same length as the number of sites.
         unique_site_id:
-            Optional list of IDs that identify the sites, these stored as
+            Optional list of IDs that identify the sites, these are stored as
             padded 8-digit strings. Same length as the number of sites.
             If provided, unique_site_id_key must also be provided.
         unique_site_id_key:

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -466,7 +466,7 @@ def set_up_spot_variable_cube(
             Optional list of latitude values of the same length as the number
             of sites.
         longitudes:
-            Optional list of longitude values  of the same length as the number
+            Optional list of longitude values of the same length as the number
             of sites.
         altitudes:
             Optional list of altitude values of the same length as the number

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -341,9 +341,9 @@ def _construct_dimension_coords(
     reflect this ordering.
 
     A realization coordinate will be created if the cube is
-    (n_spatial_dims + 1) or (n_spatial_dims + 2), even if no values for values
-    for the realizations argument are provided. To create a height coordinate,
-    the height_levels must be provided.
+    (n_spatial_dims + 1) or (n_spatial_dims + 2), even if no values for the
+    realizations argument are provided. To create a height coordinate, the
+    height_levels must be provided.
     """
 
     data_shape = data.shape

--- a/improver/synthetic_data/set_up_test_cubes.py
+++ b/improver/synthetic_data/set_up_test_cubes.py
@@ -40,7 +40,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 import iris
 import numpy as np
 from cf_units import Unit, date2num
-from iris.coords import Coord, DimCoord
+from iris.coords import AuxCoord, Coord, DimCoord
 from iris.cube import Cube
 from iris.exceptions import CoordinateNotFoundError
 from numpy import ndarray
@@ -51,6 +51,7 @@ from improver.metadata.check_datatypes import check_mandatory_standards
 from improver.metadata.constants.mo_attributes import MOSG_GRID_DEFINITION
 from improver.metadata.constants.time_types import TIME_COORDS
 from improver.metadata.forecast_times import forecast_period_coord
+from improver.spotdata import UNIQUE_ID_ATTRIBUTE
 
 DIM_COORD_ATTRIBUTES = {
     "realization": {"units": "1"},
@@ -327,34 +328,47 @@ def _create_dimension_coord(
 
 def _construct_dimension_coords(
     data: Union[MaskedArray, ndarray],
-    y_coord: DimCoord,
-    x_coord: DimCoord,
-    realizations: Union[List[float], ndarray],
-    height_levels: Union[List[float], ndarray],
-    pressure: bool,
+    y_coord: Optional[DimCoord] = None,
+    x_coord: Optional[DimCoord] = None,
+    spot_index: Optional[DimCoord] = None,
+    realizations: Optional[Union[List[float], ndarray]] = None,
+    height_levels: Optional[Union[List[float], ndarray]] = None,
+    pressure: bool = False,
 ) -> DimCoord:
     """ Create array of all dimension coordinates. These dimensions will be ordered:
     realization, height/pressure, y, x. """
+
     data_shape = data.shape
-    ndims = len(data_shape)
+    ndims = data.ndim
+    n_spatial_dims = sum([item is not None for item in [y_coord, x_coord, spot_index]])
 
-    if ndims not in (2, 3, 4):
+    if not n_spatial_dims <= ndims <= n_spatial_dims + 2:
         raise ValueError(
-            "Expected 2 to 4 dimensions on input data: got {}".format(ndims)
+            f"Expected {n_spatial_dims} to {n_spatial_dims + 2} dimensions on "
+            f"input data: got {ndims}"
         )
 
-    if realizations is not None and height_levels is not None and ndims != 4:
+    if (
+        realizations is not None
+        and height_levels is not None
+        and ndims != n_spatial_dims + 2
+    ):
         raise ValueError(
-            "Input data must have 4 dimensions to add both realization "
-            "and height coordinates: got {}".format(ndims)
+            f"Input data must have {n_spatial_dims + 2} dimensions to add both realization "
+            f"and height coordinates: got {ndims}"
         )
 
-    if height_levels is None and ndims == 4:
-        raise ValueError("Height levels must be provided if data has 4 dimensions.")
+    if height_levels is None and ndims > n_spatial_dims + 1:
+        raise ValueError(
+            "Height levels must be provided if data has > "
+            f"{n_spatial_dims + 1} dimensions."
+        )
 
     dim_coords = []
 
-    if ndims == 4 or (height_levels is None and ndims == 3):
+    if ndims == n_spatial_dims + 2 or (
+        height_levels is None and ndims == n_spatial_dims + 1
+    ):
         coord_name = "realization"
         coord_units = DIM_COORD_ATTRIBUTES[coord_name]["units"]
         coord_length = data_shape[0]
@@ -364,7 +378,7 @@ def _construct_dimension_coords(
         )
         dim_coords.append((realization_coord, 0))
 
-    if height_levels is not None and ndims in (3, 4):
+    if height_levels is not None and n_spatial_dims + 1 <= ndims <= n_spatial_dims + 2:
         # Determine the index of the height coord based on if a realization coord has been created
         i = len(dim_coords)
         coord_length = data_shape[i]
@@ -386,88 +400,19 @@ def _construct_dimension_coords(
         )
         dim_coords.append((height_coord, i))
 
-    dim_coords.append((y_coord, len(dim_coords)))
-    dim_coords.append((x_coord, len(dim_coords)))
+    if spot_index is not None:
+        dim_coords.append((spot_index, len(dim_coords)))
+    else:
+        dim_coords.append((y_coord, len(dim_coords)))
+        dim_coords.append((x_coord, len(dim_coords)))
 
     return dim_coords
 
 
-def set_up_variable_cube(
-    data: ndarray,
-    name: str = "air_temperature",
-    units: str = "K",
-    spatial_grid: str = "latlon",
-    time: datetime = datetime(2017, 11, 10, 4, 0),
-    time_bounds: Optional[Tuple[datetime, datetime]] = None,
-    frt: Optional[datetime] = None,
-    blend_time: Optional[datetime] = None,
-    realizations: Optional[Union[List[float], ndarray]] = None,
-    include_scalar_coords: Optional[List[Coord]] = None,
-    attributes: Optional[Dict[str, str]] = None,
-    standard_grid_metadata: Optional[str] = None,
-    x_grid_spacing: Optional[float] = None,
-    y_grid_spacing: Optional[float] = None,
-    domain_corner: Optional[Tuple[float, float]] = None,
-    height_levels: Optional[Union[List[float], ndarray]] = None,
-    pressure: bool = False,
-) -> Cube:
+def _yx_for_grid(data, spatial_grid, x_grid_spacing, y_grid_spacing, domain_corner):
+    """Construct y and x coordinates for gridded data based upon the shape of
+    the data array.
     """
-    Set up a cube containing a single variable field with:
-    - x/y spatial dimensions (equal area or lat / lon)
-    - optional leading "realization" dimension
-    - optional "height" dimension
-    - "time", "forecast_reference_time" and "forecast_period" scalar coords
-    - option to specify additional scalar coordinates
-    - configurable attributes
-
-    Args:
-        data:
-            2D (y-x ordered) or 3D (realization-y-x ordered) array of data
-            to put into the cube.
-        name:
-            Variable name (standard / long)
-        units:
-            Variable units
-        spatial_grid:
-            What type of x/y coordinate values to use.  Permitted values are
-            "latlon" or "equalarea".
-        time:
-            Single cube validity time
-        time_bounds:
-            Lower and upper bound on time point, if required
-        frt:
-            Single cube forecast reference time. Default value is datetime(2017, 11, 10, 0, 0).
-        blend_time:
-            Single cube blend time
-        realizations:
-            List of forecast realizations.  If not present, taken from the
-            leading dimension of the input data array (if 3D).
-        include_scalar_coords:
-            List of iris.coords.DimCoord or AuxCoord instances of length 1.
-        attributes:
-            Optional cube attributes.
-        standard_grid_metadata:
-            Recognised mosg__model_configuration for which to set up Met
-            Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
-            'gl_det' or 'gl_ens'.
-        x_grid_spacing:
-            Grid resolution along the x axis (degrees for latlon or metres for equalarea).
-        y_grid_spacing:
-            Grid resolution along the y axis (degrees for latlon or metres for equalarea).
-        domain_corner:
-            Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea).
-        height_levels:
-            List of height levels in metres or pressure levels in Pa.
-        pressure:
-            Flag to indicate whether the height levels are specified as pressure, in Pa.
-            If False, use height in metres.
-
-    Returns:
-        Cube containing a single variable field
-    """
-    if not frt and not blend_time:
-        frt = datetime(2017, 11, 10, 0, 0)
-    # construct spatial dimension coordinates
     ypoints = data.shape[-2]
     xpoints = data.shape[-1]
     y_coord, x_coord = construct_yx_coords(
@@ -478,10 +423,249 @@ def set_up_variable_cube(
         y_grid_spacing=y_grid_spacing,
         domain_corner=domain_corner,
     )
+    return y_coord, x_coord
+
+
+def set_up_spot_variable_cube(
+    data: ndarray,
+    latitudes: Optional[Union[List[float], ndarray]] = None,
+    longitudes: Optional[Union[List[float], ndarray]] = None,
+    altitudes: Optional[Union[List[float], ndarray]] = None,
+    wmo_ids: Optional[Union[List[float], ndarray]] = None,
+    unique_site_id: Optional[Union[List[str], ndarray]] = None,
+    unique_site_id_key: Optional[str] = None,
+    realizations: Optional[Union[List[float], ndarray]] = None,
+    height_levels: Optional[Union[List[float], ndarray]] = None,
+    pressure: bool = False,
+    *args,
+    **kwargs,
+):
+    """
+    Set up a spot cube containing a single variable field with:
+    - latitude, longitude, altitude, WMO ID and unique site ID coordinates
+      associated with the sites.
+    - optional leading realization coordinate.
+    - optional height or pressure levels.
+    - additional options available by keywords passed to the _variable_cube
+      function.
+
+    Args:
+        data:
+            1D (length of no. of sites) or 2D (realization-sites ordered)
+            array of data to put into the cube.
+        latitudes:
+            Optional list of latitude values of the same length as the number
+            of sites.
+        longitudes:
+            Optional list of longitude values  of the same length as the number
+            of sites.
+        altitudes:
+            Optional list of altitude values of the same length as the number
+            of sites.
+        wmo_ids:
+            Optional list of WMO IDs that identify the sites, these stored as
+            padded 5-digit strings. Same length as the number of sites.
+        unique_site_id:
+            Optional list of IDs that identify the sites, these stored as
+            padded 8-digit strings. Same length as the number of sites.
+            If provided, unique_site_id_key must also be provided.
+        unique_site_id_key:
+            Optional string that names the unique_site_id coordinate.
+        realizations:
+            List of forecast realizations.  If not present, taken from the
+            leading dimension of the input data array (if 2D).
+        height_levels:
+            List of height levels in metres or pressure levels in Pa.
+        pressure:
+            Flag to indicate whether the height levels are specified as pressure, in Pa.
+            If False, use height in metres.
+
+    Returns:
+        Cube containing a single spot variable field
+    """
+
+    n_sites = data.shape[-1]
+    spot_index = DimCoord(np.arange(n_sites), long_name="spot_index", units="1")
+
+    altitudes = (
+        altitudes if altitudes is not None else np.ones((n_sites), dtype=np.float32)
+    )
+    latitudes = (
+        latitudes
+        if latitudes is not None
+        else np.linspace(50, 60, n_sites, dtype=np.float32)
+    )
+    longitudes = (
+        longitudes
+        if longitudes is not None
+        else np.linspace(-5, 5, n_sites, dtype=np.float32)
+    )
+    wmo_ids = wmo_ids if wmo_ids is not None else range(n_sites)
+    wmo_ids = [f"{int(item):05d}" for item in wmo_ids]
+
+    alt_coord = AuxCoord(altitudes, "altitude", units="m")
+    y_coord = AuxCoord(latitudes, "latitude", units="degrees")
+    x_coord = AuxCoord(longitudes, "longitude", units="degrees")
+    id_coord = AuxCoord(wmo_ids, long_name="wmo_id")
+    unique_id_coord = None
+
+    if unique_site_id is not None:
+        if not unique_site_id_key:
+            raise ValueError(
+                "A unique_site_id_key must be provided if a unique_site_id is"
+                " provided."
+            )
+        unique_site_id = [f"{int(item):08d}" for item in unique_site_id]
+        unique_id_coord = AuxCoord(
+            unique_site_id,
+            long_name=unique_site_id_key,
+            units="no_unit",
+            attributes={UNIQUE_ID_ATTRIBUTE: "true"},
+        )
 
     dim_coords = _construct_dimension_coords(
-        data, y_coord, x_coord, realizations, height_levels, pressure
+        data,
+        spot_index=spot_index,
+        realizations=realizations,
+        height_levels=height_levels,
+        pressure=pressure,
     )
+
+    cube = _variable_cube(data, dim_coords, *args, **kwargs)
+
+    (spatial_coord_index,) = cube.coord_dims("spot_index")
+    crds = [y_coord, x_coord, alt_coord, id_coord]
+    if unique_id_coord is not None:
+        crds.append(unique_id_coord)
+
+    for crd in crds:
+        cube.add_aux_coord(crd, spatial_coord_index)
+
+    # don't allow unit tests to set up invalid cubes
+    check_mandatory_standards(cube)
+    return cube
+
+
+def set_up_variable_cube(
+    data: ndarray,
+    spatial_grid: str = "latlon",
+    x_grid_spacing: Optional[float] = None,
+    y_grid_spacing: Optional[float] = None,
+    domain_corner: Optional[Tuple[float, float]] = None,
+    realizations: Optional[Union[List[float], ndarray]] = None,
+    height_levels: Optional[Union[List[float], ndarray]] = None,
+    pressure: bool = False,
+    *args,
+    **kwargs,
+):
+    """
+    Set up a gridded cube containing a single variable field with:
+    - a lat/lon or equal areas projection.
+    - optional leading realization coordinate.
+    - optional height or pressure levels.
+    - additional options available by keywords passed to the _variable_cube
+      function.
+
+    Args:
+        data:
+            2D (y-x ordered) or 3D (realization-y-x ordered) array of data
+            to put into the cube.
+        spatial_grid:
+            What type of x/y coordinate values to use.  Permitted values are
+            "latlon" or "equalarea".
+        x_grid_spacing:
+            Grid resolution along the x axis (degrees for latlon or metres for equalarea).
+        y_grid_spacing:
+            Grid resolution along the y axis (degrees for latlon or metres for equalarea).
+        domain_corner:
+            Bottom left corner of grid domain (y,x) (degrees for latlon or metres for equalarea).
+        realizations:
+            List of forecast realizations.  If not present, taken from the
+            leading dimension of the input data array (if 3D).
+        height_levels:
+            List of height levels in metres or pressure levels in Pa.
+        pressure:
+            Flag to indicate whether the height levels are specified as pressure, in Pa.
+            If False, use height in metres.
+
+    Returns:
+        Cube containing a single gridded variable field
+    """
+
+    y_coord, x_coord = _yx_for_grid(
+        data, spatial_grid, x_grid_spacing, y_grid_spacing, domain_corner
+    )
+
+    dim_coords = _construct_dimension_coords(
+        data,
+        y_coord=y_coord,
+        x_coord=x_coord,
+        realizations=realizations,
+        height_levels=height_levels,
+        pressure=pressure,
+    )
+
+    cube = _variable_cube(data, dim_coords, *args, **kwargs)
+
+    # don't allow unit tests to set up invalid cubes
+    check_mandatory_standards(cube)
+
+    return cube
+
+
+def _variable_cube(
+    data: ndarray,
+    dim_coords: Tuple[Union[AuxCoord, DimCoord]],
+    name: str = "air_temperature",
+    units: str = "K",
+    time: datetime = datetime(2017, 11, 10, 4, 0),
+    time_bounds: Optional[Tuple[datetime, datetime]] = None,
+    frt: Optional[datetime] = None,
+    blend_time: Optional[datetime] = None,
+    include_scalar_coords: Optional[List[Coord]] = None,
+    attributes: Optional[Dict[str, str]] = None,
+    standard_grid_metadata: Optional[str] = None,
+) -> Cube:
+    """
+    Set up a cube containing a single variable field with:
+    - the provided dimension coordinates
+    - "time", "forecast_reference_time" and "forecast_period" scalar coords
+    - option to specify additional scalar coordinates
+    - configurable attributes
+
+    Args:
+        data:
+            2D (y-x ordered) or 3D (realization-y-x ordered) array of data
+            to put into the cube.
+        dim_coords:
+            Dimension coordinates for the constructed cube, e.g. the x and
+            y dimensions.
+        name:
+            Variable name (standard / long)
+        units:
+            Variable units
+        time:
+            Single cube validity time
+        time_bounds:
+            Lower and upper bound on time point, if required
+        frt:
+            Single cube forecast reference time. Default value is datetime(2017, 11, 10, 0, 0).
+        blend_time:
+            Single cube blend time
+        include_scalar_coords:
+            List of iris.coords.DimCoord or AuxCoord instances of length 1.
+        attributes:
+            Optional cube attributes.
+        standard_grid_metadata:
+            Recognised mosg__model_configuration for which to set up Met
+            Office standard grid attributes.  Should be 'uk_det', 'uk_ens',
+            'gl_det' or 'gl_ens'.
+
+    Returns:
+        Cube containing a single variable field
+    """
+    if not frt and not blend_time:
+        frt = datetime(2017, 11, 10, 0, 0)
 
     # construct list of aux_coords_and_dims
     scalar_coords = construct_scalar_time_coords(time, time_bounds, frt, blend_time)
@@ -506,18 +690,40 @@ def set_up_variable_cube(
     )
     cube.rename(name)
 
-    # don't allow unit tests to set up invalid cubes
-    check_mandatory_standards(cube)
-
     return cube
 
 
-def set_up_percentile_cube(
-    data: ndarray, percentiles: Union[List[float], ndarray], **kwargs: Any,
+def set_up_spot_percentile_cube(*args, **kwargs):
+    """Set up a cube containing spot percentiles of a variable.
+
+    Args:
+        data:
+            2D (percentile-sites ordered) array of data to put into the cube
+    Returns:
+        Cube containing spot percentiles.
+    """
+    function = set_up_spot_variable_cube
+    return _percentile_cube(function, *args, **kwargs)
+
+
+def set_up_percentile_cube(*args, **kwargs):
+    """Set up a cube containing gridded percentiles of a variable.
+
+    Args:
+        data:
+            3D (percentile-y-x ordered) array of data to put into the cube
+    Returns:
+        Cube containing gridded percentiles.
+    """
+    function = set_up_variable_cube
+    return _percentile_cube(function, *args, **kwargs)
+
+
+def _percentile_cube(
+    function, data: ndarray, percentiles: Union[List[float], ndarray], **kwargs: Any,
 ) -> Cube:
     """
     Set up a cube containing percentiles of a variable with:
-    - x/y spatial dimensions (equal area or lat / lon)
     - leading "percentile" dimension
     - "time", "forecast_reference_time" and "forecast_period" scalar coords
     - option to specify additional scalar coordinates
@@ -525,7 +731,7 @@ def set_up_percentile_cube(
 
     Args:
         data:
-            3D (percentile-y-x ordered) array of data to put into the cube
+            Array of data to put into the cube
         percentiles:
             List of int / float percentile values whose length must match the
             first dimension on the input data cube
@@ -535,7 +741,7 @@ def set_up_percentile_cube(
     Returns:
         Cube containing percentiles
     """
-    cube = set_up_variable_cube(data, realizations=percentiles, **kwargs,)
+    cube = function(data, realizations=percentiles, **kwargs,)
     cube.coord("realization").rename("percentile")
     cube.coord("percentile").units = Unit("%")
     if len(percentiles) == 1:
@@ -543,7 +749,34 @@ def set_up_percentile_cube(
     return cube
 
 
-def set_up_probability_cube(
+def set_up_spot_probability_cube(*args, **kwargs):
+    """Set up a cube containing spot probabilities at thresholds.
+
+    Args:
+        data:
+            2D (threshold-sites) array of data to put into the cube
+    Returns:
+        Cube containing spot probabilities.
+    """
+    function = set_up_spot_variable_cube
+    return _probability_cube(function, *args, **kwargs)
+
+
+def set_up_probability_cube(*args, **kwargs):
+    """Set up a cube containing gridded probabilities at thresholds.
+
+    Args:
+        data:
+            3D (threshold-y-x ordered) array of data to put into the cube
+    Returns:
+        Cube containing gridded probabilities.
+    """
+    function = set_up_variable_cube
+    return _probability_cube(function, *args, **kwargs)
+
+
+def _probability_cube(
+    function,
     data: ndarray,
     thresholds: Union[List[float], ndarray],
     variable_name: str = "air_temperature",
@@ -553,7 +786,6 @@ def set_up_probability_cube(
 ) -> Cube:
     """
     Set up a cube containing probabilities at thresholds with:
-    - x/y spatial dimensions (equal area or lat / lon)
     - leading "threshold" dimension
     - "time", "forecast_reference_time" and "forecast_period" scalar coords
     - option to specify additional scalar coordinates
@@ -564,7 +796,7 @@ def set_up_probability_cube(
 
     Args:
         data:
-            3D (threshold-y-x ordered) array of data to put into the cube
+            Array of data to put into the cube
         thresholds:
             List of int / float threshold values whose length must match the
             first dimension on the input data cube
@@ -600,9 +832,7 @@ def set_up_probability_cube(
         )
         raise ValueError(msg)
 
-    cube = set_up_variable_cube(
-        data, name=name, units="1", realizations=thresholds, **kwargs,
-    )
+    cube = function(data, name=name, units="1", realizations=thresholds, **kwargs,)
     threshold_name = variable_name.replace("_in_vicinity", "")
     cube.coord("realization").rename(threshold_name)
     cube.coord(threshold_name).var_name = "threshold"

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -44,11 +44,11 @@ from iris.cube import Cube, CubeList
 from iris.time import PartialDateTime
 from numpy import int64
 
-from improver.metadata.constants.time_types import TIME_COORDS
+from improver.metadata.constants.time_types import DT_FORMAT, TIME_COORDS
 
 
 def cycletime_to_datetime(
-    cycletime: str, cycletime_format: str = "%Y%m%dT%H%MZ"
+    cycletime: str, cycletime_format: str = DT_FORMAT
 ) -> datetime:
     """Convert a string representating the cycletime of the
     format YYYYMMDDTHHMMZ into a datetime object.
@@ -67,7 +67,7 @@ def cycletime_to_datetime(
 
 
 def datetime_to_cycletime(
-    adatetime: datetime, cycletime_format: str = "%Y%m%dT%H%MZ"
+    adatetime: datetime, cycletime_format: str = DT_FORMAT
 ) -> str:
     """Convert a datetime object into a string representing the cycletime
     of the format YYYYMMDDTHHMMZ.
@@ -87,7 +87,7 @@ def datetime_to_cycletime(
 
 def cycletime_to_number(
     cycletime: str,
-    cycletime_format: str = "%Y%m%dT%H%MZ",
+    cycletime_format: str = DT_FORMAT,
     time_unit: str = "hours since 1970-01-01 00:00:00",
     calendar: str = "gregorian",
 ) -> float:

--- a/improver_tests/blending/test_utilities.py
+++ b/improver_tests/blending/test_utilities.py
@@ -55,6 +55,7 @@ from improver.blending.utilities import (
     update_record_run_weights,
 )
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
+from improver.metadata.constants.time_types import DT_FORMAT
 from improver.synthetic_data.set_up_test_cubes import set_up_probability_cube
 
 
@@ -96,9 +97,7 @@ def cycle_cube_with_blend_record() -> Cube:
     cubes = setup_cycle_cube()
     updated_cubes = CubeList()
     for cube in cubes.slices_over("forecast_reference_time"):
-        time = (
-            cube.coord("forecast_reference_time").cell(0).point.strftime("%Y%m%dT%H%MZ")
-        )
+        time = cube.coord("forecast_reference_time").cell(0).point.strftime(DT_FORMAT)
 
         blend_record_coord = AuxCoord(
             [f"uk_det:{time}:{1:{WEIGHT_FORMAT}}"], long_name=RECORD_COORD
@@ -467,7 +466,7 @@ def test_update_record_run_weights_cycle(
     data and metadata to the input cube."""
 
     frts = [
-        cube.coord("forecast_reference_time").cell(0).point.strftime("%Y%m%dT%H%MZ")
+        cube.coord("forecast_reference_time").cell(0).point.strftime(DT_FORMAT)
         for cube in cycle_cube_with_blend_record.slices_over("forecast_reference_time")
     ]
 

--- a/improver_tests/blending/weights/test_ChooseWeightsLinear.py
+++ b/improver_tests/blending/weights/test_ChooseWeightsLinear.py
@@ -37,15 +37,13 @@ from datetime import datetime as dt
 import iris
 import numpy as np
 import pytest
-from iris.coords import AuxCoord, DimCoord
+from iris.coords import AuxCoord
 from iris.tests import IrisTest
 
 from improver.blending.weights import ChooseWeightsLinear
 from improver.metadata.forecast_times import forecast_period_coord
-from improver.spotdata.build_spotdata_cube import build_spotdata_cube
 from improver.synthetic_data.set_up_test_cubes import (
     add_coordinate,
-    construct_scalar_time_coords,
     set_up_probability_cube,
     set_up_spot_probability_cube,
     set_up_variable_cube,
@@ -122,17 +120,6 @@ def set_up_basic_model_config_spot_cube(frt=None, time_points=None):
     model_id_coord = AuxCoord([1000], long_name="model_id")
     model_config_coord = AuxCoord(["uk_det"], long_name="model_configuration")
 
-    altitudes = np.ones(n_sites, dtype=np.float32)
-    latitudes = np.arange(0, n_sites * 10, 10, dtype=np.float32)
-    longitudes = np.arange(0, n_sites * 20, 20, dtype=np.float32)
-    wmo_ids = np.arange(1000, (1000 * n_sites) + 1, 1000)
-
-    args = (altitudes, latitudes, longitudes, wmo_ids)
-    kwargs = {
-        "unique_site_id": wmo_ids,
-        "unique_site_id_key": "met_office_site_id",
-    }
-
     cubes = iris.cube.CubeList()
     for time in time_points:
         cube = set_up_spot_probability_cube(
@@ -140,25 +127,11 @@ def set_up_basic_model_config_spot_cube(frt=None, time_points=None):
             thresholds,
             time=time,
             frt=frt,
-            latitudes=latitudes,
-            longitudes=longitudes,
-            wmo_ids=wmo_ids,
             include_scalar_coords=[model_id_coord, model_config_coord],
         )
         cubes.append(cube)
     cube = cubes.merge_cube()
 
-    # cube = build_spotdata_cube(
-    #     data,
-    #     "probability_of_air_temperature_above_threshold",
-    #     "1",
-    #     *args,
-    #     **kwargs,
-    #     scalar_coords=[model_id_coord, model_config_coord, *time_coords],
-    #     additional_dims=[threshold_coord],
-    # )
-
-    # cube = add_coordinate(cube, time_points, "time", is_datetime=True)
     return cube
 
 

--- a/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
@@ -29,19 +29,21 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for the ApplyDzRescaling plugin."""
+from datetime import datetime as dt
 from typing import List
 
 import iris
 import numpy as np
 import pandas as pd
 import pytest
-from iris.coords import AuxCoord, DimCoord
+from iris.coords import AuxCoord
 from iris.cube import Cube
 
 from improver.calibration.dz_rescaling import ApplyDzRescaling
 from improver.constants import SECONDS_IN_HOUR
-from improver.metadata.constants.time_types import TIME_COORDS
+from improver.metadata.constants.time_types import DT_FORMAT, TIME_COORDS
 from improver.spotdata.build_spotdata_cube import build_spotdata_cube
+from improver.synthetic_data.set_up_test_cubes import set_up_spot_percentile_cube
 
 altitude = np.zeros(2)
 latitude = np.zeros(2)
@@ -50,61 +52,29 @@ wmo_id = ["00001", "00002"]
 
 
 def _create_forecasts(
-    forecast_reference_time: str,
-    validity_time: str,
-    forecast_period: float,
-    forecast_percs: List[float],
+    forecast_reference_time: str, validity_time: str, forecast_percs: List[float],
 ) -> Cube:
     """Create site forecast cube for testing.
 
     Args:
         forecast_reference_time: Timestamp e.g. "20170101T0000Z".
         validity_time: Timestamp e.g. "20170101T0600Z".
-        forecast_period: Forecast period in hours.
         forecast_percs: Forecast wind speed at 10th, 50th and 90th percentile.
 
     Returns:
         Forecast cube containing three percentiles and two sites.
     """
-    data = np.array(forecast_percs).repeat(2).reshape(3, 2)
+    data = np.array(forecast_percs, dtype=np.float32).repeat(2).reshape(3, 2)
+    percentiles = [10, 50, 90]
 
-    perc_coord = DimCoord(
-        np.array([10, 50, 90], dtype=np.float32), long_name="percentile", units="%",
-    )
-    fp_coord = AuxCoord(
-        np.array(
-            forecast_period * SECONDS_IN_HOUR,
-            dtype=TIME_COORDS["forecast_period"].dtype,
-        ),
-        "forecast_period",
-        units=TIME_COORDS["forecast_period"].units,
-    )
-    time_coord = AuxCoord(
-        np.array(
-            pd.Timestamp(validity_time).timestamp(), dtype=TIME_COORDS["time"].dtype,
-        ),
-        "time",
-        units=TIME_COORDS["time"].units,
-    )
-    frt_coord = AuxCoord(
-        np.array(
-            pd.Timestamp(forecast_reference_time).timestamp(),
-            dtype=TIME_COORDS["forecast_reference_time"].dtype,
-        ),
-        "forecast_reference_time",
-        units=TIME_COORDS["forecast_reference_time"].units,
-    )
-
-    cube = build_spotdata_cube(
+    cube = set_up_spot_percentile_cube(
         data,
-        "wind_speed_at_10m",
-        "m s-1",
-        altitude,
-        latitude,
-        longitude,
-        wmo_id,
-        scalar_coords=[fp_coord, time_coord, frt_coord],
-        additional_dims=[perc_coord],
+        percentiles,
+        name="wind_speed_at_10m",
+        units="m s-1",
+        wmo_ids=["00001", "00002"],
+        time=dt.strptime(validity_time, DT_FORMAT),
+        frt=dt.strptime(forecast_reference_time, DT_FORMAT),
     )
     return cube
 
@@ -193,14 +163,9 @@ def test_apply_dz_rescaling(
     validity_time = (
         pd.Timestamp(forecast_reference_time)
         + pd.Timedelta(hours=forecast_period + forecast_period_offset)
-    ).strftime("%Y%m%dT%H%MZ")
+    ).strftime(DT_FORMAT)
 
-    forecast = _create_forecasts(
-        forecast_reference_time,
-        validity_time,
-        forecast_period + forecast_period_offset,
-        forecast,
-    )
+    forecast = _create_forecasts(forecast_reference_time, validity_time, forecast,)
     # Use min(fp, 24) here to ensure that the scaling cube contains
     # the scaling factor for the last forecast_period if the specified
     # forecast period is beyond the T+24 limit of the scaling cube.
@@ -242,11 +207,9 @@ def test_use_correct_time():
 
     validity_time = (
         pd.Timestamp(forecast_reference_time) + pd.Timedelta(hours=forecast_period)
-    ).strftime("%Y%m%dT%H%MZ")
+    ).strftime(DT_FORMAT)
 
-    forecast = _create_forecasts(
-        forecast_reference_time, validity_time, forecast_period, forecast,
-    )
+    forecast = _create_forecasts(forecast_reference_time, validity_time, forecast,)
     scaling_factor = _create_scaling_factor_cube(12, forecast_period, scaling_factor)
     scaling_factor.data[0, 0, 0] = scaling_factor.data[0, 0, 0].copy() + 0.01
 
@@ -267,11 +230,9 @@ def test_mismatching_sites():
 
     validity_time = (
         pd.Timestamp(forecast_reference_time) + pd.Timedelta(hours=forecast_period)
-    ).strftime("%Y%m%dT%H%MZ")
+    ).strftime(DT_FORMAT)
 
-    forecast = _create_forecasts(
-        forecast_reference_time, validity_time, forecast_period, [10, 20, 30]
-    )
+    forecast = _create_forecasts(forecast_reference_time, validity_time, [10, 20, 30])
     scaling_factor = _create_scaling_factor_cube(3, forecast_period, 1.0)
 
     with pytest.raises(ValueError, match="The mismatched sites are: {'00002'}"):
@@ -289,11 +250,9 @@ def test_no_appropriate_scaled_dz(forecast_period, frt_hour, exception):
 
     validity_time = (
         pd.Timestamp(forecast_reference_time) + pd.Timedelta(hours=forecast_period)
-    ).strftime("%Y%m%dT%H%MZ")
+    ).strftime(DT_FORMAT)
 
-    forecast = _create_forecasts(
-        forecast_reference_time, validity_time, forecast_period, [10, 20, 30]
-    )
+    forecast = _create_forecasts(forecast_reference_time, validity_time, [10, 20, 30])
     scaling_factor = _create_scaling_factor_cube(3, forecast_period, 1.0)
 
     with pytest.raises(ValueError, match=exception):

--- a/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_apply_dz_rescaling.py
@@ -45,10 +45,7 @@ from improver.metadata.constants.time_types import DT_FORMAT, TIME_COORDS
 from improver.spotdata.build_spotdata_cube import build_spotdata_cube
 from improver.synthetic_data.set_up_test_cubes import set_up_spot_percentile_cube
 
-altitude = np.zeros(2)
-latitude = np.zeros(2)
-longitude = np.zeros(2)
-wmo_id = ["00001", "00002"]
+WMO_ID = ["00001", "00002"]
 
 
 def _create_forecasts(
@@ -72,7 +69,7 @@ def _create_forecasts(
         percentiles,
         name="wind_speed_at_10m",
         units="m s-1",
-        wmo_ids=["00001", "00002"],
+        wmo_ids=WMO_ID,
         time=dt.strptime(validity_time, DT_FORMAT),
         frt=dt.strptime(forecast_reference_time, DT_FORMAT),
     )
@@ -90,6 +87,10 @@ def _create_scaling_factor_cube(
     Returns:
         Scaling factor cube.
     """
+    altitude = np.zeros(2)
+    latitude = np.zeros(2)
+    longitude = np.zeros(2)
+
     cubelist = iris.cube.CubeList()
     for ref_hour in [3, 12]:
         for forecast_period in [6, 12, 18, 24]:
@@ -120,7 +121,7 @@ def _create_scaling_factor_cube(
                 altitude,
                 latitude,
                 longitude,
-                wmo_id,
+                WMO_ID,
                 scalar_coords=[fp_coord, frth_coord],
             )
             cubelist.append(cube)

--- a/improver_tests/calibration/dz_rescaling/test_estimate_dz_rescaling.py
+++ b/improver_tests/calibration/dz_rescaling/test_estimate_dz_rescaling.py
@@ -47,16 +47,7 @@ from improver.synthetic_data.set_up_test_cubes import (
     set_up_spot_variable_cube,
 )
 
-# Define four spots
-altitude_grid = np.array([0, 50, 20, 50])
-altitude_spot = [0, 20, 100, 80]
-latitude = np.arange(4)
-longitude = np.zeros(4)
-wmo_id = ["00001", "00002", "00003", "00004"]
-# Set forecast and truth data so that the two spots that are higher than the grid have slightly
-# higher truth values.
-forecast_data = np.array([0, 20, 10, 15])
-truth_data = np.array([0, 20, 10.2, 15.1])
+WMO_ID = ["00001", "00002", "00003", "00004"]
 
 
 def _create_forecasts(
@@ -87,7 +78,7 @@ def _create_forecasts(
                     percentiles,
                     name="wind_speed_at_10m",
                     units="m s-1",
-                    wmo_ids=wmo_id,
+                    wmo_ids=WMO_ID,
                     time=vt,
                     frt=frt,
                 )
@@ -120,7 +111,7 @@ def _create_truths(
                     truth_data,
                     name="wind_speed_at_10m",
                     units="m s-1",
-                    wmo_ids=wmo_id,
+                    wmo_ids=WMO_ID,
                     time=vt,
                     frt=frt,
                 )
@@ -135,6 +126,12 @@ def _create_neighbour_cube() -> Cube:
     Returns:
         Neighbour cube.
     """
+    # Define four spots
+    altitude_grid = np.array([0, 50, 20, 50])
+    altitude_spot = [0, 20, 100, 80]
+    latitude = np.arange(4)
+    longitude = np.zeros(4)
+
     land_data = np.zeros((9, 9))
     land_data[0:2, 4] = 1
     land_data[4, 4] = 1
@@ -174,7 +171,7 @@ def _create_neighbour_cube() -> Cube:
     )
     global_sites = [
         {"altitude": alt, "latitude": lat, "longitude": lon, "wmo_id": int(site)}
-        for alt, lat, lon, site in zip(altitude_spot, latitude, longitude, wmo_id)
+        for alt, lat, lon, site in zip(altitude_spot, latitude, longitude, WMO_ID)
     ]
     plugin = NeighbourSelection()
     cube = plugin.process(global_sites, global_orography, global_land_mask)

--- a/improver_tests/categorical/modal_code/test_ModalCategory.py
+++ b/improver_tests/categorical/modal_code/test_ModalCategory.py
@@ -41,6 +41,7 @@ from iris.cube import CubeList
 
 from improver.blending import WEIGHT_FORMAT
 from improver.categorical.modal_code import ModalCategory
+from improver.metadata.constants.time_types import DT_FORMAT
 from improver.spotdata.build_spotdata_cube import build_spotdata_cube
 from improver.synthetic_data.set_up_test_cubes import construct_scalar_time_coords
 from improver_tests.categorical.decision_tree import set_up_wxcube, wxcode_decision_tree
@@ -48,7 +49,6 @@ from improver_tests.categorical.decision_tree import set_up_wxcube, wxcode_decis
 MODEL_ID_ATTR = "mosg__model_configuration"
 RECORD_RUN_ATTR = "mosg__model_run"
 TARGET_TIME = dt(2020, 6, 15, 18)
-TIME_FORMAT = "%Y%m%dT%H%MZ"
 
 
 @pytest.fixture(name="wxcode_series")
@@ -126,8 +126,8 @@ def wxcode_series_fixture(
                 wxcubes[-1].attributes.update(
                     {
                         RECORD_RUN_ATTR: (
-                            f"uk_det:{ukv_time:{TIME_FORMAT}}:{ukv_weight:{WEIGHT_FORMAT}}\n"
-                            f"uk_ens:{enukx_time:{TIME_FORMAT}}:{enukx_weight:{WEIGHT_FORMAT}}"
+                            f"uk_det:{ukv_time:{DT_FORMAT}}:{ukv_weight:{WEIGHT_FORMAT}}\n"
+                            f"uk_ens:{enukx_time:{DT_FORMAT}}:{enukx_weight:{WEIGHT_FORMAT}}"
                         )
                     }
                 )
@@ -136,7 +136,7 @@ def wxcode_series_fixture(
                 wxcubes[-1].attributes.update(
                     {
                         RECORD_RUN_ATTR: (
-                            f"uk_ens:{enukx_time:{TIME_FORMAT}}:{enukx_weight:{WEIGHT_FORMAT}}"
+                            f"uk_ens:{enukx_time:{DT_FORMAT}}:{enukx_weight:{WEIGHT_FORMAT}}"
                         )
                     }
                 )

--- a/improver_tests/categorical/test_utilities.py
+++ b/improver_tests/categorical/test_utilities.py
@@ -112,7 +112,7 @@ class Test_categorical_attributes(IrisTest):
         data = np.array(
             [0, 1, 5, 11, 20, 5, 9, 10, 4, 2, 0, 1, 29, 30, 1, 5, 6, 6], dtype=np.int32
         ).reshape((2, 3, 3))
-        cube = set_up_variable_cube(data, "weather_code", "1",)
+        cube = set_up_variable_cube(data, name="weather_code", units="1",)
         date_times = [
             datetime.datetime(2017, 11, 19, 0, 30),
             datetime.datetime(2017, 11, 19, 1, 30),

--- a/improver_tests/precipitation_type/hail_fraction/test_HailFraction.py
+++ b/improver_tests/precipitation_type/hail_fraction/test_HailFraction.py
@@ -49,8 +49,8 @@ def setup_cubes():
     vertical_updraught_data = np.zeros((2, 2), dtype=np.float32)
     vertical_updraught = set_up_variable_cube(
         vertical_updraught_data,
-        "maximum_vertical_updraught",
-        "m s-1",
+        name="maximum_vertical_updraught",
+        units="m s-1",
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
         standard_grid_metadata="gl_ens",
@@ -59,8 +59,8 @@ def setup_cubes():
     hail_size_data = np.zeros((2, 2), dtype=np.float32)
     hail_size = set_up_variable_cube(
         hail_size_data,
-        "size_of_hail_stones",
-        "m",
+        name="size_of_hail_stones",
+        units="m",
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
         standard_grid_metadata="gl_ens",
@@ -69,8 +69,8 @@ def setup_cubes():
     cloud_condensation_level_data = np.zeros((2, 2), dtype=np.float32)
     cloud_condensation_level = set_up_variable_cube(
         cloud_condensation_level_data,
-        "air_temperature_at_condensation_level",
-        "K",
+        name="air_temperature_at_condensation_level",
+        units="K",
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
         standard_grid_metadata="gl_ens",
@@ -79,8 +79,8 @@ def setup_cubes():
     convective_cloud_top_data = np.zeros((2, 2), dtype=np.float32)
     convective_cloud_top = set_up_variable_cube(
         convective_cloud_top_data,
-        "air_temperature_at_convective_cloud_top",
-        "K",
+        name="air_temperature_at_convective_cloud_top",
+        units="K",
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
         standard_grid_metadata="gl_ens",
@@ -89,8 +89,8 @@ def setup_cubes():
     hail_melting_level_data = np.zeros((2, 2), dtype=np.float32)
     hail_melting_level = set_up_variable_cube(
         hail_melting_level_data,
-        "altitude_of_rain_from_hail_falling_level",
-        "m",
+        name="altitude_of_rain_from_hail_falling_level",
+        units="m",
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
         standard_grid_metadata="gl_ens",
@@ -99,8 +99,8 @@ def setup_cubes():
     altitude_data = np.zeros((2, 2), dtype=np.float32)
     altitude = set_up_variable_cube(
         altitude_data,
-        "altitude",
-        "m",
+        name="altitude",
+        units="m",
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
         standard_grid_metadata="gl_ens",

--- a/improver_tests/precipitation_type/snow_fraction/test_SnowFraction.py
+++ b/improver_tests/precipitation_type/snow_fraction/test_SnowFraction.py
@@ -63,8 +63,8 @@ def setup_cubes(rain_data=RAIN_DATA, snow_data=SNOW_DATA, name="{phase}rate"):
         time_bounds = (datetime(2017, 11, 10, 3, 0), datetime(2017, 11, 10, 4, 0))
     rain = set_up_variable_cube(
         rain_data,
-        name.format(phase="rain"),
-        units,
+        name=name.format(phase="rain"),
+        units=units,
         time_bounds=time_bounds,
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,
@@ -72,8 +72,8 @@ def setup_cubes(rain_data=RAIN_DATA, snow_data=SNOW_DATA, name="{phase}rate"):
     )
     snow = set_up_variable_cube(
         snow_data,
-        name.format(phase="lwe_snow"),
-        units,
+        name=name.format(phase="lwe_snow"),
+        units=units,
         time_bounds=time_bounds,
         spatial_grid="equalarea",
         attributes=COMMON_ATTRS,

--- a/improver_tests/regrid/test_AdjustLandSeaPoints.py
+++ b/improver_tests/regrid/test_AdjustLandSeaPoints.py
@@ -115,7 +115,10 @@ class Test_correct_where_input_true(IrisTest):
         data = np.ones((3, 3), dtype=np.float32)
         data[1, 1] = 0.0
         cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
         self.plugin.input_land = cube.copy()
         self.plugin.output_land = cube.copy()
@@ -191,7 +194,10 @@ class Test_correct_where_input_true(IrisTest):
         data = np.ones((5, 5), dtype=np.float32)
         data[1, 1] = 0.0
         cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
         self.plugin.output_land = cube.copy()
         self.plugin.nearest_cube = cube.copy()
@@ -252,9 +258,9 @@ class Test_process(IrisTest):
 
         self.cube = set_up_variable_cube(
             data_cube,
-            "precipitation_amount",
-            "kg m^-2",
-            "equalarea",
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
             x_grid_spacing=2000,
             y_grid_spacing=2000,
             domain_corner=(0, -50000),

--- a/improver_tests/regrid/test_RegridWithLandSeaMask.py
+++ b/improver_tests/regrid/test_RegridWithLandSeaMask.py
@@ -88,9 +88,9 @@ def define_source_target_grid_data():
     out_mask[1, 0] = 0
 
     # create cube with default spacing
-    cube_in = set_up_variable_cube(data, "air_temperature", "Celsius")
-    cube_in_mask = set_up_variable_cube(in_mask, "Land_Binary_Mask", "1")
-    cube_out_mask = set_up_variable_cube(out_mask, "Land_Binary_Mask", "1")
+    cube_in = set_up_variable_cube(data, name="air_temperature", units="Celsius")
+    cube_in_mask = set_up_variable_cube(in_mask, name="Land_Binary_Mask", units="1")
+    cube_out_mask = set_up_variable_cube(out_mask, name="Land_Binary_Mask", units="1")
 
     # modify cube coordinates to the designed value
     cube_in = modify_cube_coordinate_value(cube_in, in_lons, in_lats)
@@ -130,9 +130,9 @@ def define_source_target_grid_data_same_domain():
     out_mask[1, 0] = 0
 
     # create cube with default spacing
-    cube_in = set_up_variable_cube(data, "air_temperature", "Celsius")
-    cube_in_mask = set_up_variable_cube(in_mask, "Land_Binary_Mask", "1")
-    cube_out_mask = set_up_variable_cube(out_mask, "Land_Binary_Mask", "1")
+    cube_in = set_up_variable_cube(data, name="air_temperature", units="Celsius")
+    cube_in_mask = set_up_variable_cube(in_mask, name="Land_Binary_Mask", units="1")
+    cube_out_mask = set_up_variable_cube(out_mask, name="Land_Binary_Mask", units="1")
 
     # modify cube coordinates to the designed value
     cube_in = modify_cube_coordinate_value(cube_in, in_lons, in_lats)

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -717,7 +717,7 @@ class Test_set_up_spot_variable_cube(IrisTest):
         self.assertArrayAlmostEqual(result.data, self.data)
         self.assertEqual(result.attributes, {})
 
-        # check dimension coordinates
+        # check auxiliary coordinates associated with expected dimension
         expected_site_dim = result.coord_dims("spot_index")
         for crd in self.site_crds:
             self.assertEqual(result.coord_dims(crd), expected_site_dim)

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -924,6 +924,19 @@ class Test_set_up_spot_variable_cube(IrisTest):
         self.assertArrayEqual(result.coord("wmo_id").points, wmo_ids)
         self.assertArrayEqual(result.coord(unique_site_id_key).points, unique_ids)
 
+    def test_no_unique_id_key_exception(self):
+        """Test an exception is raised if unique_site_ids are provided but no
+        unique_site_id_key is provided."""
+
+        wmo_ids = ["00009", "00008", "00007", "00006"]
+        unique_ids = ["00000020", "00000100", "00005000", "00999999"]
+
+        msg = "A unique_site_id_key must be provided if a unique_site_id"
+        with self.assertRaisesRegex(ValueError, msg):
+            set_up_spot_variable_cube(
+                self.data, wmo_ids=wmo_ids, unique_site_id=unique_ids,
+            )
+
 
 class Test_set_up_percentile_cube(IrisTest):
     """Test the set_up_percentile_cube function"""

--- a/improver_tests/synthetic_data/test_set_up_test_cubes.py
+++ b/improver_tests/synthetic_data/test_set_up_test_cubes.py
@@ -49,6 +49,9 @@ from improver.synthetic_data.set_up_test_cubes import (
     construct_yx_coords,
     set_up_percentile_cube,
     set_up_probability_cube,
+    set_up_spot_percentile_cube,
+    set_up_spot_probability_cube,
+    set_up_spot_variable_cube,
     set_up_variable_cube,
 )
 from improver.utilities.cube_manipulation import get_dim_coord_names
@@ -443,7 +446,7 @@ class Test_set_up_variable_cube(IrisTest):
         """Test error is raised if the realizations provided do not match the
         data dimensions"""
         realizations_len = 4
-        data_len = len(self.data_3d[0])
+        data_len = self.data_3d.shape[0]
         msg = "Cannot generate {} realizations with data of length {}".format(
             realizations_len, data_len
         )
@@ -456,7 +459,7 @@ class Test_set_up_variable_cube(IrisTest):
         """Test error is raised if the heights provided do not match the
         data dimensions"""
         height_levels_len = 4
-        data_len = len(self.data_3d[0])
+        data_len = self.data_3d.shape[0]
         msg = "Cannot generate {} heights with data of length {}".format(
             height_levels_len, data_len
         )
@@ -499,7 +502,7 @@ class Test_set_up_variable_cube(IrisTest):
     def test_error_no_height_levels_4d_data(self):
         """ Tests error is raised if 4d data provided but not height_levels """
         data_4d = np.array([self.data_3d, self.data_3d])
-        msg = "Height levels must be provided if data has 4 dimensions."
+        msg = "Height levels must be provided if data has > 3 dimensions."
         with self.assertRaisesRegex(ValueError, msg):
             _ = set_up_variable_cube(data_4d)
 
@@ -690,6 +693,238 @@ class Test_set_up_variable_cube(IrisTest):
         )
 
 
+class Test_set_up_spot_variable_cube(IrisTest):
+    """Test the set_up_spot_variable_cube base function. Much of this
+    functionality overlaps with the gridded case, so these tests primarily
+    cover the spot specific elements."""
+
+    def setUp(self):
+        """Set up simple temperature data array"""
+        self.data = np.linspace(275.0, 284.0, 4).astype(np.float32)
+        self.data_2d = np.array([self.data, self.data, self.data])
+        self.site_crds = ["latitude", "longitude", "altitude", "wmo_id"]
+
+    def test_defaults(self):
+        """Test default arguments produce cube with expected dimensions
+        and metadata"""
+        result = set_up_spot_variable_cube(self.data)
+
+        # check type, data and attributes
+        self.assertIsInstance(result, iris.cube.Cube)
+        self.assertEqual(result.standard_name, "air_temperature")
+        self.assertEqual(result.name(), "air_temperature")
+        self.assertEqual(result.units, "K")
+        self.assertArrayAlmostEqual(result.data, self.data)
+        self.assertEqual(result.attributes, {})
+
+        # check dimension coordinates
+        expected_site_dim = result.coord_dims("spot_index")
+        for crd in self.site_crds:
+            self.assertEqual(result.coord_dims(crd), expected_site_dim)
+
+        # check scalar time coordinates
+        for time_coord in ["time", "forecast_reference_time"]:
+            self.assertEqual(result.coord(time_coord).dtype, np.int64)
+        self.assertEqual(result.coord("forecast_period").dtype, np.int32)
+
+        expected_time = datetime(2017, 11, 10, 4, 0)
+        time_point = iris_time_to_datetime(result.coord("time"))[0]
+        self.assertEqual(time_point, expected_time)
+
+        expected_frt = datetime(2017, 11, 10, 0, 0)
+        frt_point = iris_time_to_datetime(result.coord("forecast_reference_time"))[0]
+        self.assertEqual(frt_point, expected_frt)
+
+        self.assertEqual(result.coord("forecast_period").units, "seconds")
+        self.assertEqual(result.coord("forecast_period").points[0], 14400)
+
+        check_mandatory_standards(result)
+
+    def test_height_levels(self):
+        """Test height coordinate is added"""
+        height_levels = [1.5, 3.0, 4.5]
+        expected_units = "m"
+        expected_attributes = {"positive": "up"}
+        expected_site_dim = 1
+        result = set_up_spot_variable_cube(self.data_2d, height_levels=height_levels)
+        self.assertArrayAlmostEqual(result.data, self.data_2d)
+        self.assertEqual(result.coord_dims("height"), (0,))
+        self.assertArrayEqual(result.coord("height").points, np.array(height_levels))
+        self.assertEqual(result.coord("height").units, expected_units)
+        self.assertEqual(result.coord("height").attributes, expected_attributes)
+        for crd in self.site_crds:
+            self.assertEqual(result.coord_dims(crd)[0], expected_site_dim)
+
+    def test_pressure_levels(self):
+        """Test pressure coordinate is added"""
+        height_levels = [90000, 70000, 3000]
+        expected_units = "Pa"
+        pressure = True
+        expected_attributes = {"positive": "down"}
+        expected_site_dim = 1
+        result = set_up_spot_variable_cube(
+            self.data_2d, height_levels=height_levels, pressure=pressure
+        )
+        self.assertArrayAlmostEqual(result.data, self.data_2d)
+        self.assertEqual(result.coord_dims("pressure"), (0,))
+        self.assertArrayEqual(result.coord("pressure").points, np.array(height_levels))
+        self.assertEqual(result.coord("pressure").units, expected_units)
+        self.assertEqual(result.coord("pressure").attributes, expected_attributes)
+        for crd in self.site_crds:
+            self.assertEqual(result.coord_dims(crd)[0], expected_site_dim)
+
+    def test_realizations_from_data(self):
+        """Test realization coordinate is added for 3D data"""
+        expected_site_dim = 1
+        result = set_up_spot_variable_cube(self.data_2d)
+        self.assertArrayAlmostEqual(result.data, self.data_2d)
+        self.assertEqual(result.coord_dims("realization"), (0,))
+        self.assertArrayEqual(result.coord("realization").points, np.array([0, 1, 2]))
+        for crd in self.site_crds:
+            self.assertEqual(result.coord_dims(crd)[0], expected_site_dim)
+
+    def test_realizations(self):
+        """Test specific realization values"""
+        result = set_up_spot_variable_cube(
+            self.data_2d, realizations=np.array([0, 3, 4])
+        )
+        self.assertArrayEqual(result.coord("realization").points, np.array([0, 3, 4]))
+
+    def test_error_unmatched_realizations(self):
+        """Test error is raised if the realizations provided do not match the
+        data dimensions"""
+        realizations_len = 4
+        data_len = self.data_2d.shape[0]
+        msg = "Cannot generate {} realizations with data of length {}".format(
+            realizations_len, data_len
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_spot_variable_cube(
+                self.data_2d, realizations=np.arange(realizations_len)
+            )
+
+    def test_error_unmatched_height_levels(self):
+        """Test error is raised if the heights provided do not match the
+        data dimensions"""
+        height_levels_len = 4
+        data_len = self.data_2d.shape[0]
+        msg = "Cannot generate {} heights with data of length {}".format(
+            height_levels_len, data_len
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_spot_variable_cube(
+                self.data_2d, height_levels=np.arange(height_levels_len)
+            )
+
+    def test_realizations_from_data_height_levels(self):
+        """ Tests realizations from data and height coordinates added """
+        height_levels = [1.5, 3.0, 4.5]
+        data_3d = np.array([self.data_2d, self.data_2d])
+        expected_site_dim = 2
+        result = set_up_spot_variable_cube(data_3d, height_levels=height_levels)
+        self.assertArrayAlmostEqual(result.data, data_3d)
+        self.assertEqual(result.coord_dims("realization"), (0,))
+        self.assertArrayEqual(result.coord("realization").points, np.array([0, 1]))
+        self.assertEqual(result.coord_dims("height"), (1,))
+        self.assertArrayEqual(result.coord("height").points, np.array(height_levels))
+        for crd in self.site_crds:
+            self.assertEqual(result.coord_dims(crd)[0], expected_site_dim)
+
+    def test_realizations_height_levels(self):
+        """ Tests realizations and height coordinates added """
+        realizations = [0, 3]
+        height_levels = [1.5, 3.0, 4.5]
+        data_3d = np.array([self.data_2d, self.data_2d])
+        expected_site_dim = 2
+        result = set_up_spot_variable_cube(
+            data_3d, realizations=realizations, height_levels=height_levels
+        )
+        self.assertArrayAlmostEqual(result.data, data_3d)
+        self.assertEqual(result.coord_dims("realization"), (0,))
+        self.assertArrayEqual(
+            result.coord("realization").points, np.array(realizations)
+        )
+        self.assertEqual(result.coord_dims("height"), (1,))
+        self.assertArrayEqual(result.coord("height").points, np.array(height_levels))
+        for crd in self.site_crds:
+            self.assertEqual(result.coord_dims(crd)[0], expected_site_dim)
+
+    def test_error_no_height_levels_3d_data(self):
+        """ Tests error is raised if 3d data provided but not height_levels """
+        data_3d = np.array([self.data_2d, self.data_2d])
+        msg = "Height levels must be provided if data has > 2 dimensions."
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_spot_variable_cube(data_3d)
+
+    def test_error_too_many_dimensions(self):
+        """Test error is raised if input cube has more than 4 dimensions"""
+        data_4d = np.array([[self.data_2d, self.data_2d], [self.data_2d, self.data_2d]])
+        msg = "Expected 1 to 3 dimensions on input data: got 4"
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_spot_variable_cube(data_4d)
+
+    def test_error_not_enough_dimensions(self):
+        """Test error is raised if 3D input cube and both realizations and heights provided"""
+        realizations = [0, 3, 4]
+        height_levels = [1.5, 3.0, 4.5]
+        msg = (
+            "Input data must have 3 dimensions to add both realization "
+            "and height coordinates: got 2"
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = set_up_spot_variable_cube(
+                self.data_2d, realizations=realizations, height_levels=height_levels
+            )
+
+    def test_custom_coords(self):
+        """Test that a cube can be set-up with custom coordinates associated
+        with the spot_index, e.g. latitude, altitude, etc."""
+
+        latitudes = [50, 55, 56, 57]
+        longitudes = [-10, 5, 70, 71]
+        altitudes = [-1, 0, 30, 20]
+        wmo_ids = [9, 8, 7, 6]
+        unique_ids = [20, 100, 5000, 999999]
+        unique_site_id_key = "met_office_site_id"
+
+        result = set_up_spot_variable_cube(
+            self.data,
+            latitudes=latitudes,
+            longitudes=longitudes,
+            altitudes=altitudes,
+            wmo_ids=wmo_ids,
+            unique_site_id=unique_ids,
+            unique_site_id_key=unique_site_id_key,
+        )
+        self.assertArrayEqual(result.coord("latitude").points, latitudes)
+        self.assertArrayEqual(result.coord("longitude").points, longitudes)
+        self.assertArrayEqual(result.coord("altitude").points, altitudes)
+        self.assertArrayEqual(
+            result.coord("wmo_id").points, [f"{item:05d}" for item in wmo_ids]
+        )
+        self.assertArrayEqual(
+            result.coord(unique_site_id_key).points,
+            [f"{item:08d}" for item in unique_ids],
+        )
+
+    def test_site_ids_as_strings(self):
+        """Test that site IDs provided preformatted as strings are handled
+        correctly."""
+
+        wmo_ids = ["00009", "00008", "00007", "00006"]
+        unique_ids = ["00000020", "00000100", "00005000", "00999999"]
+        unique_site_id_key = "met_office_site_id"
+
+        result = set_up_spot_variable_cube(
+            self.data,
+            wmo_ids=wmo_ids,
+            unique_site_id=unique_ids,
+            unique_site_id_key=unique_site_id_key,
+        )
+        self.assertArrayEqual(result.coord("wmo_id").points, wmo_ids)
+        self.assertArrayEqual(result.coord(unique_site_id_key).points, unique_ids)
+
+
 class Test_set_up_percentile_cube(IrisTest):
     """Test the set_up_percentile_cube function"""
 
@@ -728,6 +963,39 @@ class Test_set_up_percentile_cube(IrisTest):
         """Test a cube with one percentile correctly stores this as a scalar
         coordinate"""
         result = set_up_percentile_cube(self.data[1:2], self.percentiles[1:2])
+        dim_coords = get_dim_coord_names(result)
+        self.assertNotIn("percentile", dim_coords)
+
+
+class Test_set_up_spot_percentile_cube(IrisTest):
+    """Test the set_up_spot_percentile_cube function. These tests are largely
+    the same as for the gridded case, omitting the grid metadata check."""
+
+    def setUp(self):
+        """Set up simple array of percentile-type data"""
+        self.data = np.array(
+            [
+                [273.5, 275.1, 274.9, 272.0],
+                [274.2, 276.4, 275.5, 274.5],
+                [275.6, 278.1, 277.2, 276.1],
+            ],
+            dtype=np.float32,
+        )
+        self.percentiles = np.array([20, 50, 80])
+
+    def test_defaults(self):
+        """Test default arguments produce cube with expected dimensions
+        and metadata"""
+        result = set_up_spot_percentile_cube(self.data, self.percentiles)
+        perc_coord = result.coord("percentile")
+        self.assertArrayEqual(perc_coord.points, self.percentiles)
+        self.assertEqual(perc_coord.units, "%")
+        check_mandatory_standards(result)
+
+    def test_single_percentile(self):
+        """Test a cube with one percentile correctly stores this as a scalar
+        coordinate"""
+        result = set_up_spot_percentile_cube(self.data[1:2], self.percentiles[1:2])
         dim_coords = get_dim_coord_names(result)
         self.assertNotIn("percentile", dim_coords)
 
@@ -816,6 +1084,66 @@ class Test_set_up_probability_cube(IrisTest):
         )
         self.assertEqual(thresh_coord.name(), "air_temperature")
         self.assertEqual(thresh_coord.var_name, "threshold")
+
+
+class Test_set_up_spot_probability_cube(IrisTest):
+    """Test the set_up_spot_probability_cube function. These tests are largely
+    the same as for the gridded case, omitting the grid metadata check."""
+
+    def setUp(self):
+        """Set up array of exceedance probabilities"""
+        self.data = np.array(
+            [[1.0, 1.0, 0.9, 0.9], [0.8, 0.8, 0.7, 0.8], [0.6, 0.4, 0.3, 0.3]],
+            dtype=np.float32,
+        )
+        self.thresholds = np.array([275.0, 275.5, 276.0], dtype=np.float32)
+
+    def test_defaults(self):
+        """Test default arguments produce cube with expected dimensions
+        and metadata"""
+        result = set_up_spot_probability_cube(self.data, self.thresholds)
+        thresh_coord = find_threshold_coordinate(result)
+        self.assertEqual(
+            result.name(), "probability_of_air_temperature_above_threshold"
+        )
+        self.assertEqual(result.units, "1")
+        self.assertArrayEqual(thresh_coord.points, self.thresholds)
+        self.assertEqual(thresh_coord.name(), "air_temperature")
+        self.assertEqual(thresh_coord.var_name, "threshold")
+        self.assertEqual(thresh_coord.units, "K")
+        self.assertEqual(len(thresh_coord.attributes), 1)
+        self.assertEqual(
+            thresh_coord.attributes["spp__relative_to_threshold"], "greater_than",
+        )
+        check_mandatory_standards(result)
+
+    def test_relative_to_threshold(self):
+        """Test ability to reset the "spp__relative_to_threshold" attribute"""
+        data = np.flipud(self.data)
+        result = set_up_spot_probability_cube(
+            data, self.thresholds, spp__relative_to_threshold="less_than"
+        )
+        self.assertEqual(len(result.coord(var_name="threshold").attributes), 1)
+        self.assertEqual(
+            result.coord(var_name="threshold").attributes["spp__relative_to_threshold"],
+            "less_than",
+        )
+
+    def test_relative_to_threshold_set(self):
+        """Test that an error is raised if the "spp__relative_to_threshold"
+        attribute has not been set when setting up a probability cube"""
+        msg = "The spp__relative_to_threshold attribute MUST be set"
+        with self.assertRaisesRegex(ValueError, msg):
+            set_up_spot_probability_cube(
+                self.data, self.thresholds, spp__relative_to_threshold=None
+            )
+
+    def test_single_threshold(self):
+        """Test a cube with one threshold correctly stores this as a scalar
+        coordinate"""
+        result = set_up_spot_probability_cube(self.data[1:2], self.thresholds[1:2])
+        dim_coords = get_dim_coord_names(result)
+        self.assertNotIn("air_temperature", dim_coords)
 
 
 class Test_add_coordinate(IrisTest):

--- a/improver_tests/utilities/solar/test_DayNightMask.py
+++ b/improver_tests/utilities/solar/test_DayNightMask.py
@@ -103,7 +103,11 @@ class Test__create_daynight_mask(IrisTest):
         data[:, 7, 7] = 0.0
 
         self.cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea", attributes=ATTRIBUTES
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
+            attributes=ATTRIBUTES,
         )
         self.spot_cube = create_spot_cube()
 
@@ -146,16 +150,16 @@ class Test__daynight_lat_lon_cube(IrisTest):
         data = np.ones((16, 16), dtype=np.float32)
         self.cube = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
+            name="precipitation_amount",
+            units="kg m^-2",
             x_grid_spacing=1,
             y_grid_spacing=1,
             domain_corner=(49, -8),
         )
         self.cube_360 = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
+            name="precipitation_amount",
+            units="kg m^-2",
             x_grid_spacing=1,
             y_grid_spacing=1,
             domain_corner=(49, 345),
@@ -210,9 +214,9 @@ class Test_process(IrisTest):
         vt = datetime(2015, 11, 20, 8, 0)
         self.cube = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
-            "equalarea",
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
             x_grid_spacing=2000,
             y_grid_spacing=2000,
             domain_corner=(0, -30000),
@@ -225,9 +229,9 @@ class Test_process(IrisTest):
         bounds = timedelta(minutes=4)
         self.cube_time_bounds = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
-            "equalarea",
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
             x_grid_spacing=2000,
             y_grid_spacing=2000,
             domain_corner=(0, -30000),
@@ -239,8 +243,8 @@ class Test_process(IrisTest):
         # Lat lon cubes
         self.cube_lat_lon = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
+            name="precipitation_amount",
+            units="kg m^-2",
             x_grid_spacing=1,
             y_grid_spacing=1,
             domain_corner=(49, -8),
@@ -249,8 +253,8 @@ class Test_process(IrisTest):
         )
         self.cube_lat_lon_360 = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
+            name="precipitation_amount",
+            units="kg m^-2",
             x_grid_spacing=1,
             y_grid_spacing=1,
             domain_corner=(49, 345),

--- a/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/test_DifferenceBetweenAdjacentGridSquares.py
@@ -51,7 +51,9 @@ class Test_create_difference_cube(IrisTest):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
         self.diff_in_y_array = np.array([[1, 2, 3], [3, 6, 9]])
-        self.cube = set_up_variable_cube(data, "wind_speed", "m s-1", "equalarea",)
+        self.cube = set_up_variable_cube(
+            data, name="wind_speed", units="m s-1", spatial_grid="equalarea",
+        )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_y_dimension(self):
@@ -95,7 +97,9 @@ class Test_calculate_difference(IrisTest):
     def setUp(self):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
-        self.cube = set_up_variable_cube(data, "wind_speed", "m s-1", "equalarea",)
+        self.cube = set_up_variable_cube(
+            data, name="wind_speed", units="m s-1", spatial_grid="equalarea",
+        )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
     def test_x_dimension(self):
@@ -150,7 +154,11 @@ class Test_process(IrisTest):
         """Set up cube."""
         data = np.array([[1, 2, 3], [2, 4, 6], [5, 10, 15]])
         self.cube = set_up_variable_cube(
-            data, "wind_speed", "m s-1", "equalarea", realizations=np.array([1, 2]),
+            data,
+            name="wind_speed",
+            units="m s-1",
+            spatial_grid="equalarea",
+            realizations=np.array([1, 2]),
         )
         self.plugin = DifferenceBetweenAdjacentGridSquares()
 
@@ -191,7 +199,11 @@ class Test_process(IrisTest):
         expected_x = np.array([[[1, 1], [2, 2], [5, 5]], [[1, 1], [0, 4], [5, 10]]])
         expected_y = np.array([[[1, 2, 3], [3, 6, 9]], [[1, 0, 3], [3, 8, 14]]])
         cube = set_up_variable_cube(
-            data, "wind_speed", "m s-1", "equalarea", realizations=np.array([1, 2]),
+            data,
+            name="wind_speed",
+            units="m s-1",
+            spatial_grid="equalarea",
+            realizations=np.array([1, 2]),
         )
         result = self.plugin.process(cube)
         self.assertIsInstance(result[0], iris.cube.Cube)

--- a/improver_tests/utilities/test_OccurrenceWithinVicinity.py
+++ b/improver_tests/utilities/test_OccurrenceWithinVicinity.py
@@ -328,9 +328,9 @@ def test_with_invalid_land_mask_coords(cube, land_mask_cube):
 def cube_with_realizations_fixture() -> Cube:
     return set_up_variable_cube(
         np.zeros((2, 4, 4), dtype=np.float32),
-        "lwe_precipitation_rate",
-        "m s-1",
-        "equalarea",
+        name="lwe_precipitation_rate",
+        units="m s-1",
+        spatial_grid="equalarea",
         x_grid_spacing=2000.0,
         y_grid_spacing=2000.0,
         domain_corner=(0.0, 0.0),

--- a/improver_tests/utilities/test_cube_checker.py
+++ b/improver_tests/utilities/test_cube_checker.py
@@ -63,7 +63,10 @@ class Test_check_for_x_and_y_axes(IrisTest):
         """Set up a cube."""
         data = np.ones((1, 5, 5), dtype=np.float32)
         self.cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
 
     def test_no_y_coordinate(self):
@@ -110,7 +113,10 @@ class Test_check_cube_coordinates(IrisTest):
         """Set up a cube."""
         data = np.ones((1, 16, 16), dtype=np.float32)
         self.cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
         self.squeezed_cube = iris.util.squeeze(self.cube)
 
@@ -194,7 +200,10 @@ class Test_find_dimension_coordinate_mismatch(IrisTest):
         """Set up a cube."""
         data = np.ones((2, 16, 16), dtype=np.float32)
         self.cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
 
     def test_no_mismatch(self):
@@ -248,10 +257,16 @@ class Test_spatial_coords_match(IrisTest):
         data_a = np.ones((1, 16, 16), dtype=np.float32)
         data_b = np.ones((1, 10, 10), dtype=np.float32)
         self.cube_a = set_up_variable_cube(
-            data_a, "precipitation_amount", "kg m^-2", "equalarea",
+            data_a,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
         self.cube_b = set_up_variable_cube(
-            data_b, "precipitation_amount", "kg m^-2", "equalarea",
+            data_b,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
 
     def test_single_cube(self):
@@ -291,7 +306,10 @@ class Test_spatial_coords_match(IrisTest):
         data_c = np.ones((4, 16, 16), dtype=np.float32)
         data_c[:, 7, 7] = 0.0
         cube_c = set_up_variable_cube(
-            data_c, "precipitation_amount", "kg m^-2", "equalarea",
+            data_c,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
         r_coord = cube_c.coord("realization")
         r_coord.points = [r * 2 for r in r_coord.points]

--- a/improver_tests/utilities/test_spatial.py
+++ b/improver_tests/utilities/test_spatial.py
@@ -304,7 +304,10 @@ class Test_convert_distance_into_number_of_grid_cells(IrisTest):
         data = np.ones((1, 16, 16), dtype=np.float32)
         data[:, 7, 7] = 0.0
         self.cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2", "equalarea",
+            data,
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
         )
 
     def test_basic_distance_to_grid_cells(self):
@@ -520,15 +523,15 @@ class Test_get_grid_y_x_values(IrisTest):
         """Set up the cube."""
         data = np.ones((1, 2, 4), dtype=np.float32)
         self.latlon_cube = set_up_variable_cube(
-            data, "precipitation_amount", "kg m^-2",
+            data, name="precipitation_amount", units="kg m^-2",
         )
         self.expected_lons = np.array([-15, -5, 5, 15, -15, -5, 5, 15]).reshape(2, 4)
         self.expected_lats = np.array([-5, -5, -5, -5, 5, 5, 5, 5]).reshape(2, 4)
         self.equalarea_cube = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
-            "equalarea",
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
             x_grid_spacing=2000,
             y_grid_spacing=2000,
             domain_corner=(-1000, -1000),
@@ -566,9 +569,9 @@ class Test_transform_grid_to_lat_lon(IrisTest):
         data = np.ones((1, 2, 2), dtype=np.float32)
         self.cube = set_up_variable_cube(
             data,
-            "precipitation_amount",
-            "kg m^-2",
-            "equalarea",
+            name="precipitation_amount",
+            units="kg m^-2",
+            spatial_grid="equalarea",
             x_grid_spacing=2000000,
             y_grid_spacing=2000000,
             domain_corner=(-1000000, -1000000),


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/430

- Adds the following helper functions for use in creating unit tests that use spot-cubes:
  - set_up_spot_variable_cube
  - set_up_spot_percentile_cube
  - set_up_spot_probability_cube
- Adds associated unit tests
- Modifies calls to the existing gridded functions where these did not use the keyword arguments explicitly.
- Modifies some unit tests as an example of how this can be used.
- Centralises the date-time format "%Y%m%dT%H%MZ" as we use this in several places and have never done so.

The commits are broken up as follows:

1. new functions, tests, fix-up existing calls, and (sorry) a partially modified choose weights test.
2. centralise the date-time format
3. modify some unit tests as examples of usage.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)