### PR TITLE
Add json file input to threshold interpolation

### DIFF
--- a/improver/utilities/threshold_interpolation.py
+++ b/improver/utilities/threshold_interpolation.py
@@ -5,7 +5,7 @@
 """Script to linearly interpolate thresholds"""
 
 import numbers
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import iris
 import numpy as np
@@ -30,18 +30,19 @@ from improver.utilities.cube_manipulation import (
 
 class ThresholdInterpolation(PostProcessingPlugin):
     def __init__(
-            self,
-            threshold_values: Optional[List[float]] = None,
-            threshold_config: Optional[Dict[str, Union[List[float], str]]] = None,
-            threshold_units: Optional[str] = None,):
+        self,
+        threshold_values: Optional[List[float]] = None,
+        threshold_config: Optional[Dict[str, Union[List[float], str]]] = None,
+        threshold_units: Optional[str] = None,
+    ):
         """
         Args:
             threshold_values:
                 List of the desired output thresholds.
             threshold_config:
                 Threshold configuration containing threshold values.
-                Best used in combination with 'threshold_units'. It should contain 
-                a dictionary of strings that can be interpreted as floats with the 
+                Best used in combination with 'threshold_units'. It should contain
+                a dictionary of strings that can be interpreted as floats with the
                 structure: "THRESHOLD_VALUE": "None" (no fuzzy bounds).
                 Repeated thresholds with different bounds are ignored; only the
                 last duplicate will be used.
@@ -70,9 +71,7 @@ class ThresholdInterpolation(PostProcessingPlugin):
         self.threshold_config = threshold_config
         print(self.threshold_config)
 
-        thresholds = self._set_thresholds(
-            threshold_values, threshold_config
-        )
+        thresholds = self._set_thresholds(threshold_values, threshold_config)
         print(thresholds)
         self.thresholds = [thresholds] if np.isscalar(thresholds) else thresholds
         print(self.thresholds)
@@ -99,7 +98,7 @@ class ThresholdInterpolation(PostProcessingPlugin):
                 and lower bounds for those values to apply fuzzy thresholding.
 
         Returns:
-            thresholds: 
+            thresholds:
                 A list of input thresholds as float64 type.
         """
         if threshold_config:
@@ -115,7 +114,7 @@ class ThresholdInterpolation(PostProcessingPlugin):
                 threshold_values = [threshold_values]
             thresholds = [float(x) for x in threshold_values]
         return thresholds
-     
+
     def mask_checking(self, forecast_at_thresholds: Cube) -> Optional[np.ndarray]:
         """
         Check if the mask is consistent across different slices of the threshold coordinate.
@@ -274,8 +273,10 @@ class ThresholdInterpolation(PostProcessingPlugin):
         original_mask = self.mask_checking(forecast_at_thresholds)
         original_units = forecast_at_thresholds.coord(self.threshold_coord).units
         if self.threshold_units is not None:
-            forecast_at_thresholds.coord(self.threshold_coord.name()).convert_units(self.threshold_units)
-            
+            forecast_at_thresholds.coord(self.threshold_coord.name()).convert_units(
+                self.threshold_units
+            )
+
         if forecast_at_thresholds.coords("realization"):
             forecast_at_thresholds = collapse_realizations(forecast_at_thresholds)
 
@@ -288,9 +289,7 @@ class ThresholdInterpolation(PostProcessingPlugin):
         )
 
         # Revert threshold coordinate units to those of the input cube.
-        threshold_cube.coord(self.threshold_coord.name()).convert_units(
-            original_units
-        )
+        threshold_cube.coord(self.threshold_coord.name()).convert_units(original_units)
 
         if original_mask is not None:
             original_mask = np.broadcast_to(original_mask, threshold_cube.shape)

--- a/improver_tests/utilities/test_ThresholdInterpolation.py
+++ b/improver_tests/utilities/test_ThresholdInterpolation.py
@@ -9,7 +9,6 @@ Unit tests for the
 
 import iris
 import numpy as np
-import array
 import pytest
 from iris.cube import Cube
 
@@ -74,16 +73,17 @@ def test_cube_returned(request, input):
     assert isinstance(result, Cube)
     assert result.units == cube.units
 
+
 def test_threshold_units(input_cube):
     """
     Test that the plugin can handle different threshold units.
     """
-    threshold_values = [.1, .15, .2, .25, .3]
-    original_thresholds = input_cube.coord("visibility_in_air").points
+    threshold_values = [0.1, 0.15, 0.2, 0.25, 0.3]
     original_units = input_cube.coord("visibility_in_air").units
     result = ThresholdInterpolation(threshold_values, threshold_units="km")(input_cube)
     # Check that units are converted back to the original input cube's units
     assert result.coord("visibility_in_air").units == original_units
+
 
 @pytest.mark.parametrize("input", ["input_cube", "masked_cube"])
 def test_interpolated_values(request, input):
@@ -105,6 +105,7 @@ def test_interpolated_values(request, input):
     )
     np.testing.assert_array_equal(result.data, expected_interpolated_values)
 
+
 @pytest.mark.parametrize("input", ["input_cube", "masked_cube"])
 def test_threshold_config_provided(request, input):
     """
@@ -116,7 +117,7 @@ def test_threshold_config_provided(request, input):
         "200.0": "None",
         "250.0": "None",
         "300.0": "None",
-        }
+    }
     cube = request.getfixturevalue(input)
     print(cube)
     result = ThresholdInterpolation(threshold_config=threshold_config)(cube)
@@ -132,18 +133,24 @@ def test_threshold_config_provided(request, input):
         dtype=np.float32,
     )
     np.testing.assert_array_equal(result.data, expected_interpolated_values)
-    assert result.coord("visibility_in_air").units == cube.coord("visibility_in_air").units
+    assert (
+        result.coord("visibility_in_air").units == cube.coord("visibility_in_air").units
+    )
     thresholds = [100, 150, 200, 250, 300]
     np.testing.assert_array_equal(result.coord("visibility_in_air").points, thresholds)
 
+
 def test_no_new_thresholds_provided():
     """
-    Test that a ValueError is raised if neither threshold_config or threshold_values 
+    Test that a ValueError is raised if neither threshold_config or threshold_values
     are set.
     """
-    with pytest.raises(ValueError, match="One of threshold_config or threshold_values"
-                       " must be provided."):
+    with pytest.raises(
+        ValueError,
+        match="One of threshold_config or threshold_values" " must be provided.",
+    ):
         ThresholdInterpolation()
+
 
 def test_metadata_copy(input_cube):
     """
@@ -199,4 +206,3 @@ def test_collapse_realizations(input_cube):
     thresholds = [100, 150, 200, 250, 300]
     result = ThresholdInterpolation(thresholds)(cube.copy())[0::2]
     np.testing.assert_array_equal(result.data, 0.5 * (cube[0].data + cube[1].data))
-


### PR DESCRIPTION
Addresses [#866](https://github.com/metoppv/mo-blue-team/issues/866)

Description
- Updated plugin to accept a JSON file

Testing:
- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)