### PR TITLE
Environment upgrade tidy-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.12
         cache: 'pip'
 
     - name: pip install pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,6 @@ below:
  - Andrew Creswick (Met Office, UK)
  - Neil Crosswaite (Met Office, UK)
  - Shafiat Dewan (Met Office, UK)
- - Rachael Esler (Bureau of Meteorology, Australia)
  - Gavin Evans (Met Office, UK)
  - Zhiliang Fan (Bureau of Meteorology, Australia)
  - Ben Fitzpatrick (Met Office, UK)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/f7dcb46e8e1b4110b3d194dba03fe526)](https://www.codacy.com/app/metoppv_tech/improver?utm_source=github.com&utm_medium=referral&utm_content=metoppv/improver&utm_campaign=Badge_Coverage)
 [![codecov](https://codecov.io/gh/metoppv/improver/branch/master/graph/badge.svg)](https://codecov.io/gh/metoppv/improver)
 [![Documentation Status](https://readthedocs.org/projects/improver/badge/?version=latest)](http://improver.readthedocs.io/en/latest/?badge=latest)
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
-[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/)
 [![DOI](https://zenodo.org/badge/85334761.svg)](https://zenodo.org/badge/latestdoi/85334761)
 
 IMPROVER is a library of algorithms for meteorological post-processing and verification.
@@ -22,22 +21,22 @@ install a mamba environment
 ```
 conda create -c conda-forge --override-channels mamba -n mamba
 ```
- 
+
 activate this mamba environment
 ```
 conda activate mamba
 ```
- 
+
 install the improver environment using mamba
 ```
-mamba create -c conda-forge python=3.7 improver -n improver
+mamba create -c conda-forge python=3 improver -n improver
 ```
- 
+
 deactivate your mamba environment
 ```
 conda deactivate
 ```
- 
+
 activate your new improver environment
 ```
 conda activate improver

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -6,13 +6,11 @@ name: improver
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - iris=3.0
+  - python=3
+  - iris>=3.12.2
   - cf_units
   - python-stratify
-  - sphinx=5.3.0
+  - sphinx
   - sphinx-autodoc-typehints
   - sphinx_rtd_theme
-  - pip
-  - pip:
-    - clize
+  - clize


### PR DESCRIPTION
A few tidy-up changes related to the environment upgrade:

- Remove references to python 3.6 and 3.7.
- Upgrade pre-commit CI environment to use python 3.12.
- Update readme environment building advice, though this may be at odds with the currently available version of improver in the conda library; this needs updating.
- Update the python version badge shown in the readme.
- Remove Rachael's name from the contributors list for now as the merge commit, despite listing Rachael as one of the 7 authors, cannot identify any single commits associated with Rachael's rainforests work and thus complains.