### PR TITLE
EPPT-2305 contrails engine mixing ratio

### DIFF
--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -16,20 +16,22 @@ from improver.utilities.common_input_handle import as_cubelist
 
 class CondensationTrailFormation(BasePlugin):
     """Plugin to calculate whether a condensation trail (contrail) will
-    form based on a given set of atmospheric conditions. The
-    calculations require cubes of the following data:
-        - Temperature
-        - Pressure
-        - Relative Humidity
+    form based on a given set of atmospheric conditions.
+
+    The calculations require cubes of the following data:
+
+    - Temperature
+    - Pressure
+    - Relative Humidity
 
     Alongside constants including the ratio of the molecular masses of
     water and air (EARTH_REPSILON), and defined values for the engine
     contrail factor.
 
     References:
-        - Schrader, M.L., 1997. Calculations of aircraft contrail
-          formation critical temperatures. Journal of Applied
-          Meteorology, 36(12), pp.1725-1729.
+        Schrader, M.L., 1997. Calculations of aircraft contrail
+        formation critical temperatures. Journal of Applied
+        Meteorology, 36(12), pp.1725-1729.
     """
 
     def __init__(self, engine_contrail_factors: list = [3e-5, 3.4e-5, 3.9e-5]):

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -36,8 +36,8 @@ class CondensationTrailFormation(BasePlugin):
         """Initialsies the Class"""
 
         self._engine_contrail_factors: np.ndarray = np.array(
-            [1, 2, 3], dtype=np.float32
-        )  #! Placeholder values until the actual values are defined
+            [3e-5, 3.4e-5, 3.9e-5], dtype=np.float32
+        )
 
     def calculate_engine_mixing_ratios(self) -> np.ndarray:
         """

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -32,18 +32,19 @@ class CondensationTrailFormation(BasePlugin):
           Meteorology, 36(12), pp.1725-1729.
     """
 
-    def __init__(self):
+    def __init__(self, engine_contrail_factors: list = [3e-5, 3.4e-5, 3.9e-5]):
         """Initialsies the Class"""
 
         self._engine_contrail_factors: np.ndarray = np.array(
-            [3e-5, 3.4e-5, 3.9e-5], dtype=np.float32
+            engine_contrail_factors, dtype=np.float32
         )
 
     def calculate_engine_mixing_ratios(self) -> np.ndarray:
         """
         Calculate the mixing ratio of the atmosphere and aircraft
-        exhaust. This calculation uses EARTH_REPSILON, which is the
-        ratio of the molecular weights of water and air on Earth.
+        exhaust (Schrader, 1997). This calculation uses
+        EARTH_REPSILON, which is the ratio of the molecular
+        weights of water and air on Earth.
 
         Returns:
             float: The mixing ratio of the atmosphere and aircraft

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -34,13 +34,22 @@ class CondensationTrailFormation(BasePlugin):
     """
 
     def __init__(self, engine_contrail_factors: list = [3e-5, 3.4e-5, 3.9e-5]):
-        """Initialsies the Class"""
+        """Initialises the Class
+
+        Args:
+            engine_contrail_factors (list, optional):
+                List of engine contrail factors to use in the
+                calculations. Defaults to [3e-5, 3.4e-5, 3.9e-5].
+                These values are for Non-, Low-, and High-Bypass
+                engines from Schrader (1997). The units are
+                kg/kg/K.
+        """
 
         self._engine_contrail_factors: np.ndarray = np.array(
             engine_contrail_factors, dtype=np.float32
         )
 
