### PR TITLE
Extract wind_downscaling CLI processing into plugin

### DIFF
--- a/improver/api/__init__.py
+++ b/improver/api/__init__.py
@@ -27,6 +27,7 @@ PROCESSING_MODULES = {
     "ApplyOrographicEnhancement": "improver.nowcasting.utilities",
     "ApplyRainForestsCalibration": "improver.calibration.rainforest_calibration",
     "ApplyReliabilityCalibration": "improver.calibration.reliability_calibration",
+    "ApplyWindDownscaling": "improver.wind_calculations.wind_downscaling",
     "BaseNeighbourhoodProcessing": "improver.nbhood.nbhood",
     "BuildUpIndex": "improver.fire_weather.build_up_index",
     "CalculateForecastBias": "improver.calibration.simple_bias_correction",

--- a/improver/cli/wind_downscaling.py
+++ b/improver/cli/wind_downscaling.py
@@ -74,64 +74,16 @@ def process(
             If the requested height value is not found.
 
     """
-    import warnings
-
-    import iris
-    from iris.exceptions import CoordinateNotFoundError
-
-    from improver.utilities.cube_extraction import apply_extraction
     from improver.wind_calculations import wind_downscaling
 
-    if output_height_level_units and output_height_level is None:
-        warnings.warn(
-            "output_height_level_units has been set but no "
-            "associated height level has been provided. These units "
-            "will have no effect."
-        )
-
-    # Attempt to iterate over the wind data by 'realization', and apply corrections to each member.
-    # If the cube has no realization coordinate (e.g. deterministic model data), treat the entire cube as a single member.
-    try:
-        wind_speed_iterator = wind_speed.slices_over("realization")
-    except CoordinateNotFoundError:
-        wind_speed_iterator = [wind_speed]
-    wind_speed_list = iris.cube.CubeList()
-    for wind_speed_slice in wind_speed_iterator:
-        result = wind_downscaling.WindTerrainAdjustment(
-            model_silhouette_roughness_cube=silhouette_roughness,
-            model_orog_stddev_cube=sigma,
-            target_orog_cube=target_orography,
-            model_orog_cube=standard_orography,
-            model_res=model_resolution,
-            model_z0_cube=vegetative_roughness,
-            height_levels_cube=None,
-            mode=mode,
-        )(wind_speed_slice)
-        wind_speed_list.append(result)
-    wind_speed = wind_speed_list.merge_cube()
-
-    # Check whether 'realization' exists as a non-dimension coordinate.
-    # If so, reinsert it as a proper dimension axis so the cube has the expected shape.
-    non_dim_coords = [x.name() for x in wind_speed.coords(dim_coords=False)]
-    if "realization" in non_dim_coords:
-        wind_speed = iris.util.new_axis(wind_speed, "realization")
-
-    # If a specific output height is requested, use apply_extraction to select
-    # the corresponding height level from the processed wind cube.
-    if output_height_level is not None:
-        constraints = {"height": output_height_level}
-        units = {"height": output_height_level_units}
-        single_level = apply_extraction(
-            wind_speed, iris.Constraint(**constraints), units
-        )
-        if not single_level:
-            raise ValueError(
-                "Requested height level not found, no cube "
-                "returned. Available height levels are:\n"
-                "{0:}\nin units of {1:}".format(
-                    wind_speed.coord("height").points, wind_speed.coord("height").units
-                )
-            )
-        wind_speed = single_level
-
-    return wind_speed
+    return wind_downscaling.ApplyWindDownscaling(
+        model_orog_stddev_cube=sigma,
+        target_orog_cube=target_orography,
+        model_orog_cube=standard_orography,
+        model_silhouette_roughness_cube=silhouette_roughness,
+        model_res=model_resolution,
+        model_z0_cube=vegetative_roughness,
+        output_height_level=output_height_level,
+        output_height_level_units=output_height_level_units,
+        mode=mode,
+    )(wind_speed)

--- a/improver/wind_calculations/wind_downscaling.py
+++ b/improver/wind_calculations/wind_downscaling.py
@@ -5,6 +5,7 @@
 """Module containing wind downscaling plugins."""
 
 import itertools
+import warnings
 from typing import Optional, Tuple, Union
 
 import iris
@@ -16,6 +17,7 @@ from numpy import ndarray
 
 from improver import BasePlugin, PostProcessingPlugin
 from improver.constants import RMDI
+from improver.utilities.cube_extraction import apply_extraction
 
 # Fractional tolerance used when deciding whether an absolute correction to
 # the computed reference height is significant. Corrections smaller than this
@@ -1250,3 +1252,107 @@ class WindTerrainAdjustment(PostProcessingPlugin):
         output_cube.transpose(np.argsort(output_dims))
 
         return output_cube
+
+
+class ApplyWindDownscaling(PostProcessingPlugin):
+    """Apply wind downscaling with optional realization and level handling."""
+
+    def __init__(
+        self,
+        model_orog_stddev_cube: Cube,
+        target_orog_cube: Cube,
+        model_orog_cube: Cube,
+        model_silhouette_roughness_cube: Cube,
+        model_res: float,
+        model_z0_cube: Optional[Cube] = None,
+        output_height_level: Optional[float] = None,
+        output_height_level_units: str = "m",
+        mode: str = "hc_and_rc",
+    ) -> None:
+        """Initialise plugin inputs and options for wind downscaling.
+
+        Args:
+            model_orog_stddev_cube: Standard deviation of model-orography height (m).
+            target_orog_cube: Orography cube on target grid (m).
+            model_orog_cube: Standard-grid model orography (m).
+            model_silhouette_roughness_cube: Model silhouette roughness (dimensionless).
+            model_res: Native model orography resolution (m).
+            model_z0_cube: Vegetative roughness length (m).
+            output_height_level: Optional output height value to extract.
+            output_height_level_units: Units for output_height_level.
+            mode: Which correction(s) to apply: "hc_and_rc", "hc", or "rc".
+        """
+        self.model_orog_stddev_cube = model_orog_stddev_cube
+        self.target_orog_cube = target_orog_cube
+        self.model_orog_cube = model_orog_cube
+        self.model_silhouette_roughness_cube = model_silhouette_roughness_cube
+        self.model_res = model_res
+        self.model_z0_cube = model_z0_cube
+        self.output_height_level = output_height_level
+        self.output_height_level_units = output_height_level_units
+        self.mode = mode
+
+    def process(self, input_cube: Cube) -> Cube:
+        """Run wind downscaling and optional single-level extraction.
+
+        Args:
+            input_cube: Wind speed on the standard grid.
+
+        Returns:
+            Processed wind-speed cube.
+
+        Raises:
+            ValueError: If a requested output height level cannot be found.
+        """
+        if self.output_height_level_units and self.output_height_level is None:
+            warnings.warn(
+                "output_height_level_units has been set but no "
+                "associated height level has been provided. These units "
+                "will have no effect."
+            )
+
+        try:
+            wind_speed_iterator = input_cube.slices_over("realization")
+        except CoordinateNotFoundError:
+            wind_speed_iterator = [input_cube]
+
+        wind_speed_list = iris.cube.CubeList()
+        for wind_speed_slice in wind_speed_iterator:
+            result = WindTerrainAdjustment(
+                model_silhouette_roughness_cube=self.model_silhouette_roughness_cube,
+                model_orog_stddev_cube=self.model_orog_stddev_cube,
+                target_orog_cube=self.target_orog_cube,
+                model_orog_cube=self.model_orog_cube,
+                model_res=self.model_res,
+                model_z0_cube=self.model_z0_cube,
+                height_levels_cube=None,
+                mode=self.mode,
+            )(wind_speed_slice)
+            wind_speed_list.append(result)
+        wind_speed = wind_speed_list.merge_cube()
+
+        non_dim_coords = [coord.name() for coord in wind_speed.coords(dim_coords=False)]
+        if "realization" in non_dim_coords:
+            wind_speed = iris.util.new_axis(wind_speed, "realization")
+
+        if self.output_height_level is not None:
+            constraints = {"height": self.output_height_level}
+            units = {"height": self.output_height_level_units}
+            single_level = apply_extraction(
+                wind_speed, iris.Constraint(**constraints), units
+            )
+            if not single_level:
+                raise ValueError(
+                    "Requested height level not found, no cube "
+                    "returned. Available height levels are:\n"
+                    "{0:}\nin units of {1:}".format(
+                        wind_speed.coord("height").points,
+                        wind_speed.coord("height").units,
+                    )
+                )
+            wind_speed = single_level
+
+        return wind_speed
+
+
+WindDownscaling = ApplyWindDownscaling

--- a/improver/wind_calculations/wind_downscaling.py
+++ b/improver/wind_calculations/wind_downscaling.py
@@ -1353,6 +1353,3 @@ class ApplyWindDownscaling(PostProcessingPlugin):
             wind_speed = single_level
 
         return wind_speed
-
-
-WindDownscaling = ApplyWindDownscaling


### PR DESCRIPTION
As suggested by Ben A, refactor the pre-existing wind_downscaling CLI by moving processing logic into a new "ApplyWindDownscaling" plugin.
 
The CLI now only handles argument parsing and validation, while the plugin manages realization handling, application of "WindTerrainAdjustment", and optional height-level extraction. 

Existing CLI arguments have been retained for backwards compatibility.

https://github.com/metoppv/mo-blue-team/issues/1141