### PR TITLE
enforce data type for cloud condensation level plugins

### DIFF
--- a/improver/psychrometric_calculations/cloud_condensation_level.py
+++ b/improver/psychrometric_calculations/cloud_condensation_level.py
@@ -135,7 +135,7 @@ class CloudCondensationLevel(PostProcessingPlugin):
         ).astype(np.float32)
         ccl_temperature = dry_adiabatic_temperature(
             self.temperature.data, self.pressure.data, ccl_pressure
-        )
+        ).astype(np.float32)
         return ccl_pressure, ccl_temperature
 
     def process(self, *cubes: Union[Cube, CubeList]) -> Tuple[Cube, Cube]:


### PR DESCRIPTION
Ticket: https://github.com/metoppv/mo-blue-team/issues/937
Acceptance_test_data_PR: https://github.com/metoppv/improver_test_data/pull/83

This PR is a tiny tweak to let the acceptance test for this batch to pass by enforcing the data type from the cloud condensation level plugin.

Testing:

- [x] Ran tests and they passed OK

