### PR TITLE
Pinned pandas in latest.yml

### DIFF
--- a/envs/latest.yml
+++ b/envs/latest.yml
@@ -32,6 +32,7 @@ dependencies:
   - filelock
   - mock
   - mypy
+  - pandas<3  # https://github.com/SciTools/iris/issues/6761
   - pytest
   - pytest-cov
   - pytest-xdist


### PR DESCRIPTION
Cached environment usage meant that the tests weren't failing for CI Tests / Test-Coverage (`latest.yml`), hence why it wasn't updated as part of https://github.com/metoppv/improver/pull/2287