-    def calculate_engine_mixing_ratios(self) -> np.ndarray:
+    def _calculate_engine_mixing_ratios(self) -> np.ndarray:
         """
         Calculate the mixing ratio of the atmosphere and aircraft
         exhaust (Schrader, 1997). This calculation uses
@@ -80,7 +89,7 @@ class CondensationTrailFormation(BasePlugin):
         self.pressure_levels = self.temperature.coord("pressure").points
 
         # Calculate the mixing ratios
-        engine_mixing_ratios = self.calculate_engine_mixing_ratios()
+        engine_mixing_ratios = self._calculate_engine_mixing_ratios()
 
         # Placeholder return to silence my type checker
         return_cube = Cube(

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -1,0 +1,56 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Module to contain Condensation trail calculations."""
+
+import numpy as np
+
+from improver import BasePlugin
+from improver.constants import EARTH_REPSILON
+
+
+class CondensationTrailFormation(BasePlugin):
+    """Plugin to calculate whether a condensation trail (contrail) will form
+    based on a given set of atmospheric conditions. The calculations require
+    cubes of the following data:
+        - Temperature
+        - Pressure
+        - Relative Humidity
+
+    Alongside constants including the ratio of the molecular masses of water
+    and air (EARTH_REPSILON), and defined values for the engine contrail factor.
+
+    References:
+        - Schrader, M.L., 1997. Calculations of aircraft contrail formation
+          critical temperatures. Journal of Applied Meteorology, 36(12),
+          pp.1725-1729.
+    """
+
+    def __init__(self):
+        """Initialise the plugin."""
+        self._engine_contrail_factors: np.ndarray = np.array(
+            [1, 2, 3], dtype=np.float32
+        )  # Placeholder values
+
+    def calculate_engine_mixing_ratios(self, pressure_levels: np.ndarray) -> np.ndarray:
+        """
+        Calculate the mixing ratio of the atmosphere and aircraft exhaust. This
+        calculation uses EARTH_REPSILON, which is the ratio of the molecular
+        weights of water and air on Earth.
+
+        Args:
+            pressure (float): The pressure of the atmosphere provided in units:
+                Pascals.
+            engine_contrail_factor (float): The engine contrail factor, provided in
+                units: kg/kg/K.
+
+        Returns:
+            float: The mixing ratio of the atmosphere and aircraft exhaust,
+                provided in units: P/K.
+        """
+        return (
+            pressure_levels[np.newaxis, :]
+            * self._engine_contrail_factors[:, np.newaxis]
+            / EARTH_REPSILON
+        )

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -4,53 +4,86 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Module to contain Condensation trail calculations."""
 
+from typing import Union
+
 import numpy as np
+from iris.cube import Cube, CubeList
 
 from improver import BasePlugin
 from improver.constants import EARTH_REPSILON
+from improver.utilities.common_input_handle import as_cubelist
 
 
 class CondensationTrailFormation(BasePlugin):
-    """Plugin to calculate whether a condensation trail (contrail) will form
-    based on a given set of atmospheric conditions. The calculations require
-    cubes of the following data:
+    """Plugin to calculate whether a condensation trail (contrail) will
+    form based on a given set of atmospheric conditions. The
+    calculations require cubes of the following data:
         - Temperature
         - Pressure
         - Relative Humidity
 
-    Alongside constants including the ratio of the molecular masses of water
-    and air (EARTH_REPSILON), and defined values for the engine contrail factor.
+    Alongside constants including the ratio of the molecular masses of
+    water and air (EARTH_REPSILON), and defined values for the engine
+    contrail factor.
 
     References:
-        - Schrader, M.L., 1997. Calculations of aircraft contrail formation
-          critical temperatures. Journal of Applied Meteorology, 36(12),
-          pp.1725-1729.
+        - Schrader, M.L., 1997. Calculations of aircraft contrail
+          formation critical temperatures. Journal of Applied
+          Meteorology, 36(12), pp.1725-1729.
     """
 
     def __init__(self):
-        """Initialise the plugin."""
+        """Initialsies the Class"""
+
         self._engine_contrail_factors: np.ndarray = np.array(
             [1, 2, 3], dtype=np.float32
-        )  # Placeholder values
+        )  #! Placeholder values until the actual values are defined
 
