### PR TITLE
add VirtualTemperature to PROCESSING_MODULES

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ below:
  - Victoria Smart (Met Office, UK)
  - Eleanor Smith (Met Office, UK)
  - Marcus Spelman (Met Office, UK)
+ - Katherine Tomkins (Met Office, UK)
  - Belinda Trotta (Bureau of Meteorology, Australia)
  - Tomasz Trzeciak (Met Office, UK)
  - Max White (Met Office, UK)

--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -120,6 +120,7 @@ PROCESSING_MODULES = {
     "Threshold": "improver.threshold",
     "TriangularWeightedBlendAcrossAdjacentPoints": "improver.blending.blend_across_adjacent_points",
     "VerticalUpdraught": "improver.wind_calculations.vertical_updraught",
+    "VirtualTemperature": "improver.virtual_temperature",
     "VisibilityCombineCloudBase": "improver.visibility.visibility_combine_cloud_base",
     "WeightAndBlend": "improver.blending.calculate_weights_and_blend",
     "WeightedBlendAcrossWholeDimension": "improver.blending.weighted_blend",


### PR DESCRIPTION
Addresses [#GitHubissuenum]
https://metoffice.atlassian.net/browse/EPPT-2352

Description
Add virtual temperature to improver list of processing modules. This is called by the EPP-Workflows application - https://github.com/MetOffice/epp_workflows/pull/160

Testing:

- [Y] Ran tests and they passed OK
- [N] Added new tests for the new feature(s) (already tested in improver_tests/test_api.py)

all tests in improver_tests:
`5550 passed, 647 skipped, 1 xfailed, 3602 warnings in 392.08s (0:06:32)`
improver_tests/test_api.py:
`115 passed, 2 warnings in 1.16s`

CLA

- [ ] If a new developer, signed up to CLA
