### PR TITLE
Fix empty array check

### DIFF
--- a/improver/regrid/bilinear.py
+++ b/improver/regrid/bilinear.py
@@ -168,7 +168,7 @@ def adjust_boundary_indexes(
         )[0]
 
         # if point_lat_lon_max_index exists, handle it.
-        if point_lat_lon_max_index:
+        if point_lat_lon_max_index.size > 0:
             point_lat_lon_max = point_lat_max[point_lat_lon_max_index[0]]
             point_lat_max = np.delete(
                 point_lat_max, np.where(point_lat_max == point_lat_lon_max)[0]


### PR DESCRIPTION
Prior to NumPy 1.24 a DeprecationWarning was given when an empty array is used in a boolean context. This is now a ValueError in more recent versions:

`ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.`

This PR fixes this in the recommended way, by evaluating the size of the array to be greater than zero.

Testing:

- [x] Ran tests and they passed OK
- [x] Ran failing IMPROVER task using this change and confirmed that it worked as it does when using older version of NumPy.
