### PR TITLE
MOBT-719: Frequency to count for time period averages

### DIFF
--- a/improver/cli/integrate_time_bounds.py
+++ b/improver/cli/integrate_time_bounds.py
@@ -15,7 +15,7 @@ def process(cube: cli.inputcube, *, new_name: str = None):
     time bounds over which it is defined to return a count or accumulation.
     The frequency or rate must be defined with time bounds, e.g. an average
     frequency across the period. This function will handle a cube with a
-    non-scalar time coordinate, multiplying each time in the coordiante by the
+    non-scalar time coordinate, multiplying each time in the coordinate by the
     related bounds.
 
     The returned cube has units equivalent to the input cube multiplied by

--- a/improver/cli/integrate_time_bounds.py
+++ b/improver/cli/integrate_time_bounds.py
@@ -10,7 +10,7 @@ from improver import cli
 
 @cli.clizefy
 @cli.with_output
-def process(cube: cli.inputcube, new_name=None):
+def process(cube: cli.inputcube, *, new_name: str = None):
     """Multiply a frequency or rate cube by the time period given by the
     time bounds over which it is defined to return a count or accumulation.
     The frequency or rate must be defined with time bounds, e.g. an average

--- a/improver/cli/integrate_time_bounds.py
+++ b/improver/cli/integrate_time_bounds.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# (C) Crown copyright, Met Office. All rights reserved.
+#
+# This file is part of IMPROVER and is released under a BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Script to multiply period average values by the period."""
+
+from improver import cli
+
+
+@cli.clizefy
+@cli.with_output
+def process(cube: cli.inputcube, new_name=None):
+    """Multiply a frequency or rate cube by the time period given by the
+    time bounds over which it is defined to return a count or accumulation.
+    The frequency or rate must be defined with time bounds, e.g. an average
+    frequency across the period.
+
+    The returned cube has units equivalent to the input cube multiplied by
+    seconds. Any time related cell methods are removed from the output cube
+    and a new "sum" over time cell method is added.
+
+    Args:
+        cube (iris.cube.Cube):
+            Cube to multiply
+        new_name (str):
+            New name for the output diagnostic.
+
+    Returns:
+        iris.cube.Cube:
+            A cube containing the time multiplied data.
+    """
+    from improver.utilities.temporal import integrate_time
+
+    return integrate_time(cube, new_name=new_name)

--- a/improver/cli/integrate_time_bounds.py
+++ b/improver/cli/integrate_time_bounds.py
@@ -14,7 +14,9 @@ def process(cube: cli.inputcube, *, new_name: str = None):
     """Multiply a frequency or rate cube by the time period given by the
     time bounds over which it is defined to return a count or accumulation.
     The frequency or rate must be defined with time bounds, e.g. an average
-    frequency across the period.
+    frequency across the period. This function will handle a cube with a
+    non-scalar time coordinate, multiplying each time in the coordiante by the
+    related bounds.
 
     The returned cube has units equivalent to the input cube multiplied by
     seconds. Any time related cell methods are removed from the output cube

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -289,7 +289,7 @@ def integrate_time(cube: Cube, new_name: str = None) -> Cube:
     time bounds over which it is defined to return a count or accumulation.
     The frequency or rate must be defined with time bounds, e.g. an average
     frequency across the period. This function will handle a cube with a
-    non-scalar time coordinate, multiplying each time in the coordiante by the
+    non-scalar time coordinate, multiplying each time in the coordinate by the
     related bounds.
 
     The returned cube has units equivalent to the input cube multiplied by

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -339,7 +339,7 @@ def integrate_time(cube: Cube, new_name: str = None) -> Cube:
     new_cell_method = CellMethod("sum", coords=["time"])
     new_cell_methods = [new_cell_method]
     for cm in integrated_cube.cell_methods:
-        if not "time" in cm.coord_names:
+        if "time" not in cm.coord_names:
             new_cell_methods.append(cm)
 
     integrated_cube.cell_methods = new_cell_methods

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -305,19 +305,23 @@ def integrate_time(cube: Cube, new_name: str = None) -> Cube:
     Returns:
         The cube with the data multiplied by the period in seconds defined
         by the time time bounds
+
+    Raises:
+        ValueError: If the input cube time coordinate does not have time
+                    bounds.
     """
     # Ensure cube has a time coordinate with bounds
     if not cube.coord("time").has_bounds():
         raise ValueError(
-            "time coordinate must have bounds to apply this time-bounds "
-            "integration")
+            "time coordinate must have bounds to apply this time-bounds " "integration"
+        )
 
     # For each grid of data associated with a time, multiply the rate / frequency
     # by the associated time interval to get an accumulation / count over the
     # period.
     integrated_cube = iris.cube.CubeList()
     for cslice in cube.slices_over("time"):
