### PR TITLE
Add ECC bounds for precipitation fraction.

### DIFF
--- a/improver/ensemble_copula_coupling/constants.py
+++ b/improver/ensemble_copula_coupling/constants.py
@@ -57,6 +57,8 @@ BOUNDS_FOR_ECDF = {
     "lwe_snowfall_rate_in_vicinity": Bounds((0, 400.0), "mm h-1"),
     "rainfall_rate": Bounds((0, 400.0), "mm h-1"),
     "rainfall_rate_in_vicinity": Bounds((0, 400.0), "mm h-1"),
+    # Precipitation time fraction
+    "fraction_of_time_classified_as_wet": Bounds((0, 1.0), "1"),
     # Temperature
     "air_temperature": (Bounds((-100 - ABSOLUTE_ZERO, 60 - ABSOLUTE_ZERO), "Kelvin")),
     "feels_like_temperature": (


### PR DESCRIPTION
Precipitation fraction, which is a fraction of a period of time, has ECC bounds that run 0-1. These need to be added to the ECC bound set.

Testing:

- [x] Ran tests and they passed OK
