### PR TITLE
Change to the recursive filter to allow an option to make zero values.

### DIFF
--- a/improver/nbhood/recursive_filter.py
+++ b/improver/nbhood/recursive_filter.py
@@ -312,8 +312,11 @@ class RecursiveFilter(PostProcessingPlugin):
         return coeffs_x, coeffs_y
 
     def process(
-        self, cube: Cube, smoothing_coefficients: CubeList, variable_mask: bool = False,
-            mask_zeros: bool = False
+        self,
+        cube: Cube,
+        smoothing_coefficients: CubeList,
+        variable_mask: bool = False,
+        mask_zeros: bool = False,
     ) -> Cube:
         """
         Set up the smoothing_coefficient parameters and run the recursive
@@ -439,12 +442,10 @@ class RecursiveFilter(PostProcessingPlugin):
         new_cube = recursed_cube.merge_cube()
         if mask_zeros:
             new_cube.data = np.ma.getdata(new_cube.data)
-            cube.data = np.ma.getdata(cube.data)
-            # This unmasks all the data on the cubes
+            # This unmasks all the data on the cube
             if cube_mask is not None:
                 # Reapplying the original mask so the data doesn't change.
                 new_cube.data = np.ma.array(new_cube.data, mask=cube_mask)
-                cube.data = np.ma.array(cube.data, mask=cube_mask)
 
         new_cube = check_cube_coordinates(cube, new_cube)
 

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -555,8 +555,8 @@ class Test_process(Test_RecursiveFilter):
         self.assertArrayEqual(mask_of_cube, mask_of_result)
 
     def test_mask_zeros_result(self):
-        """Test that if the mask_zeros option is on with masked data it
-        returns the correct result."""
+        """Test that if mask_zeros is applied to a cube that contains zeros,
+        the resulting data is correct."""
         plugin = RecursiveFilter(
             iterations=self.iterations,
         )

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -522,7 +522,7 @@ class Test_process(Test_RecursiveFilter):
         self.assertArrayAlmostEqual(result.data[0], expected_result)
 
     def test_mask_zeros(self):
-        """Test that any zeros in the data are the same at the beginning and 
+        """Test that any zeros in the data are the same at the beginning and
         end of the recursive filtering with the mask_zeros option."""
         zeros = self.cube.data==0.0
         plugin = RecursiveFilter(
@@ -553,7 +553,7 @@ class Test_process(Test_RecursiveFilter):
         )
         mask_of_result = np.ma.getmaskarray(result.data)
         self.assertArrayEqual(mask_of_cube, mask_of_result)
-        
+
     def test_mask_zeros_result(self):
         """Test that if the mask_zeros option is on with masked data it
         returns the correct result."""
@@ -566,7 +566,7 @@ class Test_process(Test_RecursiveFilter):
             mask_zeros=True,
         )
         expected = 0.17419356
-        self.assertAlmostEqual(result.data[0][0][2], expected)           
+        self.assertAlmostEqual(result.data[0][0][2], expected)        
 
     def test_multiple_thresholds_masked(self):
         """Test that recursive filter is applied correctly when each threshold slice of

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -118,13 +118,13 @@ class Test_RecursiveFilter(IrisTest):
             smoothing_coefficients_cube_x.copy()
         )
         smoothing_coefficients_cube_wrong_x_points.coord(axis="x").points = (
-            smoothing_coefficients_cube_wrong_x_points.coord(axis="x").points + 10
+                smoothing_coefficients_cube_wrong_x_points.coord(axis="x").points + 10
         )
         smoothing_coefficients_cube_wrong_y_points = (
             smoothing_coefficients_cube_y.copy()
         )
         smoothing_coefficients_cube_wrong_y_points.coord(axis="y").points = (
-            smoothing_coefficients_cube_wrong_y_points.coord(axis="y").points + 10
+                smoothing_coefficients_cube_wrong_y_points.coord(axis="y").points + 10
         )
         self.smoothing_coefficients_wrong_points = [
             smoothing_coefficients_cube_wrong_x_points,
@@ -524,7 +524,7 @@ class Test_process(Test_RecursiveFilter):
     def test_mask_zeros(self):
         """Test that any zeros in the data are the same at the beginning and
         end of the recursive filtering with the mask_zeros option."""
-        zeros = self.cube.data==0.0
+        zeros = self.cube.data == 0.0
         plugin = RecursiveFilter(
             iterations=self.iterations,
         )
@@ -533,14 +533,14 @@ class Test_process(Test_RecursiveFilter):
             smoothing_coefficients=self.smoothing_coefficients,
             mask_zeros=True,
         )
-        result_zeros = result.data==0.0
+        result_zeros = result.data == 0.0
         self.assertArrayEqual(zeros, result_zeros)
 
     def test_mask_zeros_same_mask(self):
         """Test that if mask_zeros is applied to a cube that already
         has a mask, the end result has the same mask."""
         mask = np.zeros(self.cube.data.shape)
-        mask[0][3][2] = 1
+        mask[0, 3, :] = 1
         self.cube.data = np.ma.MaskedArray(self.cube.data, mask=mask)
         mask_of_cube = np.ma.getmaskarray(self.cube.data)
         plugin = RecursiveFilter(
@@ -565,8 +565,23 @@ class Test_process(Test_RecursiveFilter):
             smoothing_coefficients=self.smoothing_coefficients,
             mask_zeros=True,
         )
-        expected = 0.17419356
-        self.assertAlmostEqual(result.data[0][0][2], expected)        
+        
+        expected = np.array(
+            [
+                [
+                    [0., 0., 0.17419356, 0., 0.],
+                    [0., 0., 0.21129033, 0., 0.],
+                    [0.2, 0.25, 0.22903226, 0.25, 0.2],
+                    [0., 0., 0.21129033, 0., 0.],
+                    [0., 0., 0.17419356, 0., 0.]
+                ]
+            ]
+        )
+        mask_of_cube = np.ma.getmaskarray(self.cube.data)
+        mask_of_result = np.ma.getmaskarray(result.data)
+
+        self.assertArrayAlmostEqual(result.data, expected)
+        self.assertArrayEqual(mask_of_cube, mask_of_result)
 
     def test_multiple_thresholds_masked(self):
         """Test that recursive filter is applied correctly when each threshold slice of

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -118,13 +118,13 @@ class Test_RecursiveFilter(IrisTest):
             smoothing_coefficients_cube_x.copy()
         )
         smoothing_coefficients_cube_wrong_x_points.coord(axis="x").points = (
-                smoothing_coefficients_cube_wrong_x_points.coord(axis="x").points + 10
+            smoothing_coefficients_cube_wrong_x_points.coord(axis="x").points + 10
         )
         smoothing_coefficients_cube_wrong_y_points = (
             smoothing_coefficients_cube_y.copy()
         )
         smoothing_coefficients_cube_wrong_y_points.coord(axis="y").points = (
-                smoothing_coefficients_cube_wrong_y_points.coord(axis="y").points + 10
+            smoothing_coefficients_cube_wrong_y_points.coord(axis="y").points + 10
         )
         self.smoothing_coefficients_wrong_points = [
             smoothing_coefficients_cube_wrong_x_points,
@@ -565,23 +565,20 @@ class Test_process(Test_RecursiveFilter):
             smoothing_coefficients=self.smoothing_coefficients,
             mask_zeros=True,
         )
