### PR TITLE
Update name of cubes from gradient module

### DIFF
--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -705,7 +705,7 @@ class GradientBetweenAdjacentGridSquares(PostProcessingPlugin):
         distances = DistanceBetweenGridSquares()(cube)
 
         for diff, distance, ax in zip(diffs, distances, axis):
-            distance.data=distance.data.astype(np.float32)
+            distance.data = distance.data.astype(np.float32)
             gradient = diff / distance
             grad_cube = self._create_output_cube(
                 gradient, "gradient_of_" + cube.name() + "_wrt_" + ax

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -705,6 +705,7 @@ class GradientBetweenAdjacentGridSquares(PostProcessingPlugin):
         distances = DistanceBetweenGridSquares()(cube)
 
         for diff, distance, ax in zip(diffs, distances, axis):
+            distance.data=distance.data.astype(np.float32)
             gradient = diff / distance
             grad_cube = self._create_output_cube(
                 gradient, "gradient_of_" + cube.name() + "_wrt_" + ax

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -699,12 +699,16 @@ class GradientBetweenAdjacentGridSquares(PostProcessingPlugin):
             - Cube after the gradients have been calculated along the
               y-axis.
         """
+        axis = ["x", "y"]
         gradients = []
         diffs = DifferenceBetweenAdjacentGridSquares()(cube)
         distances = DistanceBetweenGridSquares()(cube)
-        for diff, distance in zip(diffs, distances):
+
+        for diff, distance, ax in zip(diffs, distances, axis):
             gradient = diff / distance
-            grad_cube = self._create_output_cube(gradient, "gradient_of_" + cube.name())
+            grad_cube = self._create_output_cube(
+                gradient, "gradient_of_" + cube.name() + "_wrt_" + ax
+            )
             if self.regrid:
                 grad_cube = grad_cube.regrid(cube, iris.analysis.Linear())
             gradients.append(grad_cube)

--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -533,8 +533,8 @@ ba7a8a4dab8552656cfc38962d8cc6dce7e32d0965823c77008906d0c6afe7b5  ./generate-top
 06911b6df4f8195a9349ff12f352bd1a6251dfcdbcd9f573d652c242f4fed596  ./generate-topography-bands-weights/multi_realization/input_orog.nc
 0c52d393be6e53eaa8b9d88a38ceff5ca07772e3385f776ac85df971afaa532b  ./generate-topography-bands-weights/multi_realization/kgo.nc
 4fe3a154c46e079ab0f42c04db93c94a35b1b7e73a6b3a303f29b8a7167aaa5b  ./gradient-between-adjacent-grid-squares/input.nc
-9792de8e7df23e9272c0fe8fa647256e5871c4dc1daf78d0584d5750c868bd43  ./gradient-between-adjacent-grid-squares/with_regrid/kgo.nc
-1324ec666cd38b5ee9974396c556457a91c020a00d90c34eac1d842013f869d8  ./gradient-between-adjacent-grid-squares/without_regrid/kgo.nc
+8b0c59a4a367398fb0df7c3bb156adacd36f7316974d98553caee3d9d4d1d0cb  ./gradient-between-adjacent-grid-squares/with_regrid/kgo.nc
+4b69c62f7867dfc92b660cb902dc369361619b394e507c4648828d40f9c3eb12  ./gradient-between-adjacent-grid-squares/without_regrid/kgo.nc
 19e48705dd34036cf8e974dacdfeb510a55720f387daf64044d12b73d8d18ca7  ./gradient-between-vertical-levels/height_of_pressure_levels.nc
 fafd9c642ef7a63b1c453dae66cb55eab3d7816b02122d12da9320763d2d8db2  ./gradient-between-vertical-levels/kgo.nc
 a8eb2c78a65acb58d9535c3390fbf22249e98929002c21b5a4b5c534640d18e1  ./gradient-between-vertical-levels/orography.nc

--- a/improver_tests/utilities/spatial/test_GradientBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/spatial/test_GradientBetweenAdjacentGridSquares.py
@@ -136,8 +136,8 @@ def test_metadata(
     expected_y_coord = cube.coord(axis="y").copy(expected_y_points)
     plugin = GradientBetweenAdjacentGridSquares(regrid=regrid)
     result_x, result_y = plugin(cube)
-    for result in (result_x, result_y):
-        assert result.name() == "gradient_of_air_temperature"
+    for result, name in [(result_x, "x"), (result_y, "y")]:
+        assert result.name() == f"gradient_of_air_temperature_wrt_{name}"
         assert result.units == "K m-1"
         assert result.attributes == cube.attributes
     if regrid:

--- a/improver_tests/utilities/spatial/test_GradientBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/spatial/test_GradientBetweenAdjacentGridSquares.py
@@ -140,6 +140,7 @@ def test_metadata(
         assert result.name() == f"gradient_of_air_temperature_wrt_{name}"
         assert result.units == "K m-1"
         assert result.attributes == cube.attributes
+        assert result.data.dtype == np.float32
     if regrid:
         # In regrid mode, we expect the original spatial coords
         for axis in "xy":


### PR DESCRIPTION
EPP ticket: https://metoffice.atlassian.net/browse/EPPT-1826
Acceptance_test_data: https://github.com/metoppv/improver_test_data/pull/60

Updates the name of output cubes from the gradient-between-adjacent-modules so that the two output cubes can be distinguished.

Testing:
 - [x] Ran tests and they passed OK

