### PR TITLE
HailFraction handles masked CTT data as "no convection"

### DIFF
--- a/improver/precipitation/hail_fraction.py
+++ b/improver/precipitation/hail_fraction.py
@@ -82,18 +82,18 @@ class HailFraction(PostProcessingPlugin):
         # a hail fraction of 0 is set.
         cct_limit = 258.15
 
-        # Ensure CCT is a masked array.
-        ctt_data = convective_cloud_top.data
-        if not isinstance(ctt_data, np.ma.MaskedArray):
-            ctt_data = np.ma.masked_invalid(ctt_data)
+        # Ensure convective cloud top temperature is a masked array.
+        cct_data = convective_cloud_top.data
+        if not isinstance(cct_data, np.ma.MaskedArray):
+            cct_data = np.ma.masked_invalid(cct_data)
 
         hail_fraction = np.interp(vertical_updraught.data, [5, 50], [0, 0.25]).astype(
             np.float32
         )
         hail_fraction[
             (cloud_condensation_level.data < ccl_limit)
-            | ctt_data.mask
-            | (ctt_data > cct_limit)
+            | cct_data.mask
+            | (cct_data > cct_limit)
             | (hail_melting_level.data > orography.data)
         ] = 0
         hail_fraction[(hail_size.data > hail_size_limit) & (hail_fraction < 0.05)] = (

--- a/improver/precipitation/hail_fraction.py
+++ b/improver/precipitation/hail_fraction.py
@@ -54,6 +54,9 @@ class HailFraction(PostProcessingPlugin):
         elicitation. Next, the hail fraction is set to zero if either the cloud
         condensation level temperature is below -5 Celsius, the convective cloud top
         temperature is above -15 Celsius or the hail melting level is above orography.
+        The convective cloud top temperature can also be missing, indicating that
+        there is no deep convection, in which case the hail fraction is also set to
+        zero.
         As a final check, the hail size is then checked for hail with a size larger
         than 2 mm. If the hail size is above this limit but the hail fraction is
         below 0.05, the hail fraction is set to 0.05.
@@ -75,16 +78,22 @@ class HailFraction(PostProcessingPlugin):
         # Cloud condensation level temperature in Kelvin. If below this temperature,
         # a hail fraction of 0 is set.
         ccl_limit = 268.15
-        # Convective cloud top temperature in Kelvin. If above this temperature,
+        # Convective cloud top temperature in Kelvin. If above this temperature, or missing,
         # a hail fraction of 0 is set.
         cct_limit = 258.15
+
+        # Ensure CCT is a masked array.
+        ctt_data = convective_cloud_top.data
+        if not isinstance(ctt_data, np.ma.MaskedArray):
+            ctt_data = np.ma.masked_invalid(ctt_data)
 
         hail_fraction = np.interp(vertical_updraught.data, [5, 50], [0, 0.25]).astype(
             np.float32
         )
         hail_fraction[
             (cloud_condensation_level.data < ccl_limit)
-            | (convective_cloud_top.data > cct_limit)
+            | ctt_data.mask
+            | (ctt_data > cct_limit)
             | (hail_melting_level.data > orography.data)
         ] = 0
         hail_fraction[(hail_size.data > hail_size_limit) & (hail_fraction < 0.05)] = (

--- a/improver_tests/precipitation/hail_fraction/test_HailFraction.py
+++ b/improver_tests/precipitation/hail_fraction/test_HailFraction.py
@@ -107,6 +107,7 @@ def setup_cubes():
     )
 
 
+@pytest.mark.parametrize("cct_is_masked", (True, False))
 @pytest.mark.parametrize("model_id_attr", (None, "mosg__model_configuration"))
 @pytest.mark.parametrize(
     "vertical_updraught_value,hail_size_value,cloud_condensation_level_value,"
@@ -148,6 +149,7 @@ def test_basic(
     altitude_value,
     expected,
     model_id_attr,
+    cct_is_masked,
 ):
     """Test hail fraction plugin."""
     expected_attributes = COMMON_ATTRS.copy()
@@ -170,11 +172,10 @@ def test_basic(
     cloud_condensation_level.data = np.full_like(
         cloud_condensation_level.data, cloud_condensation_level_value
     )
-    convective_cloud_top.data = np.ma.masked_invalid(
-        np.full_like(
-            convective_cloud_top.data, convective_cloud_top_value
-        )
-    )
+    cct_data = np.full_like(convective_cloud_top.data, convective_cloud_top_value)
+    if cct_is_masked:
+        cct_data = np.ma.masked_invalid(cct_data)
+    convective_cloud_top.data = cct_data
     hail_melting_level.data = np.full_like(
         hail_melting_level.data, hail_melting_level_value
     )

--- a/improver_tests/precipitation/hail_fraction/test_HailFraction.py
+++ b/improver_tests/precipitation/hail_fraction/test_HailFraction.py
@@ -130,6 +130,8 @@ def setup_cubes():
         (75, 0.001, 263.15, 253.15, 20, 50, 0),
         # Convective cloud top temperature prevents hail
         (75, 0.001, 271.15, 263.15, 20, 50, 0),
+        # Convective cloud top temperature is missing and prevents hail
+        (75, 0.001, 271.15, np.nan, 20, 50, 0),
         # Hail melting level prevents hail
         (75, 0.001, 271.15, 253.15, 100, 50, 0),
         # Hail size causes non-zero hail fraction despite inhibitive cloud condensation
@@ -168,8 +170,10 @@ def test_basic(
     cloud_condensation_level.data = np.full_like(
         cloud_condensation_level.data, cloud_condensation_level_value
     )
-    convective_cloud_top.data = np.full_like(
-        convective_cloud_top.data, convective_cloud_top_value
+    convective_cloud_top.data = np.ma.masked_invalid(
+        np.full_like(
+            convective_cloud_top.data, convective_cloud_top_value
+        )
     )
     hail_melting_level.data = np.full_like(
         hail_melting_level.data, hail_melting_level_value


### PR DESCRIPTION
Closes #2117

The documented meaning of masked convective cloud top temperature data is "no convection" (because the convection depth is too shallow). The HailFraction plugin doesn't explicitly handle masked values and so they are treated as deep convection which can yield hail.

This change explicitly handles masked or invalid convective cloud top temperature data as "no convection" with zero hail-fraction returned.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
- [x] Impact on output data documented in a notebook