### PR TITLE
Bug fix for reliability calibration of single threshold cube

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,5 @@
 Aaron Hopkinson <aaron.hopkinson@metoffice.gov.uk> <arh89@users.noreply.github.com>
+Andrew Creswick <andrew.creswick@metoffice.gov.uk> <89418171+mo-AndrewCreswick@users.noreply.github.com>
 Anna Booton <anna.booton@metoffice.gov.uk> <anna.booton@metoffice.gov.uk>
 Anja Schubert <anja.schubert@bom.gov.au> <57921950+anja-bom@users.noreply.github.com>
 Belinda Trotta <73675905+btrotta-bom@users.noreply.github.com> <73675905+btrotta-bom@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
 Aaron Hopkinson <aaron.hopkinson@metoffice.gov.uk> <arh89@users.noreply.github.com>
-Andrew Creswick <andrew.creswick@metoffice.gov.uk> <89418171+mo-AndrewCreswick@users.noreply.github.com>
+Andrew Creswick <andrew.creswick@metoffice.gov.uk> AndrewCreswick <andrew.creswick@metoffice.gov.uk>
 Anna Booton <anna.booton@metoffice.gov.uk> <anna.booton@metoffice.gov.uk>
 Anja Schubert <anja.schubert@bom.gov.au> <57921950+anja-bom@users.noreply.github.com>
 Belinda Trotta <73675905+btrotta-bom@users.noreply.github.com> <73675905+btrotta-bom@users.noreply.github.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ below:
  - Prajwal Borkar
  - James Canvin (Bureau of Meteorology, Australia)
  - Shubhendra Singh Chauhan (DeepSource, India)
+ - Andrew Creswick (Met Office, UK)
  - Neil Crosswaite (Met Office, UK)
  - Shafiat Dewan (Met Office, UK)
  - Gavin Evans (Met Office, UK)

--- a/improver/calibration/reliability_calibration.py
+++ b/improver/calibration/reliability_calibration.py
@@ -1149,6 +1149,8 @@ class ApplyReliabilityCalibration(PostProcessingPlugin):
             UserWarning: If the probabilities must be sorted to reinstate
                          expected monotonicity following calibration.
         """
+        if not cube.coord_dims(self.threshold_coord):
+            return
         (threshold_dim,) = cube.coord_dims(self.threshold_coord)
         thresholding = probability_is_above_or_below(cube)
         if thresholding is None:

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -217,6 +217,18 @@ class Test__ensure_monotonicity_across_thresholds(Test_ReliabilityCalibrate):
 
         assert_array_equal(self.forecast.data, expected.data)
 
+    def test_single_threshold(self):
+        """Test on a probability cube with only a single threshold.
+        The data should be unchanged as it is already monotonic.
+        Additionally no warnings or exceptions should be raised."""
+
+        expected = self.forecast[0].copy()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.plugin._ensure_monotonicity_across_thresholds(self.forecast[0])
+
+        assert_array_equal(self.forecast[0].data, expected.data)
+
     def test_single_disordered_element(self):
         """Test that if the values are disordered at a single position in the
         array, this position is sorted across the thresholds, whilst the rest
@@ -260,18 +272,6 @@ class Test__ensure_monotonicity_across_thresholds(Test_ReliabilityCalibrate):
         msg = "Cube threshold coordinate does not define whether"
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin._ensure_monotonicity_across_thresholds(self.forecast)
-
-    def test_single_threshold(self):
-        """Test on a probability cube with only a single threshold.
-        The data should be unchanged as it is already monotonic.
-        Additionally no warnings or exceptions should be raised."""
-
-        expected = self.forecast[0].copy()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            self.plugin._ensure_monotonicity_across_thresholds(self.forecast[0])
-
-        assert_array_equal(self.forecast[0].data, expected.data)
 
 
 class Test__calculate_reliability_probabilities(Test_ReliabilityCalibrate):
@@ -598,15 +598,12 @@ class Test_process(Test_ReliabilityCalibrate):
         expected_0 = np.array(
             [[0.25, 0.3125, 0.375], [0.4375, 0.5, 0.5625], [0.625, 0.6875, 0.75]]
         )
