### PR TITLE
Remove non-finite SSFT noise in StochasticNoise

### DIFF
--- a/improver/calibration/stochastic_noise.py
+++ b/improver/calibration/stochastic_noise.py
@@ -176,6 +176,11 @@ class StochasticNoise(BasePlugin):
         # Convert generated noise from dB to linear scale
         noise_linear = self._from_dB(data=result).astype(np.float32, copy=False)
 
+        # Guard against non-finite values from SSFT output fiels.
+        # Treat these as zero-noise contributions.
+        if not np.all(np.isfinite(noise_linear)):
+            noise_linear = np.where(np.isfinite(noise_linear), noise_linear, 0.0)
+
         # If requested, scale noise in non-positive regions to prevent increasing values
         # where there should be no signal
         if self.scale_non_positive_noise:
@@ -241,6 +246,8 @@ class StochasticNoise(BasePlugin):
             are set to zero.
         """
         linear = 10 ** (data / 10.0)
+        # Treat any non-finite transformed values as below-threshold values
+        linear[~np.isfinite(linear)] = 0.0
         linear[linear < self.db_threshold] = 0.0
         return linear
 

--- a/improver/calibration/stochastic_noise.py
+++ b/improver/calibration/stochastic_noise.py
@@ -176,7 +176,7 @@ class StochasticNoise(BasePlugin):
         # Convert generated noise from dB to linear scale
         noise_linear = self._from_dB(data=result).astype(np.float32, copy=False)
 
-        # Guard against non-finite values from SSFT output fiels.
+        # Guard against non-finite values from SSFT output fields.
         # Treat these as zero-noise contributions.
         if not np.all(np.isfinite(noise_linear)):
             noise_linear = np.where(np.isfinite(noise_linear), noise_linear, 0.0)

--- a/improver_tests/calibration/stochastic_noise/test_StochasticNoise.py
+++ b/improver_tests/calibration/stochastic_noise/test_StochasticNoise.py
@@ -196,6 +196,44 @@ def test_scale_non_positive_noise():
     ), "Noise in non-positive regions should be <= 0"
 
 
+@pytest.mark.parametrize("scale_non_positive_noise", [False, True])
+def test_process_non_finite_noise_is_sanitized(scale_non_positive_noise: bool):
+    """Non-finite values from SSFT should not leak into output data."""
+
+    plugin = StochasticNoise(
+        ssft_init_params={"win_size": (2, 2), "overlap": 0},
+        ssft_generate_params={"seed": 0},
+        db_threshold=0.03,
+        db_threshold_units="mm/hr",
+        scale_non_positive_noise=scale_non_positive_noise,
+    )
+
+    data = np.array(
+        [
+            [[0.0, 3.0], [0.0, 4.0]],
+            [[0.0, 3.2], [0.0, 4.2]],
+        ],
+        dtype=np.float32,
+    )
+    cube = set_up_variable_cube(data=data, name="precipitation_rate", units="mm/hr")
+
+    # Force problematic SSFT output that includes non-finite values.
+    plugin.do_fft = lambda _: np.array(
+        [[np.nan, 0.0], [np.inf, -np.inf]], dtype=np.float32
+    )
+
+    with pytest.warns(UserWarning, match="multi-realization dimension"):
+        result = plugin.process(cube)
+
+    non_zero_mask = data > 0
+    np.testing.assert_array_equal(result.data[non_zero_mask], data[non_zero_mask])
+
+    non_positive_mask = data <= 0
+    assert np.all(np.isfinite(result.data[non_positive_mask]))
+    if scale_non_positive_noise:
+        assert np.all(result.data[non_positive_mask] <= 0)
+
+
 def test_process_scalar_realization_coord():
     """Test processing a cube with scalar realization coordinate.
 


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/1220

Stochastic noise generation can occasionally produce non-finite values (NaN/Inf), which then propagate into output. This leads to sporadic failures in stochastic-noise tests (see e.g. [example 1](https://github.com/metoppv/improver/actions/runs/27422324924/job/81367969021?pr=2395), [example 2](https://github.com/metoppv/improver/actions/runs/27759578513/job/82130145461)).

To fix this, updated `improver/calibration/stochastic_noise.py` to guard against non-finite values:
- In _from_dB: treat non-finite linear values as below-threshold by setting them to 0.0 before threshold masking.
- In _process_single_realization: replace any remaining non-finite values in noise_linear with 0.0 before scaling etc.

Updated `improver_tests/calibration/stochastic_noise/test_StochasticNoise.py`:
- Added test_process_non_finite_noise_is_sanitized
- Test forces do_fft output to include NaN/Inf and verifies:
  - Non-positive-region output is finite
  - Positive-region values remain unchanged
  - With scaling enabled, non-positive-region values are <= 0

Testing:
- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
