### PR TITLE
Fixes in support of configuration execution which call plugins directly (i.e. not via CLI)

### DIFF
--- a/improver/cli/copy_attributes.py
+++ b/improver/cli/copy_attributes.py
@@ -34,4 +34,4 @@ def process(
     from improver.utilities.copy_attributes import CopyAttributes
 
     plugin = CopyAttributes(attributes)
-    return plugin(cube, template_cube=template_cube)
+    return plugin(cube, template_cube)

--- a/improver/utilities/copy_attributes.py
+++ b/improver/utilities/copy_attributes.py
@@ -26,8 +26,7 @@ class CopyAttributes(BasePlugin):
         self.attributes = attributes
 
     def process(
-        self, *cubes: Union[Cube, CubeList], template_cube: Union[Cube, CubeList]
-    ) -> Union[Tuple[Union[Cube, CubeList]], Cube, CubeList]:
+        self, *cubes: Union[Cube, CubeList]) -> Union[Cube, CubeList]:
         """
         Copy attribute values from template_cube to cube, overwriting any existing values.
 
@@ -35,16 +34,16 @@ class CopyAttributes(BasePlugin):
 
         Args:
             cubes:
-                Source cube(s) to be updated.
-            template_cube:
-                Source cube to get attribute values from.
+                Source cube(s) to be updated.  Final cube provided represents the template_cube.
 
         Returns:
             Updated cube(s).
 
         """
         cubes_proc = as_cubelist(*cubes)
-        template_cube = as_cube(template_cube)
+        if len(cubes_proc) < 2:
+            raise RuntimeError(f"At least two cubes are required for this operation, got {len(cubes_proc)}")
+        template_cube = cubes_proc.pop()
 
         for cube in cubes_proc:
             new_attributes = {k: template_cube.attributes[k] for k in self.attributes}

--- a/improver/utilities/copy_attributes.py
+++ b/improver/utilities/copy_attributes.py
@@ -48,4 +48,4 @@ class CopyAttributes(BasePlugin):
         for cube in cubes_proc:
             new_attributes = {k: template_cube.attributes[k] for k in self.attributes}
             amend_attributes(cube, new_attributes)
-        return cubes if len(cubes) > 1 else cubes[0]
+        return cubes_proc if len(cubes_proc) > 1 else cubes_proc[0]

--- a/improver/utilities/copy_attributes.py
+++ b/improver/utilities/copy_attributes.py
@@ -2,13 +2,13 @@
 #
 # This file is part of IMPROVER and is released under a BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from typing import List, Tuple, Union
+from typing import List, Union
 
 from iris.cube import Cube, CubeList
 
 from improver import BasePlugin
 from improver.metadata.amend import amend_attributes
-from improver.utilities.common_input_handle import as_cube, as_cubelist
+from improver.utilities.common_input_handle import as_cubelist
 
 
 class CopyAttributes(BasePlugin):
@@ -25,8 +25,7 @@ class CopyAttributes(BasePlugin):
         """
         self.attributes = attributes
 
-    def process(
-        self, *cubes: Union[Cube, CubeList]) -> Union[Cube, CubeList]:
+    def process(self, *cubes: Union[Cube, CubeList]) -> Union[Cube, CubeList]:
         """
         Copy attribute values from template_cube to cube, overwriting any existing values.
 
