### PR TITLE
Add in ability to return midpoint of bounds

### DIFF
--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -597,7 +597,10 @@ def clip_cube_data(cube: Cube, minimum_value: float, maximum_value: float) -> Cu
 
 
 def expand_bounds(
-    result_cube: Cube, cubelist: Union[List[Cube], CubeList], coord_names: List[str]
+    result_cube: Cube,
+    cubelist: Union[List[Cube], CubeList],
+    coord_names: List[str],
+    midpoint_bound: bool = False,
 ) -> Cube:
     """Alter a coordinate on result_cube such that bounds are expanded to cover
     the entire range of the input cubes (cubelist).  The input result_cube is
@@ -606,7 +609,8 @@ def expand_bounds(
     For example, in the case of time cubes if the input cubes have
     bounds of [0000Z, 0100Z] & [0100Z, 0200Z] then the output cube will
     have bounds of [0000Z,0200Z]. The returned coordinate point will be
-    equal to the upper bound.
+    equal to the upper bound by default. If mid_point_bound is true the midpoint is
+    returned instead (e.g. 0100Z).
 
     Args:
         result_cube:
@@ -615,6 +619,9 @@ def expand_bounds(
             List of input cubes with source coords
         coord_names:
             Coordinates which should be expanded
+        midpoint_bound:
+            If True, set the coordinate point to the midpoint of the bounds;
+            otherwise, use the upper bound.
 
     Returns:
         Cube with coords expanded.
@@ -646,7 +653,11 @@ def expand_bounds(
         if result_coord.bounds.dtype in FLOAT_TYPES:
             result_coord.bounds = result_coord.bounds.astype(FLOAT_DTYPE)
 
-        result_coord.points = [new_top_bound]
+        if midpoint_bound:
+            result_coord.points = [(new_low_bound + new_top_bound) / 2]
+        else:
+            result_coord.points = [new_top_bound]
+
         if result_coord.points.dtype in FLOAT_TYPES:
             result_coord.points = result_coord.points.astype(FLOAT_DTYPE)
 

--- a/improver_tests/cube_combiner/test_CubeCombiner.py
+++ b/improver_tests/cube_combiner/test_CubeCombiner.py
@@ -267,6 +267,19 @@ class Test_process(CombinerTest):
             result.coord("time").bounds, self.cube1.coord("time").bounds
         )
 
+    def test_bounds_midpoint(self):
+        """Test that the plugin calculates the sum of the input cubes and
+        the midpoint of the bounds is returned"""
+        plugin = CubeCombiner("add", expand_bound=True, midpoint_bound=True)
+        cubelist = iris.cube.CubeList([self.cube1, self.cube2])
+        result = plugin.process(cubelist, "new_cube_name")
+        expected_data = np.full((2, 2), 1.1, dtype=np.float32)
+        self.assertEqual(result.name(), "new_cube_name")
+        self.assertArrayAlmostEqual(result.data, expected_data)
+
+        self.assertEqual(result.coord("time").points[0], 1447891200)
+        self.assertArrayEqual(result.coord("time").bounds, [[1447887600, 1447894800]])
+
     def test_unmatched_scalar_coords(self):
         """Test a scalar coordinate that is present on the first cube is
         present unmodified on the output; and if present on a later cube is


### PR DESCRIPTION
Ticket: https://metoffice.atlassian.net/browse/EPPT-2567

This PR adds in the ability to return the midpoint of bounds when an option is set in the Combine plugin.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)