### PR TITLE
RainForests: Replace treelite.Model with treelite.frontend

### DIFF
--- a/improver_tests/calibration/rainforests_calibration/conftest.py
+++ b/improver_tests/calibration/rainforests_calibration/conftest.py
@@ -280,7 +280,7 @@ def compile_models(lightgbm_models, lead_times, thresholds, tmp_path):
     for lead_time in lead_times:
         for threshold in thresholds:
             model = lightgbm_models[lead_time, threshold]
-            treelite_model = treelite.Model.from_lightgbm(model)
+            treelite_model = treelite.frontend.from_lightgbm(model)
             tl2cgen.export_lib(
                 treelite_model,
                 toolchain="gcc",


### PR DESCRIPTION
Description
The unit tests run within GitHub Actions are currently failing within environment_b due to an update to the treelite package to remove deprecated functions. An example failure is [available in this link](https://github.com/metoppv/improver/actions/runs/19102484054/job/54577658246?pr=2226) with the error `RuntimeError: treelite.Model.from_lightgbm() has been removed. Use treelite.frontend.from_lightgbm() instead`. I think this can be traced back to https://github.com/dmlc/treelite/pull/642. This PR updates the treelite usage as suggested in the error message.


Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