-    def calculate_engine_mixing_ratios(self, pressure_levels: np.ndarray) -> np.ndarray:
+    def calculate_engine_mixing_ratios(self) -> np.ndarray:
         """
-        Calculate the mixing ratio of the atmosphere and aircraft exhaust. This
-        calculation uses EARTH_REPSILON, which is the ratio of the molecular
-        weights of water and air on Earth.
-
-        Args:
-            pressure (float): The pressure of the atmosphere provided in units:
-                Pascals.
-            engine_contrail_factor (float): The engine contrail factor, provided in
-                units: kg/kg/K.
+        Calculate the mixing ratio of the atmosphere and aircraft
+        exhaust. This calculation uses EARTH_REPSILON, which is the
+        ratio of the molecular weights of water and air on Earth.
 
         Returns:
-            float: The mixing ratio of the atmosphere and aircraft exhaust,
-                provided in units: P/K.
+            float: The mixing ratio of the atmosphere and aircraft
+                exhaust, provided in units: P/K.
         """
         return (
-            pressure_levels[np.newaxis, :]
+            self.pressure_levels[np.newaxis, :]
             * self._engine_contrail_factors[:, np.newaxis]
             / EARTH_REPSILON
+        )
+
+    def process(self, *cubes: Union[Cube, CubeList]) -> Cube:
+        """
+        Main entry point of this class
+
+        Args:
+            cubes
+                air_temperature:
+                    Cube of the temperature on pressure levels.
+                relative_humidity:
+                    Cube of the relative humidity on pressure levels.
+                geopotential_height:
+                    Cube of the height above sea level on pressure levels.
+        Returns:
+            Cube of heights above sea level at which contrails will form.
+        """
+        cubes = as_cubelist(*cubes)
+        (self.temperature, self.humidity, self.height) = CubeList(cubes).extract(
+            ["air_temperature", "relative_humidity", "geopotential_height"]
+        )
+
+        # Get the pressure levels from the first cube
+        self.pressure_levels = self.temperature.coord("pressure").points
+
+        # Calculate the mixing ratios
+        engine_mixing_ratios = self.calculate_engine_mixing_ratios()
+
+        # Placeholder return to silence my type checker
+        return self.temperature(
+            data=engine_mixing_ratios,
+            name="engine_mixing_ratios",
+            units="K-1",
         )

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -67,14 +67,13 @@ class CondensationTrailFormation(BasePlugin):
                     Cube of the temperature on pressure levels.
                 relative_humidity:
                     Cube of the relative humidity on pressure levels.
