### PR TITLE
Acceptance test batch 2

### DIFF
--- a/improver/between_thresholds.py
+++ b/improver/between_thresholds.py
@@ -45,7 +45,7 @@ class OccurrenceBetweenThresholds(PostProcessingPlugin):
         threshold_diffs = np.diff(threshold_ranges)
         if any(diff < 1e-5 for diff in threshold_diffs):
             raise ValueError(
-                "Plugin cannot distinguish between thresholds at " "{} {}".format(
+                "Plugin cannot distinguish between thresholds at {} {}".format(
                     threshold_ranges, threshold_units
                 )
             )
@@ -98,7 +98,7 @@ class OccurrenceBetweenThresholds(PostProcessingPlugin):
 
         return cubes
 
-    def _get_multiplier(self) -> float:
+    def _get_multiplier(self) -> np.float32:
         """
         Check whether the cube contains "above" or "below" threshold
         probabilities.  For "above", the probability of occurrence between
@@ -124,7 +124,7 @@ class OccurrenceBetweenThresholds(PostProcessingPlugin):
                 "Input cube must contain probabilities of "
                 "occurrence above or below threshold"
             )
-        return multiplier
+        return np.float32(multiplier)
 
     def _calculate_probabilities(self) -> Cube:
         """

--- a/improver/categorical/modal_code.py
+++ b/improver/categorical/modal_code.py
@@ -320,6 +320,7 @@ class ModalCategory(BaseModalCategory):
             result = cube
         else:
             result = cube.collapsed("time", self.aggregator_instance)
+            result.data = result.data.astype(cube.data.dtype)
         self._set_blended_times(result)
 
         result = self._prepare_result_cube(

--- a/improver/categorical/modal_code.py
+++ b/improver/categorical/modal_code.py
@@ -270,7 +270,7 @@ class ModalCategory(BaseModalCategory):
         mode_result[counts < minimum_significant_count] = (
             self.code_max - self.unset_code_indicator
         )
-        return self.code_max - np.squeeze(mode_result)
+        return (self.code_max - np.squeeze(mode_result)).astype(data.dtype)
 
     @staticmethod
     def _set_blended_times(cube: Cube) -> None:
@@ -320,7 +320,6 @@ class ModalCategory(BaseModalCategory):
             result = cube
         else:
             result = cube.collapsed("time", self.aggregator_instance)
-            result.data = result.data.astype(cube.dtype)
         self._set_blended_times(result)
 
         result = self._prepare_result_cube(

--- a/improver/categorical/modal_code.py
+++ b/improver/categorical/modal_code.py
@@ -320,7 +320,7 @@ class ModalCategory(BaseModalCategory):
             result = cube
         else:
             result = cube.collapsed("time", self.aggregator_instance)
-            result.data = result.data.astype(cube.data.dtype)
+            result.data = result.data.astype(cube.dtype)
         self._set_blended_times(result)
 
         result = self._prepare_result_cube(

--- a/improver_tests/categorical/modal_code/test_ModalCategory.py
+++ b/improver_tests/categorical/modal_code/test_ModalCategory.py
@@ -186,7 +186,9 @@ def test_expected_values(wxcode_series, expected):
 @pytest.mark.parametrize("interval", [1, 3])
 @pytest.mark.parametrize("offset_reference_times", [False, True])
 @pytest.mark.parametrize("cube_type", ["gridded", "spot"])
-@pytest.mark.parametrize("data", [np.ones(12), np.ones(1)])
+@pytest.mark.parametrize(
+    "data", [np.ones(12, dtype=np.int8), np.ones(1, dtype=np.int8)]
+)
 def test_metadata(wxcode_series):
     """Check that the returned metadata is correct. In this case we expect a
     time coordinate with bounds that describe the full period over which the
@@ -234,6 +236,7 @@ def test_metadata(wxcode_series):
     else:
         expected_record_run_attr = expected_record_det + expected_record_ens.format(21)
 
+    assert np.issubdtype(result.data.dtype, np.int8)
     assert result.coord("time").points[0] == as_utc_timestamp(expected_time)
     assert result.coord("time").bounds[0][0] == as_utc_timestamp(expected_bounds[0])
     assert result.coord("time").bounds[0][1] == as_utc_timestamp(expected_bounds[1])


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/936

Description
* Enforce float32 within the `OccurrenceBetweenThresholds` to ensure that the output cube contains float32 data as required.
* Ensure that the output of cube.collapsed in the ModalCategory plugin is the same data type as the input.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