-        expected_1 = np.array([[0.25, 0.3, 0.35], [0.4, 0.45, 0.5], [0.55, 0.6, 0.65]])
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             result_0 = self.plugin.process(self.forecast[0], self.reliability_cube)
-            result_1 = self.plugin.process(self.forecast[1], self.reliability_cube)
 
         assert_allclose(result_0.data, expected_0)
-        assert_allclose(result_1.data, expected_1)
 
 
 if __name__ == "__main__":

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -261,6 +261,18 @@ class Test__ensure_monotonicity_across_thresholds(Test_ReliabilityCalibrate):
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin._ensure_monotonicity_across_thresholds(self.forecast)
 
+    def test_single_threshold(self):
+        """Test on a probability cube with only a single threshold.
+        The data should be unchanged as it is already monotonic.
+        Additionally no warnings or exceptions should be raised."""
+
+        expected = self.forecast[0].copy()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.plugin._ensure_monotonicity_across_thresholds(self.forecast[0])
+
+        assert_array_equal(self.forecast[0].data, expected.data)
+
 
 class Test__calculate_reliability_probabilities(Test_ReliabilityCalibrate):
     """Test the _calculate_reliability_probabilities method."""
@@ -578,6 +590,25 @@ class Test_process(Test_ReliabilityCalibrate):
         coords_table = [c.name() for c in self.forecast_spot_cube.coords()]
         coords_result = [c.name() for c in result.coords()]
         assert coords_table == coords_result
+
+    def test_calibrating_forecast_single_threshold(self):
+        """Test application of reliability tables on a probability cube 
+        that only contains a single threshold."""
+
+        expected_0 = np.array(
+            [[0.25, 0.3125, 0.375], [0.4375, 0.5, 0.5625], [0.625, 0.6875, 0.75]]
+        )
+        expected_1 = np.array(
+            [[0.25, 0.3, 0.35], [0.4, 0.45, 0.5], [0.55, 0.6, 0.65]]
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result_0 = self.plugin.process(self.forecast[0], self.reliability_cube)
+            result_1 = self.plugin.process(self.forecast[1], self.reliability_cube)
+
+        assert_allclose(result_0.data, expected_0)
+        assert_allclose(result_1.data, expected_1)
 
 
 if __name__ == "__main__":

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -592,7 +592,7 @@ class Test_process(Test_ReliabilityCalibrate):
         assert coords_table == coords_result
 
     def test_calibrating_forecast_single_threshold(self):
-        """Test application of reliability tables on a probability cube 
+        """Test application of reliability tables on a probability cube
         that only contains a single threshold."""
 
         expected_0 = np.array(

--- a/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
+++ b/improver_tests/calibration/reliability_calibration/test_ApplyReliabilityCalibration.py
@@ -598,9 +598,7 @@ class Test_process(Test_ReliabilityCalibrate):
         expected_0 = np.array(
             [[0.25, 0.3125, 0.375], [0.4375, 0.5, 0.5625], [0.625, 0.6875, 0.75]]
         )
-        expected_1 = np.array(
-            [[0.25, 0.3, 0.35], [0.4, 0.45, 0.5], [0.55, 0.6, 0.65]]
-        )
+        expected_1 = np.array([[0.25, 0.3, 0.35], [0.4, 0.45, 0.5], [0.55, 0.6, 0.65]])
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")


### PR DESCRIPTION
This PR fixes a bug with applying reliability calibration to a cube with only a single threshold.

When reliability calibration was applied to a cube with only a single threshold the code would fail due to the method _ensure_monotonicity_across_thresholds of ApplyReliabilityCalibration.

As there are no dimensions associated with the threshold coordinate, assigning it to a variable leads to a ValueError. With a single threshold there is no need to check for monotonicity across thresholds so we can return straight away when there are no dimensions associated with the threshold coordinate.

New unit tests are added to cover this single threshold use case.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

CLA

- [x] If a new developer, signed up to CLA
