### PR TITLE
Adding two new APIs and updating the way extract_value_from_table is called

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ below:
  - Lucy Liu (Bureau of Meteorology, Australia)
  - Daniel Mentiplay (Bureau of Meteorology, Australia)
  - Stephen Moseley (Met Office, UK)
+ - Robert Neal (Met Office, UK)
  - Meabh NicGuidhir (Met Office, UK)
  - Benjamin Owen (Bureau of Meteorology, Australia)
  - Carwyn Pelley (Met Office, UK)

--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -65,6 +65,7 @@ PROCESSING_MODULES = {
     "GenerateTimeLaggedEnsemble": "improver.utilities.time_lagging",
     "GenerateTopographicZoneWeights": "improver.generate_ancillaries.generate_topographic_zone_weights",
     "GradientBetweenAdjacentGridSquares": "improver.utilities.spatial",
+    "GradientBetweenVerticalLevels": "improver.utilities.gradient_between_vertical_levels",
     "HailFraction": "improver.precipitation_type.hail_fraction",
     "HailSize": "improver.psychrometric_calculations.hail_size",
     "height_of_maximum": "improver.utilities.cube_manipulation",

--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -53,6 +53,7 @@ PROCESSING_MODULES = {
     "EstimateDzRescaling": "improver.calibration.dz_rescaling",
     "ExpectedValue": "improver.expected_value",
     "ExtendRadarMask": "improver.nowcasting.utilities",
+    "ExtractFromTable": "improver.utilities.extract_from_table",
     "ExtractLevel": "improver.utilities.cube_extraction",
     "ExtractSubCube": "improver.utilities.cube_extraction",
     "FieldTexture": "improver.utilities.textural",

--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -53,7 +53,7 @@ PROCESSING_MODULES = {
     "EstimateDzRescaling": "improver.calibration.dz_rescaling",
     "ExpectedValue": "improver.expected_value",
     "ExtendRadarMask": "improver.nowcasting.utilities",
-    "ExtractFromTable": "improver.utilities.extract_from_table",
+    "ExtractValueFromTable": "improver.utilities.extract_from_table",
     "ExtractLevel": "improver.utilities.cube_extraction",
     "ExtractSubCube": "improver.utilities.cube_extraction",
     "FieldTexture": "improver.utilities.textural",

--- a/improver_tests/utilities/test_ExtractValueFromTable.py
+++ b/improver_tests/utilities/test_ExtractValueFromTable.py
@@ -103,9 +103,9 @@ def test_read_table(
 
     wind_gust_900m.data.fill(wind_gust_value)
     lapse_class.data.fill(lapse_class_value)
-    result = ExtractValueFromTable(row_name="lapse_class", new_name=new_name)(
-        wind_gust_900m, lapse_class, table=table
-    )
+    result = ExtractValueFromTable(
+        row_name="lapse_class", new_name=new_name, table=table
+    )(wind_gust_900m, lapse_class)
     expected_data = np.full_like(
         lapse_class.data, fill_value=expected, dtype=np.float32
     )
@@ -127,8 +127,8 @@ def test_read_table_1D(
     """Test plugin to extract values from table"""
     lapse_rate.data.fill(lapse_rate_value)
 
-    result = ExtractValueFromTable(row_name="lapse_rate")(
-        lapse_rate, wind_gust_900m, table=table_1D
+    result = ExtractValueFromTable(row_name="lapse_rate", table=table_1D)(
+        lapse_rate, wind_gust_900m
     )
 
     expected_data = np.full_like(lapse_rate.data, fill_value=expected, dtype=np.float32)
@@ -143,8 +143,8 @@ def test_read_table_1D(
 def test_too_many_cubes(table_2D, lapse_class, wind_gust_900m):
     """Test that an error is raised if the number of cubes is not equal to 2"""
     with pytest.raises(ValueError, match="Exactly 2 cubes should be provided"):
-        ExtractValueFromTable(row_name="lapse_class")(
-            wind_gust_900m, lapse_class, lapse_class, table=table_2D
+        ExtractValueFromTable(row_name="lapse_class", table=table_2D)(
+            wind_gust_900m, lapse_class, lapse_class
         )
 
 
@@ -152,6 +152,6 @@ def test_cubes_different_shapes(table_2D, lapse_class, wind_gust_900m):
     """Test that an error is raised if the cubes do not have the same shape"""
     lapse_class = lapse_class[0]
     with pytest.raises(ValueError, match="Shapes of cubes do not match"):
-        ExtractValueFromTable(row_name="lapse_class")(
-            wind_gust_900m, lapse_class, table=table_2D
+        ExtractValueFromTable(row_name="lapse_class", table=table_2D)(
+            wind_gust_900m, lapse_class
         )


### PR DESCRIPTION
Description

1. Adding two new APIs for `GradientBetweenVerticalLevels` and `ExtractValueFromTable`.

2. Changing the way `improver.utilities.extract_value_from_table` is called, so it works with the new API class `ExtractValueFromTable`.
