### PR TITLE
BUG: gh actions coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,6 @@ jobs:
                 echo "coverage_decreased=false" | tee -a $GITHUB_OUTPUT
             fi
         fi
-        # TODO: remove once debugging complete
-        echo "coverage_decreased=true" | tee -a $GITHUB_OUTPUT
 
     - name: Coverage report on coverage-reference branch
       run: |


### PR DESCRIPTION
Fix and simplified the recently merged coverage report gen/publish via actions.
I think the bug slipped in through the many subsequent merges of master into the dev branch before final merging.

Let's get this in ASAP before master changes 😋 

While doing this, I implemented improved caching for this particular job so that I could quickly iterate with testing the action (no longer re-runs pytest to generate a new report if the relevant files haven't changed).