### PR TITLE
Correct generate_ororgraphic_smoothing_coefficients doc-string

### DIFF
--- a/improver/cli/generate_orographic_smoothing_coefficients.py
+++ b/improver/cli/generate_orographic_smoothing_coefficients.py
@@ -59,7 +59,7 @@ def process(
     The smoothing coefficients are calculated from the orography gradient using
     a simple equation with the user defined value for the power:
 
-    smoothing_coefficient = coefficient * gradient**power
+    smoothing_coefficient = gradient**power
 
     The resulting values are scaled between min_gradient_smoothing_coefficient
     and max_gradient_smoothing_coefficient to give the desired range of


### PR DESCRIPTION
As an IMPROVER scientist, I like it when equations in doc-strings accurately represent the actual calculations being carried out, rather than bamboozling me.

This (~ancient~ surprisingly young) [PR](https://github.com/metoppv/improver/pull/1359) changed the `generate_orographic_smoothing_coefficients` method so that it no longer required a `coefficient` to be specified, but rather normalised the calculated smoothing coefficients between user specified min and max values. The plugin doc-strings were updated accordingly, but a vestigial reference to a `coefficient` in the CLI doc-string remains. This PR removes that reference.


