### PR TITLE
Remove deprecated None alias for empty array shape in contrails test

### DIFF
--- a/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
+++ b/improver_tests/psychrometric_calculations/condensation_trails/test_CondensationTrailFormation.py
@@ -709,7 +709,7 @@ def test_categorical_cube_output(
         (np.zeros((2, 3, 1)), np.zeros((2, 3, 4)), np.zeros(2), ValueError),
         (np.zeros((2, 1, 4)), np.zeros((2, 3, 4)), np.zeros(2), ValueError),
         (np.zeros(2), np.zeros(2), np.zeros((2, 3)), ValueError),
-        (np.zeros(2), np.zeros(2), np.zeros(None), ValueError),
+        (np.zeros(2), np.zeros(2), np.zeros(()), ValueError),
     ],
 )
 def test_process_from_arrays_raises(


### PR DESCRIPTION
When running the scheduled CI tests using `improver_latest` environment, [one of the contrails tests fails](https://github.com/metoppv/improver/actions/runs/19525691550/job/55898021468#step:6:24) due to `None` being used as an alias for an empty array shape, `()`, in the input parameters for a test. This has now been replaced and the tests pass.