### PR TITLE
EPPT 2534 Refactors CondensationTrailFormation so that the same resul…

### DIFF
--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -73,7 +73,7 @@ class CondensationTrailFormation(BasePlugin):
             / EARTH_REPSILON
         )
 
-    def process_data(
+    def process_from_arrays(
         self, temperature: np.ndarray, humidity: np.ndarray, pressure_levels: np.ndarray
     ) -> np.ndarray:
         """
@@ -125,7 +125,7 @@ class CondensationTrailFormation(BasePlugin):
         pressure_coord.convert_units("Pa")
 
         # Calculate contrail formation using numpy arrays
-        _ = self.process_data(
+        _ = self.process_from_arrays(
             temperature_cube.data, humidity_cube.data, pressure_coord.points
         )
 

--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -106,7 +106,7 @@ def test_pressure_levels_stored(
         )
         plugin.process(temperature_cube, humidity_cube)
     else:
-        plugin.process_data(temperature_data, humidity_data, pressure_levels)
+        plugin.process_from_arrays(temperature_data, humidity_data, pressure_levels)
 
     # Check that pressure_levels attribute is set correctly
     np.testing.assert_array_equal(plugin.pressure_levels, pressure_levels)


### PR DESCRIPTION
Addresses https://metoffice.atlassian.net/browse/EPPT-2534

We want to be able to run the Contrails Formation science at sites where bandwidth limitations means that contrails data cannot be downloaded, but the source data already are. Those sites have the data available in Pythin as Numpy arrays rather than Iris Cubes.

Therefore, we want to restructure our Contrails Class so that the standard `process()` method is a cube-handling wrapper for another entry point `process_data()` so that we can run the same science on both platforms.

The cube-handling wrapper needs to do any unit conversions and other meta-data handling. We cannot use class variables that are only defined in the cube-handling wrapper.

The main change is that class objects are now primarily numpy arrays instead of iris cubes (e.g. `self.temperature`, `self.pressure_levels`) and all these are defined in the inner `process_data()` method. This also meant fewer changes to the unit tests - these are now focussed on showing that the two entry points return the same values. The engine contrail factors are now class objects too as this makes the testing more robust to future changes.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
