### PR TITLE
ENH: as_iterable for improved plugin argument handling + radius_by_lead_time using it

### DIFF
--- a/improver/nbhood/__init__.py
+++ b/improver/nbhood/__init__.py
@@ -10,10 +10,10 @@ from improver.utilities.common_input_handle import as_iterable
 
 
 def radius_by_lead_time(
-    radii: Union[str, List[str]], lead_times: Optional[List[str]] = None
+    radii: Union[str, List[str]], lead_times: Optional[Union[str, List[str]]] = None
 ) -> Tuple[Union[float, List[float], Optional[List[int]]]]:
     """
-    Parse radii and lead_times provided to CLIs that use neighbourhooding.
+    Parse radii and lead_times provided that use neighbourhooding.
     If no lead times are provided, return the first radius for use at all
     lead times. If lead times are provided, ensure there are sufficient
     radii to assign one to each lead time. If so return two lists, else raise
@@ -21,9 +21,9 @@ def radius_by_lead_time(
 
     Args:
         radii:
-            Radii as a list provided by clize.
+            One or more radii.
         lead_times:
-            Lead times as a list provided by clize, or None if not set.
+            One or more lead time, or None if not set.
 
     Returns:
         - Radii as a float or list of floats.

--- a/improver/nbhood/__init__.py
+++ b/improver/nbhood/__init__.py
@@ -6,6 +6,8 @@
 
 from typing import List, Optional, Tuple, Union
 
+from improver.utilities.common_input_handle import as_iterable
+
 
 def radius_by_lead_time(
     radii: List[str], lead_times: Optional[List[str]] = None
@@ -31,6 +33,11 @@ def radius_by_lead_time(
         ValueError: If multiple radii are provided without any lead times.
         ValueError: If radii and lead_times lists are on unequal lengths.
     """
