### PR TITLE
Make is_iterable changes applicable to percentiles option

### DIFF
--- a/improver/cli/generate_percentiles.py
+++ b/improver/cli/generate_percentiles.py
@@ -15,6 +15,7 @@ def process(
     *,
     coordinates: cli.comma_separated_list = None,
     percentiles: cli.comma_separated_list = None,
+    retained_coordinates: cli.comma_separated_list = None,
     ignore_ecc_bounds_exceedance: bool = False,
     skip_ecc_bounds: bool = False,
     mask_percentiles: bool = False,
@@ -48,6 +49,10 @@ def process(
             coordinate.
         percentiles (list):
             Optional definition of percentiles at which to calculate data.
+        retained_coordinates (list):
+            Optional list of collapsed coordinates that should be retained in
+            their new scalar form. The default behaviour is to remove the
+            scalar coordinates that result from coordinate collapse.
         ignore_ecc_bounds_exceedance (bool):
             If True, where calculated percentiles are outside the ECC bounds
             range, raises a warning rather than an exception.
@@ -145,6 +150,7 @@ def process(
         result = PercentileConverter(
             coordinates,
             percentiles=percentiles,
+            retained_coordinates=retained_coordinates,
             fast_percentile_method=fast_percentile_method,
         )(cube)
     else:

--- a/improver/nbhood/nbhood.py
+++ b/improver/nbhood/nbhood.py
@@ -16,7 +16,7 @@ from improver import BasePlugin, PostProcessingPlugin
 from improver.constants import DEFAULT_PERCENTILES
 from improver.metadata.forecast_times import forecast_period_coord
 from improver.nbhood import radius_by_lead_time
-from improver.utilities.common_input_handle import as_cube
+from improver.utilities.common_input_handle import as_cube, as_iterable
 from improver.utilities.complex_conversion import complex_to_deg, deg_to_complex
 from improver.utilities.cube_checker import (
     check_cube_coordinates,
@@ -472,7 +472,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
         self,
         radii: Union[float, List[float]],
         lead_times: Optional[List] = None,
-        percentiles: List = DEFAULT_PERCENTILES,
+        percentiles: Union[float, List[float]] = DEFAULT_PERCENTILES,
     ) -> None:
         """
         Create a neighbourhood processing subclass that generates percentiles
@@ -495,7 +495,7 @@ class GeneratePercentilesFromANeighbourhood(BaseNeighbourhoodProcessing):
                 DEFAULT_PERCENTILES.
         """
         super().__init__(radii, lead_times=lead_times)
-        self.percentiles = tuple(percentiles)
+        self.percentiles = tuple(as_iterable(percentiles))
 
     def pad_and_unpad_cube(self, slice_2d: Cube, kernel: ndarray) -> Cube:
         """
@@ -766,13 +766,13 @@ class MetaNeighbourhood(BasePlugin):
     def __init__(
         self,
         neighbourhood_output: str,
-        radii: List[float],
+        radii: Union[float, List[float]],
         lead_times: Optional[List[int]] = None,
         neighbourhood_shape: str = "square",
         degrees_as_complex: bool = False,
         weighted_mode: bool = False,
         area_sum: bool = False,
-        percentiles: List[float] = DEFAULT_PERCENTILES,
+        percentiles: Union[float, List[float]] = DEFAULT_PERCENTILES,
         halo_radius: Optional[float] = None,
     ) -> None:
         """

--- a/improver_tests/percentile/test_PercentileConverter.py
+++ b/improver_tests/percentile/test_PercentileConverter.py
@@ -52,6 +52,8 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(
             result.data[:, 0, 0], self.default_percentiles * 0.1
         )
+        # Check collapsed coordinate removed
+        self.assertNotIn(collapse_coord, [crd.name() for crd in result.coords()])
         # Check coordinate name.
         self.assertEqual(result.coords()[0].name(), "percentile")
         # Check coordinate units.
@@ -87,6 +89,8 @@ class Test_process(IrisTest):
         self.assertArrayAlmostEqual(
             result.data[:, 0, 0, 0], self.default_percentiles * 0.01
         )
+        # Check collapsed coordinate removed
+        self.assertNotIn(collapse_coord, [crd.name() for crd in result.coords()])
         # Check coordinate name.
         self.assertEqual(result.coords()[0].name(), "percentile")
         # Check coordinate units.
@@ -98,6 +102,85 @@ class Test_process(IrisTest):
         )
         # Check resulting data shape.
         self.assertEqual(result.data.shape, (15, 3, 11, 11))
+
+    def test_retain_time_coordinate(self):
+        """Test that the plugin handles time being the collapse_coord and that
+        coordinate being retained as a scalar coordinate on the resulting
+        cube. In this case the input cubes have no bounds, meaning the
+        constructed scalar time coordinate simply spans the input time
+        points."""
+        data = [[list(range(1, 12, 1))] * 11] * 3
+        data = np.array(data).astype(np.float32)
+        data.resize((3, 11, 11))
+        new_cube = set_up_variable_cube(
+            data,
+            time=datetime(2017, 11, 11, 4, 0),
+            frt=datetime(2017, 11, 11, 0, 0),
+            realizations=[0, 1, 2],
+        )
+        cube = iris.cube.CubeList([self.cube, new_cube]).merge_cube()
+        collapse_coord = "time"
+
+        plugin = PercentileConverter(collapse_coord, retained_coordinates="time")
+        result = plugin.process(cube)
+
+        # Check time coordinate has been retained.
+        self.assertTrue("time" in [crd.name() for crd in result.coords()])
+        # Check time and associated forecast_reference_time scalar coordinates
+        for crd in ["time", "forecast_reference_time"]:
+            self.assertEqual(result.coord(crd).points[0], cube.coord(crd).points[-1])
+            self.assertEqual(result.coord(crd).bounds[0][0], cube.coord(crd).points[0])
+            self.assertEqual(
+                result.coord(crd).bounds[0][-1], cube.coord(crd).points[-1]
+            )
+
+    def test_retain_time_coordinate_bounds(self):
+        """Test that the plugin handles time being the collapse_coord and that
+        coordinate being retained as a scalar coordinate on the resulting
+        cube. In this case the input cubes have bounds, meaning the
+        constructed scalar time coordinate should span the input time
+        bounds."""
+        data = [[list(range(1, 12, 1))] * 11] * 3
+        data = np.array(data).astype(np.float32)
+        data.resize((3, 11, 11))
+        new_cube = set_up_variable_cube(
+            data,
+            time=datetime(2017, 11, 11, 4, 0),
+            frt=datetime(2017, 11, 11, 0, 0),
+            time_bounds=[datetime(2017, 11, 11, 3, 0), datetime(2017, 11, 11, 4, 0)],
+            realizations=[0, 1, 2],
+        )
+        self.cube.coord("time").bounds = [1510282800, 1510286400]
+
+        cube = iris.cube.CubeList([self.cube, new_cube]).merge_cube()
+        collapse_coord = "time"
+
+        plugin = PercentileConverter(collapse_coord, retained_coordinates="time")
+        result = plugin.process(cube)
+
+        # Check time coordinate has been retained.
+        self.assertTrue("time" in [crd.name() for crd in result.coords()])
+        # Check time scalar coordinate
+        self.assertEqual(result.coord("time").points[0], cube.coord("time").points[-1])
+        self.assertEqual(
+            result.coord("time").bounds[0][0], cube.coord("time").bounds[0][0]
+        )
+        self.assertEqual(
+            result.coord("time").bounds[0][-1], cube.coord("time").bounds[-1][-1]
+        )
+        # Check forecast_reference_time scalar coordinate
+        self.assertEqual(
+            result.coord("forecast_reference_time").points[0],
+            cube.coord("forecast_reference_time").points[-1],
+        )
+        self.assertEqual(
+            result.coord("forecast_reference_time").bounds[0][0],
+            cube.coord("forecast_reference_time").points[0],
+        )
+        self.assertEqual(
+            result.coord("forecast_reference_time").bounds[0][-1],
+            cube.coord("forecast_reference_time").points[-1],
+        )
 
     def test_valid_multi_coord_string_list(self):
         """Test that the plugin handles a valid list of collapse_coords passed
@@ -129,6 +212,9 @@ class Test_process(IrisTest):
                 10.0,
             ],
         )
+        # Check collapsed coordinate removed
+        for coord in collapse_coord:
+            self.assertNotIn(coord, [crd.name() for crd in result.coords()])
         # Check coordinate name.
         self.assertEqual(result.coords()[0].name(), "percentile")
         # Check coordinate units.
@@ -140,6 +226,20 @@ class Test_process(IrisTest):
         )
         # Check resulting data shape.
         self.assertEqual(result.data.shape, (15, 3))
+
+    def test_retention_of_multiple_coords(self):
+        """Test that multiple coordinates that have been collapsed can be
+        retained as scalars using the retained_coordinates option."""
+
+        collapse_coord = ["longitude", "latitude"]
+
+        plugin = PercentileConverter(
+            collapse_coord, retained_coordinates=collapse_coord
+        )
+        result = plugin.process(self.cube)
+
+        for coord in collapse_coord:
+            self.assertTrue(coord in [crd.name() for crd in result.coords()])
 
     def test_single_percentile(self):
         """Test dimensions of output at median only"""


### PR DESCRIPTION
This adaption to the is_iterable branch allows the percentiles attribute of `MetaNeighbourhood` to be set by a single value in a similar way to this adaption. 
