### PR TITLE
Fix gh action Sphinx-Pytest-Coverage: updated intersphinx inventory URLs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -374,7 +374,7 @@ intersphinx_mapping = {
     "cartopy": ("https://cartopy.readthedocs.io/latest/", None),
     "cf_units": ("https://cf-units.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy-1.15.0/reference/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/dev/", None),
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -371,10 +371,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "iris": ("https://scitools-iris.readthedocs.io/en/latest/", None),
-    "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
+    "cartopy": ("https://cartopy.readthedocs.io/latest/", None),
     "cf_units": ("https://cf-units.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy-1.6.2/reference/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy-1.15.0/reference/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/dev/", None),
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -371,7 +371,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "iris": ("https://scitools-iris.readthedocs.io/en/latest/", None),
-    "cartopy": ("https://cartopy.readthedocs.io/latest/", None),
+    "cartopy": ("https://cartopy.readthedocs.io/stable/", None),
     "cf_units": ("https://cf-units.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -370,7 +370,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "iris": ("https://scitools-iris.readthedocs.io/en/latest/", None),
+    "iris": ("https://scitools-iris.readthedocs.io/en/stable/", None),
     "cartopy": ("https://cartopy.readthedocs.io/stable/", None),
     "cf_units": ("https://cf-units.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
gh actions is failling with scitools cartopy documentation changing URL.
At the same time I have updated scipy URL (was pointing to really old version).

<img width="1264" height="376" alt="image" src="https://github.com/user-attachments/assets/8c3d3712-d539-4a13-aa44-e84a3e072472" />
https://github.com/metoppv/improver/actions/runs/17474093407/job/49629510211?pr=2185