### PR TITLE
Remove Anzer's name due to git merging behaviour

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -48,4 +48,3 @@ Victoria Smart <victoria.smart@metoffice.gov.uk> <25484420+VictoriaLouiseS@users
 Tim Pillinger <tim.pillinger@metoffice.gov.uk> <tim.pillinger@metoffice.gov.uk>
 Ying Zhao <91048290+yzhaobom@users.noreply.github.com> <91048290+yzhaobom@users.noreply.github.com>
 Zhiliang Fan <71359633+zfan001@users.noreply.github.com> <71359633+zfan001@users.noreply.github.com>
-Anzer Khan <anzer.khan@metoffice.gov.uk> <anzer.khan@metoffice.gov.uk>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ below:
  - Mark Worsfold (Met Office, UK)
  - Bruce Wright (Met Office, UK)
  - Ying Zhao (Bureau of Meteorology, Australia)
- - Anzer Khan (Met Office, UK)
 <!-- end-shortlog -->
  - Martina Friedrich (Met Office, UK, pre-GitHub)
 


### PR DESCRIPTION
Related to https://github.com/metoppv/improver/pull/2190

Description
Due to git squash-merge behaviour, Anzer's name should now be removed from the codebase as there's no commit associated with that name.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

