### PR TITLE
Eppt 2389 calculation of localised svp

### DIFF
--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -87,9 +87,13 @@ class CondensationTrailFormation(BasePlugin):
             np.ndarray: The localised vapour pressure at the given
                 pressure levels (Pa).
         """
+        # Pressure levels has to be reshaped to match the temperature and humidity dimensions
+        pressure_levels_reshaped = np.reshape(
+            pressure_levels,
+            (len(pressure_levels),) + (1,) * (self.temperature.ndim - 1),
+        )
         svp = calculate_svp_in_air(
-            temperature=self.temperature,
-            pressure=pressure_levels[:, np.newaxis, np.newaxis],  # Reshape for 3D array
+            temperature=self.temperature, pressure=pressure_levels_reshaped
         )
         return self.relative_humidity * svp
 

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -93,7 +93,10 @@ class CondensationTrailFormation(BasePlugin):
         return np.array(self.relative_humidity * svp, dtype=np.float32)
 
     def process_from_arrays(
-        self, temperature: np.ndarray, humidity: np.ndarray, pressure_levels: np.ndarray
+        self,
+        temperature: np.ndarray,
+        relative_humidity: np.ndarray,
+        pressure_levels: np.ndarray,
     ) -> np.ndarray:
         """
         Main entry point of this class for data as Numpy arrays
@@ -103,7 +106,7 @@ class CondensationTrailFormation(BasePlugin):
 
         Args:
             temperature (np.ndarray): Temperature data on pressure levels where pressure is the leading axis (K).
-            humidity (np.ndarray): Relative humidity data on pressure levels where pressure is the leading axis (kg kg-1).
+            relative_humidity (np.ndarray): Relative humidity data on pressure levels where pressure is the leading axis (kg kg-1).
             pressure_levels (np.ndarray): Pressure levels (Pa).
 
         Returns:
@@ -111,7 +114,7 @@ class CondensationTrailFormation(BasePlugin):
             This is a placeholder until the full contrail formation logic is implemented.
         """
         self.temperature = temperature
-        self.humidity = humidity
+        self.relative_humidity = relative_humidity
         self.pressure_levels = pressure_levels
         self.engine_mixing_ratios = self._calculate_engine_mixing_ratios(
             self.pressure_levels

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -90,7 +90,7 @@ class CondensationTrailFormation(BasePlugin):
         svp = calculate_svp_in_air(
             temperature=self.temperature, pressure=pressure_levels
         )
-        return self.relative_humidity * svp
+        return np.array(self.relative_humidity * svp, dtype=np.float32)
 
     def process_from_arrays(
         self, temperature: np.ndarray, humidity: np.ndarray, pressure_levels: np.ndarray

--- a/improver/psychrometric_calculations/condensation_trails.py
+++ b/improver/psychrometric_calculations/condensation_trails.py
@@ -88,9 +88,10 @@ class CondensationTrailFormation(BasePlugin):
                 pressure levels (Pa).
         """
         svp = calculate_svp_in_air(
-            temperature=self.temperature, pressure=pressure_levels
+            temperature=self.temperature,
+            pressure=pressure_levels[:, np.newaxis, np.newaxis],  # Reshape for 3D array
         )
-        return np.array(self.relative_humidity * svp, dtype=np.float32)
+        return self.relative_humidity * svp
 
     def process_from_arrays(
         self,

--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -181,38 +181,22 @@ def test_engine_mixing_ratio(
             np.array([250.0, 260.0, 270.0], dtype=np.float32),
             np.array([0.5, 0.6, 0.7], dtype=np.float32),
             np.array([100000, 90000, 80000], dtype=np.float32),
-            np.array(
-                [
-                    calculate_svp_in_air(
-                        np.float32(250.0), np.array([100000], dtype=np.float32)
-                    )
-                    * 0.5,
-                    calculate_svp_in_air(
-                        np.float32(260.0), np.array([90000], dtype=np.float32)
-                    )
-                    * 0.6,
-                    calculate_svp_in_air(
-                        np.float32(270.0), np.array([80000], dtype=np.float32)
-                    )
-                    * 0.7,
-                ],
-                dtype=np.float32,
-            ),
+            calculate_svp_in_air(
+                np.array([250.0, 260.0, 270.0], dtype=np.float32),
+                np.array([100000, 90000, 80000], dtype=np.float32),
+            )
+            * np.array([0.5, 0.6, 0.7], dtype=np.float32),
         ),
         # Test with single pressure level
         (
             np.array([280.0], dtype=np.float32),
             np.array([0.8], dtype=np.float32),
             np.array([95000], dtype=np.float32),
-            np.array(
-                [
-                    calculate_svp_in_air(
-                        np.float32(280.0), np.array([95000], dtype=np.float32)
-                    )
-                    * np.float32(0.8)
-                ],
-                dtype=np.float32,
-            ),
+            calculate_svp_in_air(
+                np.array([280.0], dtype=np.float32),
+                np.array([95000], dtype=np.float32),
+            )
+            * np.array([0.8], dtype=np.float32),
         ),
     ],
 )


### PR DESCRIPTION
[EPPT ticket 2389](https://metoffice.atlassian.net/browse/EPPT-2389)

This PR allows for the local vapour pressure to be calculated from an estimated saturation vapour pressure and a relative humidity.

Description

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)