### PR TITLE
Mobt_859_test

### DIFF
--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -165,20 +165,7 @@ class StandardiseMetadata(BasePlugin):
             import iris
 
             if cube.long_name == "probability_of_visibility_in_air_below_threshold":
-                #            if cube.coords(coord):
-                #                if cube.coords(coord, dim_coords=True):
-                #                    raise ValueError(
-                #                        "Modifying dimension coordinate values is not allowed "
-                #                        "due to the risk of introducing errors."
-                #                    )
-                #                if hasattr(value, "__len__") and len(value) > 1:
-                #                    raise ValueError(
-                #                        "Modifying multi-valued coordinates is not allowed. "
-                #                        "This functionality should be used only for very "
-                #                        "modest changes to scalar coordinates."
-                #                    )
-                #                if _is_time_coord(cube.coord(coord)):
-                #                    raise ValueError("Modifying time coordinates is not allowed.")
+
                 cube.add_aux_coord(
                     iris.coords.AuxCoord(
                         value,


### PR DESCRIPTION
Issue description:
Currently the mix suite cannot run as the cube outputs from the imenukx, imukvx and imengluk cannot be merged into a single cube. This is because the imenukx and imukvx model output cubes do not contain a height coordinate whereas imengluk does.

This is something that should be discuss with STAGE but for testing purposes the standardise.py file should be modified to add a height coordinate to a cube if one is not already present.

Acceptance criteria:

- [x] standardise.py file modified to add a height coordinate to a cube if one is not already present.


**This is not to be merged but solely for testing purposes**
