### PR TITLE
Avoid cell method duplication in ApplyEMOS

### DIFF
--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -1911,11 +1911,11 @@ class ApplyEMOS(PostProcessingPlugin):
                     random_ordering=randomise,
                     random_seed=random_seed,
                 )
-
-        # Preserve cell methods from template.
-        for cm in template.cell_methods:
-            result.add_cell_method(cm)
-
+              
+            # Preserve cell methods from template.
+            for cm in template.cell_methods:
+                result.add_cell_method(cm)
+ 
         return result
 
     def process(

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -1911,11 +1911,11 @@ class ApplyEMOS(PostProcessingPlugin):
                     random_ordering=randomise,
                     random_seed=random_seed,
                 )
-              
+
             # Preserve cell methods from template.
             for cm in template.cell_methods:
                 result.add_cell_method(cm)
- 
+
         return result
 
     def process(

--- a/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
@@ -484,7 +484,25 @@ class Test_process(IrisTest):
         self.assertAlmostEqual(
             np.mean(result.data), self.null_percentiles_expected_mean
         )
+        self.assertEqual(len(result.cell_methods), 1)  
         self.assertEqual(result.cell_methods[0], cell_methods)
+
+    def test_period_probabilities(self):
+        """Test that the desired cell methods are present on the calibrated forecasts,
+        without duplication of the cell methods, if cell methods are present on the 
+        input probability forecast."""
+        self.probabilities.coord("time").bounds = [
+            int(self.probabilities.coord("time").points - 3600),
+            int(self.probabilities.coord("time").points),
+        ]
+
+        cell_methods = CellMethod("maximum", coords="time")
+        self.probabilities.add_cell_method(cell_methods)
+
+        result = ApplyEMOS()(self.probabilities, self.coefficients, realizations_count=3)
+        self.assertIn("probability", result.name())
+        self.assertEqual(len(result.cell_methods), 1)    
+        self.assertEqual(result.cell_methods[0], cell_methods)    
 
     def test_invalid_attribute(self):
         """Test that an exception is raised if multiple different distribution

--- a/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
+++ b/improver_tests/calibration/ensemble_calibration/test_ApplyEMOS.py
@@ -484,12 +484,12 @@ class Test_process(IrisTest):
         self.assertAlmostEqual(
             np.mean(result.data), self.null_percentiles_expected_mean
         )
-        self.assertEqual(len(result.cell_methods), 1)  
+        self.assertEqual(len(result.cell_methods), 1)
         self.assertEqual(result.cell_methods[0], cell_methods)
 
     def test_period_probabilities(self):
         """Test that the desired cell methods are present on the calibrated forecasts,
-        without duplication of the cell methods, if cell methods are present on the 
+        without duplication of the cell methods, if cell methods are present on the
         input probability forecast."""
         self.probabilities.coord("time").bounds = [
             int(self.probabilities.coord("time").points - 3600),
@@ -499,10 +499,12 @@ class Test_process(IrisTest):
         cell_methods = CellMethod("maximum", coords="time")
         self.probabilities.add_cell_method(cell_methods)
 
-        result = ApplyEMOS()(self.probabilities, self.coefficients, realizations_count=3)
+        result = ApplyEMOS()(
+            self.probabilities, self.coefficients, realizations_count=3
+        )
         self.assertIn("probability", result.name())
-        self.assertEqual(len(result.cell_methods), 1)    
-        self.assertEqual(result.cell_methods[0], cell_methods)    
+        self.assertEqual(len(result.cell_methods), 1)
+        self.assertEqual(result.cell_methods[0], cell_methods)
 
     def test_invalid_attribute(self):
         """Test that an exception is raised if multiple different distribution


### PR DESCRIPTION
Addresses #https://github.com/metoppv/mo-blue-team/issues/844

This PR removes the potential for cell methods to be duplicated within the ApplyEMOS plugin, when, for example, a probability forecast describing a period is provided.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
