### PR TITLE
First cut changes in preparation for environment upgrade

### DIFF
--- a/envs/conda-forge.yml
+++ b/envs/conda-forge.yml
@@ -8,19 +8,19 @@ name: improver_conda_forge
 channels:
   - conda-forge
 dependencies:
-  - python>=3.6
+  - python=3
   # Included in improver-feedstock requirements
-  - cartopy<0.20
-  - cftime<1.5
-  - cf-units=2.1.5
+  - cartopy
+  - cftime
+  - cf-units
   - clize
   - dask
-  - iris>=3.0,<3.1
+  - iris
   - netCDF4
-  - numpy<1.21
-  - scipy<1.7
+  - numpy
+  - scipy
   - sigtools
-  - sphinx=5.3.0
+  - sphinx
   # Additional libraries to run tests, not included in improver-feedstock
   - bandit
   - filelock
@@ -29,6 +29,3 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
-  # Pinned dependencies of dependencies
-  - pillow<=10.0.1  # https://github.com/metoppv/improver/issues/2010
-  - pandas<=2.0.0  # https://github.com/metoppv/improver/issues/2010

--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -4,28 +4,28 @@ channels:
   - conda-forge
   - main
 dependencies:
-  - python=3.7
+  - python=3
   # Required
-  - cartopy=0.19
-  - cftime=1.2.1
-  - cf-units=2.1.5
-  - clize=4.1.1
-  - dask=2021.8.1
-  - iris=3.0.3
-  - netCDF4=1.4.1
-  - numpy=1.20.2
-  - pandas=1.2.4
-  - pytz=2020.5
-  - scipy=1.6.2
-  - sigtools=2.0.2
-  - sphinx=4.0.1
+  - cartopy
+  - cftime
+  - cf-units
+  - clize
+  - dask
+  - iris
+  - netCDF4
+  - numpy
+  - pandas
+  - pytz
+  - scipy
+  - sigtools
+  - sphinx
   # Optional
-  - fastparquet=0.7.1
-  - statsmodels=0.12.2
-  - numba=0.53.1
+  - fastparquet
+  - statsmodels
+  - numba
   - pygam=0.8.0
-  - pysteps=1.4.1
-  - python-stratify=0.1.1
+  - pysteps
+  - python-stratify
   - python-utils=3.5.2
   # Development
   - astroid

--- a/envs/environment_b.yml
+++ b/envs/environment_b.yml
@@ -7,26 +7,26 @@ name: improver_b
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3
   # Required
-  - cartopy=0.19
-  - cftime=1.2.1
-  - cf-units=2.1.5
-  - clize=4.2.0
-  - dask=2021.8.1
-  - iris=3.0.3
-  - netCDF4=1.5.7
-  - numpy=1.20
-  - pandas=1.3.4
-  - pytz=2020.5
-  - scipy=1.6.2
-  - sigtools=2.0.3
-  - sphinx=4.0.2
+  - cartopy
+  - cftime
+  - cf-units
+  - clize
+  - dask
+  - iris
+  - netCDF4
+  - numpy
+  - pandas
+  - pytz
+  - scipy
+  - sigtools
+  - sphinx
   # Optional
-  - lightgbm=3.2.1
-  - numba=0.53.1
-  - python-stratify=0.2.post0
-  - treelite=2.3.0
+  - lightgbm
+  - numba
+  - python-stratify
+  - treelite
   # Development
   - astroid
   - bandit
@@ -40,5 +40,3 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
-  # pinned dependencies of dependencies
-  - pyparsing=3.1.2

--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -9,14 +9,14 @@ channels:
 dependencies:
   - python=3
   # Required
-  - cartopy<0.20
-  - cftime<1.5
-  - cf-units=2.1.5
+  - cartopy
+  - cftime
+  - cf-units
   - clize
   - dask
-  - iris>=3.0
+  - iris
   - netCDF4
-  - numpy<1.21
+  - numpy
   - pytz
   - scipy
   - sigtools
@@ -29,7 +29,7 @@ dependencies:
   - pygam=0.8.0
   - pysteps
   - python-utils=3.5.2
-  - treelite=2.3.0
+  - treelite
   # Development
   - astroid
   - bandit
@@ -44,6 +44,3 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
   - threadpoolctl
