### PR TITLE
Add option to ignore the grid hash to the CLI

### DIFF
--- a/improver/cli/spot_extract.py
+++ b/improver/cli/spot_extract.py
@@ -23,6 +23,7 @@ def process(
     suppress_warnings: bool = False,
     realization_collapse: bool = False,
     subset_coord: str = None,
+    ignore_grid_match: bool = False,
 ):
     """Module to run spot data extraction.
 
@@ -113,6 +114,17 @@ def process(
             spot forecast is passed in, the entire spot cube will be processed and
             returned. The neighbour selection method options have no impact if a
             spot cube is passed in.
+        ignore_grid_match:
+            If True, the coordinate hash comparison between the diagnostic cube and
+            the neighbour cube will be ignored. This is not recommended, but
+            allows the version of Iris and/or Numpy in the plug-in execution
+            environment to be different from those that generated the neighbour cube.
+            If False, the grid match check will be performed and an error raised if the
+            cubes do not match. The default is False, and it is recommended to ensure
+            that the neighbour cube is generated on the same grid as the diagnostic cube
+            to avoid any potential issues with incorrect coordinate extraction.
+            @TODO: Remove this option once the hash calculation is more robust and can
+            be reliably used across different versions of Iris and Numpy.
 
     Returns:
         iris.cube.Cube:
@@ -132,4 +144,5 @@ def process(
         suppress_warnings=suppress_warnings,
         realization_collapse=realization_collapse,
         subset_coord=subset_coord,
+        ignore_grid_match=ignore_grid_match,
     )(cubes)

--- a/improver/spotdata/spot_manipulation.py
+++ b/improver/spotdata/spot_manipulation.py
@@ -49,6 +49,7 @@ class SpotManipulation(BasePlugin):
         suppress_warnings: bool = False,
         realization_collapse: bool = False,
         subset_coord: str = None,
+        ignore_grid_match: bool = False,
     ) -> None:
         """
         Initialise the wrapper plugin using the selected options.
@@ -139,6 +140,7 @@ class SpotManipulation(BasePlugin):
         self.suppress_warnings = suppress_warnings
         self.realization_collapse = realization_collapse
         self.subset_coord = subset_coord
+        self.ignore_grid_match = ignore_grid_match
 
     def process(self, cubes: CubeList) -> Cube:
         """
@@ -193,7 +195,8 @@ class SpotManipulation(BasePlugin):
                     raise ValueError("No spot sites retained after subsetting.")
         else:
             result = SpotExtraction(
-                neighbour_selection_method=self.neighbour_selection_method
+                neighbour_selection_method=self.neighbour_selection_method,
+                ignore_grid_match=self.ignore_grid_match,
             )(neighbour_cube, cube, new_title=self.new_title)
 
         if self.realization_collapse:


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/1138, https://github.com/metoppv/improver/pull/2360

Description
This PR exposes the option to ignore the grid hash within the spot extract CLI. The option to ignore the grid hash within the SpotExtract plugin was added in https://github.com/metoppv/improver/pull/2360.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
