### PR TITLE
Fix readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-22.9"
 
 conda:
   environment: doc/rtd_environment.yml

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -8,9 +8,11 @@ channels:
 dependencies:
   - python=3
   - iris>=3.12.2
-  - cf_units
   - python-stratify
-  - sphinx
-  - sphinx-autodoc-typehints
-  - sphinx_rtd_theme
   - clize
+  - pip
+  - pip:
+    - cf_units
+    - sphinx
+    - sphinx-autodoc-typehints
+    - sphinx_rtd_theme


### PR DESCRIPTION
Following the environment upgrade the readthedocs build is not completing successfully. This is a result of the tidy-up PR which updated the python version used for readthedocs: 

https://app.readthedocs.org/projects/improver/builds/29039406/

https://github.com/metoppv/improver/commit/a5ba51c2f893574b495a0151256e36e9cc41d362

The issue here is that cf_units has not had a recent conda update. The latest version available via conda-forge is 2.0.1. Via pip, and required for iris >3.12, are versions of cf_units >3 (we use 3.3 in improver_unpinned). The fix here is to explicitly install cf_units via pip within the conda recipe. I've also moved the sphinx components into the pip install as this was raising a warning otherwise:

>Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
>- pip: []
>- sphinx


Testing:

I've build the docs in a fork using this environment.
The build succeeds: https://app.readthedocs.org/projects/bens-improver-fork/builds/29041185/
The docs look correct for the sections that were previously broken: https://bens-improver-fork.readthedocs.io/en/fix_readthedocs/improver.html