### PR TITLE
Updated testing information on readthedocs

### DIFF
--- a/doc/source/Code-Style-Guide.rst
+++ b/doc/source/Code-Style-Guide.rst
@@ -653,7 +653,8 @@ validating that the behaviour is as expected. In IMPROVER, GitHub
 Actions are used to run a series of tests on each pull request to ensure
 that the pull request meets the expected standards. Tests can be run
 from the top-level directory using bin/improver-tests or using
-`pytest <https://docs.pytest.org/en/latest/>`_.
+`pytest <https://docs.pytest.org/en/latest/>`_. Further instructions on 
+running these tests can be found in the :ref:`Test suite`.
 
 Unit Testing
 ~~~~~~~~~~~~
@@ -678,7 +679,7 @@ Unit tests should:
    dimensions (consistent with what is enforced by the 'load' module).
 2. Use centralised test `cube set-up
    utilities <https://github.com/metoppv/improver/blob/master/improver/synthetic_data/set_up_test_cubes.py>`_
-   where possible.
+   where possible to ensure input cubes conform to the IMPROVER metadata standard.
 3. Consider the most likely uses of the plugin and ensure these are represented
    in the unit tests.
 4. Consider possible edge cases e.g. cubes with different input dimensions.

--- a/doc/source/How-to-implement-a-command-line-utility.rst
+++ b/doc/source/How-to-implement-a-command-line-utility.rst
@@ -76,9 +76,10 @@ checksums listed in
 <https://github.com/metoppv/improver/blob/master/improver_tests/acceptance/SHA256SUMS>`_.
 Changes to the checksum file in the code repository identify when
 changes are made to the code requiring corresponding changes to the data
-files. The acceptance test data files are maintained in a public repository:
-`https://github.com/metoppv/improver_test_data`, with the directory
-structure being based on the CLI plugin names.
+files. The acceptance test data files are maintained in the 
+`improver_test_data <https://github.com/metoppv/improver_test_data>`_ open 
+source repository on GitHub, with the directory structure being based on 
+the CLI plugin names.
 
 Use of checksums
 ~~~~~~~~~~~~~~~~

--- a/doc/source/Running-at-your-site.rst
+++ b/doc/source/Running-at-your-site.rst
@@ -99,8 +99,11 @@ At the Python interpreter prompt:
    print(output)
    iris.save(output, "output.nc")
 
+.. _Test suite:
 Test suite
 ----------
+
+Tests should be run before use to ensure expected functionality at your site.
 
 Tests can be run from the top-level directory using bin/improver-tests
 or directly using `pytest <https://docs.pytest.org/en/latest/>`_.
@@ -118,10 +121,13 @@ tests are quick to run. Unit tests are run as part of the test suite on
    pytest -m 'not acc'
    # To run a particular function within a unit test, you can use the :: notation
    pytest -m improver_tests/test_unit_test.py::Test_function
+   # An applied example
+   pytest -m improver_tests/standardise/tests_standardise.py
+   
 
 The CLI (command line interface) acceptance tests use known good output
 (KGO) files for validating that the behaviour is as expected. This data
-can be found in the `improver_test_data` open source repository on GitHub.
+can be found in the `improver_test_data <https://github.com/metoppv/improver_test_data>`_ open source repository on GitHub.
 
 The path to the acceptance test data is set using the
 ``IMPROVER_ACC_TEST_DIR`` environment variable. Acceptance tests will be
@@ -135,11 +141,40 @@ To run the acceptance tests you can use the following:
    pytest -m acc
    # Acceptance tests can be run significantly faster in parallel using the pytest-xdist plugin
    pytest -n 8
-   # An example of running just one particular acceptance test
+   # The structure of running just one particular acceptance test
    pytest -v -s -m acc -k test_cli_name.py
+   # An applied example
+   pytest -v -s -m acc -k test_weighted_blending.py
+   # To run a particular function within an acceptance test, you can use the :: notation
+   pytest -v improver-tests/acceptance/test_weighted_blending.py::test_weights_dict
 
 To run all tests together at once, the following command can be input
 
 .. code:: bash
 
    bin/improver-tests # runs all tests