-        multiplier, = np.diff(cslice.coord("time").cell(0).bound)
+        (multiplier,) = np.diff(cslice.coord("time").cell(0).bound)
         multiplier = multiplier.total_seconds()
         cslice.data *= multiplier
         integrated_cube.append(cslice)

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -288,7 +288,9 @@ def integrate_time(cube: Cube, new_name: str = None) -> Cube:
     Multiply a frequency or rate cube by the time period given by the
     time bounds over which it is defined to return a count or accumulation.
     The frequency or rate must be defined with time bounds, e.g. an average
-    frequency across the period.
+    frequency across the period. This function will handle a cube with a
+    non-scalar time coordinate, multiplying each time in the coordiante by the
+    related bounds.
 
     The returned cube has units equivalent to the input cube multiplied by
     seconds.
@@ -304,7 +306,7 @@ def integrate_time(cube: Cube, new_name: str = None) -> Cube:
 
     Returns:
         The cube with the data multiplied by the period in seconds defined
-        by the time time bounds
+        by the bounds on the time coordinate.
 
     Raises:
         ValueError: If the input cube time coordinate does not have time
@@ -313,7 +315,7 @@ def integrate_time(cube: Cube, new_name: str = None) -> Cube:
     # Ensure cube has a time coordinate with bounds
     if not cube.coord("time").has_bounds():
         raise ValueError(
-            "time coordinate must have bounds to apply this time-bounds " "integration"
+            "time coordinate must have bounds to apply this time-bounds integration"
         )
 
     # For each grid of data associated with a time, multiply the rate / frequency

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -535,6 +535,9 @@ caa759d708afc535223bcf35924e98962675f6e3f690fe1f82c5de5ba08302b4  ./hail-size/te
 c4451e5a94a946215e5a3e09787b0d25c215aa4511110f46b6015c1c5aab13c9  ./hail-size/wet_bulb_freezing_altitude.nc
 0af18a52713334627696679bb369bb00332e5cb8f8a1a82ca9a2a7612071e6d3  ./hail-size/with_id_attr/kgo.nc
 76d84b674d8c0c9bed8bd27fad6697be7559c9ebe1c13296363717cbcd888add  ./hail-size/without_id_attr/kgo.nc
+cebc2ccbe6c8e33b3e39d65f07d189172133a3fc6c22e3567c61572e14750cef  ./integrate-time-bounds/basic/kgo.nc
+b8ae3b9d3db05fc0c8479bb707465aeaf140202ab4477d025f5c793e2d287dc8  ./integrate-time-bounds/basic/kgo_renamed.nc
+5aaa03199faf9df5fda699936b33df862b071b3790b04791fef31d8cc0fd074a  ./integrate-time-bounds/basic/lightning_frequency.nc
 84562b15f63f014168f6808bee71995a84185d3a62bf436eb7a537010dcf4015  ./interpolate-using-difference/basic/orog.nc
 854bba49c9daa66d930c2ea74300607297cd836ed8579e0a449a40e738e18af1  ./interpolate-using-difference/basic/sleet_rain_max_limited_kgo.nc
 0bcbf3e7d168b97a8229e24866ef110b11f6dd61d14c8d6f18d9c2003d93d5b8  ./interpolate-using-difference/basic/sleet_rain_min_limited_kgo.nc

