### PR TITLE
MOBT-797: Coordinate retention in percentile generation

### DIFF
--- a/improver/cli/generate_percentiles.py
+++ b/improver/cli/generate_percentiles.py
@@ -15,6 +15,7 @@ def process(
     *,
     coordinates: cli.comma_separated_list = None,
     percentiles: cli.comma_separated_list = None,
+    retained_coordinates: cli.comma_separated_list = None,
     ignore_ecc_bounds_exceedance: bool = False,
     skip_ecc_bounds: bool = False,
     mask_percentiles: bool = False,
@@ -48,6 +49,10 @@ def process(
             coordinate.
         percentiles (list):
             Optional definition of percentiles at which to calculate data.
+        retained_coordinates (list):
+            Optional list of collapsed coordinates that should be retained in
+            their new scalar form. The default behaviour is to remove the
+            scalar coordinates that result from coordinate collapse.
         ignore_ecc_bounds_exceedance (bool):
             If True, where calculated percentiles are outside the ECC bounds
             range, raises a warning rather than an exception.
@@ -145,6 +150,7 @@ def process(
         result = PercentileConverter(
             coordinates,
             percentiles=percentiles,
+            retained_coordinates=retained_coordinates,
             fast_percentile_method=fast_percentile_method,
         )(cube)
     else:

--- a/improver/percentile.py
+++ b/improver/percentile.py
@@ -13,9 +13,9 @@ from iris.exceptions import CoordinateNotFoundError
 
 from improver import BasePlugin
 from improver.constants import DEFAULT_PERCENTILES
+from improver.metadata.constants.time_types import TIME_COORDS
 from improver.metadata.probabilistic import find_percentile_coordinate
 from improver.metadata.utilities import enforce_time_point_standard
-from improver.metadata.constants.time_types import TIME_COORDS
 from improver.utilities.cube_manipulation import collapsed
 
 

--- a/improver/percentile.py
+++ b/improver/percentile.py
@@ -14,6 +14,8 @@ from iris.exceptions import CoordinateNotFoundError
 from improver import BasePlugin
 from improver.constants import DEFAULT_PERCENTILES
 from improver.metadata.probabilistic import find_percentile_coordinate
+from improver.metadata.utilities import enforce_time_point_standard
+from improver.metadata.constants.time_types import TIME_COORDS
 from improver.utilities.cube_manipulation import collapsed
 
 
@@ -28,6 +30,7 @@ class PercentileConverter(BasePlugin):
         self,
         collapse_coord: Union[str, List[str]],
         percentiles: Optional[List[float]] = None,
+        retained_coordinates: Optional[Union[str, List[str]]] = None,
         fast_percentile_method: bool = True,
     ) -> None:
         """
@@ -41,6 +44,13 @@ class PercentileConverter(BasePlugin):
             percentiles:
                 Percentile values at which to calculate; if not provided uses
                 DEFAULT_PERCENTILES. (optional)
+            retained_coordinates:
+                Optional list of collapsed coordinates that should be retained
+                in their new scalar form. The default behaviour is to remove
+                the scalar coordinates that result from coordinate collapse.
+            fast_percentile_method:
+                If True use the numpy percentile method within Iris, which is
+                much faster than scipy, but cannot handle masked data.
 
         Raises:
             TypeError: If collapse_coord is not a string.
@@ -65,6 +75,7 @@ class PercentileConverter(BasePlugin):
         # percentile coordinate has a consistent name regardless of the order
         # in which the user provides the original coordinate names.
         self.collapse_coord = sorted(collapse_coord)
+        self.retained_coordinates = retained_coordinates
         self.fast_percentile_method = fast_percentile_method
 
     def __repr__(self) -> str:
@@ -114,8 +125,23 @@ class PercentileConverter(BasePlugin):
             )
 
             result.data = result.data.astype(data_type)
-            for coord in self.collapse_coord:
+
+            remove_crds = self.collapse_coord
+            if self.retained_coordinates is not None:
+                remove_crds = [
+                    crd
+                    for crd in self.collapse_coord
+                    if crd not in self.retained_coordinates
+                ]
+            for coord in remove_crds:
                 result.remove_coord(coord)
+
+            # If a time related coordinate has been collapsed we need to
+            # enforce the IMPROVER standard of a coordinate point that aligns
+            # with the upper bound of the period.
+            if any([crd in TIME_COORDS for crd in self.collapse_coord]):
+                enforce_time_point_standard(result)
+
             percentile_coord = find_percentile_coordinate(result)
             result.coord(percentile_coord).rename("percentile")
             result.coord(percentile_coord).units = "%"

--- a/improver_tests/percentile/test_PercentileConverter.py
+++ b/improver_tests/percentile/test_PercentileConverter.py
@@ -130,7 +130,9 @@ class Test_process(IrisTest):
         for crd in ["time", "forecast_reference_time"]:
             self.assertEqual(result.coord(crd).points[0], cube.coord(crd).points[-1])
             self.assertEqual(result.coord(crd).bounds[0][0], cube.coord(crd).points[0])
-            self.assertEqual(result.coord(crd).bounds[0][-1], cube.coord(crd).points[-1])
+            self.assertEqual(
+                result.coord(crd).bounds[0][-1], cube.coord(crd).points[-1]
+            )
 
     def test_retain_time_coordinate_bounds(self):
         """Test that the plugin handles time being the collapse_coord and that
@@ -160,12 +162,25 @@ class Test_process(IrisTest):
         self.assertTrue("time" in [crd.name() for crd in result.coords()])
         # Check time scalar coordinate
         self.assertEqual(result.coord("time").points[0], cube.coord("time").points[-1])
-        self.assertEqual(result.coord("time").bounds[0][0], cube.coord("time").bounds[0][0])
-        self.assertEqual(result.coord("time").bounds[0][-1], cube.coord("time").bounds[-1][-1])
+        self.assertEqual(
+            result.coord("time").bounds[0][0], cube.coord("time").bounds[0][0]
+        )
+        self.assertEqual(
+            result.coord("time").bounds[0][-1], cube.coord("time").bounds[-1][-1]
+        )
         # Check forecast_reference_time scalar coordinate
-        self.assertEqual(result.coord("forecast_reference_time").points[0], cube.coord("forecast_reference_time").points[-1])
-        self.assertEqual(result.coord("forecast_reference_time").bounds[0][0], cube.coord("forecast_reference_time").points[0])
-        self.assertEqual(result.coord("forecast_reference_time").bounds[0][-1], cube.coord("forecast_reference_time").points[-1])
+        self.assertEqual(
+            result.coord("forecast_reference_time").points[0],
+            cube.coord("forecast_reference_time").points[-1],
+        )
+        self.assertEqual(
+            result.coord("forecast_reference_time").bounds[0][0],
+            cube.coord("forecast_reference_time").points[0],
+        )
+        self.assertEqual(
+            result.coord("forecast_reference_time").bounds[0][-1],
+            cube.coord("forecast_reference_time").points[-1],
+        )
 
     def test_valid_multi_coord_string_list(self):
         """Test that the plugin handles a valid list of collapse_coords passed
@@ -218,12 +233,13 @@ class Test_process(IrisTest):
 
         collapse_coord = ["longitude", "latitude"]
 
-        plugin = PercentileConverter(collapse_coord, retained_coordinates=collapse_coord)
+        plugin = PercentileConverter(
+            collapse_coord, retained_coordinates=collapse_coord
+        )
         result = plugin.process(self.cube)
 
         for coord in collapse_coord:
             self.assertTrue(coord in [crd.name() for crd in result.coords()])
-
 
     def test_single_percentile(self):
         """Test dimensions of output at median only"""


### PR DESCRIPTION
This PR enables the retention of scalar coordinates that are generated when collapsing coordinates to generate percentiles. It also ensures that if these retained coordinates are time related (time, forecast_period, forecast_reference_time), they are modified to ensure that the point is aligned to the upper bound, adhering with IMPROVER's metadata standards.

The purpose of this change is to enable the production of typical wind speed diagnostics with our existing tooling. The suite chain will become:

```mermaid
flowchart TD

A(wind speed in 3-hours) --> B(merge CLI: construct 24-hour cube with time coordinate) --> C(generate_percentiles CLI: collapse time and realization coordinates to generate percentiles)
```

This change ensures that the time period covered by the diagnostic is available on the final diagnostic. Note that we will recycle the midnight validity time for adjacent days, e.g.

Day 1: 20250115T0000Z, 03, 06, 09, 12, 15, 18, 21, 20250116T0000Z
Day 2: 20250116T0000Z, 03, 06, 09, 12, 15, 18, 21, 20250117T0000Z

The wind speed diagnostics do no cover a period, so we use as many samples as we can for a given day. This means that, in the example shown here the 20250116T0000Z forecast is included in the forecast for day 1 and day 2. The generate_percentiles CLI will create bounds from the time points (as there are no bounds here), which results in bounds that span the whole 24-hours on the output cube.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
