### PR TITLE
Fill value

### DIFF
--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -57,6 +57,7 @@ def save_netcdf(
     filename: str,
     compression_level: int = 1,
     least_significant_digit: Optional[int] = None,
+    fill_value: Optional[float] = None,
 ) -> None:
     """Save the input Cube or CubeList as a NetCDF file and check metadata
     where required for integrity.
@@ -80,7 +81,10 @@ def save_netcdf(
             http://www.esrl.noaa.gov/psd/data/gridded/conventions/cdc_netcdf_standard.shtml
             for details. When used with `compression level`, this will result in lossy
             compression.
-
+        fill_value:
+            If specified, will set the fill value for missing data. If not specified,
+            the default fill value for the data type will be used. There must be masked
+            data in the cube for this to have an effect.
     Raises:
         warning if cubelist contains cubes of varying dimensions.
     """
@@ -144,5 +148,6 @@ def save_netcdf(
         zlib=compression_level > 0,
         chunksizes=chunksizes,
         least_significant_digit=least_significant_digit,
+        fill_value=fill_value,
     )
     os.rename(ftmp, filename)

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -83,8 +83,8 @@ def save_netcdf(
             compression.
         fill_value:
             If specified, will set the fill value for missing data. If not specified,
-            the default fill value for the data type will be used. There must be masked
-            data in the cube for this to have an effect.
+            the default fill value for the data type will be used. This will set
+            the _FillValue attribute in the NetCDF file.
     Raises:
         warning if cubelist contains cubes of varying dimensions.
     """

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -83,8 +83,9 @@ def save_netcdf(
             compression.
         fill_value:
             If specified, will set the fill value for missing data. If not specified,
-            the default fill value for the data type will be used. This will set
-            the _FillValue attribute in the NetCDF file.
+            the default fill value for the data type will be used. If the data is not masked then
+            the numpy array's fill value will retain the default value while the _FillValue attribute
+            in the NetCDF file will be updated.
     Raises:
         warning if cubelist contains cubes of varying dimensions.
     """

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -228,6 +228,23 @@ class Test_save_netcdf(IrisTest):
         cube = load_cube(self.filepath)
         self.assertNotIn("least_significant_digit", cube.attributes)
 
+    def test_fill_value_no_mask(self):
+        """Test that fill_value is not set if there is no masked data."""
+        save_netcdf(self.cube, self.filepath)
+        cube = load_cube(self.filepath)
+        self.assertEqual(
+            cube.data.get_fill_value(), 1e20
+        )  # Default fill value for float32
+
+    def test_fill_value_with_mask(self):
+        """Test that fill_value can be overriden."""
+        cube = self.cube.copy()
+        mask = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        cube.data = np.ma.masked_array(cube.data, mask=mask)
+        save_netcdf(cube, self.filepath, fill_value=99)
+        cube = load_cube(self.filepath)
+        self.assertEqual(cube.data.get_fill_value(), 99)
+
 
 @pytest.fixture(name="bitshaving_cube")
 def bitshaving_cube_fixture():


### PR DESCRIPTION
Addresses https://metoffice.atlassian.net/browse/EPPT-2170

This PR adds in the ability to specify a fill value when saving a netcdf file

In order to solve an EPP problem we need to set the _FillValue attribute however this can't be tested on iris cubes as it is an attribute reserved for netCDF4 as is used by the acceptance tests. However there aren't any acceptance tests for the save function so I have just run my own checks to make sure that this functionality is being completed:

![image](https://github.com/user-attachments/assets/ede9216a-8a5c-41f2-987e-22982c928e53)


Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

