### PR TITLE
Save pollen index categorical data as int32

### DIFF
--- a/improver/pollen/pollen_index_for_period.py
+++ b/improver/pollen/pollen_index_for_period.py
@@ -58,7 +58,7 @@ class PollenIndexForPeriod(PostProcessingPlugin):
         # Set values which are masked in _output_cube to nan
         self._output_cube.data = np.where(
             np.isnan(input_data), np.nan, self._output_cube.data
-        )
+        ).astype(np.int32)
 
     def _metadata(self, taxa: str):
         """Change the cube name and other metadata.

--- a/improver/pollen/pollen_index_for_period.py
+++ b/improver/pollen/pollen_index_for_period.py
@@ -4,8 +4,6 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Calculations to produce Pollen Indexes for a period (Hourly or Daily)."""
 
-from copy import deepcopy
-
 import numpy as np
 from iris.cube import Cube
 
@@ -50,15 +48,10 @@ class PollenIndexForPeriod(PostProcessingPlugin):
         if taxa not in self._POLLEN_INDEX:
             raise ValueError(f"Pollen taxa {taxa} not handled")
         thresholds = self._POLLEN_INDEX[taxa]
-        input_data = deepcopy(self._output_cube.data)
         # Use np.digitize to find the index of the first threshold that is greater than the data value
         self._output_cube.data = (
             np.digitize(self._output_cube.data, thresholds) - 1
         ).astype(np.int32)  # Subtract 1 to get 0-based index
-        # Set values which are masked in _output_cube to nan
-        self._output_cube.data = np.where(
-            np.isnan(input_data), np.nan, self._output_cube.data
-        ).astype(np.int32)
 
     def _metadata(self, taxa: str):
         """Change the cube name and other metadata.

--- a/improver/pollen/pollen_index_for_period.py
+++ b/improver/pollen/pollen_index_for_period.py
@@ -10,7 +10,6 @@ import numpy as np
 from iris.cube import Cube
 
 from improver import PostProcessingPlugin
-from improver.metadata.constants import FLOAT_DTYPE
 
 from .utilities import build_output_cube_with_new_units
 
@@ -55,7 +54,7 @@ class PollenIndexForPeriod(PostProcessingPlugin):
         # Use np.digitize to find the index of the first threshold that is greater than the data value
         self._output_cube.data = (
             np.digitize(self._output_cube.data, thresholds) - 1
-        ).astype(FLOAT_DTYPE)  # Subtract 1 to get 0-based index
+        ).astype(np.int32)  # Subtract 1 to get 0-based index
         # Set values which are masked in _output_cube to nan
         self._output_cube.data = np.where(
             np.isnan(input_data), np.nan, self._output_cube.data

--- a/improver/pollen/pollen_maximum_index_for_period.py
+++ b/improver/pollen/pollen_maximum_index_for_period.py
@@ -11,7 +11,6 @@ import numpy as np
 from iris.cube import Cube, CubeList
 
 from improver import PostProcessingPlugin
-from improver.metadata.constants import FLOAT_DTYPE
 from improver.utilities.common_input_handle import as_cubelist
 
 
@@ -48,7 +47,7 @@ class PollenMaximumIndexForPeriod(PostProcessingPlugin):
         # Create a new numpy array with this shape to hold the pollen index values, and fill it
         # with the maximum values across the taxa dimension
         pollen_index_data = np.max(stacked_data, axis=0)
-        self._output_cube.data = pollen_index_data.astype(FLOAT_DTYPE)
+        self._output_cube.data = pollen_index_data.astype(np.int32)
         # Set values which are masked in _output_cube to nan
         self._output_cube.data = np.where(
             np.isnan(input_data), np.nan, self._output_cube.data

--- a/improver/pollen/pollen_maximum_index_for_period.py
+++ b/improver/pollen/pollen_maximum_index_for_period.py
@@ -51,7 +51,7 @@ class PollenMaximumIndexForPeriod(PostProcessingPlugin):
         # Set values which are masked in _output_cube to nan
         self._output_cube.data = np.where(
             np.isnan(input_data), np.nan, self._output_cube.data
-        )
+        ).astype(np.int32)
 
     def _metadata(self):
         """Change the cube name and other metadata.

--- a/improver/pollen/pollen_maximum_index_for_period.py
+++ b/improver/pollen/pollen_maximum_index_for_period.py
@@ -42,16 +42,10 @@ class PollenMaximumIndexForPeriod(PostProcessingPlugin):
         # Stack the cubes along a new taxa dimension and calculate the maximum across that dimension
         stacked_data = np.stack([cube.data for cube in cubes], axis=0)
 
-        # Keep a copy of one of the input cubes' data to use for masking the output data later
-        input_data = deepcopy(cubes[0].data)
         # Create a new numpy array with this shape to hold the pollen index values, and fill it
         # with the maximum values across the taxa dimension
         pollen_index_data = np.max(stacked_data, axis=0)
         self._output_cube.data = pollen_index_data.astype(np.int32)
-        # Set values which are masked in _output_cube to nan
-        self._output_cube.data = np.where(
-            np.isnan(input_data), np.nan, self._output_cube.data
-        ).astype(np.int32)
 
     def _metadata(self):
         """Change the cube name and other metadata.


### PR DESCRIPTION
The Pollen Index data is made of discrete integer values 0 to 4 inclusive, and should therefore be saved as `numpy.int32`. It is currently being written to NetCDF files as `numpy.float32`.

Testing:

- [x] Ran tests and they passed OK
- [x] Executed a Pollen workflow to check that results output for Pollen Index are correctly saved as `int32`, and that validation checks on the output files pass correctly.
