### PR TITLE
BUG: Fix Scheduled Tests Sphinx-Pytest-Coverage

### DIFF
--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -45,3 +45,6 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
+  # Pinned dependencies of dependencies
+  - pillow<=10.0.1  # https://github.com/metoppv/improver/issues/2010
+  - pandas<=2.0.0  # https://github.com/metoppv/improver/issues/2010


### PR DESCRIPTION
Scheduled sphinx build fails.  Same failure as the one I fixed from the other environment yml impacting CI for PRs previously.
This PR pulls over pinned packages introduced to the `conda-forge.yml` into the `latest.yml` file as I did in https://github.com/metoppv/improver/pull/2011

See [here](https://github.com/metoppv/improver/actions/runs/10138073967/job/28029201432#step:5:21)

![image](https://github.com/user-attachments/assets/edba786c-cd5b-4ab3-ae26-caa1e30958a5)

```
...
Exception occurred:
  File "/usr/share/miniconda/envs/imlatest/lib/python3.9/site-packages/PIL/_typing.py", line 10, in <module>
    NumpyArray = npt.NDArray[Any]
AttributeError: module 'numpy.typing' has no attribute 'NDArray'
The full traceback has been saved in /tmp/sphinx-err-y5_5n0y9.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:39: html] Error 2
make: Leaving directory '/home/runner/work/improver/improver/doc'
```