### PR TITLE
MOBT-956 Environment upgrade: Estimate EMOS from tables

### DIFF
--- a/improver/cli/estimate_emos_coefficients_from_table.py
+++ b/improver/cli/estimate_emos_coefficients_from_table.py
@@ -129,15 +129,13 @@ def process(
 
     # Load forecasts from parquet file filtering by diagnostic and blend_time.
     forecast_period_td = pd.Timedelta(int(forecast_period), unit="seconds")
-    # tz_localize(None) is used to facilitate filtering, although the dataframe
-    # is expected to be timezone aware upon load.
     cycletimes = pd.date_range(
         end=pd.Timestamp(cycletime)
         - pd.Timedelta(1, unit="days")
         - forecast_period_td.floor("D"),
         periods=int(training_length),
         freq="D",
-    ).tz_localize(None)
+    )
     filters = [[("diagnostic", "==", diagnostic), ("blend_time", "in", cycletimes)]]
     forecast_df = pd.read_parquet(forecast, filters=filters)
 


### PR DESCRIPTION
Removes timezone delocalisation for filtering of cycle times within the CLI.

This change must accompany the related acceptance test data changes:
https://github.com/metoppv/improver_test_data/pull/97

It must also, in operations, accompany the changes made to parquet table creation within the suite:
https://github.com/metoppv/mo-blue-team/issues/957