+
+The tests available using the ``improver-tests`` interface are documented in the table 
+below.
+
+.. list-table:: Test Types
+   :header-rows: 1
+
+   * - Test Type
+     - Summary
+   * - black
+     - Auto-formats code (by default, applies changes to files rather than check-only)
+   * - isort
+     - Sorts imports (by default, applies changes to files rather than check-only)
+   * - pylintE
+     - Check whether `pylint <https://www.pylint.org/>`_ reports any errors.
+   * - pylint
+     - `Pylint <https://www.pylint.org/>`_ returns an assessment including a score for 
+       each file that it analyses.
+   * - doc
+     - Build the documentation from the code docstrings using `Sphinx <https://www.sphinx-doc.org/en/master/>`_.
+   * - unit
+     - Run unit tests that test individual functions within the IMPROVER code.
+   * - cli
+     - Run the Command Line Interface (CLI) acceptance tests to test both the interface 
+       itself and by using known good output to check the code's behaviour.

--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -94,7 +94,7 @@ The current list of CLIs can be `found here`_.
 
 Sample data for testing CLIs
 ============================
-The test data used for the acceptance tests within IMPROVER is available in an open-source repository on GitHub: https://github.com/metoppv/improver_test_data.
+The test data used for the acceptance tests within IMPROVER is available in an open-source `repository <https://github.com/metoppv/improver_test_data>` on GitHub.
 Using this test data, along with the acceptance tests within the improver repository, provides a good start for exploring the functionality available.
 
 Publications & Presentations

--- a/improver/precipitation_type/hail_fraction.py
+++ b/improver/precipitation_type/hail_fraction.py
@@ -64,7 +64,7 @@ class HailFraction(PostProcessingPlugin):
         References:
             Dennis, E.J., and M.R. Kumjian. 2017.
             “The Impact of Vertical Wind Shear on Hail Growth in Simulated Supercells.”
-            J. Atmos. Sci. 74 (3): 641-663. doi:https://doi.org/10.1175/JAS-D-16-0066.1.
+            J. Atmos. Sci. 74 (3): 641-663. https://doi.org/10.1175/JAS-D-16-0066.1.
 
         Returns:
             Hail fraction array.

--- a/improver/psychrometric_calculations/hail_size.py
+++ b/improver/psychrometric_calculations/hail_size.py
@@ -69,10 +69,10 @@ class HailSize(BasePlugin):
     References
         - Hand, W., and G. Cappelluti. 2011. “A global hail climatology using the UK
           Met Office convection diagnosis procedure (CDP) and model analyses.”
-          Meteorological Applications 18: 446-458. doi:https://doi.org/10.1002/met.236
+          Meteorological Applications 18: 446-458. https://doi.org/10.1002/met.236
         - Fawbush, E.J., and R.C. Miller. 1953. “A method for forecasting hailstone size
           at the earth's surface.” Bulletin of the American Meteorological Society 34: 235-244.
-          doi: https://doi.org/10.1175/1520-0477-34.6.235
+          https://doi.org/10.1175/1520-0477-34.6.235
     """
 
     def __init__(self, model_id_attr: str = None):

--- a/improver/wind_calculations/vertical_updraught.py
+++ b/improver/wind_calculations/vertical_updraught.py
@@ -25,9 +25,9 @@ class VerticalUpdraught(BasePlugin):
     the UKPP CDP code.
 
     Hand, W. 2002. "The Met Office Convection Diagnosis Scheme." Meteorological Applications
-        9(1): 69-83. doi:10.1017/S1350482702001081.
+        9(1): 69-83. https://doi.org/10.1017/S1350482702001081.
     Golding, B.W. 1998. "Nimrod: A system for generating automated very short range forecasts."
-        Meteorol. Appl. 5: 1-16. doi:https://doi.org/10.1017/S1350482798000577.
+        Meteorol. Appl. 5: 1-16. https://doi.org/10.1017/S1350482798000577.
     """
 
     def __init__(self, model_id_attr: str = None):


### PR DESCRIPTION
Integrated information on Confluence into readthedocs, made some links implicit, removed 'doi:' before html links, and clarified why users should centralise test cube set-up utilities

Addresses [#870](https://github.com/metoppv/mo-blue-team/issues/870)