### PR TITLE
BLD: Fix CI Tests / Sphinx-Pytest-Coverage (conda-forge) failing

### DIFF
--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -30,3 +30,4 @@ dependencies:
   - threadpoolctl
   # Pinned dependencies of dependencies
   - pillow<=10.0.1  # https://github.com/metoppv/improver/issues/2010
+  - pandas<=2.0.0  # https://github.com/metoppv/improver/issues/2010

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -28,3 +28,5 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
+  # Pinned dependencies of dependencies
+  - pillow<=10.0.1  # https://github.com/metoppv/improver/issues/2010


### PR DESCRIPTION
Changes in environment resulting in failure in `CI Tests / Sphinx-Pytest-Coverage (conda-forge)`

Most recent working `CI Tests / Sphinx-Pytest-Coverage (conda-forge)` run:

package | version | CI
--- | --- | ---
pandas | 2.0.0 (py39h2ad29b5_0) | [link](https://github.com/metoppv/improver/actions/runs/9091630360/job/24986612615?pr=1997#step:5:153)
pillow | 10.0.1 (py39h444a776_1) | [link](https://github.com/metoppv/improver/actions/runs/9091630360/job/24986612615?pr=1997#step:5:156)

Most recent (broken) `CI Tests / Sphinx-Pytest-Coverage (conda-forge)` run:

package | version | CI
--- | --- | ---
pandas | 2.2.2 (py39hfc16268_1) | [link](https://github.com/metoppv/improver/actions/runs/9810862589/job/27091941214#step:5:156)
pillow | 10.4.0 (py39h16a7006_0) | [link](https://github.com/metoppv/improver/actions/runs/9810862589/job/27091941214#step:5:159)

Failure in CI:

https://github.com/metoppv/improver/actions/runs/9810862589/job/27091941214?pr=2003
```
...
  File "/usr/share/miniconda/envs/imconda-forge/lib/python3.9/site-packages/PIL/Image.py", line 68, in <module>
    from ._typing import StrOrBytesPath, TypeGuard
  File "/usr/share/miniconda/envs/imconda-forge/lib/python3.9/site-packages/PIL/_typing.py", line 10, in <module>
    NumpyArray = npt.NDArray[Any]
AttributeError: module 'numpy.typing' has no attribute 'NDArray'
```

after pinning pillow only, we get a little further but still fails:

https://github.com/metoppv/improver/actions/runs/9835034815/job/27147915426#step:6:519
```
WARNING: autodoc: failed to import module 'dataframe_utilities' from module 'improver.calibration'; the following exception was raised:
C extension: None not built. If you want to import pandas from the source directory, you may need to run 'python setup.py build_ext' to build the C extensions first.
WARNING: autodoc: failed to import module 'dz_rescaling' from module 'improver.calibration'; the following exception was raised:
C extension: None not built. If you want to import pandas from the source directory, you may need to run 'python setup.py build_ext' to build the C extensions first.
```

## Issues

- Closes https://github.com/metoppv/improver/issues/2010