-  # Pinned dependencies of dependencies
-  - pillow<=10.0.1  # https://github.com/metoppv/improver/issues/2010
-  - pandas<=2.0.0  # https://github.com/metoppv/improver/issues/2010

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -94,9 +94,7 @@ def split_forecasts_and_truth(
     return forecast, truth, land_sea_mask
 
 
-def split_forecasts_and_coeffs(
-    cubes: CubeList, land_sea_mask_name: Optional[str] = None
-):
+def split_forecasts_and_coeffs(cubes: List, land_sea_mask_name: Optional[str] = None):
     """Split the input forecast, coefficients, static additional predictors,
     land sea-mask and probability template, if provided. The coefficients
     cubes and land-sea mask are identified based on their name. The

--- a/improver/psychrometric_calculations/cloud_top_temperature.py
+++ b/improver/psychrometric_calculations/cloud_top_temperature.py
@@ -43,9 +43,9 @@ class CloudTopTemperature(PostProcessingPlugin):
                 Name of model ID attribute to be copied from source cubes to output cube
         """
         self.model_id_attr = model_id_attr
-        self.t_at_ccl = Cube(None)
-        self.p_at_ccl = Cube(None)
-        self.temperature = Cube(None)
+        self.t_at_ccl = Cube(shape=(0,))
+        self.p_at_ccl = Cube(shape=(0,))
+        self.temperature = Cube(shape=(0,))
         self.minimum_t_diff = 4
 
     def _calculate_cct(self) -> ndarray:

--- a/improver/wind_calculations/vertical_updraught.py
+++ b/improver/wind_calculations/vertical_updraught.py
@@ -39,8 +39,8 @@ class VerticalUpdraught(BasePlugin):
                 Name of model ID attribute to be copied from source cubes to output cube
         """
         self.model_id_attr = model_id_attr
-        self.cape = Cube(None)
-        self.precip = Cube(None)
+        self.cape = Cube(shape=(0,))
+        self.precip = Cube(shape=(0,))
         self.cube_names = [
             "atmosphere_convective_available_potential_energy",
             "lwe_precipitation_rate_max",

--- a/improver_tests/calibration/rainforests_calibration/conftest.py
+++ b/improver_tests/calibration/rainforests_calibration/conftest.py
@@ -42,7 +42,7 @@ def thresholds():
 
 @pytest.fixture
 def lead_times():
-    return np.array([24, 48], dtype=np.int)
+    return np.array([24, 48], dtype=np.int32)
 
 
 @pytest.fixture

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -298,7 +298,7 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test a realization forecast input."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList([self.realization_forecast, self.coefficient_cubelist]),
+                [self.realization_forecast, self.coefficient_cubelist],
                 self.land_sea_mask_name,
             )
         )
@@ -313,7 +313,7 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test a percentile forecast input."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList([self.percentile_forecast, self.coefficient_cubelist]),
+                [self.percentile_forecast, self.coefficient_cubelist],
                 self.land_sea_mask_name,
             )
         )
@@ -327,9 +327,9 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test a probability forecast input."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList([self.probability_forecast, self.coefficient_cubelist]),
-                self.land_sea_mask_name,
-            )
+                [self.probability_forecast, self.coefficient_cubelist]
+            ),
+            self.land_sea_mask_name,
         )
         self.assertCubeEqual(forecast, self.probability_forecast[0])
         self.assertCubeListEqual(coeffs, self.coefficient_cubelist)
@@ -341,13 +341,11 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test the addition of a static additional predictor."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList(
-                    [
-                        self.realization_forecast,
-                        self.coefficient_cubelist,
-                        self.additional_predictors,
-                    ]
-                ),
+                [
+                    self.realization_forecast,
+                    self.coefficient_cubelist,
+                    self.additional_predictors,
+                ],
                 self.land_sea_mask_name,
             )
         )
@@ -361,13 +359,11 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test the addition of a land-sea mask."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList(
-                    [
-                        self.realization_forecast,
-                        self.coefficient_cubelist,
-                        self.land_sea_mask,
-                    ]
-                ),
+                [
+                    self.realization_forecast,
+                    self.coefficient_cubelist,
+                    self.land_sea_mask,
+                ],
                 self.land_sea_mask_name,
             )
         )
@@ -382,7 +378,7 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test when not providing the land_sea_mask_name option."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList([self.realization_forecast, self.coefficient_cubelist])
+                [self.realization_forecast, self.coefficient_cubelist]
             )
         )
 
@@ -396,13 +392,11 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         """Test the addition of a probability template cube."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList(
-                    [
-                        self.realization_forecast,
-                        self.coefficient_cubelist,
-                        self.probability_forecast,
-                    ]
-                ),
+                [
+                    self.realization_forecast,
+                    self.coefficient_cubelist,
+                    self.probability_forecast,
+                ],
                 self.land_sea_mask_name,
             )
         )