@@ -42,7 +41,9 @@ class CopyAttributes(BasePlugin):
         """
         cubes_proc = as_cubelist(*cubes)
         if len(cubes_proc) < 2:
-            raise RuntimeError(f"At least two cubes are required for this operation, got {len(cubes_proc)}")
+            raise RuntimeError(
+                f"At least two cubes are required for this operation, got {len(cubes_proc)}"
+            )
         template_cube = cubes_proc.pop()
 
         for cube in cubes_proc:

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -403,7 +403,7 @@ class ExtractLevel(BasePlugin):
         Args:
             cube:
                 Cube of variable on levels (3D) (modified in-place).
-"""
+        """
         if np.isfinite(cube.data).all() and not np.ma.is_masked(cube.data):
             return
         data = np.ma.masked_invalid(cube.data)
@@ -413,7 +413,9 @@ class ExtractLevel(BasePlugin):
         # We don't really care so long as it is non-zero and has the same sign.
         increasing_order = np.all(np.diff(cube.coord(self.coordinate).points) > 0)
         sign = 1 if self.positive_correlation == increasing_order else -1
-        v_increment = sign * 10 ** (-int(cube.attributes.get("least_significant_digit", 2)))
+        v_increment = sign * 10 ** (
+            -int(cube.attributes.get("least_significant_digit", 2))
+        )
         self._one_way_fill(
             data, coordinate_axis, coordinate_points, v_increment, reverse=True
         )

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -413,7 +413,7 @@ class ExtractLevel(BasePlugin):
         # We don't really care so long as it is non-zero and has the same sign.
         increasing_order = np.all(np.diff(cube.coord(self.coordinate).points) > 0)
         sign = 1 if self.positive_correlation == increasing_order else -1
-        v_increment = sign * 10 ** (-cube.attributes.get("least_significant_digit", 2))
+        v_increment = sign * 10 ** (-int(cube.attributes.get("least_significant_digit", 2)))
         self._one_way_fill(
             data, coordinate_axis, coordinate_points, v_increment, reverse=True
         )

--- a/improver_tests/utilities/copy_attributes/test_CopyAttributes.py
+++ b/improver_tests/utilities/copy_attributes/test_CopyAttributes.py
@@ -4,7 +4,7 @@
 # See LICENSE in the root of the repository for full licensing details.
 from unittest.mock import patch, sentinel
 
-from iris.cube import Cube
+from iris.cube import Cube, CubeList
 
 from improver.utilities.copy_attributes import CopyAttributes
 
@@ -13,19 +13,16 @@ class HaltExecution(Exception):
     pass
 
 
-@patch("improver.utilities.copy_attributes.as_cube")
 @patch("improver.utilities.copy_attributes.as_cubelist")
-def test_as_cubelist_called(mock_as_cubelist, mock_as_cube):
-    mock_as_cubelist.return_value = sentinel.cubelist
-    mock_as_cube.side_effect = HaltExecution
+def test_as_cubelist_called(mock_as_cubelist):
+    mock_as_cubelist.side_effect = HaltExecution
     try:
         CopyAttributes(["attribA", "attribB"])(
-            sentinel.cube0, sentinel.cube1, template_cube=sentinel.template_cube
+            sentinel.cube0, sentinel.cube1, sentinel.template_cube
         )
     except HaltExecution:
         pass
-    mock_as_cubelist.assert_called_once_with(sentinel.cube0, sentinel.cube1)
-    mock_as_cube.assert_called_once_with(sentinel.template_cube)
+    mock_as_cubelist.assert_called_once_with(sentinel.cube0, sentinel.cube1, sentinel.template_cube)
 
 
 def test_copy_attributes_multi_input():
@@ -47,8 +44,8 @@ def test_copy_attributes_multi_input():
     )
 
     plugin = CopyAttributes(attributes)
-    result = plugin.process(cube0, cube1, template_cube=template_cube)
-    assert type(result) is tuple
+    result = plugin.process(cube0, cube1, template_cube)
+    assert type(result) is CubeList
     for res in result:
         assert res.attributes["attribA"] == "tempA"
         assert res.attributes["attribB"] == "tempB"
@@ -70,7 +67,7 @@ def test_copy_attributes_single_input():
     )
 
     plugin = CopyAttributes(attributes)
-    result = plugin.process(cube0, template_cube=template_cube)
+    result = plugin.process(cube0, template_cube)
     assert type(result) is Cube
     assert result.attributes["attribA"] == "tempA"
     assert result.attributes["attribB"] == "tempB"

--- a/improver_tests/utilities/copy_attributes/test_CopyAttributes.py
+++ b/improver_tests/utilities/copy_attributes/test_CopyAttributes.py
@@ -22,7 +22,9 @@ def test_as_cubelist_called(mock_as_cubelist):
         )
     except HaltExecution:
         pass
-    mock_as_cubelist.assert_called_once_with(sentinel.cube0, sentinel.cube1, sentinel.template_cube)
+    mock_as_cubelist.assert_called_once_with(
+        sentinel.cube0, sentinel.cube1, sentinel.template_cube
+    )
 
 
 def test_copy_attributes_multi_input():

--- a/improver_tests/utilities/cube_extraction/test_ExtractLevel.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractLevel.py
@@ -201,6 +201,22 @@ def test_basic(
         cube_shape_check_without_realizations(result)
 
 
+@pytest.mark.parametrize("least_significant_digit", (None, 2, np.int32(2)))
+def test_fill_invalid_supported_lsd_types(
+    temperature_on_height_levels, least_significant_digit
+):
+    """
+    Ensure performing power of negative python int/numpy int least_significant_digit supported.
+    """
+    cube = temperature_on_height_levels
+    cube.data = np.ma.MaskedArray(cube.data, mask=False)
+    cube.data.mask[0, 0, 0, 0] = True
+    if least_significant_digit is not None:
+        cube.attributes["least_significant_digit"] = least_significant_digit
+    plugin = ExtractLevel(value_of_level=277, positive_correlation=True)
+    plugin(cube)
+
+
 @pytest.mark.parametrize(
     "index, expected",
     (


### PR DESCRIPTION
## Motivation

- Support EPP execution with dagrunner.
- Supporting IMPROVER execution with dagrunner.

## Summary of changes

1. Enforce python int type for powers.

  ```python
  File "/path/to/cylc-run/epp_demo/lib/python3.9/site-packages/improver/utilities/cube_extraction.py", line 416, in fill_invalid    v_increment = sign * 10 ** (-cube.attributes.get("least_significant_digit", 2))
  ...
  ValueError: Integers to negative integer powers are not allowed
  ```

2. `CopyAttributes` bad arguments passing (template cube).

## Issues

- https://github.com/MetOffice/improver_suite/issues/2253