### PR TITLE
Virtual Temperature - replace Iris multiply with Numpy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ below:
  - Victoria Smart (Met Office, UK)
  - Eleanor Smith (Met Office, UK)
  - Marcus Spelman (Met Office, UK)
+ - Katherine Tomkins (Met Office, UK)
  - Belinda Trotta (Bureau of Meteorology, Australia)
  - Tomasz Trzeciak (Met Office, UK)
  - Max White (Met Office, UK)

--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -120,6 +120,7 @@ PROCESSING_MODULES = {
     "Threshold": "improver.threshold",
     "TriangularWeightedBlendAcrossAdjacentPoints": "improver.blending.blend_across_adjacent_points",
     "VerticalUpdraught": "improver.wind_calculations.vertical_updraught",
+    "VirtualTemperature": "improver.virtual_temperature",
     "VisibilityCombineCloudBase": "improver.visibility.visibility_combine_cloud_base",
     "WeightAndBlend": "improver.blending.calculate_weights_and_blend",
     "WeightedBlendAcrossWholeDimension": "improver.blending.weighted_blend",

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -355,6 +355,7 @@ class HumidityMixingRatio(BasePlugin):
         )
 
         try:
+            # check if there is a pressure cube by examining the cube names
             self.pressure = cubes.extract_cube(check_for_pressure_cube(cubes))
         except ConstraintMismatchError:
             # If no pressure cube is provided, check if pressure is a coordinate in the temperature and relative humidity cubes
@@ -382,7 +383,7 @@ class HumidityMixingRatio(BasePlugin):
 
 
 def check_for_pressure_cube(cubes) -> str:
-    """Checks a list of cubes to see if any has the pressure in the name"""
+    """Checks a list of cubes to see if any has the pressure in the name and returns the name as a string"""
     for cube in cubes:
         cubename = cube.name()
         if "pressure" in cubename:

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -384,10 +384,17 @@ class HumidityMixingRatio(BasePlugin):
 
 def check_for_pressure_cube(cubes) -> str:
     """Checks a list of cubes to see if any has the pressure in the name and returns the name as a string"""
+    pressure_names = []
     for cube in cubes:
         cubename = cube.name()
         if "pressure" in cubename:
-            return cubename
+            pressure_names.append(cubename)
+    if len(pressure_names) > 1:
+        raise ValueError("More than one cube with 'pressure' in name found.")
+    if pressure_names:
+        return pressure_names[0]
+    else:
+        return None
 
 
 class PhaseChangeLevel(BasePlugin):

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -382,7 +382,7 @@ class HumidityMixingRatio(BasePlugin):
 
 
 def check_for_pressure_cube(cubes) -> str:
-    """Checks a list of cubes to see if one has the pressure in the name"""
+    """Checks a list of cubes to see if any has the pressure in the name"""
     for cube in cubes:
         cubename = cube.name()
         if "pressure" in cubename:

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -355,7 +355,7 @@ class HumidityMixingRatio(BasePlugin):
         )
 
         try:
-            self.pressure = cubes.extract_cube("surface_air_pressure")
+            self.pressure = cubes.extract_cube(check_for_pressure_cube(cubes))
         except ConstraintMismatchError:
             # If no pressure cube is provided, check if pressure is a coordinate in the temperature and relative humidity cubes
             temp_coord_flag = any(
@@ -379,6 +379,14 @@ class HumidityMixingRatio(BasePlugin):
             * self.rel_humidity.data
         )
         return self._make_humidity_cube(humidity)
+
+
+def check_for_pressure_cube(cubes) -> str:
+    """Checks a list of cubes to see if one has the pressure in the name"""
+    for cube in cubes:
+        cubename = cube.name()
+        if "pressure" in cubename:
+            return cubename
 
 
 class PhaseChangeLevel(BasePlugin):

