### PR TITLE
rebadge_forecasts_as_latest_cycle modified for use in the mix suite

### DIFF
--- a/improver/metadata/forecast_times.py
+++ b/improver/metadata/forecast_times.py
@@ -229,6 +229,9 @@ def rebadge_forecasts_as_latest_cycle(
 
     Returns:
         Updated cubes
+
+    Raises:
+        ValueError: if blend_time is present on some cubes but not all.
     """
     if cycletime is None and len(cubes) == 1:
         return cubes


### PR DESCRIPTION
This PR modifies the rebadge_forecasts_as_latest_cycle function to look for and update a blend_time if it is present on the cubes being rebadged. This ensures that the blend time and forecast reference time cannot get out of step.

This function has not been used for model blended diagnostics before, but it can have a use there, but to be useful it must also handle the blend_time coordinate if it exists, rather than just the forecast_reference_time. 

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)