### PR TITLE
Add in plugin to calculate the probability of snow at the surface

### DIFF
--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -109,6 +109,7 @@ PROCESSING_MODULES = {
     "ShowerConditionProbability": "improver.precipitation.shower_condition_probability",
     "SignificantPhaseMask": "improver.psychrometric_calculations.significant_phase_mask",
     "SnowFraction": "improver.precipitation.snow_fraction",
+    "SnowProbabilityAtSurface": "improver.precipitation.snow_probability_at_surface",
     "SnowSplitter": "improver.precipitation.snow_splitter",
     "SpatiallyVaryingWeightsFromMask": "improver.blending.spatial_weights",
     "SpotExtraction": "improver.spotdata.spot_extraction",

--- a/improver/precipitation/snow_probability_at_surface.py
+++ b/improver/precipitation/snow_probability_at_surface.py
@@ -1,0 +1,58 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Plugin to construct the probability that snow could occur at the surface"""
+
+import numpy as np
+from iris.cube import Cube
+
+from improver import BasePlugin
+from improver.metadata.utilities import (
+    create_new_diagnostic_cube,
+    generate_mandatory_attributes,
+)
+
+
+class SnowProbabilityAtSurface(BasePlugin):
+    """Plugin to calculate the probability that snow could be being present at the surface.
+
+    The probability is calculated by looking at the wet bulb temperature integral at the surface. If the
+    wet bulb temperature is 0 Kelvin metres then the probability of snow is set to 1. If it is
+    greater than 225 Kelvin metres then the probability is set to zero. For values in between
+    0 and 225, the probability varies linearly.
+    """
+
+    def __init__(self) -> None:
+        self.xp = [0, 225]
+        self.yp = [1, 0]
+
+    def process(self, wet_bulb_temp_int_at_surf: Cube) -> Cube:
+        """
+        Generate a probability that snow could be present at the surface based on input wet bulb temperature integral at surface.
+
+        Args:
+            wet_bulb_temp_int_at_surf:
+                A cube of wet bulb temperature integral at the surface
+
+        Returns:
+            Probability of snow occuring at surface.
+        """
+
+        input_shape = wet_bulb_temp_int_at_surf.shape
+        data = wet_bulb_temp_int_at_surf.data.flatten()
+
+        prob_snow = np.interp(data, self.xp, self.yp)
+
+        prob_snow_reshaped = np.reshape(prob_snow, input_shape)
+        snow_probability_cube = create_new_diagnostic_cube(
+            "probability_of_snow_at_surface",
+            "1",
+            template_cube=wet_bulb_temp_int_at_surf,
+            mandatory_attributes=generate_mandatory_attributes(
+                [wet_bulb_temp_int_at_surf]
+            ),
+            data=prob_snow_reshaped,
+        )
+
+        return snow_probability_cube

--- a/improver_tests/precipitation/snow_probability/test_snow_probability.py
+++ b/improver_tests/precipitation/snow_probability/test_snow_probability.py
@@ -1,0 +1,50 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for SnowProbabilityAtSurface plugin"""
+
+import numpy as np
+import pytest
+
+from improver.precipitation.snow_probability_at_surface import (
+    SnowProbabilityAtSurface,
+)
+from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
+
+ATTRIBUTES = {
+    "institution": "Met Office",
+    "source": "Met Office Unified Model",
+    "title": "UKV Forecast on UK 2 km Standard Grid",
+}
+
+
+@pytest.fixture()
+def wet_bulb_temperature():
+    """Create a test cube of wet bulb temperature at surface"""
+    data = np.full(
+        (2, 3), 100, dtype=np.float32
+    )  # dummy data that will be overriden in tests
+    wet_bulb_temp_at_surf = set_up_variable_cube(
+        data,
+        name="wet_bulb_temperature_integral",
+        units=1,
+        attributes=ATTRIBUTES,
+    )
+
+    return wet_bulb_temp_at_surf
+
+
+@pytest.mark.parametrize(
+    "wb_temp_data , expected_probability",
+    ((-3, 1), (0, 1), (56.25, 0.75), (112.5, 0.5), (168.75, 0.25), (225, 0), (255, 0)),
+)
+def test_scenarios(wet_bulb_temperature, wb_temp_data, expected_probability):
+    """Test the snow probability at surface plugin for a range of input wet bulb integral temperatures."""
+    wet_bulb_temperature.data.fill(wb_temp_data)
+
+    result = SnowProbabilityAtSurface()(wet_bulb_temperature)
+    assert np.all(result.data == expected_probability)
+    assert result.name() == "probability_of_snow_at_surface"
+    assert result.units == "1"
+    assert result.attributes == ATTRIBUTES

--- a/improver_tests/precipitation/snow_probability_at_surface/test_snow_probability_at_surface.py
+++ b/improver_tests/precipitation/snow_probability_at_surface/test_snow_probability_at_surface.py
@@ -20,8 +20,8 @@ ATTRIBUTES = {
 
 
 @pytest.fixture()
-def wet_bulb_temperature():
-    """Create a test cube of wet bulb temperature at surface"""
+def wet_bulb_temperature_integral():
+    """Create a test cube of wet bulb temperature integral at surface"""
     data = np.full(
         (2, 3), 100, dtype=np.float32
     )  # dummy data that will be overriden in tests
@@ -39,11 +39,11 @@ def wet_bulb_temperature():
     "wb_temp_data , expected_probability",
     ((-3, 1), (0, 1), (56.25, 0.75), (112.5, 0.5), (168.75, 0.25), (225, 0), (255, 0)),
 )
-def test_scenarios(wet_bulb_temperature, wb_temp_data, expected_probability):
+def test_scenarios(wet_bulb_temperature_integral, wb_temp_data, expected_probability):
     """Test the snow probability at surface plugin for a range of input wet bulb integral temperatures."""
-    wet_bulb_temperature.data.fill(wb_temp_data)
+    wet_bulb_temperature_integral.data.fill(wb_temp_data)
 
-    result = SnowProbabilityAtSurface()(wet_bulb_temperature)
+    result = SnowProbabilityAtSurface()(wet_bulb_temperature_integral)
     assert np.all(result.data == expected_probability)
     assert result.name() == "probability_of_snow_at_surface"
     assert result.units == "1"

--- a/improver_tests/precipitation/snow_probability_at_surface/test_snow_probability_at_surface.py
+++ b/improver_tests/precipitation/snow_probability_at_surface/test_snow_probability_at_surface.py
@@ -28,10 +28,9 @@ def wet_bulb_temperature_integral():
     wet_bulb_temp_at_surf = set_up_variable_cube(
         data,
         name="wet_bulb_temperature_integral",
-        units=1,
+        units="K m",
         attributes=ATTRIBUTES,
     )
-
     return wet_bulb_temp_at_surf
 
 
@@ -45,6 +44,20 @@ def test_scenarios(wet_bulb_temperature_integral, wb_temp_data, expected_probabi
 
     result = SnowProbabilityAtSurface()(wet_bulb_temperature_integral)
     assert np.all(result.data == expected_probability)
+    assert result.name() == "probability_of_snow_at_surface"
+    assert result.units == "1"
+    assert result.attributes == ATTRIBUTES
+
+
+def test_masked_data(wet_bulb_temperature_integral):
+    """Test the snow probability at surface plugin for masked data"""
+
+    wet_bulb_temperature_integral.data = np.ma.masked_all_like(
+        wet_bulb_temperature_integral.data
+    )
+    result = SnowProbabilityAtSurface()(wet_bulb_temperature_integral)
+
+    assert result.data.mask.all()
     assert result.name() == "probability_of_snow_at_surface"
     assert result.units == "1"
     assert result.attributes == ATTRIBUTES


### PR DESCRIPTION
EPP ticket: https://metoffice.atlassian.net/browse/EPPT-2318

This PR adds in a plugin to calculate the probability that snow could occur at the surface based on a provided wet bulb temperature integral.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
