### PR TITLE
MOBT-290 Environment upgrade: enforce consistency

### DIFF
--- a/improver/utilities/forecast_reference_enforcement.py
+++ b/improver/utilities/forecast_reference_enforcement.py
@@ -213,9 +213,8 @@ class EnforceConsistentForecasts(PostProcessingPlugin):
 
         new_forecast = forecast.copy()
         required_dtype = new_forecast.data.dtype
-        new_forecast.data = np.clip(
-            new_forecast.data, lower_bound, upper_bound, dtype=required_dtype
-        )
+        new_forecast.data = np.clip(new_forecast.data, lower_bound, upper_bound)
+        new_forecast.data = new_forecast.data.astype(required_dtype)
         if self.use_latest_update_time:
             forecast_cycle_coords = [
                 crd


### PR DESCRIPTION
Move dtype setting out of numpy.clip call as this causes a casting error.
Allow clipping to occur, then apply type casting to result to ensure data type is unchanged.

Testing:

- [x] Ran tests and they passed OK