### PR TITLE
Cast to the original dtype of the points in `expand_bounds` 

### DIFF
--- a/improver/utilities/cube_manipulation.py
+++ b/improver/utilities/cube_manipulation.py
@@ -724,10 +724,12 @@ def expand_bounds(
             result_coord.bounds = result_coord.bounds.astype(FLOAT_DTYPE)
 
         if midpoint_bound:
-            result_coord.points = [(new_low_bound + new_top_bound) / 2]
+            midpoint = (new_low_bound + new_top_bound) / 2
+            result_coord.points = np.array([midpoint], dtype=result_coord.points.dtype)
         else:
-            result_coord.points = [new_top_bound]
-
+            result_coord.points = np.array(
+                [new_top_bound], dtype=result_coord.points.dtype
+            )
         if result_coord.points.dtype in FLOAT_TYPES:
             result_coord.points = result_coord.points.astype(FLOAT_DTYPE)
 

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -7,6 +7,7 @@
 import copy
 import os
 import unittest
+from datetime import datetime
 from tempfile import mkdtemp
 
 import iris
@@ -15,7 +16,9 @@ import pytest
 from iris.coords import CellMethod
 from netCDF4 import Dataset
 
+from improver.metadata.constants.time_types import TIME_COORDS
 from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
+from improver.utilities.cube_manipulation import expand_bounds
 from improver.utilities.load import load_cube
 from improver.utilities.save import _order_cell_methods, save_netcdf
 
@@ -360,6 +363,68 @@ class Test__order_cell_methods(unittest.TestCase):
         self.cube.cell_methods = copy.copy(cell_methods)
         _order_cell_methods(self.cube)
         self.assertEqual(self.cube.cell_methods, cell_methods)
+
+
+def test_save_netcdf_fails_with_float_time_dtype(tmp_path):
+    """Test that saving a cube with float dtype for time/forecast_reference_time fails as expected."""
+    filepath = tmp_path / "temp.nc"
+    data = np.ones((3, 3), dtype=np.float32)
+    frt = datetime(2015, 11, 19, 0)
+    time_points = [datetime(2015, 11, 19, 1), datetime(2015, 11, 19, 3)]
+    time_bounds = [
+        [datetime(2015, 11, 19, 0), datetime(2015, 11, 19, 2)],
+        [datetime(2015, 11, 19, 1), datetime(2015, 11, 19, 3)],
+    ]
+    cubelist = iris.cube.CubeList()
+    for tpoint, tbounds in zip(time_points, time_bounds):
+        cube = set_up_variable_cube(data, frt=frt, time=tpoint, time_bounds=tbounds)
+        cubelist.append(cube)
+
+    result_cube = expand_bounds(
+        cubelist[0], cubelist, ["time", "forecast_reference_time"], midpoint_bound=True
+    )
+
+    result_cube.coord("time").points = result_cube.coord("time").points.astype(
+        np.float32
+    )
+    result_cube.coord("forecast_reference_time").points = result_cube.coord(
+        "forecast_reference_time"
+    ).points.astype(np.float32)
+
+    with pytest.raises(ValueError):
+        save_netcdf(result_cube, filepath)
+
+
+def test_save_netcdf_succeeds_with_int_time_dtype(tmp_path):
+    """Test that saving a cube with int dtype for time/forecast_reference_time passes after fix."""
+    filepath = tmp_path / "temp.nc"
+    data = np.ones((3, 3), dtype=np.float32)
+    frt = datetime(2015, 11, 19, 0)
+    time_points = [datetime(2015, 11, 19, 1), datetime(2015, 11, 19, 3)]
+    time_bounds = [
+        [datetime(2015, 11, 19, 0), datetime(2015, 11, 19, 2)],
+        [datetime(2015, 11, 19, 1), datetime(2015, 11, 19, 3)],
+    ]
+    cubelist = iris.cube.CubeList()
+    for tpoint, tbounds in zip(time_points, time_bounds):
+        cube = set_up_variable_cube(data, frt=frt, time=tpoint, time_bounds=tbounds)
+        cube.coord("time").points = cube.coord("time").points.astype(
+            TIME_COORDS["time"].dtype
+        )
+        cube.coord("time").bounds = cube.coord("time").bounds.astype(
+            TIME_COORDS["time"].dtype
+        )
+        cube.coord("forecast_reference_time").points = cube.coord(
+            "forecast_reference_time"
+        ).points.astype(TIME_COORDS["forecast_reference_time"].dtype)
+        cubelist.append(cube)
+
+    result_cube = expand_bounds(
+        cubelist[0], cubelist, ["time", "forecast_reference_time"], midpoint_bound=True
+    )
+
+    save_netcdf(result_cube, filepath)
+    assert filepath.exists()
 
 
 if __name__ == "__main__":

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -391,7 +391,7 @@ def test_save_netcdf_fails_with_float_time_dtype(tmp_path):
         "forecast_reference_time"
     ).points.astype(np.float32)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="does not have required dtype"):
         save_netcdf(result_cube, filepath)
 
 
@@ -408,15 +408,13 @@ def test_save_netcdf_succeeds_with_int_time_dtype(tmp_path):
     cubelist = iris.cube.CubeList()
     for tpoint, tbounds in zip(time_points, time_bounds):
         cube = set_up_variable_cube(data, frt=frt, time=tpoint, time_bounds=tbounds)
-        cube.coord("time").points = cube.coord("time").points.astype(
-            TIME_COORDS["time"].dtype
-        )
-        cube.coord("time").bounds = cube.coord("time").bounds.astype(
-            TIME_COORDS["time"].dtype
-        )
+        time_dtype = TIME_COORDS["time"].dtype
+        cube.coord("time").points = cube.coord("time").points.astype(time_dtype)
+        cube.coord("time").bounds = cube.coord("time").bounds.astype(time_dtype)
+        frt_dtype = TIME_COORDS["forecast_reference_time"].dtype
         cube.coord("forecast_reference_time").points = cube.coord(
             "forecast_reference_time"
-        ).points.astype(TIME_COORDS["forecast_reference_time"].dtype)
+        ).points.astype(frt_dtype)
         cubelist.append(cube)
 
     result_cube = expand_bounds(


### PR DESCRIPTION
### Description
In `expand_bounds()` in `improver/utilities/cube_manipulation.py`, cast the midpoint back to the original coordinate dtype, When using Combine with `midpoint_bound=True` , the midpoint calculation  inside `expand_bounds` :  
```
result_coord.points = [(new_low_bound + new_top_bound) / 2]
```
produces a `float32` value due to Python’s division operator, even when the original coordinate points are integers. This causes IMPROVER’s metadata check `check_mandatory_standards()`  to fail inside the `save_netcdf` function:
```
ValueError: forecast_period of type <class 'iris.coords.DimCoord'> does not have required dtype.
Expected: int32, Actual (points): float32, Actual (bounds): int32
time of type <class 'iris.coords.DimCoord'> does not have required dtype.
Expected: int64, Actual (points): float32, Actual (bounds): int64
```
This was discovered during the development of Triggered Lightning workflow, where `midpoint=True` is required for the temporal max step to produce correct validity time metadata.


