### PR TITLE
Mobt915: environment upgrade - Orographic enhancement

### DIFF
--- a/improver/orographic_enhancement.py
+++ b/improver/orographic_enhancement.py
@@ -402,7 +402,7 @@ class OrographicEnhancement(BasePlugin):
         # set standard deviation for Gaussian weighting function in grid
         # squares
         grid_spacing_m = 1000.0 * self.grid_spacing_km
-        stddev = wind_speed * self.cloud_lifetime_s / grid_spacing_m
+        stddev = (wind_speed * self.cloud_lifetime_s / grid_spacing_m).astype(np.float32)
         variance = np.square(stddev)
 
         # calculate weighted values at source points

--- a/improver/orographic_enhancement.py
+++ b/improver/orographic_enhancement.py
@@ -402,7 +402,9 @@ class OrographicEnhancement(BasePlugin):
         # set standard deviation for Gaussian weighting function in grid
         # squares
         grid_spacing_m = 1000.0 * self.grid_spacing_km
-        stddev = (wind_speed * self.cloud_lifetime_s / grid_spacing_m).astype(np.float32)
+        stddev = (wind_speed * self.cloud_lifetime_s / grid_spacing_m).astype(
+            np.float32
+        )
         variance = np.square(stddev)
 
         # calculate weighted values at source points


### PR DESCRIPTION
Addresses  #[915](https://github.com/metoppv/mo-blue-team/issues/915)

This PR introduces one minor change to the orographic enhancement script to so that the output is as expected following the updated IMPROVER conda environment.

The only test to fail was _Test_process::test_basic_ as the output orographically enhanced data was an instance of float64, not float32 as expected.  Print statements for each variable across the script revealed that the issue originates from the local variable _stddev_ within __compute_weighted_values_ being float64 in the new environment, despite the same datatypes for its inputs (a mix of float32 and float64. I suspect the issue is likely caused by some change in type promotion rules.

Accordingly, I cast _stddev_ to float32, resolving the test failure.