### PR TITLE
Mobt 914 env update nowcasting

### DIFF
--- a/improver/nowcasting/lightning.py
+++ b/improver/nowcasting/lightning.py
@@ -443,7 +443,7 @@ class NowcastLightning(PostProcessingPlugin):
                             data_range=(0.0, 1.0),
                             scale_range=ice_scaling,
                             clip=True,
-                        ),
+                        ).astype(np.float32),
                         cube_slice.data,
                     )
             new_cube_list.append(cube_slice)

--- a/improver_tests/nowcasting/lightning/test_NowcastLightning.py
+++ b/improver_tests/nowcasting/lightning/test_NowcastLightning.py
@@ -303,7 +303,7 @@ class Test__modify_first_guess(IrisTest):
         """Test that the method raises an error if the meta-data cube has no
         time coordinate."""
         self.cube.remove_coord("time")
-        msg = "Expected to find exactly 1 time coordinate, but found none."
+        msg = "Expected to find exactly 1 'time' coordinate, but found none."
         with self.assertRaisesRegex(CoordinateNotFoundError, msg):
             self.plugin._modify_first_guess(
                 self.cube, self.fg_cube, self.ltng_cube, self.precip_cube, None

--- a/improver_tests/nowcasting/optical_flow/test_OpticalFlow.py
+++ b/improver_tests/nowcasting/optical_flow/test_OpticalFlow.py
@@ -629,16 +629,16 @@ class Test_process_dimensionless(IrisTest):
         )
         self.assertIsInstance(ucomp, np.ndarray)
         self.assertIsInstance(vcomp, np.ndarray)
-        self.assertAlmostEqual(np.mean(ucomp), 0.97735876)
-        self.assertAlmostEqual(np.mean(vcomp), -0.97735894)
+        self.assertAlmostEqual(np.mean(ucomp), 0.97735876, places=6)
+        self.assertAlmostEqual(np.mean(vcomp), -0.97735894, places=6)
 
     def test_axis_inversion(self):
         """Test inverting x and y axis indices gives the correct result"""
         ucomp, vcomp = self.plugin.process_dimensionless(
             self.first_input, self.second_input, 1, 0, self.smoothing_kernel
         )
-        self.assertAlmostEqual(np.mean(ucomp), -0.97735894)
-        self.assertAlmostEqual(np.mean(vcomp), 0.97735876)
+        self.assertAlmostEqual(np.mean(ucomp), -0.97735894, places=6)
+        self.assertAlmostEqual(np.mean(vcomp), 0.97735876, places=6)
 
 
 class Test_process(IrisTest):
@@ -703,7 +703,7 @@ class Test_process(IrisTest):
         """Test velocity values are as expected (in m/s)"""
         ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
         self.assertAlmostEqual(np.mean(ucube.data), -2.1719084)
-        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084)
+        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084, places=6)
 
     def test_values_perturbation(self):
         """Test velocity values are as expected when input cubes are presented
@@ -716,7 +716,7 @@ class Test_process(IrisTest):
         self.cube1.coord("forecast_period").points = [15 * 60]
         ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
         self.assertAlmostEqual(np.mean(ucube.data), -2.1719084)
-        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084)
+        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084, places=6)
 
     def test_values_with_precip_rate_in_m_per_s(self):
         """Test velocity values are as expected (in m/s) when the input
@@ -726,7 +726,7 @@ class Test_process(IrisTest):
         self.cube2.convert_units("m s-1")
         ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
         self.assertAlmostEqual(np.mean(ucube.data), -2.1719084)
-        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084)
+        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084, places=6)
 
     def test_values_with_masked_data(self):
         """Test velocity values are as expected when masked cubes are used as
@@ -769,10 +769,10 @@ class Test_process(IrisTest):
             unmasked_cube1, unmasked_cube2, boxsize=3
         )
 
-        self.assertAlmostEqual(np.mean(ucube_masked.data), -1.4995803)
-        self.assertAlmostEqual(np.mean(vcube_masked.data), 1.4995805)
-        self.assertAlmostEqual(np.mean(ucube_unmasked.data), -0.2869996)
-        self.assertAlmostEqual(np.mean(vcube_unmasked.data), 0.28699964)
+        self.assertAlmostEqual(np.mean(ucube_masked.data), -1.4995803, places=6)
+        self.assertAlmostEqual(np.mean(vcube_masked.data), 1.4995805, places=6)
+        self.assertAlmostEqual(np.mean(ucube_unmasked.data), -0.2869996, places=6)
+        self.assertAlmostEqual(np.mean(vcube_unmasked.data), 0.28699964, places=6)
 
     def test_error_for_unconvertable_units(self):
         """Test that an exception is raised if the input precipitation cubes
@@ -812,7 +812,7 @@ class Test_process(IrisTest):
 
         ucube, vcube = self.plugin.process(self.cube1, self.cube2, boxsize=3)
         self.assertAlmostEqual(np.mean(ucube.data), -2.1719084 * 2.0)
-        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084 * 2.0)
+        self.assertAlmostEqual(np.mean(vcube.data), 2.1719084 * 2.0, places=6)
 
     def test_increase_time_interval(self):
         """Test that increasing the time interval between radar frames above

--- a/improver_tests/nowcasting/utilities/test_ApplyOrographicEnhancement.py
+++ b/improver_tests/nowcasting/utilities/test_ApplyOrographicEnhancement.py
@@ -483,7 +483,7 @@ class Test_process(IrisTest):
             new_precip_cubes.append(precip_cube)
 
         plugin = ApplyOrographicEnhancement("add")
-        result = plugin.process(self.precip_cubes, self.oe_cube)
+        result = plugin.process(precip_cubes, self.oe_cube)
 
         self.assertIsInstance(result, iris.cube.CubeList)
         for aresult, precip_cube in zip(result, self.precip_cubes):
@@ -530,7 +530,7 @@ class Test_process(IrisTest):
             new_precip_cubes.append(precip_cube)
 
         plugin = ApplyOrographicEnhancement("subtract")
-        result = plugin.process(self.precip_cubes, self.oe_cube)
+        result = plugin.process(precip_cubes, self.oe_cube)
         self.assertIsInstance(result, iris.cube.CubeList)
         for aresult, precip_cube in zip(result, self.precip_cubes):
             self.assertIsInstance(aresult.data, np.ma.MaskedArray)


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/914

Updates the nowcasting code so that unit tests pass with the unpinned environment.

1. Some output data were of type float64 instead of float32
2. Several tests were testing data values to 7 decimal places and some results have changed at the 6th place. I have adjusted the test tolerance to permit this.
3. Two tests for masked data were not working as expected. On inspection, I found that the data passed into the tested method was not the data that had been prepared for the test. I'm not sure how the test was passing before (I suspect that the behaviour of `copy` on Iris cubes has improved), but it now does.

Testing:

- [x] Ran tests and they passed OK

