### PR TITLE
Mobt913: Environment upgrade - Metadata

### DIFF
--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -323,6 +323,8 @@ def _find_latest_cycletime(cubelist: Union[CubeList, List[Cube]]) -> datetime:
         if next_coord.points[0] > frt_coord.points[0]:
             frt_coord = next_coord
     (cycletime,) = frt_coord.units.num2date(
-        frt_coord.points, only_use_cftime_datetimes=False
+        frt_coord.points,
+        only_use_cftime_datetimes=False,
+        only_use_python_datetimes=True,
     )
     return cycletime

--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -322,5 +322,7 @@ def _find_latest_cycletime(cubelist: Union[CubeList, List[Cube]]) -> datetime:
         next_coord.convert_units(frt_coord.units)
         if next_coord.points[0] > frt_coord.points[0]:
             frt_coord = next_coord
-    (cycletime,) = frt_coord.units.num2date(frt_coord.points)
+    (cycletime,) = frt_coord.units.num2date(
+        frt_coord.points, only_use_cftime_datetimes=False
+    )
     return cycletime

--- a/improver_tests/metadata/test_check_datatypes.py
+++ b/improver_tests/metadata/test_check_datatypes.py
@@ -9,7 +9,6 @@ import unittest
 import numpy as np
 from iris.coords import AuxCoord
 from iris.cube import CubeList
