### PR TITLE
Improver api changes

### DIFF
--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -73,6 +73,7 @@ PROCESSING_MODULES = {
     "LightningFromCapePrecip": "improver.lightning",
     "LightningMultivariateProbability_USAF2024": "improver.lightning",
     "ManipulateReliabilityTable": "improver.calibration.reliability_calibration",
+    "maximum_in_height": "improver.utilities.cube_manipulation",
     "MaxInTimeWindow": "improver.cube_combiner",
     "MergeCubes": "improver.utilities.cube_manipulation",
     "MergeCubesForWeightedBlending": "improver.blending.weighted_blend",

--- a/improver/cli/standardise.py
+++ b/improver/cli/standardise.py
@@ -57,11 +57,10 @@ def process(
     """
     from improver.standardise import StandardiseMetadata
 
-    return StandardiseMetadata()(
-        cube,
+    return StandardiseMetadata(
         new_name=new_name,
         new_units=new_units,
         coords_to_remove=coords_to_remove,
         coord_modification=coord_modification,
         attributes_dict=attributes_config,
-    )
+    )(cube)


### PR DESCRIPTION
Some left over changes to IMPROVER api to support eppgl_precip_type configuration for EPP.

- `improver.utilities.cube_manipulation` missing from api list (needed for EPP).
- Updated `StandardiseMetadata` plugin so that arguments have been moved to the init to make in line with IMPROVER guidelines.

## Issues

- https://github.com/MetOffice/epp_workflows/pull/68
- https://github.com/MetOffice/improver_suite/issues/2253
- https://github.com/MetOffice/epp_workflows/pull/55