+    if lead_times is not None:
+        lead_times = as_iterable(lead_times)
+    if radii is not None:
+        radii = as_iterable(radii)
+
     if lead_times is None:
         if not len(radii) == 1:
             raise ValueError(

--- a/improver/nbhood/__init__.py
+++ b/improver/nbhood/__init__.py
@@ -10,7 +10,7 @@ from improver.utilities.common_input_handle import as_iterable
 
 
 def radius_by_lead_time(
-    radii: List[str], lead_times: Optional[List[str]] = None
+    radii: Union[str, List[str]], lead_times: Optional[List[str]] = None
 ) -> Tuple[Union[float, List[float], Optional[List[int]]]]:
     """
     Parse radii and lead_times provided to CLIs that use neighbourhooding.

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -16,7 +16,7 @@ from improver import BasePlugin, PostProcessingPlugin
 from improver.constants import DEFAULT_PERCENTILES
 from improver.metadata.forecast_times import forecast_period_coord
 from improver.nbhood import radius_by_lead_time
-from improver.utilities.common_input_handle import as_cube
+from improver.utilities.common_input_handle import as_cube, as_iterable
 from improver.utilities.complex_conversion import complex_to_deg, deg_to_complex
 from improver.utilities.cube_checker import (
     check_cube_coordinates,
@@ -472,7 +472,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
         self,
         radii: Union[float, List[float]],
         lead_times: Optional[List] = None,
-        percentiles: List = DEFAULT_PERCENTILES,
+        percentiles: Union[float, List[float]] = DEFAULT_PERCENTILES,
     ) -> None:
         """
         Create a neighbourhood processing subclass that generates percentiles
@@ -495,7 +495,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
                 DEFAULT_PERCENTILES.
         """
         super().__init__(radii, lead_times=lead_times)
-        self.percentiles = tuple(percentiles)
+        self.percentiles = tuple(as_iterable(percentiles))
 
     def pad_and_unpad_cube(self, slice_2d: Cube, kernel: ndarray) -> Cube:
         """
@@ -766,13 +766,13 @@ class MetaNeighbourhood(BasePlugin):
     def __init__(
         self,
         neighbourhood_output: str,
-        radii: List[float],
+        radii: Union[float, List[float]],
         lead_times: Optional[List[int]] = None,
         neighbourhood_shape: str = "square",
         degrees_as_complex: bool = False,
         weighted_mode: bool = False,
         area_sum: bool = False,
-        percentiles: List[float] = DEFAULT_PERCENTILES,
+        percentiles: Union[float, List[float]] = DEFAULT_PERCENTILES,
         halo_radius: Optional[float] = None,
     ) -> None:
         """

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -491,7 +491,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
                 within 'radii' are defined. The lead times are expected
                 in hours.
             percentiles:
-                Percentile values at which to calculate; if not provided uses
+                Percentile value(s) at which to calculate; if not provided uses
                 DEFAULT_PERCENTILES.
         """
         super().__init__(radii, lead_times=lead_times)
@@ -783,7 +783,7 @@ class MetaNeighbourhood(BasePlugin):
                 The form of the results generated using neighbourhood processing.
                 If "probabilities" is selected, the mean probability with a
                 neighbourhood is calculated. If "percentiles" is selected, then
-                the percentiles are calculated with a neighbourhood. Calculating
+                the percentile(s) is/are calculated with a neighbourhood. Calculating
                 percentiles from a neighbourhood is only supported for a circular
                 neighbourhood, and the input cube should be ensemble realizations.
                 The calculation of percentiles from a neighbourhood is notably slower
@@ -816,7 +816,7 @@ class MetaNeighbourhood(BasePlugin):
             area_sum:
                 Return sum rather than fraction over the neighbourhood area.
             percentiles:
-                Calculates value at the specified percentiles from the
+                Calculates value at the specified percentile(s) from the
                 neighbourhood surrounding each grid point. This argument has no
                 effect if the output is probabilities.
             halo_radius:

--- a/improver/utilities/common_input_handle.py
+++ b/improver/utilities/common_input_handle.py
@@ -2,11 +2,20 @@
 #
 # This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from typing import Union
+from typing import Iterable, Union
 
 from iris.cube import Cube, CubeList
 
 from improver.utilities.flatten import flatten
+
+
+def as_iterable(obj):
+    """Return obj as an iterable, or an empty list if obj is None."""
+    if obj is None:
+        return []
+    elif not isinstance(obj, Iterable) or isinstance(obj, (str, bytes)):
+        obj = [obj]
+    return obj
 
 
 def as_cubelist(*cubes: Union[Cube, CubeList]):

--- a/improver_tests/utilities/common_input_handle/test_as_iterable.py
+++ b/improver_tests/utilities/common_input_handle/test_as_iterable.py
@@ -1,0 +1,36 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+from improver.utilities.common_input_handle import as_iterable
+
+
+def test_none():
+    """Test that None returns an empty list."""
+    result = as_iterable(None)
+    assert result == []
+
+
+def test_non_iterable():
+    """Test that a non-iterable object is returned as a list."""
+    result = as_iterable(1)
+    assert result == [1]
+
+
+def test_string():
+    """Test that a string is returned as a list."""
+    result = as_iterable("1")
+    assert result == ["1"]
+
+
+def test_bytes():
+    """Test that bytes are returned as a list."""
+    result = as_iterable(b"1")
+    assert result == [b"1"]
+
+
+def test_iterable():
+    """Test that an iterable object is returned as is."""
+    src = tuple(range(1))
+    result = as_iterable(src)
+    assert result is src


### PR DESCRIPTION
Addresses: N/A

Description:

1. Added new `as_terable` to improver utilities, with a similar mindset to the previously added `as_cube` and `as_cubes` functions there.  This intends to improve the robustness of the plugin UI so that it does not unnecessarily require an iterable of an object when technically it should accommodate 1 of that object.
2. Made use of this `as_iterable` in the radius_by_lead_time.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

CLA

- [ ] ~If a new developer, signed up to CLA~
