### PR TITLE
Update improver_example_data check in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         environment-file: envs/${{ matrix.env }}.yml
         init-shell: bash
-        cache-environment: false
+        cache-environment: true
 
     - name: Environment info
       run: |


### PR DESCRIPTION
Intended to address CI failures in https://github.com/metoppv/improver/pull/2257

Description
This PR corrects the environment building in GitHub Actions, so that the existence of a PR with a name that matches the PR number of an IMPROVER is checked. If the relevant remote branch is not found, then the improver_example_data `master` is used, rather than the branch number.

[This commit](https://github.com/metoppv/improver/pull/2258/commits/eb9ffac40cb18e04d9ca073c3c984fa447fd5de4) forced the rebuilding of the environments used by the GitHub Actions and shows that the `master` branch from the improver_example_data repo has been checked out.

Testing:

- [ ] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)