### PR TITLE
TEST: Fix scheduled.yml and switch CI to using micromamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,56 +14,43 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      id: cache
+
+    - uses: mamba-org/setup-micromamba@v2
       with:
-        path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}', runner.os, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
+        environment-file: envs/${{ matrix.env }}.yml
+        init-shell: bash
+        cache-environment: true
 
-    - name: conda env update
-      if: steps.cache.outputs.cache-hit != 'true'
+    - name: Environment info
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda update -q -n base -c defaults conda
-        conda install -q -n base -c conda-forge -c nodefaults mamba
-        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env create -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
-
-    - name: conda info
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        conda info
-        conda list
+        micromamba info
+        micromamba list
+      shell: bash -el {0}
 
     - name: sphinx documentation
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         make -C doc html SPHINXOPTS="-W --keep-going"
+      shell: micromamba-shell {0}
 
     - name: pytest without coverage
       if: matrix.env == 'conda-forge'
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         pytest
+      shell: micromamba-shell {0}
 
     - name: pytest with coverage
       if: matrix.env != 'conda-forge'
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         pytest --cov=improver --cov-report xml:coverage.xml
+      shell: micromamba-shell {0}
 
     - name: codacy upload
       if: env.CODACY_PROJECT_TOKEN && matrix.env == 'environment_a'
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         python-codacy-coverage -v -r coverage.xml
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      shell: micromamba-shell {0}
 
     - name: codecov upload
       uses: codecov/codecov-action@v5
@@ -133,36 +120,24 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: actions/cache@v4
-      id: cache
+    - uses: mamba-org/setup-micromamba@v2
       with:
-        path: /usr/share/miniconda/envs/im${{ matrix.env }}
-        key: ${{ format('{0}-conda-improver-{1}-{2}', runner.os, matrix.env, hashFiles(format('envs/{0}.yml', matrix.env))) }}
+        environment-file: envs/${{ matrix.env }}.yml
+        init-shell: bash
+        cache-environment: true
 
-    - name: conda env update
-      if: steps.cache.outputs.cache-hit != 'true'
+    - name: Environment info
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda update -q -n base -c defaults conda
-        conda install -q -n base -c conda-forge mamba
-        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env create -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
-
-    - name: conda info
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        conda info
-        conda list
+        micromamba info
+        micromamba list
+      shell: bash -el {0}
 
     - name: safety
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         safety check || true
+      shell: micromamba-shell {0}
 
     - name: bandit
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         bandit -r improver
+      shell: micromamba-shell {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: mamba-org/setup-micromamba@v2
+    - name: Environment creation
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: envs/${{ matrix.env }}.yml
         init-shell: bash
@@ -120,7 +121,8 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: mamba-org/setup-micromamba@v2
+    - name: Environment creation
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: envs/${{ matrix.env }}.yml
         init-shell: bash

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: '7 4 * * *'
   workflow_dispatch:
+
 jobs:
   Sphinx-Pytest-Coverage:
     runs-on: ubuntu-22.04
@@ -13,106 +14,96 @@ jobs:
       fail-fast: false
       matrix:
         env: [latest]
+
     if: github.repository_owner == 'metoppv'
     steps:
+
     - uses: actions/checkout@v4
-    - name: conda env update
+
+    - name: Environment creation
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        environment-file: envs/${{ matrix.env }}.yml
+        init-shell: bash
+        cache-environment: true
+
+    - name: Environment info
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda update -q -n base -c defaults conda
-        conda install -q -n base -c conda-forge -c nodefaults mamba
-        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env create -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
-    - name: conda info
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        conda info
-        conda list
+        micromamba info
+        micromamba list
+      shell: bash -el {0}
+
     - name: sphinx documentation
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         make -C doc html SPHINXOPTS="-W --keep-going"
+      shell: micromamba-shell {0}
+
     - name: pytest without coverage
-      if: matrix.env != 'environment_a'
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         pytest
-    - name: pytest with coverage
-      if: matrix.env == 'environment_a'
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        pytest --cov=improver --cov-report xml:coverage.xml
-    - name: codacy upload
-      if: env.CODACY_PROJECT_TOKEN && matrix.env == 'environment_a'
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        python-codacy-coverage -v -r coverage.xml
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-    - name: codecov upload
-      uses: codecov/codecov-action@v5
-      if: matrix.env == 'environment_a'
+      shell: micromamba-shell {0}
+
   Safety-Bandit:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         env: [latest]
+
     if: github.repository_owner == 'metoppv'
     steps:
+
     - uses: actions/checkout@v4
-    - name: conda env update
+
+    - name: Environment creation
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        environment-file: envs/${{ matrix.env }}.yml
+        init-shell: bash
+        cache-environment: true
+
+    - name: Environment info
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda update -q -n base -c defaults conda
-        conda install -q -n base -c conda-forge -c nodefaults mamba
-        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env create -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
-    - name: conda info
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        conda info
-        conda list
+        micromamba info
+        micromamba list
+      shell: bash -el {0}
+
     - name: safety
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         safety check || true
+      shell: micromamba-shell {0}
+
     - name: bandit
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         bandit -r improver
+      shell: micromamba-shell {0}
+
   Type-checking:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         env: [latest]
+
     if: github.repository_owner == 'metoppv'
     steps:
+
     - uses: actions/checkout@v4
-    - name: conda env update
+
+    - name: Environment creation
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        environment-file: envs/${{ matrix.env }}.yml
+        init-shell: bash
+        cache-environment: true
+
+    - name: Environment info
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda update -q -n base -c defaults conda
-        conda install -q -n base -c conda-forge -c nodefaults mamba
-        rm -f /usr/share/miniconda/pkgs/cache/*.json # workaround for mamba-org/mamba#488
-        mamba env create -q --file envs/${{ matrix.env }}.yml --name im${{ matrix.env }}
-    - name: conda info
-      run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
-        conda info
-        conda list
+        micromamba info
+        micromamba list
+      shell: bash -el {0}
+
     - name: mypy
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate im${{ matrix.env }}
         mypy improver || true
+      shell: micromamba-shell {0}

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -38,3 +38,7 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
+# pinned dependencies of dependencies
+  - hdf5=1.10.2
+  - opencv=3.4.2
+  - libzlib=1.2.13

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -2,6 +2,7 @@
 name: improver_a
 channels:
   - conda-forge
+  - main
 dependencies:
   - python=3.7
   # Required
@@ -38,7 +39,3 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
-# pinned dependencies of dependencies
-  - hdf5=1.10.2
-  - opencv=3.4.2
-  - libzlib=1.2.13


### PR DESCRIPTION
Switching to [micromamba](https://github.com/mamba-org/setup-micromamba) (the recommended approach to installation for mamba).  As per changes made to [improver_suite](https://github.com/MetOffice/improver_suite/pull/2403).

`environment_a` was having trouble with dependencies being resolved as micromamba fetches only from conda-forge by default (that is, using main was implicit before with conda mamba).  e.g. opencv related packages are from main as we see from a [recent action job run](https://github.com/metoppv/improver/actions/runs/12282461896/job/34273728578?pr=2065)).  Intriducing an explicit 'main' dependency fixes the issue.

Fixes scheduled IMPROVER CI:

![image](https://github.com/user-attachments/assets/0d740077-dd4b-40cb-875d-b11a4e48ed51)

## Note

Haven't/can't test `scheduled.yml` workflow but can make an additional change if a mistake has creeped in.

## Issues

- https://github.com/MetOffice/improver_suite/issues/2214