### PR TITLE
change categorical cube dtype from int32 to int8

### DIFF
--- a/improver/categorical/decision_tree.py
+++ b/improver/categorical/decision_tree.py
@@ -629,7 +629,7 @@ class ApplyDecisionTree(BasePlugin):
             template_cube,
             mandatory_attributes,
             optional_attributes=optional_attributes,
-            data=np.ma.masked_all_like(template_cube.data).astype(np.int32),
+            data=np.ma.masked_all_like(template_cube.data).astype(np.int8),
         )
         if self.record_run_attr and self.model_id_attr is not None:
             # Use set(cubes) here as the prepare_input_cubes method returns a list

--- a/improver/categorical/decision_tree.py
+++ b/improver/categorical/decision_tree.py
@@ -629,7 +629,7 @@ class ApplyDecisionTree(BasePlugin):
             template_cube,
             mandatory_attributes,
             optional_attributes=optional_attributes,
-            data=np.ma.masked_all_like(template_cube.data).astype(np.int8),
+            data=np.ma.masked_all_like(template_cube.data).astype(np.int16),
         )
         if self.record_run_attr and self.model_id_attr is not None:
             # Use set(cubes) here as the prepare_input_cubes method returns a list

--- a/improver_tests/categorical/decision_tree/test_ApplyDecisionTree.py
+++ b/improver_tests/categorical/decision_tree/test_ApplyDecisionTree.py
@@ -1762,7 +1762,7 @@ class Test_process(Test_WXCode):
         result = self.plugin.process(self.cubes)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAndMaskEqual(result.data, self.expected_wxcode)
-        self.assertEqual(result.dtype, np.int32)
+        self.assertEqual(result.dtype, np.int8)
         self.assertEqual(
             result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 12, 0)
         )

--- a/improver_tests/categorical/decision_tree/test_ApplyDecisionTree.py
+++ b/improver_tests/categorical/decision_tree/test_ApplyDecisionTree.py
@@ -1762,7 +1762,7 @@ class Test_process(Test_WXCode):
         result = self.plugin.process(self.cubes)
         self.assertIsInstance(result, iris.cube.Cube)
         self.assertArrayAndMaskEqual(result.data, self.expected_wxcode)
-        self.assertEqual(result.dtype, np.int8)
+        self.assertEqual(result.dtype, np.int16)
         self.assertEqual(
             result.coord("blend_time").cell(0).point, dt(2017, 10, 9, 12, 0)
         )


### PR DESCRIPTION
Description:

This PR updates the data type of the categorical output cube in `ApplyDecisionTree` from `int32` to `int16` to avoid type coercion issues when multiplying with float32 masks. The corresponding unit test has been updated to assert that the output dtype is `np.int16`