### PR TITLE
Use latest FRT option for cube combiner

### DIFF
--- a/improver/cli/combine.py
+++ b/improver/cli/combine.py
@@ -18,6 +18,7 @@ def process(
     minimum_realizations=None,
     cell_method_coordinate=None,
     expand_bound=True,
+    use_latest_frt=False,
 ):
     r"""Combine input cubes.
 
@@ -48,6 +49,9 @@ def process(
             provided. This is only available for max, min and mean operations.
         expand_bound (bool):
             If True then coord bounds will be extended to represent all cubes being combined.
+        use_latest_frt (bool):
+            If True then the latest forecast_reference_time available across the input cubes
+            will be used for the output with a suitably updated forecast_period.
     Returns:
         result (iris.cube.Cube):
             Returns a cube with the combined data.
@@ -61,4 +65,5 @@ def process(
         new_name=new_name,
         cell_method_coordinate=cell_method_coordinate,
         expand_bound=expand_bound,
+        use_latest_frt=use_latest_frt,
     )(*cubes)

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -54,23 +54,32 @@ class Combine(BasePlugin):
                 An operation to use in combining input cubes. One of:
                 +, -, \*, add, subtract, multiply, min, max, mean
             broadcast (str):
-                If specified, broadcast input cubes to the stated coord prior to combining -
-                the coord must already exist on the first input cube.
+                If specified, broadcast input cubes to the stated coord prior
+                to combining - the coord must already exist on the first input
+                cube.
             minimum_realizations (int):
-                If specified, the input cubes will be filtered to ensure that only realizations that
-                include all available lead times are combined. If the number of realizations that
-                meet this criteria are fewer than this integer, an error will be raised.
-                Minimum value is 1.
+                If specified, the input cubes will be filtered to ensure that
+                only realizations that include all available lead times are
+                combined. If the number of realizations that meet this criteria
+                are fewer than this integer, an error will be raised. Minimum
+                value is 1.
             new_name (str):
                 New name for the resulting dataset.
             cell_method_coordinate (str):
-                If specified, a cell method is added to the output with the coordinate
-                provided. This is only available for max, min and mean operations.
+                If specified, a cell method is added to the output with the
+                coordinate provided. This is only available for max, min and
+                mean operations.
             expand_bound:
-                If True then coord bounds will be extended to represent all cubes being combined.
+                If True then scalar coord bounds will be extended to represent
+                all cubes being combined. For example a time coordinate will
+                be set using the latest time available as the point and with
+                bounds describing the range. If false the first cube provided
+                sets the metadata and the scalar coordinates from this cube
+                will be used.
             use_latest_frt:
-                If True then the latest forecast_reference_time available across the input cubes
-                will be used for the output with a suitably updated forecast_period.
+                If True then the latest forecast_reference_time available
+                across the input cubes will be used for the output with a
+                suitably updated forecast_period.
         """
         try:
             self.minimum_realizations = int(minimum_realizations)
@@ -193,14 +202,21 @@ class CubeCombiner(BasePlugin):
         Args:
             operation:
                 Operation (+, - etc) to apply to the incoming cubes.
-            cell_method_coordinate:
-                If specified, a cell method is added to the output with the coordinate
-                provided. This is only available for max, min and mean operations.
-            broadcast:
-                If specified, broadcast input cubes to the stated coord prior to combining -
-                the coord must already exist on the first input cube.
+            cell_method_coordinate (str):
+                If specified, a cell method is added to the output with the
+                coordinate provided. This is only available for max, min and
+                mean operations.
+            broadcast (str):
+                If specified, broadcast input cubes to the stated coord prior
+                to combining - the coord must already exist on the first input
+                cube.
             expand_bound:
-                If True then coord bounds will be extended to represent all cubes being combined.
+                If True then scalar coord bounds will be extended to represent
+                all cubes being combined. For example a time coordinate will
+                be set using the latest time available as the point and with
+                bounds describing the range. If false the first cube provided
+                sets the metadata and the scalar coordinates from this cube
+                will be used.
 
         Raises:
             ValueError: if operation is not recognised in dictionary


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/965

Add use_latest_frt option to the cube combiner. In combination with the expand_bound option this allows the time coordinates of a diagnostic to be expanded to represent a period, with the time point at the end of the inputs. The forecast reference time however will remain a single point scalar as the input cubes have been unified to this point prior to the combination step.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
