### PR TITLE
MOBT-810: Fix SpotManipulation skip_ecc_bounds bug

### DIFF
--- a/improver/cli/spot_extract.py
+++ b/improver/cli/spot_extract.py
@@ -87,12 +87,13 @@ def process(
             Demotes exceptions where calculated percentiles are outside the ECC
             bounds range to warnings.
         skip_ecc_bounds (bool):
-            If True, ECC bounds are not included when probabilities
-            are converted to percentiles. This has the effect that percentiles
-            outside of the range given by the input percentiles will be computed
-            by nearest neighbour interpolation from the nearest available percentile,
-            rather than using linear interpolation between the nearest available
-            percentile and the ECC bound.
+            If True, ECC bounds are not included when converting probabilities to
+            percentiles or from one set of percentiles to another. This has the
+            effect that percentiles outside of the range given by the input
+            percentiles will be computed by nearest neighbour interpolation from
+            the nearest available percentile, rather than using linear
+            interpolation between the nearest available percentile and the ECC
+            bound.
         new_title (str):
             New title for the spot-extracted data.  If None, this attribute is
             removed from the output cube since it has no prescribed standard

--- a/improver/spotdata/spot_manipulation.py
+++ b/improver/spotdata/spot_manipulation.py
@@ -236,7 +236,7 @@ class SpotManipulation(BasePlugin):
                     ]
                     result = extract_subcube(result, constraint)
                 else:
-                    result = ResamplePercentiles()(
+                    result = ResamplePercentiles(skip_ecc_bounds=self.skip_ecc_bounds)(
                         result, percentiles=extract_percentiles
                     )
 

--- a/improver/spotdata/spot_manipulation.py
+++ b/improver/spotdata/spot_manipulation.py
@@ -100,12 +100,13 @@ class SpotManipulation(BasePlugin):
                 Demotes exceptions where calculated percentiles are outside the ECC
                 bounds range to warnings.
             skip_ecc_bounds (bool):
-                If True, ECC bounds are not included when probabilities
-                are converted to percentiles. This has the effect that percentiles
-                outside of the range given by the input percentiles will be computed
-                by nearest neighbour interpolation from the nearest available percentile,
-                rather than using linear interpolation between the nearest available
-                percentile and the ECC bound.
+                If True, ECC bounds are not included when converting probabilities to
+                percentiles or from one set of percentiles to another. This has the
+                effect that percentiles outside of the range given by the input
+                percentiles will be computed by nearest neighbour interpolation from
+                the nearest available percentile, rather than using linear
+                interpolation between the nearest available percentile and the ECC
+                bound.
             new_title (str):
                 New title for the spot-extracted data.  If None, this attribute is
                 removed from the output cube since it has no prescribed standard

--- a/improver_tests/spotdata/test_SpotManipulation.py
+++ b/improver_tests/spotdata/test_SpotManipulation.py
@@ -177,6 +177,15 @@ def add_grid_hash(target, source):
             {"extract_percentiles": [50]},
             np.array([278.5, 279.5]),
         ),
+        # Resample existing percentiles to extract target percentiles. Use skip_ecc_bounds option so that the largest
+        # extracted percentile should be derived by nearest neighbour interpolation.
+        (
+            gridded_percentiles,
+            np.arange(273, 291).reshape(2, 3, 3),
+            np.array([[[1, 2], [0, 0], [5, 10]]]),
+            {"extract_percentiles": [50, 90], "skip_ecc_bounds": True},
+            np.array([[278.5, 279.5], [283, 284]]),
+        ),
         # Extract single percentile from a probability input cube.
         (
             gridded_probabilities,


### PR DESCRIPTION
The SpotManipulation plugin has some logic within in which determines which plugin is called to produce the desired forecast representation from the input forecast. The SpotManipulation plugin allows a skip_ecc_bounds input to be given, however this input is not passed along to the ResamplePercentiles plugin when converting a forecast containing one set of percentiles to another set of percentiles.

This PR fixes this small bug and adds a unit test for the fix.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
