### PR TITLE
Modified percentile generation functionality within IMPROVER to only use ECC bounds when required

### DIFF
--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -238,7 +238,7 @@ class ResamplePercentiles(BasePlugin):
     ) -> bool:
         """
         Function to check whether ECC bounds are required for the percentile generation
-            process. ECC bounds are only necessary if any of the desired percentiles are
+        process. ECC bounds are only necessary if any of the desired percentiles are
         greater than/less than the largest/smallest of the original percentiles.
 
         Args:
@@ -547,7 +547,7 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
     ) -> bool:
         """
         Function to check whether ECC bounds are required for the percentile generation
-            process. ECC bounds are only necessary if the largest threshold defined on a
+        process. ECC bounds are only necessary if the largest threshold defined on a
         cube has non-zero probability of being exceeded.
 
         Args:

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -716,11 +716,11 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
             if self._assess_if_ecc_bounds_needed(
                 forecast_probabilities, threshold_points, threshold_name
             ):
-                phenom_name = get_threshold_coord_name_from_probability_name(
+                threshold_name = get_threshold_coord_name_from_probability_name(
                     forecast_probabilities.name()
                 )
                 cube_units = forecast_probabilities.coord(threshold_coord.name()).units
-                bounds_pairing = get_bounds_of_distribution(phenom_name, cube_units)
+                bounds_pairing = get_bounds_of_distribution(threshold_name, cube_units)
                 (threshold_points, probabilities_for_cdf) = (
                     self._add_bounds_to_thresholds_and_probabilities(
                         threshold_points, probabilities_for_cdf, bounds_pairing

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -565,8 +565,6 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
         largest_threshold_slice = forecast_probabilities.extract(
             iris.Constraint(**{threshold_name: threshold_points[-1]})
         )
-        # if largest_threshold_slice is None:
-        #     return False
         if np.any(largest_threshold_slice.data != 0):
             return True
         else:

--- a/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
+++ b/improver/ensemble_copula_coupling/ensemble_copula_coupling.py
@@ -238,7 +238,7 @@ class ResamplePercentiles(BasePlugin):
     ) -> bool:
         """
         Function to check whether ECC bounds are required for the percentile generation
-	    process. ECC bounds are only necessary if any of the desired percentiles are 
+            process. ECC bounds are only necessary if any of the desired percentiles are
         greater than/less than the largest/smallest of the original percentiles.
 
         Args:
@@ -251,8 +251,10 @@ class ResamplePercentiles(BasePlugin):
             Boolean indicating whether ECC bounds are needed (True if needed, False if
             not).
         """
-        if (desired_percentiles[0] < original_percentiles[0] or
-            desired_percentiles[-1] > original_percentiles[-1]):
+        if (
+            desired_percentiles[0] < original_percentiles[0]
+            or desired_percentiles[-1] > original_percentiles[-1]
+        ):
             return True
         else:
             return False
@@ -545,7 +547,7 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
     ) -> bool:
         """
         Function to check whether ECC bounds are required for the percentile generation
-	    process. ECC bounds are only necessary if the largest threshold defined on a 
+            process. ECC bounds are only necessary if the largest threshold defined on a
         cube has non-zero probability of being exceeded.
 
         Args:
@@ -569,7 +571,6 @@ class ConvertProbabilitiesToPercentiles(BasePlugin):
             return True
         else:
             return False
-        
 
     def _add_bounds_to_thresholds_and_probabilities(
         self,

--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -498,13 +498,14 @@ class Test__probabilities_to_percentiles(IrisTest):
         self.assertTrue(result)
 
     def test__assess_if_ecc_bounds_needed_false(self):
-        """Test that if there is not a non-zero probability of values exceeding the greatest
-        threshold, the method returns false."""
+        """Test that if there is not a non-zero probability of values exceeding the 
+        greatest threshold, the method returns false."""
         threshold_coord = find_threshold_coordinate(self.cube)
         dimension_name = threshold_coord.name()
         threshold_points = threshold_coord.points
 
-        # create a modified cube where the probability of exceeding the largest threshold is always zero
+        # create a modified cube where the probability of exceeding the largest 
+        # threshold is always zero
         modified_cube = self.cube.copy()
         modified_cube.data[-1, :, :] = np.zeros([3, 3])
 

--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -485,24 +485,33 @@ class Test__probabilities_to_percentiles(IrisTest):
 
         self.assertArrayEqual(result.data.mask, expected_mask)
 
-    def test__assess_if_ecc_bounds_needed(self):
+    def test__assess_if_ecc_bounds_needed_true(self):
         """Test that if there is a non-zero probability of values exceeding the greatest
-        threshold, ECC bounds are searched for; otherwise ECC bounds are not searched
-        for."""
+        threshold, the method returns true."""
         threshold_coord = find_threshold_coordinate(self.cube)
         dimension_name = threshold_coord.name()
         threshold_points = threshold_coord.points
 
-        result_true = Plugin()._assess_if_ecc_bounds_needed(
+        result = Plugin()._assess_if_ecc_bounds_needed(
             self.cube, threshold_points, dimension_name
         )
-        self.assertTrue(result_true)
+        self.assertTrue(result)
 
-        threshold_points_all_zero = np.full_like(threshold_points, 0)
-        result_false = Plugin()._assess_if_ecc_bounds_needed(
-            self.cube, threshold_points_all_zero, dimension_name
+    def test__assess_if_ecc_bounds_needed_false(self):
+        """Test that if there is not a non-zero probability of values exceeding the greatest
+        threshold, the method returns false."""
+        threshold_coord = find_threshold_coordinate(self.cube)
+        dimension_name = threshold_coord.name()
+        threshold_points = threshold_coord.points
+
+        # create a modified cube where the probability of exceeding the largest threshold is always zero
+        modified_cube = self.cube.copy()
+        modified_cube.data[-1, :, :] = np.zeros([3, 3])
+
+        result = Plugin()._assess_if_ecc_bounds_needed(
+            modified_cube, threshold_points, dimension_name
         )
-        self.assertFalse(result_false)
+        self.assertFalse(result)
 
 
 class Test_process(IrisTest):

--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -498,13 +498,13 @@ class Test__probabilities_to_percentiles(IrisTest):
         self.assertTrue(result)
 
     def test__assess_if_ecc_bounds_needed_false(self):
-        """Test that if there is not a non-zero probability of values exceeding the 
+        """Test that if there is not a non-zero probability of values exceeding the
         greatest threshold, the method returns false."""
         threshold_coord = find_threshold_coordinate(self.cube)
         dimension_name = threshold_coord.name()
         threshold_points = threshold_coord.points
 
-        # create a modified cube where the probability of exceeding the largest 
+        # create a modified cube where the probability of exceeding the largest
         # threshold is always zero
         modified_cube = self.cube.copy()
         modified_cube.data[-1, :, :] = np.zeros([3, 3])

--- a/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ConvertProbabilitiesToPercentiles.py
@@ -485,6 +485,25 @@ class Test__probabilities_to_percentiles(IrisTest):
 
         self.assertArrayEqual(result.data.mask, expected_mask)
 
+    def test__assess_if_ecc_bounds_needed(self):
+        """Test that if there is a non-zero probability of values exceeding the greatest
+        threshold, ECC bounds are searched for; otherwise ECC bounds are not searched
+        for."""
+        threshold_coord = find_threshold_coordinate(self.cube)
+        dimension_name = threshold_coord.name()
+        threshold_points = threshold_coord.points
+
+        result_true = Plugin()._assess_if_ecc_bounds_needed(
+            self.cube, threshold_points, dimension_name
+        )
+        self.assertTrue(result_true)
+
+        threshold_points_all_zero = np.full_like(threshold_points, 0)
+        result_false = Plugin()._assess_if_ecc_bounds_needed(
+            self.cube, threshold_points_all_zero, dimension_name
+        )
+        self.assertFalse(result_false)
+
 
 class Test_process(IrisTest):
     """

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -435,7 +435,7 @@ class Test__interpolate_percentiles(IrisTest):
         self.assertTrue(result)
 
     def test__assess_if_ecc_bounds_needed_false(self):
-        """Test that if the requested percentiles are inside the bounds of the input 
+        """Test that if the requested percentiles are inside the bounds of the input
         percentiles the method returns False.
         """
         original_percentiles = self.percentiles  # [10, 50, 90]

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -421,24 +421,31 @@ class Test__interpolate_percentiles(IrisTest):
         )
         self.assertArrayAlmostEqual(result.data, data, decimal=5)
 
-    def test__assess_if_ecc_bounds_needed(self):
-        """Test that ECC bounds are only search for in the percentile generation process
-        if the desired percentiles are outside the bounds of the original percentiles.
+    def test__assess_if_ecc_bounds_needed_true(self):
+        """Test that if the requested percentiles are outside the bounds of the input percentiles the method
+        returns True.
         """
         original_percentiles = self.percentiles  # [10, 50, 90]
         desired_percentiles = [8, 48, 92]
 
-        result_true = Plugin()._assess_if_ecc_bounds_needed(
+        result = Plugin()._assess_if_ecc_bounds_needed(
             original_percentiles, desired_percentiles
         )
 
-        self.assertTrue(result_true)
+        self.assertTrue(result)
 
+    def test__assess_if_ecc_bounds_needed_false(self):
+        """Test that if the requested percentiles are inside the bounds of the input percentiles the method
+        returns False.
+        """
+        original_percentiles = self.percentiles  # [10, 50, 90]
         desired_percentiles = [11, 50, 90]
-        result_false = Plugin()._assess_if_ecc_bounds_needed(
+
+        result = Plugin()._assess_if_ecc_bounds_needed(
             original_percentiles, desired_percentiles
         )
-        self.assertFalse(result_false)
+
+        self.assertFalse(result)
 
 
 class Test_process(IrisTest):

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -422,8 +422,8 @@ class Test__interpolate_percentiles(IrisTest):
         self.assertArrayAlmostEqual(result.data, data, decimal=5)
 
     def test__assess_if_ecc_bounds_needed_true(self):
-        """Test that if the requested percentiles are outside the bounds of the input percentiles the method
-        returns True.
+        """Test that if the requested percentiles are outside the bounds of the input
+        percentiles the method returns True.
         """
         original_percentiles = self.percentiles  # [10, 50, 90]
         desired_percentiles = [8, 48, 92]
@@ -435,8 +435,8 @@ class Test__interpolate_percentiles(IrisTest):
         self.assertTrue(result)
 
     def test__assess_if_ecc_bounds_needed_false(self):
-        """Test that if the requested percentiles are inside the bounds of the input percentiles the method
-        returns False.
+        """Test that if the requested percentiles are inside the bounds of the input 
+        percentiles the method returns False.
         """
         original_percentiles = self.percentiles  # [10, 50, 90]
         desired_percentiles = [11, 50, 90]

--- a/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
+++ b/improver_tests/ensemble_copula_coupling/test_ResamplePercentiles.py
@@ -421,6 +421,25 @@ class Test__interpolate_percentiles(IrisTest):
         )
         self.assertArrayAlmostEqual(result.data, data, decimal=5)
 
+    def test__assess_if_ecc_bounds_needed(self):
+        """Test that ECC bounds are only search for in the percentile generation process
+        if the desired percentiles are outside the bounds of the original percentiles.
+        """
+        original_percentiles = self.percentiles  # [10, 50, 90]
+        desired_percentiles = [8, 48, 92]
+
+        result_true = Plugin()._assess_if_ecc_bounds_needed(
+            original_percentiles, desired_percentiles
+        )
+
+        self.assertTrue(result_true)
+
+        desired_percentiles = [11, 50, 90]
+        result_false = Plugin()._assess_if_ecc_bounds_needed(
+            original_percentiles, desired_percentiles
+        )
+        self.assertFalse(result_false)
+
 
 class Test_process(IrisTest):
     """Test the process plugin of the Resample Percentiles plugin."""


### PR DESCRIPTION
Addresses #2098 

Description:
Added and implemented a method to the classes ResamplePercentiles and ConvertProbabilitiesToPercentiles within ensemble_copula_coupling.py which assesses if ECC bounds are needed. The methods output a boolean which is used to control whether ECC bounds are searched for.

Testing:
- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)