### PR TITLE
Developer_tools: Updates metadata interpreter to print dict-like strings from CubeAttrsDict objects

### DIFF
--- a/improver/developer_tools/metadata_interpreter.py
+++ b/improver/developer_tools/metadata_interpreter.py
@@ -7,6 +7,7 @@
 import re
 from typing import Callable, Dict, Iterable, List
 
+import iris.cube
 from iris.coords import CellMethod, Coord
 from iris.cube import Cube
 from iris.exceptions import CoordinateNotFoundError
@@ -337,9 +338,15 @@ class MOMetadataInterpreter:
                     f"expected substring {BLEND_TITLE_SUBSTR}."
                 )
 
-    def check_attributes(self, attrs: Dict) -> None:
+    @staticmethod
+    def _cubeattrsdict_as_dict(attrs: iris.cube.CubeAttrsDict) -> dict:
+        """Returns a dict from a CubeAttrsDict, because it has preferable str() methods"""
+        return {key: value for key, value in attrs.items()}
+
+    def check_attributes(self, cube_attrs: iris.cube.CubeAttrsDict) -> None:
         """Checks for unexpected attributes, then interprets values for model
         information and checks for self-consistency"""
+        attrs = self._cubeattrsdict_as_dict(cube_attrs)
         if self.diagnostic in DIAG_ATTRS:
             permitted_attributes = COMPLIANT_ATTRS + DIAG_ATTRS[self.diagnostic]
         else:

--- a/improver/developer_tools/metadata_interpreter.py
+++ b/improver/developer_tools/metadata_interpreter.py
@@ -7,9 +7,8 @@
 import re
 from typing import Callable, Dict, Iterable, List
 
-import iris.cube
 from iris.coords import CellMethod, Coord
-from iris.cube import Cube
+from iris.cube import Cube, CubeAttrsDict
 from iris.exceptions import CoordinateNotFoundError
 
 from improver.metadata.check_datatypes import check_mandatory_standards
@@ -339,11 +338,11 @@ class MOMetadataInterpreter:
                 )
 
     @staticmethod
-    def _cubeattrsdict_as_dict(attrs: iris.cube.CubeAttrsDict) -> dict:
+    def _cubeattrsdict_as_dict(attrs: CubeAttrsDict) -> dict:
         """Returns a dict from a CubeAttrsDict, because it has preferable str() methods"""
         return {key: value for key, value in attrs.items()}
 
-    def check_attributes(self, cube_attrs: iris.cube.CubeAttrsDict) -> None:
+    def check_attributes(self, cube_attrs: CubeAttrsDict) -> None:
         """Checks for unexpected attributes, then interprets values for model
         information and checks for self-consistency"""
         attrs = self._cubeattrsdict_as_dict(cube_attrs)

--- a/improver/developer_tools/metadata_interpreter.py
+++ b/improver/developer_tools/metadata_interpreter.py
@@ -337,15 +337,11 @@ class MOMetadataInterpreter:
                     f"expected substring {BLEND_TITLE_SUBSTR}."
                 )
 
-    @staticmethod
-    def _cubeattrsdict_as_dict(attrs: CubeAttrsDict) -> dict:
-        """Returns a dict from a CubeAttrsDict, because it has preferable str() methods"""
-        return {key: value for key, value in attrs.items()}
-
     def check_attributes(self, cube_attrs: CubeAttrsDict) -> None:
         """Checks for unexpected attributes, then interprets values for model
         information and checks for self-consistency"""
-        attrs = self._cubeattrsdict_as_dict(cube_attrs)
+        # Convert cube attributes to a dictionary for nicer formatted strings
+        attrs = dict(cube_attrs)
         if self.diagnostic in DIAG_ATTRS:
             permitted_attributes = COMPLIANT_ATTRS + DIAG_ATTRS[self.diagnostic]
         else:

--- a/improver_tests/developer_tools/test_MOMetadataInterpreter.py
+++ b/improver_tests/developer_tools/test_MOMetadataInterpreter.py
@@ -267,7 +267,7 @@ def test_warning_wind_gust_attribute_wrong_diagnostic(
     wind_gust_percentile_cube.rename("wind_speed")
     interpreter.run(wind_gust_percentile_cube)
     assert interpreter.warnings == [
-        "dict_keys(['source', 'title', 'institution', 'mosg__model_configuration', "
+        "dict_keys(['title', 'source', 'institution', 'mosg__model_configuration', "
         "'wind_gust_diagnostic']) include unexpected attributes ['wind_gust_diagnostic']. "
         "Please check the standard to ensure this is valid."
     ]
@@ -284,7 +284,7 @@ def test_warning_unexpected_cell_method(wind_gust_percentile_cube, interpreter):
     )
     interpreter.run(wind_gust_percentile_cube)
     assert interpreter.warnings == [
-        "Unexpected cell method variance: time. Please check the standard to "
+        "Unexpected cell method time: variance. Please check the standard to "
         "ensure this is valid"
     ]
 

--- a/improver_tests/developer_tools/test_display_interpretation.py
+++ b/improver_tests/developer_tools/test_display_interpretation.py
@@ -61,7 +61,7 @@ def test_warnings_displayed(wind_gust_percentile_cube, interpreter):
         "It has undergone no significant post-processing\n"
         "It contains data from MOGREPS-UK\n"
         "WARNINGS:\n"
-        "dict_keys(['source', 'title', 'institution', 'mosg__model_configuration', "
+        "dict_keys(['title', 'source', 'institution', 'mosg__model_configuration', "
         "'wind_gust_diagnostic', 'enigma']) include unexpected attributes ['enigma']. "
         "Please check the standard to ensure this is valid.\n"
     )


### PR DESCRIPTION
Developer_tools: Updates metadata interpreter to print dict-like strings from CubeAttrsDict objects

Addresses https://github.com/metoppv/mo-blue-team/issues/908

The main issue in the developer_tools section is that `Cube.attributes` has changed from being a standard dict object to a [CubeAttrsDict](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris.cube.html#iris.cube.CubeAttrsDict) object. This still has a `keys()` method, but the accompanying `__str__` method prints both keys and values, which is unhelpful. I have added a one-line function to convert these objects back into standard dict objects ONLY where we are printing out information from them. Then the only change is the ordering of the keys, as global keys are now returned before local keys and "title" is a global key.

Another iris change ([4249](https://github.com/SciTools/iris/pull/4279)) is that CellMethods now print in the CF-convention of `f"{coord}: {method}"` rather than `f"{method}: {coord}"` which results in one unit test changing.

Testing:

- [x] Ran tests and they passed OK