-        
+
         expected = np.array(
             [
                 [
-                    [0., 0., 0.17419356, 0., 0.],
-                    [0., 0., 0.21129033, 0., 0.],
+                    [0.0, 0.0, 0.17419356, 0.0, 0.0],
+                    [0.0, 0.0, 0.21129033, 0.0, 0.0],
                     [0.2, 0.25, 0.22903226, 0.25, 0.2],
-                    [0., 0., 0.21129033, 0., 0.],
-                    [0., 0., 0.17419356, 0., 0.]
+                    [0.0, 0.0, 0.21129033, 0.0, 0.0],
+                    [0.0, 0.0, 0.17419356, 0.0, 0.0],
                 ]
             ]
         )
-        mask_of_cube = np.ma.getmaskarray(self.cube.data)
-        mask_of_result = np.ma.getmaskarray(result.data)
 
         self.assertArrayAlmostEqual(result.data, expected)
-        self.assertArrayEqual(mask_of_cube, mask_of_result)
 
     def test_multiple_thresholds_masked(self):
         """Test that recursive filter is applied correctly when each threshold slice of

--- a/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
+++ b/improver_tests/nbhood/recursive_filter/test_RecursiveFilter.py
@@ -521,6 +521,53 @@ class Test_process(Test_RecursiveFilter):
         )
         self.assertArrayAlmostEqual(result.data[0], expected_result)
 
+    def test_mask_zeros(self):
+        """Test that any zeros in the data are the same at the beginning and 
+        end of the recursive filtering with the mask_zeros option."""
+        zeros = self.cube.data==0.0
+        plugin = RecursiveFilter(
+            iterations=self.iterations,
+        )
+        result = plugin(
+            self.cube,
+            smoothing_coefficients=self.smoothing_coefficients,
+            mask_zeros=True,
+        )
+        result_zeros = result.data==0.0
+        self.assertArrayEqual(zeros, result_zeros)
+
+    def test_mask_zeros_same_mask(self):
+        """Test that if mask_zeros is applied to a cube that already
+        has a mask, the end result has the same mask."""
+        mask = np.zeros(self.cube.data.shape)
+        mask[0][3][2] = 1
+        self.cube.data = np.ma.MaskedArray(self.cube.data, mask=mask)
+        mask_of_cube = np.ma.getmaskarray(self.cube.data)
+        plugin = RecursiveFilter(
+            iterations=self.iterations,
+        )
+        result = plugin(
+            self.cube,
+            smoothing_coefficients=self.smoothing_coefficients,
+            mask_zeros=True,
+        )
+        mask_of_result = np.ma.getmaskarray(result.data)
+        self.assertArrayEqual(mask_of_cube, mask_of_result)
+        
+    def test_mask_zeros_result(self):
+        """Test that if the mask_zeros option is on with masked data it
+        returns the correct result."""
+        plugin = RecursiveFilter(
+            iterations=self.iterations,
+        )
+        result = plugin(
+            self.cube,
+            smoothing_coefficients=self.smoothing_coefficients,
+            mask_zeros=True,
+        )
+        expected = 0.17419356
+        self.assertAlmostEqual(result.data[0][0][2], expected)           
+
     def test_multiple_thresholds_masked(self):
         """Test that recursive filter is applied correctly when each threshold slice of
         a cube has a different mask and variable_mask is True."""


### PR DESCRIPTION
I have made changes to the recursive filter to allow an option to mask zero values. This takes into account any previous mask and reapplies at the end so there is no change to any original masking. 

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