-                geopotential_height:
-                    Cube of the height above sea level on pressure levels.
+
         Returns:
             Cube of heights above sea level at which contrails will form.
         """
         cubes = as_cubelist(*cubes)
-        (self.temperature, self.humidity, self.height) = CubeList(cubes).extract(
-            ["air_temperature", "relative_humidity", "geopotential_height"]
+        (self.temperature, self.humidity) = CubeList(cubes).extract(
+            ["air_temperature", "relative_humidity"]
         )
 
         # Get the pressure levels from the first cube

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -2,7 +2,7 @@
 #
 # This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-"""Module to contain Condensation trail calculations."""
+"""Module to contain Condensation trail formation calculations."""
 
 from typing import Union
 
@@ -20,9 +20,8 @@ class CondensationTrailFormation(BasePlugin):
 
     The calculations require cubes of the following data:
 
-    - Temperature
-    - Pressure
-    - Relative Humidity
+    - Temperature on pressure levels.
+    - Relative Humidity on pressure levels.
 
     Alongside constants including the ratio of the molecular masses of
     water and air (EARTH_REPSILON), and defined values for the engine

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -82,8 +82,10 @@ class CondensationTrailFormation(BasePlugin):
         engine_mixing_ratios = self.calculate_engine_mixing_ratios()
 
         # Placeholder return to silence my type checker
-        return self.temperature(
-            data=engine_mixing_ratios,
-            name="engine_mixing_ratios",
-            units="K-1",
+        return_cube = Cube(
+            engine_mixing_ratios,
+            long_name="engine_mixing_ratios",
+            units="Pa/K",
         )
+
+        return return_cube

--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -45,9 +45,9 @@ def test_CondensationTrailFormation_initialisation():
     """Check that the plugin is initialised correctly."""
     plugin = CondensationTrailFormation()
     assert isinstance(plugin._engine_contrail_factors, np.ndarray)
-    #! The values here are placeholders and should be replaced with the actual expected values
     np.testing.assert_array_equal(
-        plugin._engine_contrail_factors, np.array([1, 2, 3], dtype=np.float32)
+        plugin._engine_contrail_factors,
+        np.array([3e-5, 3.4e-5, 3.9e-5], dtype=np.float32),
     )
 
 
@@ -84,17 +84,14 @@ def test_pressure_levels(cube_with_pressure_factory, pressure_levels):
         (
             np.array([100000], dtype=np.float32),
             (3, 1),
-            np.array([[160776.87385446], [321553.74770893], [482330.62156339]]),
+            np.array([[4.823306], [5.466414], [6.2702975]], dtype=np.float32),
         ),
         (
             np.array([100000, 90000], dtype=np.float32),
             (3, 2),
             np.array(
-                [
-                    [160776.87385446, 144699.18646902],
-                    [321553.74770893, 289398.37293804],
-                    [482330.62156339, 434097.55940705],
-                ]
+                [[4.823306, 4.3409758], [5.466414, 4.919772], [6.2702975, 5.643268]],
+                dtype=np.float32,
             ),
         ),
         (
@@ -102,10 +99,11 @@ def test_pressure_levels(cube_with_pressure_factory, pressure_levels):
             (3, 3),
             np.array(
                 [
-                    [160776.87385446, 144699.18646902, 128621.49908357],
-                    [321553.74770893, 289398.37293804, 257242.99816714],
-                    [482330.62156339, 434097.55940705, 385864.49725072],
-                ]
+                    [4.823306, 4.3409758, 3.8586447],
+                    [5.466414, 4.919772, 4.373131],
+                    [6.2702975, 5.643268, 5.016238],
+                ],
+                dtype=np.float32,
             ),
         ),
     ],
@@ -129,4 +127,6 @@ def test_engine_mixing_ratio(
 
     # Check that calculate_engine_mixing_ratios works after process
     mixing_ratios = plugin.calculate_engine_mixing_ratios()
+    print(repr(mixing_ratios))
     assert mixing_ratios.shape == expected_shape
+    np.testing.assert_array_equal(mixing_ratios, expected_mixing_ratios)

--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -4,9 +4,12 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the CondensationTrailFormation plugin"""
 
+from typing import List, Optional, Tuple
+
 import iris
 import numpy as np
 import pytest
