### PR TITLE
Adding a plugin to calculate the virtual temperature (version 2)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,7 @@ Meabh NicGuidhir <meabh.nicguidhir@metoffice.gov.uk> <meabh.nicguidhir@metoffice
 Neil Crosswaite <neil.crosswaite@metoffice.gov.uk> <43375279+neilCrosswaite@users.noreply.github.com>
 Paul Abernethy <paul.abernethy@metoffice.gov.uk> <paul.abernethy@metoffice.gov.uk>
 Peter Jordan <peter.jordan@metoffice.gov.uk> <52462411+mo-peterjordan@users.noreply.github.com>
+Phil Relton <phil.relton@metoffice.gov.uk> <phil.relton@metoffice.gov.uk>
 Sam Griffiths <sam.griffiths@metoffice.gov.uk> <122271903+SamGriffithsMO@users.noreply.github.com>
 Shafiat Dewan <87321907+ShafiatDewan@users.noreply.github.com> <87321907+ShafiatDewan@users.noreply.github.com>
 Shubhendra Singh Chauhan <withshubh@gmail.com> <withshubh@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ below:
  - Benjamin Owen (Bureau of Meteorology, Australia)
  - Carwyn Pelley (Met Office, UK)
  - Tim Pillinger (Met Office, UK)
+ - Phil Relton (Met Office, UK)
  - Fiona Rust (Met Office, UK)
  - Chris Sampson (Met Office, UK)
  - Caroline Sandford (Met Office, UK)

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -1,0 +1,65 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Calculate the virtual temperature from temperature and humidity mixing ratio."""
+
+from typing import Union
+
+from iris.cube import Cube, CubeList
+
+from improver import BasePlugin
+from improver.utilities.common_input_handle import as_cubelist
+
+
+class VirtualTemperature(BasePlugin):
+    """Plugin class to handle virtual temperature calculations."""
+
+    @staticmethod
+    def get_virtual_temperature(temperature: Cube, humidity_mixing_ratio: Cube) -> Cube:
+        """
+        Calculate the virtual temperature from temperature and humidity mixing ratio.
+
+        Args:
+            temperature:
+                Cube of temperature.
+            humidity_mixing_ratio:
+                Cube of humidity mixing ratio.
+
+        Returns:
+            Cube of virtual_temperature.
+        """
+        # Calculate the virtual temperature
+        virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
+
+        # Update the cube metadata
+        virtual_temperature.rename("virtual_temperature")
+        virtual_temperature.attributes["units_metadata"] = "on-scale"
+
+        return virtual_temperature
+
+    def process(self, *cubes: Union[Cube, CubeList]) -> Cube:
+        """
+        Main entry point for this class.
+
+        Args:
+            cubes:
+                air_temperature:
+                    Cube of temperature.
+                humidity_mixing_ratio:
+                    Cube of humidity mixing ratios.
+
+        Returns:
+            Cube of virtual_temperature.
+        """
+
+        # Get the cubes into the correct format and extract the relevant cubes
+        cubes = as_cubelist(*cubes)
+        (self.temperature, self.humidity_mixing_ratio) = cubes.extract_cubes(
+            ["air_temperature", "humidity_mixing_ratio"]
+        )
+
+        # Calculate the virtual temperature
+        return self.get_virtual_temperature(
+            self.temperature, self.humidity_mixing_ratio
+        )

--- a/improver_tests/virtual_temperature/test_VirtualTemperature.py
+++ b/improver_tests/virtual_temperature/test_VirtualTemperature.py
@@ -1,0 +1,79 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the VirtualTemperature plugin"""
+
+from unittest.mock import patch, sentinel
+
+import numpy as np
+import pytest
+from iris.cube import Cube
+
+from improver.virtual_temperature import VirtualTemperature
+from improver_tests.utilities.copy_attributes.test_CopyAttributes import HaltExecution
+
+
+@pytest.fixture(name="temperature_cube")
+def temperature_cube_fixture() -> Cube:
+    """
+    Set up a temperature cube for use in tests.
+    Has 2 realizations, 7 latitudes spanning from 60S to 60N and 3 longitudes.
+    """
+    data = np.full((2, 7, 3), dtype=np.float32, fill_value=273.15)
+    cube = Cube(
+        data,
+        standard_name="air_temperature",
+        units="K",
+    )
+    return cube
+
+
+@pytest.fixture(name="humidity_mixing_ratio_cube")
+def humidity_mixing_ratio_cube_fixture() -> Cube:
+    """
+    Set up a humidity mixing ratio cube for use in tests.
+    Has 2 realizations, 7 latitudes spanning from 60S to 60N and 3 longitudes.
+    """
+    data = np.full((2, 7, 3), dtype=np.float32, fill_value=0.01)
+    cube = Cube(
+        data,
+        standard_name="humidity_mixing_ratio",
+        units="1",
+    )
+    return cube
+
+
+@pytest.fixture(name="virtual_temperature_cube")
+def virtual_temperature_cube_fixture() -> Cube:
+    """
+    Set up a virtual temperature cube for use in tests.
+    Has 2 realizations, 7 latitudes spanning from 60S to 60N and 3 longitudes.
+    """
+    data = np.full((2, 7, 3), dtype=np.float32, fill_value=274.81622)
+    cube = Cube(
+        data,
+        standard_name="virtual_temperature",
+        units="K",
+        attributes={"units_metadata": "on-scale"},
+    )
+    return cube
+
+
+@patch("improver.virtual_temperature.as_cubelist")
+def test_as_cubelist_called(mock_as_cubelist):
+    """Test that the as_cubelist function is called with the input cubes"""
+    mock_as_cubelist.side_effect = HaltExecution
+    try:
+        VirtualTemperature()(sentinel.cube1, sentinel.cube2)
+    except HaltExecution:
+        pass
+    mock_as_cubelist.assert_called_once_with(sentinel.cube1, sentinel.cube2)
+
+
+def test_VirtualTemperature_get_virtual_temperature(
+    temperature_cube, humidity_mixing_ratio_cube, virtual_temperature_cube
+):
+    """Test the get_virtual_temperature method produces a virtual temperature cube"""
+    result = VirtualTemperature()(temperature_cube, humidity_mixing_ratio_cube)
+    assert result == virtual_temperature_cube

--- a/improver_tests/virtual_temperature/test_VirtualTemperature.py
+++ b/improver_tests/virtual_temperature/test_VirtualTemperature.py
@@ -11,7 +11,7 @@ import pytest
 from iris.cube import Cube
 
 from improver.virtual_temperature import VirtualTemperature
-from improver_tests.utilities.copy_attributes.test_CopyAttributes import HaltExecution
+from improver_tests.utilities.copy_metadata.test_CopyMetadata import HaltExecution
 
 
 @pytest.fixture(name="temperature_cube")


### PR DESCRIPTION
Address: https://metoffice.atlassian.net/browse/EPPT-1965

This PR adds a plugin to calculate the virtual temperature based on the air temperature and humidity mixing ratio.

No CLI added due to the move to the DAG runner.

This is a replacement for the closed #2058 to avoid history rewrites and git configuration issues.

Testing:

Ran tests and they passed OK

    Added new tests for the new feature(s)

CLA

If a new developer, signed up to CLA