--- a/improver/psychrometric_calculations/psychrometric_calculations.py
+++ b/improver/psychrometric_calculations/psychrometric_calculations.py
@@ -369,7 +369,7 @@ class HumidityMixingRatio(BasePlugin):
                 self.generate_pressure_cube()
             else:
                 raise ValueError(
-                    "No pressure cube called 'surface_air_pressure' found and no pressure coordinate found in temperature or relative humidity cubes"
+                    "No pressure cube with name 'pressure' found and no pressure coordinate found in temperature or relative humidity cubes"
                 )
 
         self.mandatory_attributes = generate_mandatory_attributes(

--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -264,6 +264,8 @@ class StandardiseMetadata(BasePlugin):
             The processed cube
         """
         cube = as_cube(cube)
+        if self._coords_to_remove:
+            self._remove_scalar_coords(cube, self._coords_to_remove)
         cube = self._rm_air_temperature_status_flag(cube)
         cube = self._collapse_scalar_dimensions(cube)
 
@@ -271,8 +273,7 @@ class StandardiseMetadata(BasePlugin):
             cube.rename(self._new_name)
         if self._new_units:
             cube.convert_units(self._new_units)
-        if self._coords_to_remove:
-            self._remove_scalar_coords(cube, self._coords_to_remove)
+
         if self._coord_modification:
             self._modify_scalar_coord_value(cube, self._coord_modification)
         if self._attributes_dict:

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -48,6 +48,8 @@ def _check_metadata(cube: Cube) -> None:
             misinterpretation on "load"
     """
     check_mandatory_standards(cube)
+    print("unit", cf_units.Unit(cube.units))
+    print("unit evaluation: ", cf_units.Unit(cube.units).is_unknown())
     if cf_units.Unit(cube.units).is_unknown():
         raise ValueError("{} has unknown units".format(cube.name()))
 

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -48,6 +48,7 @@ def _check_metadata(cube: Cube) -> None:
             misinterpretation on "load"
     """
     check_mandatory_standards(cube)
+    print("is cube lazy? ", cube.has_lazy_data())
     if cf_units.Unit(cube.units).is_unknown():
         raise ValueError("{} has unknown units".format(cube.name()))
 

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -48,7 +48,6 @@ def _check_metadata(cube: Cube) -> None:
             misinterpretation on "load"
     """
     check_mandatory_standards(cube)
-    print("is cube lazy? ", cube.has_lazy_data())
     if cf_units.Unit(cube.units).is_unknown():
         raise ValueError("{} has unknown units".format(cube.name()))
 

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -48,8 +48,6 @@ def _check_metadata(cube: Cube) -> None:
             misinterpretation on "load"
     """
     check_mandatory_standards(cube)
-    print("unit", cf_units.Unit(cube.units))
-    print("unit evaluation: ", cf_units.Unit(cube.units).is_unknown())
     if cf_units.Unit(cube.units).is_unknown():
         raise ValueError("{} has unknown units".format(cube.name()))
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,15 +30,13 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
-        print("temperature units are: ", temperature.units)
-        print("humidity mixing ratio units are: ", humidity_mixing_ratio.units)
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
         # Update the cube metadata
-        print("vitual temperature units are: ", virtual_temperature.units)
-        # virtual_temperature.units = "K"
         virtual_temperature.rename("virtual_temperature")
         virtual_temperature.attributes["units_metadata"] = "on-scale"
+        print(virtual_temperature.units)
+        print(virtual_temperature)
 
         return virtual_temperature
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -34,7 +34,7 @@ class VirtualTemperature(BasePlugin):
 
         # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")
-        virtual_temperature.attributes["units_metadata"] = "on-scale"
+        # virtual_temperature.attributes["units_metadata"] = "on-scale"
         print(virtual_temperature.units)
         print(virtual_temperature)
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -34,9 +34,7 @@ class VirtualTemperature(BasePlugin):
 
         # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")
-        # virtual_temperature.attributes["units_metadata"] = "on-scale"
-        print(virtual_temperature.units)
-        print(virtual_temperature)
+        virtual_temperature.attributes["units_metadata"] = "on-scale"
 
         return virtual_temperature
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -32,6 +32,8 @@ class VirtualTemperature(BasePlugin):
         # Calculate the virtual temperature
         temperature.convert_units("K")
         humidity_mixing_ratio.convert_units("kg kg-1")
+        temperature.data
+        humidity_mixing_ratio.data
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
         # Update the cube metadata

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,8 +30,6 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
-        # temperature.units = "K"
-        # humidity_mixing_ratio.units = "1"
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
         # Update the cube metadata including adding the required units (Kelvin)

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,6 +30,8 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
+        temperature.convert_units("K")
+        humidity_mixing_ratio.convert_units("kg kg-1")
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
         # Update the cube metadata

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,11 +30,20 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
+        print(temperature)
+        print(temperature.units)
+        print(humidity_mixing_ratio)
+        print(humidity_mixing_ratio.units)
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
+        print(virtual_temperature)
 
         # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")
+        print(virtual_temperature)
+        print(virtual_temperature.units)
         virtual_temperature.attributes["units_metadata"] = "on-scale"
+        print(virtual_temperature)
+        print(virtual_temperature.units)
 
         return virtual_temperature
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -29,6 +29,8 @@ class VirtualTemperature(BasePlugin):
         Returns:
             Cube of virtual_temperature.
         """
+        # enforce units of humidity_mixing_ratio to 1 to ensure units are maintained in result
+        humidity_mixing_ratio.units = 1
         # Calculate the virtual temperature
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -36,7 +36,7 @@ class VirtualTemperature(BasePlugin):
 
         # Update the cube metadata
         print("vitual temperature units are: ", virtual_temperature.units)
-        virtual_temperature.units = "K"
+        # virtual_temperature.units = "K"
         virtual_temperature.rename("virtual_temperature")
         virtual_temperature.attributes["units_metadata"] = "on-scale"
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,9 +30,13 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
+        print("temperature units are: ", temperature.units)
+        print("humidity mixing ratio units are: ", humidity_mixing_ratio.units)
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
         # Update the cube metadata
+        print("vitual temperature units are: ", virtual_temperature.units)
+        virtual_temperature.units = "K"
         virtual_temperature.rename("virtual_temperature")
         virtual_temperature.attributes["units_metadata"] = "on-scale"
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -36,6 +36,7 @@ class VirtualTemperature(BasePlugin):
 
         # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")
+        virtual_temperature.units = "K"
         virtual_temperature.attributes["units_metadata"] = "on-scale"
 
         return virtual_temperature

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,7 +30,7 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
-        # temperature.units = "K"
+        temperature.units = "K"
         humidity_mixing_ratio.units = "1"
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,13 +30,13 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
-        temperature.units = "K"
-        humidity_mixing_ratio.units = "1"
+        # temperature.units = "K"
+        # humidity_mixing_ratio.units = "1"
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
         # Update the cube metadata including adding the required units (Kelvin)
         virtual_temperature.rename("virtual_temperature")
-        # virtual_temperature.units = "K"
+        virtual_temperature.units = "K"
         virtual_temperature.attributes["units_metadata"] = "on-scale"
 
         return virtual_temperature

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -32,9 +32,8 @@ class VirtualTemperature(BasePlugin):
         # Calculate the virtual temperature
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
-        # Update the cube metadata including adding the required units (Kelvin)
+        # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")
-        virtual_temperature.units = "K"
         virtual_temperature.attributes["units_metadata"] = "on-scale"
 
         return virtual_temperature

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -30,20 +30,11 @@ class VirtualTemperature(BasePlugin):
             Cube of virtual_temperature.
         """
         # Calculate the virtual temperature
-        print(temperature)
-        print(temperature.units)
-        print(humidity_mixing_ratio)
-        print(humidity_mixing_ratio.units)
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
-        print(virtual_temperature)
 
         # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")
-        print(virtual_temperature)
-        print(virtual_temperature.units)
         virtual_temperature.attributes["units_metadata"] = "on-scale"
-        print(virtual_temperature)
-        print(virtual_temperature.units)
 
         return virtual_temperature
 

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -29,14 +29,14 @@ class VirtualTemperature(BasePlugin):
         Returns:
             Cube of virtual_temperature.
         """
-        # enforce units of humidity_mixing_ratio to 1 to ensure units are maintained in result
-        humidity_mixing_ratio.units = 1
         # Calculate the virtual temperature
+        # temperature.units = "K"
+        humidity_mixing_ratio.units = "1"
         virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
 
-        # Update the cube metadata
+        # Update the cube metadata including adding the required units (Kelvin)
         virtual_temperature.rename("virtual_temperature")
-        virtual_temperature.units = "K"
+        # virtual_temperature.units = "K"
         virtual_temperature.attributes["units_metadata"] = "on-scale"
 
         return virtual_temperature

--- a/improver/virtual_temperature.py
+++ b/improver/virtual_temperature.py
@@ -32,9 +32,7 @@ class VirtualTemperature(BasePlugin):
         # Calculate the virtual temperature
         temperature.convert_units("K")
         humidity_mixing_ratio.convert_units("kg kg-1")
-        temperature.data
-        humidity_mixing_ratio.data
-        virtual_temperature = temperature * (1 + 0.61 * humidity_mixing_ratio)
+        virtual_temperature = temperature.copy(temperature.data * (1 + 0.61 * humidity_mixing_ratio.data))
 
         # Update the cube metadata
         virtual_temperature.rename("virtual_temperature")

--- a/improver_tests/psychrometric_calculations/test_HumidityMixingRatio.py
+++ b/improver_tests/psychrometric_calculations/test_HumidityMixingRatio.py
@@ -168,6 +168,38 @@ def test_height_levels():
     assert np.isclose(result.data, 1.459832e-2, atol=1e-7).all()
 
 
+def test_height_levels_above_surface():
+    """Check that the plugin works with height level data"""
+
+    temperature = set_up_variable_cube(
+        np.full((1, 2, 2, 2), fill_value=293, dtype=np.float32),
+        name="air_temperature",
+        units="K",
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
+        vertical_levels=[100, 400],
+        height=True,
+    )
+    pressure_cube = set_up_variable_cube(
+        np.full((1, 2, 2, 2), fill_value=100000, dtype=np.float32),
+        name="some_random_air_pressure",
+        units="Pa",
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
+        vertical_levels=[100, 400],
+        height=True,
+    )
+    rel_humidity = set_up_variable_cube(
+        np.full((1, 2, 2, 2), fill_value=1.0, dtype=np.float32),
+        name="relative_humidity",
+        units="1",
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
+        vertical_levels=[100, 400],
+        height=True,
+    )
+    result = HumidityMixingRatio()([temperature, pressure_cube, rel_humidity])
+    metadata_ok(result, temperature)
+    assert np.isclose(result.data, 1.459832e-2, atol=1e-7).all()
+
+
 def test_pressure_levels():
     """Check that the plugin works with pressure level data when pressure cube is not provided"""
     temperature = set_up_variable_cube(

--- a/improver_tests/psychrometric_calculations/test_HumidityMixingRatio.py
+++ b/improver_tests/psychrometric_calculations/test_HumidityMixingRatio.py
@@ -231,7 +231,8 @@ def test_error_raised_no_pressure_coordinate_or_pressure_cube(
     """Check that the plugin raises an error if there is no pressure coordinate and no pressure cube"""
     with pytest.raises(
         ValueError,
-        match="No pressure cube called 'surface_air_pressure' found and no pressure coordinate",
+        match="No pressure cube with name 'pressure' found and no pressure coordinate "
+        "found in temperature or relative humidity cubes",
     ):
         HumidityMixingRatio()([temperature, rel_humidity])
 

--- a/improver_tests/psychrometric_calculations/test_HumidityMixingRatio.py
+++ b/improver_tests/psychrometric_calculations/test_HumidityMixingRatio.py
@@ -299,3 +299,28 @@ def test_check_nothing_returned_when_no_pressure_cube():
     cubelist = [temperature, rel_humidity]
     result = check_for_pressure_cube(cubelist)
     assert result is None
+
+
+def test_error_returned_when_more_than_one_named_pressure_cube():
+    temperature = set_up_variable_cube(
+        np.full((1, 2, 2, 2), fill_value=293, dtype=np.float32),
+        name="some_random_pressure",
+        units="K",
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
+        vertical_levels=[95000, 100000],
+        pressure=True,
+    )
+    rel_humidity = set_up_variable_cube(
+        np.full((1, 2, 2, 2), fill_value=1.0, dtype=np.float32),
+        name="another_random_pressure",
+        units="1",
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
+        vertical_levels=[95000, 100000],
+        pressure=True,
+    )
+    cubelist = [temperature, rel_humidity]
+    with pytest.raises(
+        ValueError,
+        match="More than one cube with 'pressure' in name found.",
+    ):
+        check_for_pressure_cube(cubelist)


### PR DESCRIPTION
For reasons that I don't understand, when using Iris cube multiply (`result = cube_a * cube_b`) with multithreading, the units of `result` are not stable and unexpectedly change to "unknown".

A solution is to change the code to use Numpy to do the multiplying and bypass the Cube multiplication.

Testing:

- [ ] Ran tests and they passed OK
