### PR TITLE
BUG: correct save perms to 644

### DIFF
--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -147,6 +147,7 @@ def save_netcdf(
                 fill_value=fill_value,
             )
         os.rename(tmp_filename, filename)
+        os.chmod(filename, 0o644)
 
 
 def _cube_attributes_for_save(cube: Cube):

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -82,6 +82,8 @@ class Test_save_netcdf(unittest.TestCase):
         self.assertFalse(os.path.exists(self.filepath))
         save_netcdf(self.cube, self.filepath)
         self.assertTrue(os.path.exists(self.filepath))
+        # check permissions are set to 644
+        self.assertEqual(oct(os.stat(self.filepath).st_mode)[-3:], "644")
 
     def test_compression(self):
         """Test data gets compressed with default complevel 1 when saved"""


### PR DESCRIPTION
#2397 resulted in files that are only read/writable by the user (permissions "600") rather than including read-permissions for group and all too (permissions "644"). This PR ensures the permissions are as intended.