-from iris.tests import IrisTest
 
 from improver.metadata.check_datatypes import (
     check_mandatory_standards,
@@ -23,7 +22,7 @@ from improver.synthetic_data.set_up_test_cubes import (
 )
 
 
-class Test_check_mandatory_standards(IrisTest):
+class Test_check_mandatory_standards(unittest.TestCase):
     """Test whether a cube conforms to mandatory dtype and units standards."""
 
     def setUp(self):
@@ -76,7 +75,7 @@ class Test_check_mandatory_standards(IrisTest):
             # describing all aspects of the cube (including a checksum of the
             # data) to verify that nothing has been changed anywhere on the
             # cube.
-            self.assertStringEqual(
+            self.assertEqual(
                 CubeList([cube]).xml(checksum=True),
                 CubeList([result]).xml(checksum=True),
             )
@@ -154,7 +153,7 @@ class Test_check_mandatory_standards(IrisTest):
             check_mandatory_standards(self.percentile_cube)
 
 
-class Test_enforce_dtypes(IrisTest):
+class Test_enforce_dtypes(unittest.TestCase):
     """Test whether a cube conforms to mandatory dtype and units standards."""
 
     def setUp(self):
@@ -186,7 +185,7 @@ class Test_enforce_dtypes(IrisTest):
         enforce_dtype("add", inputs, result)
         result_checksums = [CubeList([c]).xml(checksum=True) for c in inputs + [result]]
         for a, b in zip(expected_checksums, result_checksums):
-            self.assertStringEqual(a, b)
+            self.assertEqual(a, b)
 
     def test_fail(self):
         """Test non-conformant data (error is thrown and inputs are not changed)"""
@@ -208,10 +207,10 @@ class Test_enforce_dtypes(IrisTest):
             enforce_dtype("add", inputs, result)
         result_checksums = [CubeList([c]).xml(checksum=True) for c in inputs + [result]]
         for a, b in zip(expected_checksums, result_checksums):
-            self.assertStringEqual(a, b)
+            self.assertEqual(a, b)
 
 
-class Test_check_units(IrisTest):
+class Test_check_units(unittest.TestCase):
     """Test method to check object units"""
 
     def setUp(self):
@@ -230,7 +229,7 @@ class Test_check_units(IrisTest):
         # The following statement renders each cube into an XML string
         # describing all aspects of the cube (including a checksum of the
         # data) to verify that nothing has been changed anywhere on the cube.
-        self.assertStringEqual(
+        self.assertEqual(
             CubeList([self.cube]).xml(checksum=True),
             CubeList([input_cube]).xml(checksum=True),
         )

--- a/improver_tests/metadata/test_utilities.py
+++ b/improver_tests/metadata/test_utilities.py
@@ -11,6 +11,7 @@ from typing import Callable, List
 import iris
 import numpy as np
 import pytest
+from iris.coords import CellMethod
 from iris.cube import Cube, CubeList
 from numpy.testing import assert_array_equal
 
@@ -37,7 +38,9 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
         self.template_cube = set_up_variable_cube(
             280 * np.ones((3, 5, 5), dtype=np.float32), standard_grid_metadata="uk_det"
         )
-        self.template_cube.add_cell_method("time (max): 1 hour")
+        self.template_cube.add_cell_method(
+            CellMethod(method="max", coords="time", intervals="1 hour")
+        )
         self.name = "lwe_precipitation_rate"
         self.units = "mm h-1"
         self.mandatory_attributes = MANDATORY_ATTRIBUTE_DEFAULTS.copy()
@@ -57,7 +60,7 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
             result.coords(dim_coords=False), self.template_cube.coords(dim_coords=False)
         )
         self.assertFalse(np.allclose(result.data, self.template_cube.data))
-        self.assertDictEqual(result.attributes, self.mandatory_attributes)
+        self.assertDictEqual(dict(result.attributes), self.mandatory_attributes)
         self.assertFalse(result.cell_methods)
         self.assertEqual(result.data.dtype, np.float32)
 
@@ -74,7 +77,7 @@ class Test_create_new_diagnostic_cube(unittest.TestCase):
             self.mandatory_attributes,
             optional_attributes=attributes,
         )
-        self.assertDictEqual(result.attributes, expected_attributes)
+        self.assertDictEqual(dict(result.attributes), expected_attributes)
 
     def test_missing_mandatory_attribute(self):
         """Test error is raised if any mandatory attribute is missing"""
@@ -265,7 +268,7 @@ class Test_generate_hash(unittest.TestCase):
         cube = set_up_variable_cube(np.ones((3, 3)).astype(np.float32))
         hash_input = cube.coord("latitude")
         result = generate_hash(hash_input)
-        expected = "ee6a057f5eeef0e94a853cfa98f3c22b121dda31ada3378ce9466e48d06f9887"
+        expected = "8648557d66ca6ee8bf765d00e85dff1963c827af4140d47b6fe16be854b28796"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 
@@ -299,7 +302,7 @@ class Test_create_coordinate_hash(unittest.TestCase):
 
         hash_input = set_up_variable_cube(np.zeros((3, 3)).astype(np.float32))
         result = create_coordinate_hash(hash_input)
-        expected = "54812a6fed0f92fe75d180d63a6bd6c916407ea1e7e5fd32a5f20f86ea997fac"
+        expected = "f167a9ea5d46e575a1b7918fb04f49697d07299c1b21010e40cd21ec351ab4c7"
         self.assertIsInstance(result, str)
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
Addresses [#913](https://github.com/metoppv/mo-blue-team/issues/913) and [#150](https://github.com/metoppv/mo-strategic-issues/issues/150).

This PR updates the metadata unit tests as required so that they are compatible with the updated IMPROVER conda environment. The fixes are listed below.

**improver/metadata/forecast_times.py**

- Since the release of cftime 1.1.0, num2date by default returns a cftime.datetime object instead of the datetime.datetime object the tests want. I have therefore set the kwarg only_use_cftime_datetimes to False.

**improver_tests/metadata/test_check_datatypes.py**

- Iris.tests.IrisTest depracated. Therefore can't call 'assertStringEqual'. Replaced test class inheritance from IrisTest to UnitTest as seen this has been done elsewhere, and called assertEqual method.

**improver_tests/metadata/test_utilities.py**
- assertDictEqual requires two dictionaries to compare. The result.attributes dictionary returned is a CubeAttrsDict which is not a true dictionary. Therefore type-casted the CubeAttrsDict to a dictionary.
- Fixed use of add_cell_method method to use the CellMethod class instead of only a string
- Updated expected hashes for Test_generate_hash tests test_coordinate_input and test_cube_basic. Updates made due to differences in underlying cube structure, now neatened. See below for before-and-after comparisons for both the basic test cube and representation of a coordinate (latitude here).

![image](https://github.com/user-attachments/assets/579a4ff0-807b-4551-a53a-bd771b5b8b78)
![image](https://github.com/user-attachments/assets/224efc9d-f16e-4223-afee-76dbee7dbb27)

![image](https://github.com/user-attachments/assets/9aeab346-a4f9-438e-8647-bfa123c9be54)
![image](https://github.com/user-attachments/assets/fb67f0f0-c903-4b88-803d-e2f6ef0ace40)

