### PR TITLE
Add GAM fit/predict functionality for SAMOS

### DIFF
--- a/improver/utilities/statistical.py
+++ b/improver/utilities/statistical.py
@@ -1,0 +1,94 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Module to contain statistical methods."""
+
+from improver import BasePlugin
+from copy import deepcopy
+from pygam import GAM, l, s, te, f
+from typing import Dict
+
+
+class FitGAM(BasePlugin):
+    """
+    Class for fitting Generalized Additive Models which predict the mean and standard deviation of input forecasts or observations.
+
+    This class wraps around pyGAM (https://pygam.readthedocs.io/en/latest/index.html), which is used for fitting the model.
+
+    """
+
+    def __init__(
+        self,
+        model_specification: Dict,
+        max_iter: int = 100,
+        tol: float = 0.0001,
+        distribution: str = 'normal',
+        link: str = 'identity',
+        fit_intercept: bool = True,
+    ):
+        """
+        Initialize class for fitting Generalized Additive Models using pyGAM.
+        """
+        self.model_specification = model_specification
+        self.max_iter = max_iter
+        self.tol = tol
+        self.distribution = distribution
+        self.link = link
+        self.fit_intercept = fit_intercept
+
+    def create_pygam_model(self):
+        """
+        Create a GAM model using pyGAM from the model_specification dictionary.
+
+        Returns:
+            GAM model equation constructed using pyGAM model terms.
+        """
+        for index, (key, values) in enumerate(self.model_specification.items()):
+            # For each key in the dictionary, parse the value to create a pyGAM term from that value.
+            # The first term in the dictionary value defines the type of term, the second defines which variables are
+            # included in that term, and the 3rd contains a dictionary of other arguments.
+            if values[0] == "l":  # linear term
+                new_term = l(*values[1], **values[2])
+            elif values[0] == "s":  # spline term
+                new_term = s(*values[1], **values[2])
+            elif values[0] == "te":  # tensor term
+                new_term = te(*values[1], **values[2])
+            elif values[0] == "f":  # factor term
+                new_term = f(*values[1], **values[2])
+            else:
+                msg = (
+                    f"An unrecognised term has been included in the GAM model specification. The term was {values[0]},"
+                    f" the accepted terms are l, s, te, f.")
+                raise ValueError(msg)
+
+            if index == 0:
+                # initialise the equation variable
+                eqn = deepcopy(new_term)
+            else:
+                # add new term to the existing equation
+                eqn += new_term
+
+        return eqn
+
+    def process(self, X, y):
+        """
+        Process things.
+
+        Args:
+            X:
+            y:
+
+        Returns:
+        """
+        eqn = self.create_pygam_model()
+        gam = GAM(
+            eqn,
+            max_iter=self.max_iter,
+            tol=self.tol,
+            distribution=self.distribution,
+            link=self.link,
+            fit_intercept=self.fit_intercept
+        ).fit(X, y)
+
+        return gam

--- a/improver/utilities/statistical.py
+++ b/improver/utilities/statistical.py
@@ -3,6 +3,7 @@
 # This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
 """Module to contain statistical methods."""
+import numpy as np
 
 from improver import BasePlugin
 from copy import deepcopy
@@ -10,12 +11,13 @@ from pygam import GAM, l, s, te, f
 from typing import Dict
 
 
-class FitGAM(BasePlugin):
+class GAMFit(BasePlugin):
     """
-    Class for fitting Generalized Additive Models which predict the mean and standard deviation of input forecasts or observations.
+    Class for fitting Generalized Additive Models (GAMs) which predict the mean and standard deviation of input
+    forecasts or observations.
 
-    This class wraps around pyGAM (https://pygam.readthedocs.io/en/latest/index.html), which is used for fitting the model.
-
+    This class uses functionality from pyGAM (https://pygam.readthedocs.io/en/latest/index.html), which is used for
+    fitting the model.
     """
 
     def __init__(
@@ -28,7 +30,25 @@ class FitGAM(BasePlugin):
         fit_intercept: bool = True,
     ):
         """
-        Initialize class for fitting Generalized Additive Models using pyGAM.
+        Initialize class for fitting GAMs using pyGAM.
+
+        Args:
+            model_specification:
+                a dictionary with arbitrary keys and values a list of three items (in order):
+                    1. a string containing a single pyGAM term; one of 'l' (linear), 's' (spline), 'te' (tensor), or
+                    'f' (factor)
+                    2. a list of integers which correspond to the features to be included in that term
+                    3. a dictionary of kwargs to be included when defining the term
+            max_iter:
+                a pyGAM argument which determines the maximum iterations allowed when fitting the GAM
+            tol:
+                a pyGAM argument determining the tolerance used to define the stopping criteria
+            distribution:
+                a pyGAM argument determining the distribution to be used in the model
+            link:
+                a pyGAM argument determining the link function to be used in the model
+            fit_intercept:
+                a pyGAM argument determining whether to include an intercept term in the model
         """
         self.model_specification = model_specification
         self.max_iter = max_iter
@@ -47,7 +67,7 @@ class FitGAM(BasePlugin):
         for index, (key, values) in enumerate(self.model_specification.items()):
             # For each key in the dictionary, parse the value to create a pyGAM term from that value.
             # The first term in the dictionary value defines the type of term, the second defines which variables are
-            # included in that term, and the 3rd contains a dictionary of other arguments.
+            # included in that term, and the third contains a dictionary of kwargs.
             if values[0] == "l":  # linear term
                 new_term = l(*values[1], **values[2])
             elif values[0] == "s":  # spline term
@@ -71,15 +91,16 @@ class FitGAM(BasePlugin):
 
         return eqn
 
-    def process(self, X, y):
+    def process(self, X: np.ndarray, y: np.ndarray):
         """
-        Process things.
+        Fit a GAM model using pyGAM.
 
         Args:
-            X:
-            y:
+            X: An array of predictors
+            y: An array of target values associated with the predictors in X
 
         Returns:
+            A fitted pyGAM GAM model.
         """
         eqn = self.create_pygam_model()
         gam = GAM(
@@ -92,3 +113,22 @@ class FitGAM(BasePlugin):
         ).fit(X, y)
 
         return gam
+
+
+class GAMPredict(BasePlugin):
+    """Class for predicting new outputs from a fitted GAM given new input variables."""
+    def __init__(self):
+        """Initialize class"""
+    def process(self, gam, X: np.ndarray) -> np.ndarray:
+        """
+        Use pyGAM functionality to predict values from a fitted GAM.
+
+        Args:
+            gam: Fitted pyGAM GAM model
+            X: An array of inputs to use to predict new values. Must have the same number of columns as used for
+            training.
+
+        Returns:
+            A 1-D array of values predicted by the GAM.
+        """
+        return gam.predict(X)

--- a/improver/utilities/statistical.py
+++ b/improver/utilities/statistical.py
@@ -3,21 +3,22 @@
 # This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
 """Module to contain statistical methods."""
+
+from copy import deepcopy
+from typing import Dict
+
 import numpy as np
+from pygam import GAM, f, l, s, te
 
 from improver import BasePlugin
-from copy import deepcopy
-from pygam import GAM, l, s, te, f
-from typing import Dict
 
 
 class GAMFit(BasePlugin):
     """
-    Class for fitting Generalized Additive Models (GAMs) which predict the mean and standard deviation of input
+    Class for fitting Generalized Additive Models (GAMs) which predict the mean or standard deviation of input
     forecasts or observations.
 
-    This class uses functionality from pyGAM (https://pygam.readthedocs.io/en/latest/index.html), which is used for
-    fitting the model.
+    This class uses functionality from pyGAM (https://pygam.readthedocs.io/en/latest/index.html) to fit the model.
     """
 
     def __init__(
@@ -25,8 +26,8 @@ class GAMFit(BasePlugin):
         model_specification: Dict,
         max_iter: int = 100,
         tol: float = 0.0001,
-        distribution: str = 'normal',
-        link: str = 'identity',
+        distribution: str = "normal",
+        link: str = "identity",
         fit_intercept: bool = True,
     ):
         """
@@ -79,14 +80,15 @@ class GAMFit(BasePlugin):
             else:
                 msg = (
                     f"An unrecognised term has been included in the GAM model specification. The term was {values[0]},"
-                    f" the accepted terms are l, s, te, f.")
+                    f" the accepted terms are l, s, te, f."
+                )
                 raise ValueError(msg)
 
             if index == 0:
-                # initialise the equation variable
+                # Initialize the equation variable
                 eqn = deepcopy(new_term)
             else:
-                # add new term to the existing equation
+                # Add new term to the existing equation
                 eqn += new_term
 
         return eqn
@@ -109,7 +111,7 @@ class GAMFit(BasePlugin):
             tol=self.tol,
             distribution=self.distribution,
             link=self.link,
-            fit_intercept=self.fit_intercept
+            fit_intercept=self.fit_intercept,
         ).fit(X, y)
 
         return gam
@@ -117,8 +119,10 @@ class GAMFit(BasePlugin):
 
 class GAMPredict(BasePlugin):
     """Class for predicting new outputs from a fitted GAM given new input variables."""
+
     def __init__(self):
         """Initialize class"""
+
     def process(self, gam, X: np.ndarray) -> np.ndarray:
         """
         Use pyGAM functionality to predict values from a fitted GAM.

--- a/improver_tests/utilities/test_GAMPredict.py
+++ b/improver_tests/utilities/test_GAMPredict.py
@@ -3,12 +3,13 @@
 # This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the GAMPredict class within statistical.py"""
+
 import numpy as np
 import pytest
+from pygam import GAM, f, s
+from pygam.datasets import wage
 
 from improver.utilities.statistical import GAMPredict
-from pygam import GAM, s, f
-from pygam.datasets import wage
 
 
 @pytest.mark.parametrize(
@@ -17,23 +18,23 @@ from pygam.datasets import wage
         (
             [[2006, 32, 1]],
             [92.13292996],
-        ),  # test prediction of a single new value
+        ),  # Test prediction of a single new value
         (
             [[2006, 32, 1], [2009, 18, 1], [2004, 78, 4]],
             [92.13292996, 66.06155349, 132.48350915],
-        ),  # test prediction of multiple new values
+        ),  # Test prediction of multiple new values
         (
             [[2010, 90, 4], [2050, 160, 2]],
-            [160.20340934, 284.10127629]
-        ),  # test prediction of new values where the continuous inputs are greater than those used in training to
-            # demonstrate that we can extrapolate beyond the bounds of the training dataset.
+            [160.20340934, 284.10127629],
+        ),  # Test prediction of new values where the continuous inputs are greater than those used in training to
+        # demonstrate that we can extrapolate beyond the bounds of the training dataset.
         (
             [[2002, 15, 0], [1950, 1, 2]],
-            [43.40042416, -161.03952442]
-        ),  # test prediction of new values where the continuous inputs are less than those used in training to
-            # demonstrate that we can extrapolate beyond the bounds of the training dataset. This test also demonstrates
-            # that extrapolation can lead to nonsensical results, such as a negative wage.
-    ]
+            [43.40042416, -161.03952442],
+        ),  # Test prediction of new values where the continuous inputs are less than those used in training to
+        # demonstrate that we can extrapolate beyond the bounds of the training dataset. This test also demonstrates
+        # that extrapolation can lead to nonsensical results, such as a negative wage.
+    ],
 )
 def test_process(X_new, expected):
     """Test that the process method returns the expected results. Uses an example of a fitted model from pyGAM quick

--- a/improver_tests/utilities/test_GAMPredict.py
+++ b/improver_tests/utilities/test_GAMPredict.py
@@ -1,0 +1,46 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the GAMPredict class within statistical.py"""
+import numpy as np
+import pytest
+
+from improver.utilities.statistical import GAMPredict
+from pygam import GAM, s, f
+from pygam.datasets import wage
+
+
+@pytest.mark.parametrize(
+    "X_new,expected",
+    [
+        (
+            [[2006, 32, 1]],
+            [92.13292996],
+        ),  # test prediction of a single new value
+        (
+            [[2006, 32, 1], [2009, 18, 1], [2004, 78, 4]],
+            [92.13292996, 66.06155349, 132.48350915],
+        ),  # test prediction of multiple new values
+        (
+            [[2010, 90, 4], [2050, 160, 2]],
+            [160.20340934, 284.10127629]
+        ),  # test prediction of new values where the continuous inputs are greater than those used in training to
+            # demonstrate that we can extrapolate beyond the bounds of the training dataset.
+        (
+            [[2002, 15, 0], [1950, 1, 2]],
+            [43.40042416, -161.03952442]
+        ),  # test prediction of new values where the continuous inputs are less than those used in training to
+            # demonstrate that we can extrapolate beyond the bounds of the training dataset. This test also demonstrates
+            # that extrapolation can lead to nonsensical results, such as a negative wage.
+    ]
+)
+def test_process(X_new, expected):
+    """Test that the process method returns the expected results. Uses an example of a fitted model from pyGAM quick
+    start documentation: https://pygam.readthedocs.io/en/latest/notebooks/quick_start.html#Fit-a-Model."""
+    X, y = wage()
+
+    gam = GAM(s(0) + s(1) + f(2)).fit(X, y)
+    result = GAMPredict().process(gam, X_new)
+
+    np.testing.assert_array_almost_equal(result, expected)

