### PR TITLE
Adds unit test for improver.api

### DIFF
--- a/improver_tests/test_api.py
+++ b/improver_tests/test_api.py
@@ -1,3 +1,7 @@
+# (C) Crown copyright, Met Office. All rights reserved.
+#
+# This file is part of IMPROVER and is released under a BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 import pytest
 
 from improver import api

--- a/improver_tests/test_api.py
+++ b/improver_tests/test_api.py
@@ -1,5 +1,6 @@
-from improver import api
 import pytest
+
+from improver import api
 
 
 @pytest.mark.parametrize("module", (api.PROCESSING_MODULES.keys()))

--- a/improver_tests/test_api.py
+++ b/improver_tests/test_api.py
@@ -1,0 +1,8 @@
+from improver import api
+import pytest
+
+
+@pytest.mark.parametrize("module", (api.PROCESSING_MODULES.keys()))
+def test_all_values_are_callable(module):
+    """Checks that each item in the PROCESSING_MODULES dict points to a callable object"""
+    assert callable(getattr(api, module))


### PR DESCRIPTION
While reviewing @cpelley's changes for DAG-runner, I found that this API lookup didn't have a unit test to prove that all the targets actually point to a usable object. This could result in unexpected behaviour. I've added a simple test that passes if each item points to an object that is callable.

Testing:
 - [x] Ran tests and they passed OK

