### PR TITLE
Eppt 2747 triggered lightning changes

### DIFF
--- a/improver/blending/calculate_weights_and_blend.py
+++ b/improver/blending/calculate_weights_and_blend.py
@@ -6,7 +6,7 @@
 
 import warnings
 from copy import copy
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import iris
 import numpy as np
@@ -30,6 +30,7 @@ from improver.blending.weights import (
     ChooseDefaultWeightsNonLinear,
     ChooseWeightsLinear,
 )
+from improver.utilities.common_input_handle import as_cubelist
 from improver.utilities.spatial import (
     check_if_grid_is_equal_area,
     distance_to_number_of_grid_cells,
@@ -206,7 +207,7 @@ class WeightAndBlend(PostProcessingPlugin):
 
     def process(
         self,
-        cubelist: Union[List[Cube], CubeList],
+        *cubes: Union[Cube, CubeList],
         cycletime: Optional[str] = None,
         model_id_attr: Optional[str] = None,
         record_run_attr: Optional[str] = None,
@@ -220,8 +221,7 @@ class WeightAndBlend(PostProcessingPlugin):
         given by self.blend_coord.
 
         Args:
-            cubelist:
-                List of cubes to be merged and blended
+            *cubes: One or more Iris Cubes or CubeLists.
             cycletime:
                 The forecast reference time to be used after blending has been
                 applied, in the format YYYYMMDDTHHMMZ. If not provided, the
@@ -271,6 +271,8 @@ class WeightAndBlend(PostProcessingPlugin):
                 "record_run_attr can only be used with model_id_attr, which "
                 "has not been provided."
             )
+
+        cubelist = as_cubelist(*cubes)
 
         # Prepare cubes for weighted blending, including creating custom metadata
         # for multi-model blending. The merged cube has a monotonically ascending


### PR DESCRIPTION
---

## **Why is this change required?**

**Current Situation:**  
  The `WeightAndBlend` plugin expects a single keyword argument (`cubelist`) as a list. However, the EPP workflow graph (e.g., for Triggered Lightning) passes multiple Cubes as separate positional arguments, not as a list.
  
https://github.com/MetOffice/epp_workflows/pull/408/changes#diff-21f276d3256d62739d80e29135b78dd9056bf8c3628159097d0fb0ee91edd3a1

**What happens:**

Parameters used for plugin:

https://github.com/MetOffice/epp_workflows/pull/408/changes#diff-bad026f58ea1948b89c981a5a5c5fe2a631d81bdec7a08cba90e061e9244b926

```
"blend_precipitation": {
        "call": (
            "improver.api.WeightAndBlend",
            {
                "blend_coord": "model",
                "wts_calc_method": "dict",
                "weighting_coord": "forecast_period",
                "wts_dict": EPP_TL_PRECIP_BLEND_WEIGHTS,
            },
            {
                "model_id_attr": "mosg__model_configuration",
                "cycletime": constants.CYCLE_TIME_STR,
            },
        )
    },
    
```      


When two Cubes are passed as positional arguments and `cycletime` is also passed as a keyword argument, Python tries to assign the second Cube to `cycletime` (as a positional argument) and also assigns the keyword value, resulting in:  
  ```
  TypeError: WeightAndBlend.process() got multiple values for argument 'cycletime'
  ```
https://cylchub/services/cylc-review/view/anzer.khan?&suite=test_workflow%2Ftest_12&no_fuzzy_time=0&path=log/job/20260122T0600Z/execute_eppuk_triggered_lightning_48hr/01/job.err#47


**Testing**

When testing the `eppuk-triggered-lightening` with the improver version of the current branch. 

https://cylchub/services/cylc-review/view/anzer.khan?&suite=test_workflow%2Ftest_13&no_fuzzy_time=0&path=log/job/20260122T0600Z/install_cold_improver/01/job.out#33

The plugin works and expected produces the blend cube for all the given leadtimes

https://cylchub/services/cylc-review/taskjobs/anzer.khan/?suite=test_workflow%2Ftest_13

The output location for the cylc-run to inspect the output:
`/data/users/anzer.khan/cylc-run/test_workflow/test_13/share/cycle/20260122T0600Z/send/20260122T0600Z`

```
/cylc-run/test_workflow/test_13/share/cycle/20260122T0600Z/send/20260122T0600Z/
20260122T0600Z-PT0000H00M-blended_precip.nc  20260122T1545Z-PT0009H45M-blended_precip.nc  20260123T0130Z-PT0019H30M-blended_precip.nc  20260123T1115Z-PT0029H15M-blended_precip.nc  20260123T2100Z-PT0039H00M-blended_precip.nc
20260122T0615Z-PT0000H15M-blended_precip.nc  20260122T1600Z-PT0010H00M-blended_precip.nc  20260123T0145Z-PT0019H45M-blended_precip.nc  20260123T1130Z-PT0029H30M-blended_precip.nc  20260123T2115Z-PT0039H15M-blended_precip.nc
20260122T0630Z-PT0000H30M-blended_precip.nc  20260122T1615Z-PT0010H15M-blended_precip.nc  20260123T0200Z-PT0020H00M-blended_precip.nc  20260123T1145Z-PT0029H45M-blended_precip.nc  20260123T2130Z-PT0039H30M-blended_precip.nc
20260122T0645Z-PT0000H45M-blended_precip.nc  20260122T1630Z-PT0010H30M-blended_precip.nc  20260123T0215Z-PT0020H15M-blended_precip.nc  20260123T1200Z-PT0030H00M-blended_precip.nc  20260123T2145Z-PT0039H45M-blended_precip.nc
20260122T0700Z-PT0001H00M-blended_precip.nc  20260122T1645Z-PT0010H45M-blended_precip.nc  20260123T0230Z-PT0020H30M-blended_precip.nc  20260123T1215Z-PT0030H15M-blended_precip.nc  20260123T2200Z-PT0040H00M-blended_precip.nc
20260122T0715Z-PT0001H15M-blended_precip.nc  20260122T1700Z-PT0011H00M-blended_precip.nc  20260123T0245Z-PT0020H45M-blended_precip.nc  20260123T1230Z-PT0030H30M-blended_precip.nc  20260123T2215Z-PT0040H15M-blended_precip.nc
20260122T0730Z-PT0001H30M-blended_precip.nc  20260122T1715Z-PT0011H15M-blended_precip.nc  20260123T0300Z-PT0021H00M-blended_precip.nc  20260123T1245Z-PT0030H45M-blended_precip.nc  20260123T2230Z-PT0040H30M-blended_precip.nc
20260122T0745Z-PT0001H45M-blended_precip.nc  20260122T1730Z-PT0011H30M-blended_precip.nc  20260123T0315Z-PT0021H15M-blended_precip.nc  20260123T1300Z-PT0031H00M-blended_precip.nc  20260123T2245Z-PT0040H45M-blended_precip.nc
20260122T0800Z-PT0002H00M-blended_precip.nc  20260122T1745Z-PT0011H45M-blended_precip.nc  20260123T0330Z-PT0021H30M-blended_precip.nc  20260123T1315Z-PT0031H15M-blended_precip.nc  20260123T2300Z-PT0041H00M-blended_precip.nc
20260122T0815Z-PT0002H15M-blended_precip.nc  20260122T1800Z-PT0012H00M-blended_precip.nc  20260123T0345Z-PT0021H45M-blended_precip.nc  20260123T1330Z-PT0031H30M-blended_precip.nc  20260123T2315Z-PT0041H15M-blended_precip.nc
20260122T0830Z-PT0002H30M-blended_precip.nc  20260122T1815Z-PT0012H15M-blended_precip.nc  20260123T0400Z-PT0022H00M-blended_precip.nc  20260123T1345Z-PT0031H45M-blended_precip.nc  20260123T2330Z-PT0041H30M-blended_precip.nc
20260122T0845Z-PT0002H45M-blended_precip.nc  20260122T1830Z-PT0012H30M-blended_precip.nc  20260123T0415Z-PT0022H15M-blended_precip.nc  20260123T1400Z-PT0032H00M-blended_precip.nc  20260123T2345Z-PT0041H45M-blended_precip.nc
```
---