### PR TITLE
Eppt 2747 layer mean temperature fixes

### DIFF
--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -84,6 +84,8 @@ PROCESSING_MODULES = {
     "Integration": "improver.utilities.mathematical_operations",
     "InterpolateUsingDifference": "improver.utilities.interpolation",
     "LapseRate": "improver.temperature.lapse_rate",
+    "LayerTemperatureInterpolation": "improver.temperature.layer_mean_temperature",
+    "CalculateLayerMeanTemperature": "improver.temperature.layer_mean_temperature",
     "LightningFromCapePrecip": "improver.lightning",
     "LightningMultivariateProbability_USAF2024": "improver.lightning",
     "ManipulateReliabilityTable": "improver.calibration.reliability_calibration",

--- a/improver/temperature/layer_mean_temperature.py
+++ b/improver/temperature/layer_mean_temperature.py
@@ -92,7 +92,7 @@ class CalculateLayerMeanTemperature(BasePlugin):
             2D cube of layer mean temperature.
         """
         # Set up array for holding sum of products of temperature and vertical distance
-        layer_temp_product = np.zeros(layer_cube.data.shape[1:])
+        layer_temp_product = np.zeros(layer_cube.data.shape[1:], dtype=np.float32)
 
         # Estimate mean temperature of layers and
         # Weight by vertical extent of layer
@@ -112,7 +112,9 @@ class CalculateLayerMeanTemperature(BasePlugin):
         )
 
         # Divide by total thickness to get mean
-        lmt_array = layer_temp_product / (altitude_array[-1] - altitude_array[0])
+        lmt_array = (
+            layer_temp_product / (altitude_array[-1] - altitude_array[0])
+        ).astype(np.float32)
 
         if verbosity:
             print("Layer mean temperature array:", lmt_array)
@@ -122,6 +124,7 @@ class CalculateLayerMeanTemperature(BasePlugin):
             lmt_array,
             var_name="air_temperature",
             units="K",
+            attributes=layer_cube.attributes.copy(),
             dim_coords_and_dims=(
                 (layer_cube.coord("projection_y_coordinate"), 0),
                 (layer_cube.coord("projection_x_coordinate"), 1),


### PR DESCRIPTION
[EPPT-3150](https://metoffice.atlassian.net/browse/EPPT-3150)

This PR adds missing follow-up changes for the `LayerTemperatureInterpolation` and `CalculateLayerMeanTemperature` plugins introduced in : https://github.com/metoppv/improver/pull/2321

1. Register plugins in IMPROVER API
2. Enforce float32 output dtype
3. Propagate IMPROVER metadata to output cube