### PR TITLE
EPPT-3458 fsi mandatory ffmc clipping

### DIFF
--- a/improver/fire_weather/fine_fuel_moisture_code.py
+++ b/improver/fire_weather/fine_fuel_moisture_code.py
@@ -3,10 +3,9 @@
 # This file is part of 'IMPROVER' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
 import os
-from typing import Union
 
 import numpy as np
-from iris.cube import Cube, CubeList
+from iris.cube import Cube
 
 from improver.fire_weather import IterativeFireWeatherBase
 
@@ -65,32 +64,6 @@ class FineFuelMoistureCode(IterativeFireWeatherBase):
     input_ffmc: Cube
     initial_moisture_content: np.ndarray
     moisture_content: np.ndarray
-
-    def process(
-        self,
-        *cubes: Union[Cube, CubeList],
-        month: int | None = None,
-        initialise: bool = False,
-        clip_ffmc: bool = False,
-    ) -> Cube:
-        """
-        Args:
-            *cubes:
-                One or more input cubes as specified by INPUT_CUBE_NAMES. When initialise is True `cubes` should
-                exclude the OUTPUT_CUBE_NAME, which should otherwise be given as the iterative input.
-            month:
-                Month parameter (1-12), required only if REQUIRES_MONTH is True
-            initialise:
-                True when starting the iterative process else False
-            clip_ffmc:
-                If true fine fuel moisture code values will be clipped to
-                    a minimum of 0 and a maximum of 101.
-
-        Returns:
-            The calculated output cube.
-        """
-        self.clip_ffmc = clip_ffmc
-        return super().process(cubes, month=month, initialise=initialise)
 
     def _calculate(self) -> np.ndarray:
         """Calculate the Fine Fuel Moisture Code (FFMC).
@@ -154,7 +127,7 @@ class FineFuelMoistureCode(IterativeFireWeatherBase):
         )
 
         # Step 9: Calculate fine fuel moisture code (FFMC) from moisture content
-        ffmc = self._calculate_ffmc_from_moisture_content(self.clip_ffmc)
+        ffmc = self._calculate_ffmc_from_moisture_content()
 
         return ffmc
 
@@ -335,27 +308,17 @@ class FineFuelMoistureCode(IterativeFireWeatherBase):
 
         return new_moisture_content
 
-    def _calculate_ffmc_from_moisture_content(
-        self, clip_ffmc: bool = False
-    ) -> np.ndarray:
+    def _calculate_ffmc_from_moisture_content(self) -> np.ndarray:
         """Calculates the fine fuel moisture code (FFMC) from the moisture
         content.
 
         From Van Wagner and Pickett (1985), Page 5: Equation 10, and Step 9.
 
-        Args:
-            clip_ffmc:
-                If true fine fuel moisture code values will be clipped to
-                    a minimum of 0 and a maximum of 101.
-
         Returns:
-            The calculated FFMC values (dimensionless, clipped range 0-101).
-            Return array will be clipped only if clip_ffmc is True.
+            The calculated FFMC values (dimensionless, clipped to range 0-101).
             Array shape matches input cube data shape.
 
         """
         # Equation 10: Calculate FFMC from moisture content
         ffmc = 59.5 * (250.0 - self.moisture_content) / (147.2 + self.moisture_content)
-        if clip_ffmc:
-            return np.clip(ffmc, 0, 101)
-        return ffmc
+        return np.clip(ffmc, 0, 101)

--- a/improver/fire_weather/initial_spread_index.py
+++ b/improver/fire_weather/initial_spread_index.py
@@ -96,7 +96,7 @@ class InitialSpreadIndex(FireWeatherBase):
         spread_factor = (
             91.9
             * np.exp(self.moisture_content * -0.1386)
-            * (1.0 + (self.moisture_content**5.31) / 4.93e7)
+            * (1.0 + (np.abs(self.moisture_content) ** 5.31) / 4.93e7)
         )
         return spread_factor
 

--- a/improver/fire_weather/initial_spread_index.py
+++ b/improver/fire_weather/initial_spread_index.py
@@ -96,7 +96,7 @@ class InitialSpreadIndex(FireWeatherBase):
         spread_factor = (
             91.9
             * np.exp(self.moisture_content * -0.1386)
-            * (1.0 + (np.abs(self.moisture_content) ** 5.31) / 4.93e7)
+            * (1.0 + (self.moisture_content**5.31) / 4.93e7)
         )
         return spread_factor
 

--- a/improver_tests/fire_weather/test_fine_fuel_moisture_code.py
+++ b/improver_tests/fire_weather/test_fine_fuel_moisture_code.py
@@ -573,37 +573,16 @@ def test__calculate_ffmc_from_moisture_content(
 
 @pytest.mark.parametrize(
     "moisture_content_val, expected_array_val",
-    [
-        (0.0, 101.05298913),
-        (16.0, 85.3125),
-        (250.0, 0.0),
-        (-10.0, 112.75510204),
-        (500.0, -22.98362176),
-    ],
-)
-def test_moisture_conversion_without_clip(moisture_content_val, expected_array_val):
-    """Test a range of moisture content values with clip_ffmc=False."""
-    plugin = FineFuelMoistureCode()
-
-    plugin.moisture_content = np.full(5, moisture_content_val)
-    expected_array = np.full(5, expected_array_val)
-
-    ffmc = plugin._calculate_ffmc_from_moisture_content(False)
-    assert np.allclose(ffmc, expected_array, atol=0.01)
-
-
-@pytest.mark.parametrize(
-    "moisture_content_val, expected_array_val",
     [(0.0, 101.0), (16.0, 85.3125), (250.0, 0.0), (-10.0, 101.0), (500.0, 0)],
 )
-def test_moisture_conversion_with_clip(moisture_content_val, expected_array_val):
-    """Test a range of moisture content values with clip_ffmc=True."""
+def test_moisture_conversion(moisture_content_val, expected_array_val):
+    """Test a range of moisture content values."""
     plugin = FineFuelMoistureCode()
 
     plugin.moisture_content = np.full(5, moisture_content_val)
     expected_array = np.full(5, expected_array_val)
 
-    ffmc = plugin._calculate_ffmc_from_moisture_content(True)
+    ffmc = plugin._calculate_ffmc_from_moisture_content()
     assert np.allclose(ffmc, expected_array, atol=0.01)
 
 
@@ -650,7 +629,7 @@ def test_process(
     """
     cubes = input_cubes(temp_val, precip_val, rh_val, wind_val, ffmc_val)
     plugin = FineFuelMoistureCode()
-    result = plugin.process(cubes, clip_ffmc=True)
+    result = plugin.process(cubes)
     # Check output type and shape
     assert hasattr(result, "data")
     assert result.data.shape == cubes[0].data.shape

--- a/improver_tests/fire_weather/test_fine_fuel_moisture_code.py
+++ b/improver_tests/fire_weather/test_fine_fuel_moisture_code.py
@@ -599,7 +599,8 @@ def test_moisture_conversion(moisture_content_val, expected_array_val):
         (10.0, 15.0, 95.0, 5.0, 85.0, 20.70),
         # Case 4: Precipitation just below threshold (should not adjust)
         (20.0, 0.4, 50.0, 10.0, 85.0, 86.82),
-        # Case 5: Extreme values should should be clipped to maximum (edge case)
+        # Case 5: Extreme values of FFMC must be clipped to maximum of 101 to avoid
+        # negative values in the moisture content (edge case)
         (40.0, 0.0, 0.0, 60.0, 100.0, 101),
     ],
 )

--- a/improver_tests/fire_weather/test_fine_fuel_moisture_code.py
+++ b/improver_tests/fire_weather/test_fine_fuel_moisture_code.py
@@ -599,6 +599,8 @@ def test_moisture_conversion(moisture_content_val, expected_array_val):
         (10.0, 15.0, 95.0, 5.0, 85.0, 20.70),
         # Case 4: Precipitation just below threshold (should not adjust)
         (20.0, 0.4, 50.0, 10.0, 85.0, 86.82),
+        # Case 5: Extreme values should should be clipped to maximum (edge case)
+        (40.0, 0.0, 0.0, 60.0, 100.0, 101),
     ],
 )
 def test_process(


### PR DESCRIPTION
[Ticket](https://metoffice.atlassian.net/browse/EPPT-3458)

Ensures fine fuel moisture content is always clipped to values in the range 0 - 101. 

This prevents NaN values infrequently occurring in the initial spread index.
