### PR TITLE
Change upper bounds for Pollen index categorisation

### DIFF
--- a/improver/pollen/pollen_index_for_period.py
+++ b/improver/pollen/pollen_index_for_period.py
@@ -25,8 +25,6 @@ class PollenIndexForPeriod(PostProcessingPlugin):
 
     #: Threshold index levels - minimum value (grains/m3) for each index.
     _POLLEN_INDEX = {  # 0=No pollen, 1=Low, 2=Moderate, 3=High, 4=Very High
-        # (5=extra level just for contour levels)
-        "index": np.array([0, 1, 2, 3, 4, 5]).astype(np.int32),
         "grass": np.array([0.0, 0.01, 30.0, 50.0, 150.0, np.inf]),
         "birch": np.array([0.0, 0.01, 40.0, 80.0, 200.0, np.inf]),
         "oak": np.array([0.0, 0.01, 30.0, 50.0, 200.0, np.inf]),

--- a/improver/pollen/pollen_index_for_period.py
+++ b/improver/pollen/pollen_index_for_period.py
@@ -27,15 +27,15 @@ class PollenIndexForPeriod(PostProcessingPlugin):
     _POLLEN_INDEX = {  # 0=No pollen, 1=Low, 2=Moderate, 3=High, 4=Very High
         # (5=extra level just for contour levels)
         "index": np.array([0, 1, 2, 3, 4, 5]).astype(np.int32),
-        "grass": np.array([0.0, 0.01, 30.0, 50.0, 150.0, 5000.0]),
-        "birch": np.array([0.0, 0.01, 40.0, 80.0, 200.0, 5000.0]),
-        "oak": np.array([0.0, 0.01, 30.0, 50.0, 200.0, 5000.0]),
-        "hazel": np.array([0.0, 0.01, 30.0, 50.0, 80.0, 5000.0]),
-        "alder": np.array([0.0, 0.01, 30.0, 50.0, 80.0, 5000.0]),
-        "ash": np.array([0.0, 0.01, 30.0, 50.0, 200.0, 5000.0]),
-        "plane": np.array([0.0, 0.01, 30.0, 50.0, 200.0, 5000.0]),
-        "nettle": np.array([0.0, 0.01, 40.0, 80.0, 200.0, 5000.0]),
-        "weed": np.array([0.0, 0.01, 40.0, 80.0, 200.0, 5000.0]),
+        "grass": np.array([0.0, 0.01, 30.0, 50.0, 150.0, np.inf]),
+        "birch": np.array([0.0, 0.01, 40.0, 80.0, 200.0, np.inf]),
+        "oak": np.array([0.0, 0.01, 30.0, 50.0, 200.0, np.inf]),
+        "hazel": np.array([0.0, 0.01, 30.0, 50.0, 80.0, np.inf]),
+        "alder": np.array([0.0, 0.01, 30.0, 50.0, 80.0, np.inf]),
+        "ash": np.array([0.0, 0.01, 30.0, 50.0, 200.0, np.inf]),
+        "plane": np.array([0.0, 0.01, 30.0, 50.0, 200.0, np.inf]),
+        "nettle": np.array([0.0, 0.01, 40.0, 80.0, 200.0, np.inf]),
+        "weed": np.array([0.0, 0.01, 40.0, 80.0, 200.0, np.inf]),
     }
 
     # The output cube is a deepcopy of the input cube (to keep metadata) and is then manipulated in place


### PR DESCRIPTION
The categorisation of Pollen concentration values into Pollen index values puts concentration values into 5 categories of 0 to 4 (None, Low, Medium, High, Very High) for Pollen Index. The upper value for the Very High category has been changed from an arbitrary value of 5000.0 to `numpy.inf` - there is now no upper bounds for this.

Testing:

- [x] Ran tests and they passed OK
- [x] Ran Pollen calculations (using the Met Office EPP workflows suite)  before and after change and there is no difference in the data in the outputs (the only difference in the NetCDF files being in the history metadata tag, since this includes creation time for the file).