+from iris.cube import Cube
 
 from improver.psychrometric_calculations.condensation_trails import (
     CondensationTrailFormation,
@@ -20,35 +23,77 @@ LOCAL_MANDATORY_ATTRIBUTES = {
 }
 
 
-@pytest.fixture
-def cube_with_pressure_factory():
-    def _make_cube(data, name, pressure_levels):
-        cube = set_up_variable_cube(
-            data,
-            name=name,
-            units="K" if "temperature" in name else "%" if "humidity" in name else "m",
-            attributes=LOCAL_MANDATORY_ATTRIBUTES,
-        )
-        pressure_coord = iris.coords.DimCoord(
-            pressure_levels, units="Pa", var_name="pressure"
-        )
-        # Remove first dim coord if present
-        if cube.coords(dim_coords=True):
-            cube.remove_coord(cube.coords(dim_coords=True)[0].name())
-        cube.add_dim_coord(pressure_coord, 0)
-        return cube
+def cube_with_pressure_factory(
+    data: np.ndarray, name: str, pressure_levels: np.ndarray
+) -> Cube:
+    """
+    Create an Iris cube with a specified pressure DimCoord as the
+    leading dimension.
 
-    return _make_cube
+    Args:
+        data (np.ndarray): The data array for the cube, with the first
+            dimension matching the length of pressure_levels.
+        name (str): The name of the variable (e.g., "air_temperature").
+        pressure_levels (np.ndarray): 1D array of pressure levels to use
+            as the leading dimension coordinate.
 
-
-def test_CondensationTrailFormation_initialisation():
-    """Check that the plugin is initialised correctly."""
-    plugin = CondensationTrailFormation()
-    assert isinstance(plugin._engine_contrail_factors, np.ndarray)
-    np.testing.assert_array_equal(
-        plugin._engine_contrail_factors,
-        np.array([3e-5, 3.4e-5, 3.9e-5], dtype=np.float32),
+    Returns:
+        Cube: An Iris cube with the specified data, name, and pressure
+            coordinate.
+    """
+    cube = set_up_variable_cube(
+        data,
+        name=name,
+        units="K" if "temperature" in name else "%" if "humidity" in name else "m",
+        attributes=LOCAL_MANDATORY_ATTRIBUTES,
     )
+    pressure_coord = iris.coords.DimCoord(
+        pressure_levels, units="Pa", var_name="pressure"
+    )
+    # Remove first dim coord if present
+    if cube.coords(dim_coords=True):
+        cube.remove_coord(cube.coords(dim_coords=True)[0].name())
+    cube.add_dim_coord(pressure_coord, 0)
+    return cube
+
+
+@pytest.mark.parametrize(
+    "provided_engine_contrail_factors, expected_factors",
+    [
+        (None, np.array([3e-5, 3.4e-5, 3.9e-5], dtype=np.float32)),  # Test default
+        ([1e-5, 1.4e-5, 1.9e-5], np.array([1e-5, 1.4e-5, 1.9e-5], dtype=np.float32)),
+        ([2e-5, 2.4e-5, 2.9e-5], np.array([2e-5, 2.4e-5, 2.9e-5], dtype=np.float32)),
+        ([3e-5, 3.4e-5, 3.9e-5], np.array([3e-5, 3.4e-5, 3.9e-5], dtype=np.float32)),
+    ],
+)
+def test_initialisation_with_arguments_and_defaults(
+    provided_engine_contrail_factors: Optional[List[float]],
+    expected_factors: np.ndarray,
+) -> None:
+    """
+    Test that the CondensationTrailFormation plugin can be initialised
+    with custom or default engine contrail factors.
+
+    This test checks that when a custom list of engine contrail factors
+    is provided to the plugin, or when no list is provided (using
+    defaults), the internal _engine_contrail_factors attribute is
+    correctly set as a numpy array with the expected values.
+
+    Args:
+        provided_engine_contrail_factors (Optional[List[float]]): List
+            of engine contrail factors to initialise the plugin with,
+            or None for defaults.
+        expected_factors (np.ndarray): The expected numpy array of
+            engine contrail factors.
+    """
+    if provided_engine_contrail_factors is not None:
+        plugin = CondensationTrailFormation(
+            engine_contrail_factors=provided_engine_contrail_factors
+        )
+    else:
+        plugin = CondensationTrailFormation()
+    assert isinstance(plugin._engine_contrail_factors, np.ndarray)
+    np.testing.assert_array_equal(plugin._engine_contrail_factors, expected_factors)
 
 
 @pytest.mark.parametrize(
@@ -59,7 +104,23 @@ def test_CondensationTrailFormation_initialisation():
         (np.array([100000, 90000, 80000], dtype=np.float32)),
     ],
 )
