### PR TITLE
Remove references to UTC_offset

### DIFF
--- a/doc/source/extended_documentation/spotdata/build_spotdata_cube/build_spotdata_cube_examples.rst
+++ b/doc/source/extended_documentation/spotdata/build_spotdata_cube/build_spotdata_cube_examples.rst
@@ -11,7 +11,6 @@ For a cube containing diagnostic values::
           altitude                        x
           latitude                        x
           longitude                       x
-          utc_offset                      x
           wmo_site                        x
      Scalar coordinates:
           forecast_reference_time: 2018-07-13 09:00:00

--- a/improver/metadata/constants/time_types.py
+++ b/improver/metadata/constants/time_types.py
@@ -23,5 +23,4 @@ TIME_COORDS = {
     "forecast_reference_time": _TIME_REFERENCE_SPEC,
     "blend_time": _TIME_REFERENCE_SPEC,
     "forecast_period": _TIME_INTERVAL_SPEC,
-    "UTC_offset": _TIME_INTERVAL_SPEC,
 }


### PR DESCRIPTION
Remove references to UTC_offset coordinates as we no longer handle timezone information within IMPROVER.

Testing:
 - [x] Ran tests and they passed OK
