### PR TITLE
conda-forge sphinx doc build failure CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Environment info
       run: |
+        micromamba install setuptools
         micromamba info
         micromamba list
       shell: bash -el {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI Tests
 on:
   pull_request:
   push:
+    branches:
+      - default  # Run tests only when changes are pushed to 'default'
   workflow_dispatch:
 jobs:
   Sphinx-Pytest-Coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - default  # Run tests only when changes are pushed to 'default'
+      - master  # Run tests only when changes are pushed to 'default'
   workflow_dispatch:
 jobs:
   Sphinx-Pytest-Coverage:
@@ -26,7 +26,6 @@ jobs:
 
     - name: Environment info
       run: |
-        micromamba install setuptools
         micromamba info
         micromamba list
       shell: bash -el {0}

--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -25,6 +25,7 @@ dependencies:
   - bandit
   - filelock
   - pytest
+  - setuptools
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl


### PR DESCRIPTION
- Stop test duplication (limit push to default branch).
- Include setuptools in conda-forge environment.

```
WARNING: autodoc: failed to import module 'cli.wet_bulb_freezing_level' from module 'improver'; the following exception was raised:
No module named 'pkg_resources'
```