-def test_pressure_levels(cube_with_pressure_factory, pressure_levels):
+def test_pressure_levels(
+    pressure_levels: np.ndarray,
+) -> None:
+    """
+    Test that the CondensationTrailFormation plugin correctly sets the
+    pressure_levels attribute after processing cubes with various
+    pressure level arrays.
+
+    This test creates temperature, humidity, and height cubes with the
+    given pressure levels, runs the CondensationTrailFormation plugin,
+    and checks that the plugin's pressure_levels attribute matches the
+    input pressure levels.
+
+    Args:
+        pressure_levels (np.ndarray): Array of pressure levels to use
+            for the cubes.
+    """
     shape = (len(pressure_levels), 3, 2)
     temperature_cube = cube_with_pressure_factory(
         np.full(shape, 250, dtype=np.float32), "air_temperature", pressure_levels
@@ -109,8 +170,27 @@ def test_pressure_levels(cube_with_pressure_factory, pressure_levels):
     ],
 )
 def test_engine_mixing_ratio(
-    cube_with_pressure_factory, pressure_levels, expected_shape, expected_mixing_ratios
-):
+    pressure_levels: np.ndarray,
+    expected_shape: Tuple,
+    expected_mixing_ratios: np.ndarray,
+) -> None:
+    """
+    Test that the engine mixing ratios are calculated correctly for
+    various pressure level arrays.
+
+    This test creates temperature, humidity, and height cubes with the
+    given pressure levels, runs the CondensationTrailFormation plugin,
+    and checks that the calculated engine mixing ratios match the
+    expected values and shapes.
+
+    Args:
+        pressure_levels (np.ndarray): Array of pressure levels to use
+            for the cubes.
+        expected_shape (tuple): Expected shape of the mixing ratios
+            output.
+        expected_mixing_ratios (np.ndarray): Expected mixing ratios for
+            the given input.
+    """
     shape = (len(pressure_levels), 3, 2)
     temperature_cube = cube_with_pressure_factory(
         np.full(shape, 250, dtype=np.float32), "air_temperature", pressure_levels
@@ -127,6 +207,4 @@ def test_engine_mixing_ratio(
 
     # Check that calculate_engine_mixing_ratios works after process
     mixing_ratios = plugin.calculate_engine_mixing_ratios()
-    print(repr(mixing_ratios))
-    assert mixing_ratios.shape == expected_shape
     np.testing.assert_array_equal(mixing_ratios, expected_mixing_ratios)

--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -183,6 +183,6 @@ def test_engine_mixing_ratio(
     plugin = CondensationTrailFormation()
     plugin.process(temperature_cube, humidity_cube)
 
-    # Check that calculate_engine_mixing_ratios works after process
-    mixing_ratios = plugin.calculate_engine_mixing_ratios()
+    # Check that _calculate_engine_mixing_ratios works after process
+    mixing_ratios = plugin._calculate_engine_mixing_ratios()
     np.testing.assert_array_equal(mixing_ratios, expected_mixing_ratios)

--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -1,0 +1,132 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the CondensationTrailFormation plugin"""
+
+import iris
+import numpy as np
+import pytest
+
+from improver.psychrometric_calculations.condensation_trails import (
+    CondensationTrailFormation,
+)
+from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
+
+LOCAL_MANDATORY_ATTRIBUTES = {
+    "title": "unit test data",
+    "source": "unit test",
+    "institution": "somewhere",
+}
+
+
+@pytest.fixture
+def cube_with_pressure_factory():
+    def _make_cube(data, name, pressure_levels):
+        cube = set_up_variable_cube(
+            data,
+            name=name,
+            units="K" if "temperature" in name else "%" if "humidity" in name else "m",
+            attributes=LOCAL_MANDATORY_ATTRIBUTES,
+        )
+        pressure_coord = iris.coords.DimCoord(
+            pressure_levels, units="Pa", var_name="pressure"
+        )
+        # Remove first dim coord if present
+        if cube.coords(dim_coords=True):
+            cube.remove_coord(cube.coords(dim_coords=True)[0].name())
+        cube.add_dim_coord(pressure_coord, 0)
+        return cube
+
+    return _make_cube
+
+
+def test_CondensationTrailFormation_initialisation():
+    """Check that the plugin is initialised correctly."""
+    plugin = CondensationTrailFormation()
+    assert isinstance(plugin._engine_contrail_factors, np.ndarray)
+    #! The values here are placeholders and should be replaced with the actual expected values
+    np.testing.assert_array_equal(
+        plugin._engine_contrail_factors, np.array([1, 2, 3], dtype=np.float32)
+    )
+
+
+@pytest.mark.parametrize(
+    "pressure_levels",
+    [
+        (np.array([100000], dtype=np.float32)),
+        (np.array([100000, 90000], dtype=np.float32)),
+        (np.array([100000, 90000, 80000], dtype=np.float32)),
+    ],
+)
+def test_pressure_levels(cube_with_pressure_factory, pressure_levels):
+    shape = (len(pressure_levels), 3, 2)
+    temperature_cube = cube_with_pressure_factory(
+        np.full(shape, 250, dtype=np.float32), "air_temperature", pressure_levels
+    )
+    humidity_cube = cube_with_pressure_factory(
+        np.full(shape, 50, dtype=np.float32), "relative_humidity", pressure_levels
+    )
+    height_cube = cube_with_pressure_factory(
+        np.full(shape, 10000, dtype=np.float32), "geopotential_height", pressure_levels
+    )
+
+    plugin = CondensationTrailFormation()
+    plugin.process(temperature_cube, humidity_cube, height_cube)
+
+    # Check that pressure_levels attribute is set correctly
+    np.testing.assert_array_equal(plugin.pressure_levels, pressure_levels)
+
+
+@pytest.mark.parametrize(
+    "pressure_levels, expected_shape, expected_mixing_ratios",
+    [
+        (
+            np.array([100000], dtype=np.float32),
+            (3, 1),
+            np.array([[160776.87385446], [321553.74770893], [482330.62156339]]),
+        ),
+        (
+            np.array([100000, 90000], dtype=np.float32),
+            (3, 2),
+            np.array(
+                [
+                    [160776.87385446, 144699.18646902],
+                    [321553.74770893, 289398.37293804],
+                    [482330.62156339, 434097.55940705],
+                ]
+            ),
+        ),
+        (
+            np.array([100000, 90000, 80000], dtype=np.float32),
+            (3, 3),
+            np.array(
+                [
+                    [160776.87385446, 144699.18646902, 128621.49908357],
+                    [321553.74770893, 289398.37293804, 257242.99816714],
+                    [482330.62156339, 434097.55940705, 385864.49725072],
+                ]
+            ),
+        ),
+    ],
+)
+def test_engine_mixing_ratio(
+    cube_with_pressure_factory, pressure_levels, expected_shape, expected_mixing_ratios
+):
+    shape = (len(pressure_levels), 3, 2)
+    temperature_cube = cube_with_pressure_factory(
+        np.full(shape, 250, dtype=np.float32), "air_temperature", pressure_levels
+    )
+    humidity_cube = cube_with_pressure_factory(
+        np.full(shape, 50, dtype=np.float32), "relative_humidity", pressure_levels
+    )
+    height_cube = cube_with_pressure_factory(
+        np.full(shape, 10000, dtype=np.float32), "geopotential_height", pressure_levels
+    )
+
+    plugin = CondensationTrailFormation()
+    plugin.process(temperature_cube, humidity_cube, height_cube)
+
+    # Check that calculate_engine_mixing_ratios works after process
+    mixing_ratios = plugin.calculate_engine_mixing_ratios()
+    assert mixing_ratios.shape == expected_shape


### PR DESCRIPTION
[Ticket](https://metoffice.atlassian.net/browse/EPPT-2305)

Description:
The engine mixing ratio is a required calculation in the estimation of condensation trail formation height. This PR sets up the basic class for formation calculations and adds in the method required to calculate the engine mixing ratio from specified values of engine contrail factors.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
