### PR TITLE
Ensure the forecast dataframe is being filtered in place

### DIFF
--- a/improver/calibration/quantile_regression_random_forest.py
+++ b/improver/calibration/quantile_regression_random_forest.py
@@ -255,9 +255,8 @@ def _drop_nans_from_forecast_df(
         ValueError: If more than the specific proportion of the forecast data has been
         removed after dropping NaNs.
     """
-    forecast_df = forecast_df[merge_columns + feature_column_names]
     forecast_df_length = len(forecast_df)
-    forecast_df.dropna(inplace=True)
+    forecast_df.dropna(inplace=True, subset=merge_columns + feature_column_names)
     if (
         forecast_df_length - len(forecast_df)
     ) / forecast_df_length > valid_forecast_proportion:


### PR DESCRIPTION
https://github.com/metoppv/improver/pull/2214/files made changes to filter out nans from the forecast data. There was a significant amount of rewriting after the initial implementation and testing which introduced a small bug meaning our filtering was being applied to a copy of the forecast dataframe rather than the original. As such nan values in the training forecast data have still been included and are leading to nan values in the calibrated forecasts after application.

This change ensures that the filtering is applied to the original forecast dataframe which goes on to be used.

Testing:
- [x] Ran tests and they passed OK

## Demonstration

The QRF model that is being applied in a case that is failing in the PS47 suite was recreated on the command line. Print statements were added to highlight if nan values were found in the forecast dataframe after it had passed through the function designed to remove them.

The sections below show the impact of the changes. After this fix is applied the only column containing nans is the period column which is only set for some diagnostics and is not used in the training. The other columns, e.g. wind_from_direction that previously contained nans are now suitably filtered.

<details>
<summary>Version in the PS47 suites</summary>
<pre>
<code>
ANY NANS IN FORECAST DF
altitude                                 False
blend_time                               False
forecast_period                          False
forecast_reference_time                  False
latitude                                 False
longitude                                False
time                                     False
wmo_id                                   False
station_id                               False
cf_name                                  False
units                                    False
experiment                               False
period                                    True
height                                   False
diagnostic                               False
wind_from_direction                       True
difference_in_altitude                   False
distance_to_ocean                        False
distance_to_water                        False
land_area_fraction                       False
vegetative_roughness_length              False
visibility_in_air_mean                   False
visibility_in_air_std                    False
visibility_in_air_members_below_10000    False
visibility_in_air_min                    False
visibility_in_air_max                    False
visibility_in_air_in_vicinity_mean        True
visibility_in_air_in_vicinity_std        False
visibility_in_air_in_vicinity_min         True
wind_speed_mean                          False
wind_speed_std                           False
wind_speed_max                           False
relative_humidity_mean                    True
relative_humidity_max                     True
cloud_area_fraction_mean                 False
cloud_area_fraction_std                  False
wind_speed_of_gust_mean                   True
wind_speed_of_gust_min                    True
wind_speed_of_gust_max                    True
</code>
</pre>
</details>

<details>
<summary>With these changes</summary>
<pre>
<code>
ANY NANS IN FORECAST DF
altitude                                 False
blend_time                               False
forecast_period                          False
forecast_reference_time                  False
latitude                                 False
longitude                                False
time                                     False
wmo_id                                   False
station_id                               False
cf_name                                  False
units                                    False
experiment                               False
period                                    True
height                                   False
diagnostic                               False
wind_from_direction                      False
difference_in_altitude                   False
distance_to_ocean                        False
distance_to_water                        False
land_area_fraction                       False
vegetative_roughness_length              False
visibility_in_air_mean                   False
visibility_in_air_std                    False
visibility_in_air_members_below_10000    False
visibility_in_air_min                    False
visibility_in_air_max                    False
visibility_in_air_in_vicinity_mean       False
visibility_in_air_in_vicinity_std        False
visibility_in_air_in_vicinity_min        False
wind_speed_mean                          False
wind_speed_std                           False
wind_speed_max                           False
relative_humidity_mean                   False
relative_humidity_max                    False
cloud_area_fraction_mean                 False
cloud_area_fraction_std                  False
wind_speed_of_gust_mean                  False
wind_speed_of_gust_min                   False
wind_speed_of_gust_max                   False
</code>
</pre>
</details>