### PR TITLE
Ensure acceptance test writes to temporary location

### DIFF
--- a/improver_tests/acceptance/SHA256SUMS
+++ b/improver_tests/acceptance/SHA256SUMS
@@ -455,7 +455,6 @@ e8e9661759ebf7cf8e78d259a33a57ba8a5f055a013bda68daf2f265d28de367  ./estimate-sam
 7c0268d6117de9002033a72a0388c963094c0f87b2448c2455802e41750960e0  ./estimate-samos-gam/kgo.pkl
 a979ae8ee62d3e7867ac6ed31a423c03bd65fc52f818d7e24ad212f789352c61  ./estimate-samos-gam/kgo_extra_cube.pkl
 33ae30a74bc600b0f4ff10feff1ae3443323f1c17e57ec6c2f0aec4cb0e72ae5  ./estimate-samos-gam/kgo_sites.pkl
-3bfb4f1b610528f34096745613fc62db3ca10b7f38c54b2495996a9b2cdfc695  ./estimate-samos-gam/output.pkl
 8964d00ec69f384501269e0093bb7c4684d1fd7cf292a8286ee4ea68fe3b73e4  ./estimate-samos-gam/roughness_length.nc
 34222261b96e60ffd281637d5876cf84664a59efc9977407cb3a7de30c99b0c9  ./estimate-samos-gam/samos_model_spec_simple.json
 cc3fb6e27313a487f17a69ca223523e86f3fa6c7c71f08574d2efcecab5bc4a2  ./estimate-samos-gams-from-table/distance_to_water.nc

--- a/improver_tests/acceptance/test_estimate_samos_gams.py
+++ b/improver_tests/acceptance/test_estimate_samos_gams.py
@@ -103,7 +103,7 @@ def test_gam_cube_gam_features(tmp_path):
     acc.compare(output_path, kgo_path, file_type="generic_pickle")
 
 
-def test_gam_at_sites():
+def test_gam_at_sites(tmp_path):
     """
     Test estimate-samos-gams-coefficients for diagnostic with assumed
     normal distribution and additional features provided as a cube.
@@ -115,7 +115,7 @@ def test_gam_at_sites():
     kgo_dir = acc.kgo_root() / "estimate-samos-gam"
     kgo_path = kgo_dir / "kgo_sites.pkl"
     model_specification_path = kgo_dir / "samos_model_spec_simple.json"
-    output_path = kgo_dir / "output.pkl"
+    output_path = tmp_path / "output.pkl"
 
     gam_features = "latitude,longitude,height"
     args = [


### PR DESCRIPTION
Related to https://github.com/metoppv/improver/pull/2203

Description
This PR corrects the test_gam_at_sites acceptance test, so that it writes to a temporary location, as usual, rather than writing to the same directory as the KGOs.
Associated with https://github.com/metoppv/improver_test_data/pull/111

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

