### PR TITLE
Add height_of_maximum to api

### DIFF
--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -67,6 +67,7 @@ PROCESSING_MODULES = {
     "GradientBetweenAdjacentGridSquares": "improver.utilities.spatial",
     "HailFraction": "improver.precipitation_type.hail_fraction",
     "HailSize": "improver.psychrometric_calculations.hail_size",
+    "height_of_maximum": "improver.utilities.cube_manipulation",
     "HumidityMixingRatio": "improver.psychrometric_calculations.psychrometric_calculations",
     "Integration": "improver.utilities.mathematical_operations",
     "InterpolateUsingDifference": "improver.utilities.interpolation",


### PR DESCRIPTION
The EPP project is switching to api calls of IMPROVER, rather than CLI. This means that we need the `height_of_maximum` function to be callable from the api.

Testing:
 - [x] Ran tests and they passed OK