### PR TITLE
MOBT-958 Environment upgrade: remove deprecations

### DIFF
--- a/improver/__init__.py
+++ b/improver/__init__.py
@@ -6,12 +6,11 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("improver").version
-except DistributionNotFound:
+    __version__ = version("improver")
+except PackageNotFoundError:
     # package is not installed
     pass
 


### PR DESCRIPTION
Removes reliance on deprecated `pkg_resources` package.

Testing see: https://github.com/metoppv/mo-blue-team/issues/958#issuecomment-3083444327