@@ -417,15 +411,13 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         land-sea mask and a probability template."""
         (forecast, coeffs, additional_predictors, land_sea_mask, template) = (
             split_forecasts_and_coeffs(
-                CubeList(
-                    [
-                        self.realization_forecast,
-                        self.coefficient_cubelist,
-                        self.additional_predictors,
-                        self.land_sea_mask,
-                        self.probability_forecast,
-                    ]
-                ),
+                [
+                    self.realization_forecast,
+                    self.coefficient_cubelist,
+                    self.additional_predictors,
+                    self.land_sea_mask,
+                    self.probability_forecast,
+                ],
                 self.land_sea_mask_name,
             )
         )
@@ -440,20 +432,18 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         msg = "Providing multiple probability cubes"
         with self.assertRaisesRegex(ValueError, msg):
             split_forecasts_and_coeffs(
-                CubeList(
-                    [
-                        self.probability_forecast,
-                        self.coefficient_cubelist,
-                        self.probability_forecast,
-                    ]
-                ),
+                [
+                    self.probability_forecast,
+                    self.coefficient_cubelist,
+                    self.probability_forecast,
+                ],
                 self.land_sea_mask_name,
             )
 
     def test_no_coefficients(self):
         """Test if no EMOS coefficients are provided."""
         _, coeffs, _, _, _ = split_forecasts_and_coeffs(
-            CubeList([self.percentile_forecast]), self.land_sea_mask_name
+            [self.percentile_forecast], self.land_sea_mask_name
         )
         self.assertIsNone(coeffs)
 
@@ -462,7 +452,7 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         msg = "No forecast is present"
         with self.assertRaisesRegex(ValueError, msg):
             split_forecasts_and_coeffs(
-                CubeList([self.coefficient_cubelist]), self.land_sea_mask_name
+                [self.coefficient_cubelist], self.land_sea_mask_name
             )
 
     def test_duplicate_forecasts(self):
@@ -470,15 +460,13 @@ class Test_split_forecasts_and_coeffs(ImproverTest):
         msg = "Multiple items have been provided"
         with self.assertRaisesRegex(ValueError, msg):
             split_forecasts_and_coeffs(
-                CubeList(
-                    [
-                        self.percentile_forecast,
-                        self.coefficient_cubelist,
-                        self.land_sea_mask,
-                        self.probability_forecast,
-                        self.percentile_forecast,
-                    ]
-                ),
+                [
+                    self.percentile_forecast,
+                    self.coefficient_cubelist,
+                    self.land_sea_mask,
+                    self.probability_forecast,
+                    self.percentile_forecast,
+                ],
                 self.land_sea_mask_name,
             )
 

--- a/improver_tests/categorical/modal_code/test_ModalCategory.py
+++ b/improver_tests/categorical/modal_code/test_ModalCategory.py
@@ -58,7 +58,7 @@ def wxcode_series_fixture(
             wxfrt = time - timedelta(hours=42)
         wxdata = np.ones((2, 2), dtype=np.int8)
 
-        if len(data[i].shape) > 0 and np.product(wxdata.shape) == data[i].shape[0]:
+        if len(data[i].shape) > 0 and np.prod(wxdata.shape) == data[i].shape[0]:
             wxdata = np.reshape(data[i], wxdata.shape)
         else:
             if len(data[i].shape) == 0:

--- a/improver_tests/generate_ancillaries/test_OrographicSmoothingCoefficients.py
+++ b/improver_tests/generate_ancillaries/test_OrographicSmoothingCoefficients.py
@@ -71,7 +71,7 @@ def smoothing_coefficients_fixture() -> CubeList:
 def mask_fixture() -> Cube:
     """Returns an example mask."""
 
-    data = np.zeros((6, 6), dtype=np.int)
+    data = np.zeros((6, 6), dtype=np.int32)
     data[2:-2, 2:-2] = 1
     mask = set_up_variable_cube(
         data,

--- a/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
+++ b/improver_tests/nbhood/nbhood/test_BaseNeighbourhoodProcessing.py
@@ -66,7 +66,7 @@ class Test_process(IrisTest):
 
     def test_single_point_nan(self):
         """Test behaviour for a single NaN grid cell."""
-        self.cube.data[6][7] = np.NAN
+        self.cube.data[6][7] = np.nan
         msg = "NaN detected in input cube data"
         with self.assertRaisesRegex(ValueError, msg):
             NBHood(self.RADIUS)(self.cube)

--- a/improver_tests/nowcasting/optical_flow/test_utilities.py
+++ b/improver_tests/nowcasting/optical_flow/test_utilities.py
@@ -49,7 +49,7 @@ class Test_check_input_coords(IrisTest):
         vel2.add_aux_coord(DimCoord(2, standard_name="realization"))
         (invalid_3d,) = (iris.cube.CubeList([vel1, vel2])).merge()
         msg = "Cube has 3"
-        with self.assertRaisesRegexp(InvalidCubeError, msg):
+        with self.assertRaisesRegex(InvalidCubeError, msg):
             check_input_coords(invalid_3d)
 
     def test_time(self):
@@ -57,7 +57,7 @@ class Test_check_input_coords(IrisTest):
         cube = self.valid.copy()
         cube.remove_coord("time")
         msg = "Input cube has no time coordinate"
-        with self.assertRaisesRegexp(InvalidCubeError, msg):
+        with self.assertRaisesRegex(InvalidCubeError, msg):
             check_input_coords(cube, require_time=True)
 
 

--- a/improver_tests/nowcasting/utilities/test_ApplyOrographicEnhancement.py
+++ b/improver_tests/nowcasting/utilities/test_ApplyOrographicEnhancement.py
@@ -379,7 +379,7 @@ class Test__apply_minimum_precip_rate(IrisTest):
             [
                 [
                     [0.0, 1.0, 2.0],
-                    [np.NaN, np.NaN, np.NaN],
+                    [np.nan, np.nan, np.nan],
                     [0.0, 1.0, MIN_PRECIP_RATE_MMH],
                 ]
             ]
@@ -388,7 +388,7 @@ class Test__apply_minimum_precip_rate(IrisTest):
         subtracted_cube = self.subtracted_cube.copy()
         subtracted_cube.convert_units("mm/hr")
         subtracted_cube.data = np.array(
-            [[[0.0, 1.0, 2.0], [np.NaN, np.NaN, np.NaN], [0.0, 1.0, 0.0]]]
+            [[[0.0, 1.0, 2.0], [np.nan, np.nan, np.nan], [0.0, 1.0, 0.0]]]
         )
         subtracted_cube.convert_units("m/s")
         plugin = ApplyOrographicEnhancement("subtract")

--- a/improver_tests/precipitation/precipitation_duration/test_PrecipitationDuration.py
+++ b/improver_tests/precipitation/precipitation_duration/test_PrecipitationDuration.py
@@ -119,9 +119,9 @@ def precip_cubes(
     function = request.param
 
     if function == set_up_spot_probability_cube:
-        acc_sites = np.product(acc_data.shape[-2:])
+        acc_sites = np.prod(acc_data.shape[-2:])
         acc_data = acc_data.reshape(acc_data.shape[:-2] + (acc_sites,))
-        rate_sites = np.product(rate_data.shape[-2:])
+        rate_sites = np.prod(rate_data.shape[-2:])
         rate_data = rate_data.reshape(rate_data.shape[:-2] + (rate_sites,))
 
     frt, times, bounds = data_times(start_time, end_time, period)
@@ -667,7 +667,7 @@ def test_process(
     result = plugin.process(precip_cubes)
 
     if result.coords("wmo_id"):
-        n_sites = np.product(acc_data.shape[-2:])
+        n_sites = np.prod(acc_data.shape[-2:])
         expected = expected.reshape(expected.shape[:-2] + (n_sites,))
 
     assert_array_equal(result.data, expected)

--- a/improver_tests/regrid/test_RegridWithLandSeaMask.py
+++ b/improver_tests/regrid/test_RegridWithLandSeaMask.py
@@ -44,14 +44,14 @@ def define_source_target_grid_data():
     data = np.arange(20).reshape(4, 5).astype(np.float32)
 
     # input grid mask info
-    in_mask = np.empty((4, 5), dtype=np.int)
+    in_mask = np.empty((4, 5), dtype=np.int32)
     in_mask[:, :] = 1
     in_mask[0, 2] = 0
     in_mask[2, 2:4] = 0
     in_mask[3, 2:4] = 0
 
     # output grid mask info
-    out_mask = np.empty((8, 11), dtype=np.int)
+    out_mask = np.empty((8, 11), dtype=np.int32)
     out_mask[:, :] = 1
     out_mask[0, 4:7] = 0
     out_mask[1, 5] = 0
@@ -88,14 +88,14 @@ def define_source_target_grid_data_same_domain():
     data = np.arange(20).reshape(4, 5).astype(np.float32)
 
     # input grid mask info
-    in_mask = np.empty((4, 5), dtype=np.int)
+    in_mask = np.empty((4, 5), dtype=np.int32)
     in_mask[:, :] = 1
     in_mask[0, 2] = 0
     in_mask[2, 2:4] = 0
     in_mask[3, 2:4] = 0
 
     # output grid mask info
-    out_mask = np.empty((7, 9), dtype=np.int)
+    out_mask = np.empty((7, 9), dtype=np.int32)
     out_mask[:, :] = 1
     out_mask[0, 3:6] = 0
     out_mask[1, 4] = 0

--- a/improver_tests/temperature/lapse_rate/test_LapseRate.py
+++ b/improver_tests/temperature/lapse_rate/test_LapseRate.py
@@ -179,7 +179,7 @@ class Test_process(IrisTest):
         not a cube."""
         incorrect_input = 50.0
         msg = "Temperature input is not a cube, but {0}".format(type(incorrect_input))
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             LapseRate(nbhood_radius=1).process(
                 incorrect_input, self.orography, self.land_sea_mask
             )
