### PR TITLE
Modify SAMOS training error to warning

### DIFF
--- a/improver/calibration/samos_calibration.py
+++ b/improver/calibration/samos_calibration.py
@@ -7,6 +7,7 @@ This module defines all the "plugins" specific to Standardised Anomaly Model Out
 Statistics (SAMOS).
 """
 
+import warnings
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import iris
@@ -545,7 +546,8 @@ class TrainGAMsForSAMOS(BasePlugin):
                     "coordinate must contain more than one point. The following time "
                     f"coordinate was found: {input_cube.coord('time')}."
                 )
-                raise ValueError(msg)
+                warnings.warn(msg)
+                return None
 
         # Calculate mean and standard deviation from input cube.
         stat_cubes = self.calculate_cube_statistics(input_cube)

--- a/improver/cli/estimate_samos_gams.py
+++ b/improver/cli/estimate_samos_gams.py
@@ -123,4 +123,7 @@ def process(
         additional_fields=gam_additional_fields,
     )
 
+    if forecast_gams is None or truth_gams is None:
+        return
+
     return [forecast_gams, truth_gams]

--- a/improver/cli/estimate_samos_gams_from_table.py
+++ b/improver/cli/estimate_samos_gams_from_table.py
@@ -166,4 +166,7 @@ def process(
         additional_fields=additional_predictors,
     )
 
+    if forecast_gams is None or truth_gams is None:
+        return
+
     return [forecast_gams, truth_gams]

--- a/improver_tests/calibration/samos_calibration/test_TrainGAMsForSAMOS.py
+++ b/improver_tests/calibration/samos_calibration/test_TrainGAMsForSAMOS.py
@@ -444,12 +444,16 @@ def test_missing_required_coordinates_exception(exception, model_specification):
             "coordinate in order to allow the calculation of means and standard "
             "deviations."
         )
+        with pytest.raises(ValueError, match=msg):
+            TrainGAMsForSAMOS(model_specification).process(input_cube, features)
     elif exception == "single_point_time_coord":
         msg = (
             "The input cube does not contain a realization coordinate. In order to "
             "calculate means and standard deviations the time coordinate must "
             "contain more than one point."
         )
-
-    with pytest.raises(ValueError, match=msg):
-        TrainGAMsForSAMOS(model_specification).process(input_cube, features)
+        with pytest.warns(UserWarning, match=msg):
+            result = TrainGAMsForSAMOS(model_specification).process(
+                input_cube, features
+            )
+            assert result is None


### PR DESCRIPTION
This PR makes a small change to some of the SAMOS training code. At the moment, an error is raised if the input cube to `TrainGAMsForSAMOS` has no realization coordinate and a time coordinate with only 1 point. After this change, a warning will be raised instead, and `None` returned. This will ensure that should this scenario be achieved in operations, the whole suite doesn't fall over.

The `estimate_samos_gams` and `estimate_samos_gams_from_table` CLIs have been modified so that if the plugin returns `None`, no result will be returned from the CLI. This prevents a situation where GAMs have been fit successfully to either the forecast or truth data, but not both, which would cause an error in later CLI calls in the processing chains.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