--- a/improver_tests/acceptance/test_integrate_time_bounds.py
+++ b/improver_tests/acceptance/test_integrate_time_bounds.py
@@ -1,0 +1,37 @@
+# (C) Crown copyright, Met Office. All rights reserved.
+#
+# This file is part of IMPROVER and is released under a BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""
+Tests for the integrate_time_bounds CLI
+"""
+
+import pytest
+
+from . import acceptance as acc
+
+pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
+CLI = acc.cli_name_with_dashes(__file__)
+run_cli = acc.run_cli(CLI)
+
+
+def test_basic(tmp_path):
+    """Test conversion of lightning frequency to count."""
+    kgo_dir = acc.kgo_root() / "integrate-time-bounds/basic"
+    kgo_path = kgo_dir / "kgo.nc"
+    input_path = kgo_dir / "lightning_frequency.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)
+
+
+def test_rename(tmp_path):
+    """Test renaming the output diagnostic using the new-name kwarg."""
+    kgo_dir = acc.kgo_root() / "integrate-time-bounds/basic"
+    kgo_path = kgo_dir / "kgo_renamed.nc"
+    input_path = kgo_dir / "lightning_frequency.nc"
+    output_path = tmp_path / "output.nc"
+    args = [input_path, "--new-name", "number_of_lightning_flashes_per_unit_area", "--output", output_path]
+    run_cli(args)
+    acc.compare(output_path, kgo_path)

--- a/improver_tests/acceptance/test_integrate_time_bounds.py
+++ b/improver_tests/acceptance/test_integrate_time_bounds.py
@@ -32,6 +32,12 @@ def test_rename(tmp_path):
     kgo_path = kgo_dir / "kgo_renamed.nc"
     input_path = kgo_dir / "lightning_frequency.nc"
     output_path = tmp_path / "output.nc"
-    args = [input_path, "--new-name", "number_of_lightning_flashes_per_unit_area", "--output", output_path]
+    args = [
+        input_path,
+        "--new-name",
+        "number_of_lightning_flashes_per_unit_area",
+        "--output",
+        output_path,
+    ]
     run_cli(args)
     acc.compare(output_path, kgo_path)

--- a/improver_tests/utilities/temporal/test_temporal.py
+++ b/improver_tests/utilities/temporal/test_temporal.py
@@ -584,6 +584,24 @@ def test_integrate_time(period_cube, kwargs, expected):
         assert result.name() == kwargs["new_name"]
 
 
+@pytest.mark.parametrize("data,period_lengths", [(np.ones((5, 5)), [3600])])
+def test_integrate_non_second_units(period_cube):
+    """Test that input data with a rate expressed in a different time unit,
+    e.g. per minute, is returned with units that describe the data
+    correctly. The data itself will be expressed as an integral over seconds
+    but the cube units will include the necessary factor to account for the
+    differing input units."""
+
+    expected = np.full(period_cube.shape, 3600)
+    expected_units = Unit(f"{1./60} m-2")
+    period_cube.units = Unit("m-2 minute-1")
+
+    result = integrate_time(period_cube.copy())
+
+    np.testing.assert_array_equal(result.data, expected)
+    assert result.units == expected_units
+
+
 @pytest.mark.parametrize("data,period_lengths", [(np.ones((5, 5)), [10800])])
 def test_integrate_time_exception(period_cube):
     """Tests that the integrate_time function raises an exception if the cube


### PR DESCRIPTION
This change adds a function and CLI to multiply average rates / frequencies within periods by the length of the period over which they are defined to yield an accumulation / count over the same period. This is to be used in the first instance for converting lightning flash frequencies into counts.

Acceptance test data: https://github.com/metoppv/improver_test_data/pull/49

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)