### PR TITLE
Fix CI tests in 1.6.x release branch

### DIFF
--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -28,3 +28,6 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
+  # Pinned dependencies of dependencies
+  - pillow<=10.0.1  # https://github.com/metoppv/improver/issues/2010
+  - pandas<=2.0.0  # https://github.com/metoppv/improver/issues/2010


### PR DESCRIPTION
Related to https://github.com/metoppv/improver/pull/2023

Description
This copies the solution to #2010 from #2011 into the 1.6.x release branch to fix an issue with the Sphinx builds failing for the environment built using conda-forge.yml.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