@@ -189,7 +189,7 @@ class Test_process(IrisTest):
         not a cube."""
         incorrect_input = 50.0
         msg = "Orography input is not a cube, but {0}".format(type(incorrect_input))
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             LapseRate(nbhood_radius=1).process(
                 self.temperature, incorrect_input, self.land_sea_mask
             )
@@ -199,7 +199,7 @@ class Test_process(IrisTest):
         not a cube."""
         incorrect_input = 50.0
         msg = "Land/Sea mask input is not a cube, but {0}".format(type(incorrect_input))
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             LapseRate(nbhood_radius=1).process(
                 self.temperature, self.orography, incorrect_input
             )
@@ -209,7 +209,7 @@ class Test_process(IrisTest):
         wrong unit."""
         #  Swap cubes around so have wrong units.
         msg = r"Unable to convert from 'Unit\('m'\)' to 'Unit\('K'\)'."
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LapseRate(nbhood_radius=1).process(
                 self.orography, self.orography, self.land_sea_mask
             )
@@ -218,7 +218,7 @@ class Test_process(IrisTest):
         """Test code raises a Value Error if the orography cube is the
         wrong unit."""
         msg = r"Unable to convert from 'Unit\('K'\)' to 'Unit\('metres'\)'."
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LapseRate(nbhood_radius=1).process(
                 self.temperature, self.temperature, self.land_sea_mask
             )
@@ -268,7 +268,7 @@ class Test_process(IrisTest):
         less than input minimum lapse rate"""
         msg = "Maximum lapse rate is less than minimum lapse rate"
 
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LapseRate(max_lapse_rate=-1, min_lapse_rate=1).process(
                 self.temperature, self.orography, self.land_sea_mask
             )
