### PR TITLE
Read the docs fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,6 @@ build:
 
 conda:
   environment: doc/rtd_environment.yml
+
+sphinx:
+  configuration: doc/source/conf.py


### PR DESCRIPTION
Add sphinx config path explicitly to readthedocs yaml file to accommodate recent deprecation, see:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config

Testing:
Built the latest docs using this change which can be seen here: https://bens-improver-fork.readthedocs.io/en/latest/