### PR TITLE
Removing a name from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,6 @@ below:
  - Ryan Cocking (Met Office, UK)
  - Andrew Creswick (Met Office, UK)
  - Neil Crosswaite (Met Office, UK)
- - Jonathan Davies (Met Office, UK)
  - Shafiat Dewan (Met Office, UK)
  - Rachael Esler (Bureau of Meteorology, Australia)
  - Gavin Evans (Met Office, UK)


### PR DESCRIPTION
Removed a name from CONTRIBUTING.md.
This is because it was causing issues with the GitHub checks, specifically the PR-standards one, as seen here: https://github.com/metoppv/improver/actions/runs/25922152585/job/76193695172

Testing:

- [x] Ran tests and they passed OK