@@ -278,7 +278,7 @@ class Test_process(IrisTest):
         is less than zero"""
         msg = "Neighbourhood radius is less than zero"
 
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LapseRate(nbhood_radius=-1).process(
                 self.temperature, self.orography, self.land_sea_mask
             )
@@ -288,7 +288,7 @@ class Test_process(IrisTest):
         is less than zero"""
         msg = "Maximum height difference is less than zero"
 
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             LapseRate(max_height_diff=-1).process(
                 self.temperature, self.orography, self.land_sea_mask
             )

--- a/improver_tests/threshold/conftest.py
+++ b/improver_tests/threshold/conftest.py
@@ -80,7 +80,7 @@ def deterministic_cube() -> Cube:
 def single_realization_cube() -> Cube:
     """Return the diagnostic cube with a scalar realization coordinate."""
     cube = diagnostic_cube()
-    cube = add_coordinate(cube, [0], "realization", dtype=np.int)
+    cube = add_coordinate(cube, [0], "realization", dtype=np.int32)
     return cube
 
 

--- a/improver_tests/threshold/test_LatitudeDependentThreshold.py
+++ b/improver_tests/threshold/test_LatitudeDependentThreshold.py
@@ -267,7 +267,7 @@ class Test_process(IrisTest):
 
     def test_threshold_point_nan(self):
         """Test behaviour for a single NaN grid cell."""
