### PR TITLE
Pin pygam to below 0.11

### DIFF
--- a/envs/environment_a.yml
+++ b/envs/environment_a.yml
@@ -18,7 +18,7 @@ dependencies:
   - statsmodels
   - geopandas
   - numba
-  - pygam
+  - pygam<0.11
   - pysteps
   - python-stratify
   # Development

--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -22,7 +22,7 @@ dependencies:
   - statsmodels
   - lightgbm
   - numba
-  - pygam
+  - pygam<0.11
   - pysteps
   - treelite
   - tl2cgen


### PR DESCRIPTION
Related to #2238 

Description
In https://github.com/metoppv/improver/pull/2238 and viewable in [these GitHub Actions](https://github.com/metoppv/improver/actions/runs/19537347953/job/55934573350#step:9:2012), the environment_a CI tests had the failure: FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/micromamba/envs/improver_a/lib/python3.12/site-packages/pygam/datasets/wage.csv'. This has arisen because we use the wage.csv file as a test dataset within our unit tests, and changes to the pygam packaging mean that this hasn't been included within the latest release of pygam. This PR pins pygam to <0.11 within our environments: environment_a, which runs as part of the CI tests on each PR, and latest, which runs as day as part of scheduled tests.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