--- a/improver_tests/utilities/test_GAMPredict.py
+++ b/improver_tests/utilities/test_GAMPredict.py
@@ -27,13 +27,13 @@ from improver.utilities.statistical import GAMPredict
             [[2010, 90, 4], [2050, 160, 2]],
             [160.20340934, 284.10127629],
         ),  # Test prediction of new values where the continuous inputs are greater than those used in training to
-        # demonstrate that we can extrapolate beyond the bounds of the training dataset.
+            # demonstrate that we can extrapolate beyond the bounds of the training dataset.
         (
             [[2002, 15, 0], [1950, 1, 2]],
             [43.40042416, -161.03952442],
         ),  # Test prediction of new values where the continuous inputs are less than those used in training to
-        # demonstrate that we can extrapolate beyond the bounds of the training dataset. This test also demonstrates
-        # that extrapolation can lead to nonsensical results, such as a negative wage.
+            # demonstrate that we can extrapolate beyond the bounds of the training dataset. This test also demonstrates
+            # that extrapolation can lead to nonsensical results, such as a negative wage.
     ],
 )
 def test_process(X_new, expected):

--- a/improver_tests/utilities/test_statistical.py
+++ b/improver_tests/utilities/test_statistical.py
@@ -1,0 +1,124 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the plugins and functions within statistical.py"""
+import numpy as np
+import pytest
+
+from improver.utilities.statistical import FitGAM
+from pygam import GAM, l, s, te, f
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "model_specification": {"term": ["l", [0], {}]}
+        },  # define a model specification but leave all other inputs as default
+        {
+            "model_specification": {"term": ["l", [0], {}]},
+            "max_iter": 200,
+            "tol": 0.1,
+        },  # check that inputs related to model fitting are initialised correctly
+        {
+            "model_specification": {"term": ["l", [0], {}]},
+            "distribution": "gamma",
+            "link": "inverse",
+            "fit_intercept": False,
+        },  # check that inputs related to the GAM model design are initialised correctly
+
+    ]
+)
+def test__init__(kwargs):
+    expected = {
+        "model_specification": None,
+        "max_iter": 100,
+        "tol": 0.0001,
+        "distribution": "normal",
+        "link": "identity",
+        "fit_intercept": True
+    }
+    expected.update(kwargs)
+    result = FitGAM(**kwargs)
+
+    for key in [key for key in kwargs.keys()]:
+        assert getattr(result, key) == kwargs[key]
+
+
+@pytest.mark.parametrize(
+    "test,model_specification",
+    [
+        (
+            "basic",
+            {
+                 "term_1": ["l", [0], {}],
+                 "term_2": ["s", [1], {}],
+                 "term_3": ["te", [2, 3], {}],
+                 "term_4": ["f", [4], {}]
+            },
+        ),  # test that each type of GAM term can be created correctly
+        (
+            "with_kwargs",
+            {
+                "term_1": ["l", [0], {"lam": 0.8}],
+                "term_2": ["s", [1], {"n_splines": 10, "basis": "cp"}],
+            },
+        ),  # test that kwargs are passed to the pyGAM terms correctly
+        (
+            "exception",
+            {
+                "term_1": ["l", [0], {}],
+                "term_2": ["kittens", [1], {}],
+            },
+        )  # test that an exception is raised when an unknown term is provided
+    ]
+)
+def test_create_pygam_model(test, model_specification):
+    """Test that this method correctly creates a pyGAM equation and raises an exception when
+    provided with a bad input."""
+    if test in ["basic", "with_kwargs"]:
+        if test is "basic":
+            expected = l(0) + s(1) + te(2, 3) + f(4)
+        elif test is "with_kwargs":
+            expected = l(0, lam=0.8) + s(1, n_splines=10, basis="cp")
+        result = FitGAM(model_specification).create_pygam_model()
+        assert result == expected
+    elif test is "exception":
+        expected_msg = "An unrecognised term has been included in the GAM model specification."
+        with pytest.raises(ValueError, match=expected_msg):
+            FitGAM(model_specification).create_pygam_model()
+
+
+def test_process():
+    """Test that the process method returns the expected results. Uses an example from the pyGAM quick start
+    documentation: https://pygam.readthedocs.io/en/latest/notebooks/quick_start.html#Fit-a-Model."""
+    from pygam.datasets import wage
+
+    X, y = wage()
+    model_specification = {"term_1": ["s", [0], {}], "term_2": ["s", [1], {}], "term_3": ["f", [2], {}]}
+
+    expected = GAM(s(0) + s(1) + f(2)).fit(X, y)
+    result = FitGAM(model_specification).process(X, y)
+
+    for i, term in enumerate(result.terms):
+        # for each non-intercept term in each fitted GAM, compare their partial dependence values and confidence
+        # intervals, which should be equal if the fitted models are the same.
+        if term.isintercept:
+            continue
+
+        XX = result.generate_X_grid(term=i)
+        result_pdep, result_confi = result.partial_dependence(term=i, X=XX, width=0.95)
+        expected_pdep, expected_confi = expected.partial_dependence(term=i, X=XX, width=0.95)
+
+        assert np.array_equal(result_pdep, expected_pdep)
+        assert np.array_equal(result_confi, expected_confi)
+
+    for key in list(result.statistics_.keys()):
+        # check that other features of the fitted GAM models are equal.
+        if key in [
+            "n_samples", "m_features", "edof", "scale", "AIC", "AICc", "GCV", "UBRE", "loglikelihood", "deviance"
+        ]:
+            assert result.statistics_[key] == expected.statistics_[key]
+        else:
+            assert np.array_equal(result.statistics_[key], expected.statistics_[key])


### PR DESCRIPTION
Addresses #[775](https://github.com/metoppv/mo-blue-team/issues/775)

Description
Adds functionality to allow fitting GAMs and predicting new values from the fitted models. Working with GAMs is handled using the [pyGAM](https://pygam.readthedocs.io/en/latest/index.html) package. 

Testing:
- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