-        self.cube.data[2][2] = np.NAN
+        self.cube.data[2][2] = np.nan
         msg = "NaN detected in input cube data"
         with self.assertRaisesRegex(ValueError, msg):
             self.plugin(self.cube)

--- a/improver_tests/utilities/cube_extraction/test_cube_extraction.py
+++ b/improver_tests/utilities/cube_extraction/test_cube_extraction.py
@@ -38,7 +38,8 @@ def islambda(function):
             True if the input object is a lambda function, False if not.
     """
     return (
-        isinstance(function, collections.Callable) and function.__name__ == "<lambda>"
+        isinstance(function, collections.abc.Callable)
+        and function.__name__ == "<lambda>"
     )
 
 

--- a/improver_tests/utilities/test_flatten.py
+++ b/improver_tests/utilities/test_flatten.py
@@ -23,10 +23,8 @@ def get_cube(name) -> Cube:
         ([1, [2, [3, 4], 5], [6, [7, 8]], 9], [1, 2, 3, 4, 5, 6, 7, 8, 9]),
         # Cubes and CubeLists
         (
-            CubeList(
-                [get_cube("0"), get_cube("1"), CubeList([get_cube("2"), get_cube("3")])]
-            ),
-            [get_cube("0"), get_cube("1"), get_cube("2"), get_cube("3")],
+            CubeList([get_cube("0"), get_cube("1"), get_cube("2"), get_cube("3")]),
+            CubeList([get_cube("0"), get_cube("1"), get_cube("2"), get_cube("3")]),
         ),
         # Numpy arrays
         (

--- a/improver_tests/utilities/test_load.py
+++ b/improver_tests/utilities/test_load.py
@@ -198,7 +198,7 @@ class Test_load_cube(IrisTest):
     def test_prefix_cube_removed(self):
         """Test metadata prefix cube is discarded during load"""
         msg = "No cubes found"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             load_cube(self.filepath, "prefixes")
 
     def test_no_lazy_load(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py37"
+target-version = "py312"
 
 [tool.ruff.lint]
 extend-select = ["E", "F", "W", "I"]  # add C90 later

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.12
 packages = find:
 setup_requires =
     setuptools >= 38.3.0


### PR DESCRIPTION
Part of https://github.com/metoppv/mo-strategic-issues/issues/150

Description
This PR provides an initial set of changes to reduce the errors and failures when upgrading the package versions used by the improver repo. Please note that this is targeting a feature branch, rather than master. I've also unpinned the environments used by GitHub Actions.

The issues addressed in this PR:

- Iris now strictly only allows cubes within a cubelist, whereas previously you could put a cubelist in a cubelist. I've corrected some instances of this behaviour.
- np.product => np.prod
- np.int => np.int32
- np.NAN => np.nan
- np.NaN => np.nan
- assertRaisesRegexp => assertRaisesRegex
- Cube(None) => Cube(shape=(0,))

There are a large number of other errors that will be addressed by forthcoming PRs.

Feature branch tests:
```
922 failed, 5633 passed, 140 skipped, 1 xpassed, 3827 warnings, 493 errors in 131.53s (0:02:11)
```
i.e. a ~20% failure rate.

Following this PR:
```
805 failed, 6120 passed, 228 skipped, 1 xpassed, 3900 warnings, 11 errors in 124.60s (0:02:04)
```
i.e. a ~12% failure rate.

Testing:

- [x] Ran tests and they passed OK

