### PR TITLE
MAINT: improver save refactor and support for overriding all arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,7 @@ jobs:
 
     - name: pytest
       run: |
-        #pytest
-        python -u -X faulthandler -m pytest -p no:faulthandler
+        pytest
       shell: micromamba-shell {0}
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,8 @@ jobs:
 
     - name: pytest
       run: |
-        pytest
+        #pytest
+        python -u -X faulthandler -m pytest -p no:faulthandler
       shell: micromamba-shell {0}
 
 

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -364,7 +364,12 @@ def with_output(
             or all([isinstance(x, Cube) for x in result])
         )
     ):
-        save_netcdf(result, output, compression_level, least_significant_digit)
+        save_netcdf(
+            result,
+            output,
+            complevel=compression_level,
+            least_significant_digit=least_significant_digit,
+        )
         if pass_through_output:
             return ObjectAsStr(result, output)
         return

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -4,9 +4,9 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Module for saving netcdf cubes with desired attribute types."""
 
-import os
 import tempfile
 import warnings
+from pathlib import Path
 from typing import Union
 
 import cf_units
@@ -101,7 +101,7 @@ def _derive_chunksizes(cubelist):
 
 def save_netcdf(
     cubelist: Union[Cube, CubeList],
-    filename: str,
+    filename: str | Path,
     complevel: int = 1,
     zlib: bool | None = None,
     shuffle: bool = True,
@@ -192,25 +192,27 @@ def save_netcdf(
     if chunksizes is None:
         chunksizes = _derive_chunksizes(cubelist)
 
+    filename = Path(filename)
+
     # save atomically by writing to a unique temporary file of the form <filename>-<unique>.tmp
     with tempfile.NamedTemporaryFile(
-        dir=os.path.dirname(filename),
-        prefix=os.path.basename(filename) + "-",
+        dir=filename.parent,
+        prefix=filename.name + "-",
         suffix=".tmp",
     ) as tmp_file:
-        tmp_filename = tmp_file.name
+        tmp_filename = Path(tmp_file.name)
         with iris.FUTURE.context(save_split_attrs=True):
             iris.fileformats.netcdf.save(
                 cubelist,
-                tmp_filename,
+                str(tmp_filename),
                 complevel=complevel,
                 shuffle=shuffle,
                 zlib=zlib,
                 chunksizes=chunksizes,
                 **kwargs,
             )
-        os.rename(tmp_filename, filename)
-        os.chmod(filename, 0o644)
+        tmp_filename.replace(filename)
+        filename.chmod(0o644)
 
 
 def _cube_attributes_for_save(cube: Cube):

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -96,7 +96,7 @@ def _derive_chunksizes(cubelist):
         chunksizes = [1] * rcube.ndim
         chunksizes[rxdim] = rcube.shape[rxdim]
         chunksizes[rydim] = rcube.shape[rydim]
-    return chunksizes if derive_chunksize else None
+    return tuple(chunksizes) if derive_chunksize else None
 
 
 def save_netcdf(
@@ -161,7 +161,7 @@ def save_netcdf(
             "The 'compression_level' argument is deprecated and will be removed in a future release. "
             "Please use 'complevel' instead.  Overriding 'complevel' with 'compression_level' if both "
             "are provided.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         complevel = kwargs.pop("compression_level", None)

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -125,9 +125,12 @@ def save_netcdf(
         complevel = 1
     else:
         # iris does no validation of the compression level, so we do it here
-        old_complevel = complevel
-        complevel = int(complevel)
-        if complevel != old_complevel or complevel not in range(10):
+        try:
+            old_complevel = complevel
+            complevel = int(complevel)
+            if old_complevel != complevel or complevel not in range(10):
+                raise ValueError
+        except (ValueError, TypeError):
             raise ValueError(
                 "Compression level must be an integer value between 0 and 9 (0 to disable compression)"
             )

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -58,6 +58,10 @@ def _check_metadata(cube: Cube) -> None:
 def save_netcdf(
     cubelist: Union[Cube, CubeList],
     filename: str,
+    complevel: int = 1,
+    zlib: bool | None = None,
+    shuffle: bool = True,
+    chunksizes: tuple | None = None,
     **kwargs,
 ) -> None:
     """
@@ -67,73 +71,106 @@ def save_netcdf(
     Uses the functionality provided by iris.fileformats.netcdf.save with
     local_keys to record non-global attributes as data attributes rather than
     global attributes.  The save is made with
-    iris.FUTURE.context(save_split_attrs=True).  The following argument
-    defaults for save deviate from iris.fileformats.netcdf.save defaults:
-    - chunksizes are set to (1, 1, x, y) if all cubes have the same xy shape
-      and the chunksizes are not specified in kwargs.
-    - complevel default is 1 (iris default is 4)
-    - zlib is set to True if complevel > 0 (iris default is False)
-    - shuffle is set to True (iris default is False)
+    iris.FUTURE.context(save_split_attrs=True).
+    iris.fileformats.netcdf.save will add a new "least_significant_digit"
+    attribute, but will not update an existing attribute when saving with
+    different precision. Therefore, we remove the "least_significant_digit"
+    attribute if present.
+
+    We further deviate from iris.fileformats.netcdf.save default behaviour
+    as per keyword arguments.
 
     Args:
         cubelist:
             Cube or CubeList to be saved.
         filename:
             Filename to save input cube(s)
+        complevel:
+            Compression level for the NetCDF file. Must be an integer between 0 and 9
+            where 0 disables compression. Default is 1 (iris default is 4).
+        zlib:
+            Whether to use zlib compression. If None (default), set to True
+            if complevel > 0, otherwise False. iris default is False.
+        shuffle:
+            Whether to use HDF5 shuffle filter. Default is True (iris default is False).
+        chunksizes:
+            Tuple defining chunk sizes for the output file. If None (default),
+            automatically determined as (1, 1, x, y) if all cubes have the same xy shape.
         **kwargs:
             Additional keyword arguments to pass to iris.fileformats.netcdf.save.
 
     Raises:
         ValueError:
-            If compression_level is not between 0 and 9.
+            If complevel is not between 0 and 9.
+
 
     Warns:
+        If compression_level is passed via kwargs (deprecated, use complevel instead).
         If cubelist contains cubes of varying dimensions.
     """
     cubelist = as_cubelist(cubelist)
 
+    # Handle deprecated compression_level argument
     if "compression_level" in kwargs:
         warnings.warn(
             "The 'compression_level' argument is deprecated and will be removed in a future release. "
-            "Please use 'complevel' instead.",
+            "Please use 'complevel' instead.  Overriding 'complevel' with 'compression_level' if both "
+            "are provided.",
             DeprecationWarning,
+            stacklevel=2,
         )
-    complevel = kwargs.pop("compression_level", None)
-    complevel = kwargs.pop("complevel", complevel)
+        complevel = kwargs.pop("compression_level", None)
+
     if complevel is None:
         complevel = 1
     else:
+        # iris does no validation of the compression level, so we do it here
+        old_complevel = complevel
         complevel = int(complevel)
-        if complevel not in range(10):
-            # iris does no validation of the compression level, so we do it here
+        if complevel != old_complevel or complevel not in range(10):
             raise ValueError(
                 "Compression level must be an integer value between 0 and 9 (0 to disable compression)"
             )
-    zlib = kwargs.pop("zlib", complevel > 0 if complevel is not None else False)
-    shuffle = kwargs.pop("shuffle", True)
+
+    if zlib is None:
+        zlib = complevel > 0
 
     for cube in cubelist:
         _order_cell_methods(cube)
         _check_metadata(cube)
-        # iris.fileformats.netcdf.save will add a new "least_significant_digit"
-        # attribute, but will not update an existing attribute when saving with
-        # different precision. Therefore, we remove the "least_significant_digit"
-        # attribute if present.
         cube.attributes.pop("least_significant_digit", None)
         _cube_attributes_for_save(cube)
 
-    chunksizes = kwargs.pop("chunksizes", None)
     if chunksizes is None:
-        if len({cube.shape[:2] for cube in cubelist}) == 1:
-            cube = cubelist[0]
-            if cube.ndim >= 2:
-                # If all xy slices are the same shape, use this to determine
-                # the chunksize for the netCDF (eg. 1, 1, 970, 1042)
-                xy_chunksizes = [cube.shape[-2], cube.shape[-1]]
-                chunksizes = tuple([1] * (cube.ndim - 2) + xy_chunksizes)
-        else:
-            msg = "Chunksize not set as cubelist contains cubes of varying dimensions"
-            warnings.warn(msg)
+        rcube = cubelist[0]
+        rx = rcube.coord(axis="x", dim_coords=True)
+        rxdim = rcube.coord_dims(rx)[0]
+        ry = rcube.coord(axis="y", dim_coords=True)
+        rydim = rcube.coord_dims(ry)[0]
+        apply_chunksize = True
+        if len(cubelist) > 1:
+            for cube in cubelist[1:]:
+                # check that chunksizes can apply to the full cubelist
+                xdim = cube.coord(axis="x", dim_coords=True)[0]
+                ydim = cube.coord(axis="y", dim_coords=True)[0]
+                if (
+                    cube.ndim != rcube.ndim
+                    or xdim != rxdim
+                    or ydim != rydim
+                    or cube.shape[xdim] != rcube.shape[rxdim]
+                    or cube.shape[ydim] != rcube.shape[rydim]
+                ):
+                    apply_chunksize = False
+                    msg = "Chunksize not set as cubelist contains cubes of varying x-y shape/mapping"
+                    warnings.warn(msg)
+                    break
+
+        if apply_chunksize and rcube.ndim >= 2:
+            # If all xy slices are the same shape, use this to determine
+            # the chunksize for the netCDF (eg. 1, 1, 970, 1042)
+            chunksizes = [1] * rcube.ndim
+            chunksizes[rxdim] = rcube.shape[rxdim]
+            chunksizes[rydim] = rcube.shape[rydim]
 
     # save atomically by writing to a unique temporary file of the form <filename>-<unique>.tmp
     with tempfile.NamedTemporaryFile(

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -55,6 +55,50 @@ def _check_metadata(cube: Cube) -> None:
         raise ValueError("{} has unknown units".format(cube.name()))
 
 
+def _horizontal_grid(cube):
+    x = cube.coord(axis="x", dim_coords=True)
+    xdim = cube.coord_dims(x)[0]
+    y = cube.coord(axis="y", dim_coords=True)
+    ydim = cube.coord_dims(y)[0]
+    return xdim, ydim, x, y
+
+
+def _derive_chunksizes(cubelist):
+    derive_chunksize = True
+    rcube = cubelist[0]
+    try:
+        rxdim, rydim, rx, ry = _horizontal_grid(rcube)
+    except iris.exceptions.CoordinateNotFoundError:
+        return None
+
+    if derive_chunksize and len(cubelist) > 1:
+        for cube in cubelist[1:]:
+            # check that chunksizes can apply to the full cubelist
+            try:
+                xdim, ydim, x, y = _horizontal_grid(cube)
+            except iris.exceptions.CoordinateNotFoundError:
+                return None
+            if (
+                cube.ndim != rcube.ndim  # same dimensionality
+                or xdim != rxdim  # same x dimension mapping
+                or ydim != rydim  # same y dimension mapping
+                or cube.shape[xdim] != rcube.shape[rxdim]  # same x dimension size
+                or cube.shape[ydim] != rcube.shape[rydim]  # same y dimension size
+            ):
+                derive_chunksize = False
+                msg = "Chunksize not set as cubelist contains cubes of varying x-y shape/mapping"
+                warnings.warn(msg)
+                break
+
+    if derive_chunksize and rcube.ndim >= 2:
+        # If all xy slices are the same shape, use this to determine
+        # the chunksize for the netCDF (eg. 1, 1, 970, 1042)
+        chunksizes = [1] * rcube.ndim
+        chunksizes[rxdim] = rcube.shape[rxdim]
+        chunksizes[rydim] = rcube.shape[rydim]
+    return chunksizes if derive_chunksize else None
+
+
 def save_netcdf(
     cubelist: Union[Cube, CubeList],
     filename: str,
@@ -95,7 +139,8 @@ def save_netcdf(
             Whether to use HDF5 shuffle filter. Default is True (iris default is False).
         chunksizes:
             Tuple defining chunk sizes for the output file. If None (default),
-            automatically determined as (1, 1, x, y) if all cubes have the same xy shape.
+            automatically determined as a 1 for all dimensions except the x and y
+            dimensions, which are set to the full size of the x and y dimensions.
         **kwargs:
             Additional keyword arguments to pass to iris.fileformats.netcdf.save.
 
@@ -145,35 +190,7 @@ def save_netcdf(
         _cube_attributes_for_save(cube)
 
     if chunksizes is None:
-        rcube = cubelist[0]
-        rx = rcube.coord(axis="x", dim_coords=True)
-        rxdim = rcube.coord_dims(rx)[0]
-        ry = rcube.coord(axis="y", dim_coords=True)
-        rydim = rcube.coord_dims(ry)[0]
-        apply_chunksize = True
-        if len(cubelist) > 1:
-            for cube in cubelist[1:]:
-                # check that chunksizes can apply to the full cubelist
-                xdim = cube.coord(axis="x", dim_coords=True)[0]
-                ydim = cube.coord(axis="y", dim_coords=True)[0]
-                if (
-                    cube.ndim != rcube.ndim
-                    or xdim != rxdim
-                    or ydim != rydim
-                    or cube.shape[xdim] != rcube.shape[rxdim]
-                    or cube.shape[ydim] != rcube.shape[rydim]
-                ):
-                    apply_chunksize = False
-                    msg = "Chunksize not set as cubelist contains cubes of varying x-y shape/mapping"
-                    warnings.warn(msg)
-                    break
-
-        if apply_chunksize and rcube.ndim >= 2:
-            # If all xy slices are the same shape, use this to determine
-            # the chunksize for the netCDF (eg. 1, 1, 970, 1042)
-            chunksizes = [1] * rcube.ndim
-            chunksizes[rxdim] = rcube.shape[rxdim]
-            chunksizes[rydim] = rcube.shape[rydim]
+        chunksizes = _derive_chunksizes(cubelist)
 
     # save atomically by writing to a unique temporary file of the form <filename>-<unique>.tmp
     with tempfile.NamedTemporaryFile(

--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -7,7 +7,7 @@
 import os
 import tempfile
 import warnings
-from typing import Optional, Union
+from typing import Union
 
 import cf_units
 import iris
@@ -15,6 +15,7 @@ import iris.fileformats
 from iris.cube import Cube, CubeAttrsDict, CubeList
 
 from improver.metadata.check_datatypes import check_mandatory_standards
+from improver.utilities.common_input_handle import as_cubelist
 
 
 def _order_cell_methods(cube: Cube) -> None:
@@ -57,37 +58,30 @@ def _check_metadata(cube: Cube) -> None:
 def save_netcdf(
     cubelist: Union[Cube, CubeList],
     filename: str,
-    compression_level: int = 1,
-    least_significant_digit: Optional[int] = None,
-    fill_value: Optional[float] = None,
+    **kwargs,
 ) -> None:
-    """Save the input Cube or CubeList as a NetCDF file and check metadata
+    """
+    Save the input Cube or CubeList as a NetCDF file and check metadata
     where required for integrity.
 
     Uses the functionality provided by iris.fileformats.netcdf.save with
     local_keys to record non-global attributes as data attributes rather than
-    global attributes.
+    global attributes.  The save is made with
+    iris.FUTURE.context(save_split_attrs=True).  The following argument
+    defaults for save deviate from iris.fileformats.netcdf.save defaults:
+    - chunksizes are set to (1, 1, x, y) if all cubes have the same xy shape
+      and the chunksizes are not specified in kwargs.
+    - complevel default is 1 (iris default is 4)
+    - zlib is set to True if complevel > 0 (iris default is False)
+    - shuffle is set to True (iris default is False)
 
     Args:
         cubelist:
-            Cube or list of cubes to be saved
+            Cube or CubeList to be saved.
         filename:
             Filename to save input cube(s)
-        compression_level:
-            1-9 to specify compression level, or 0 to not compress (default compress
-            with complevel 1)
-        least_significant_digit:
-            If specified will truncate the data to a precision given by
-            10**(-least_significant_digit), e.g. if least_significant_digit=2, then the data will
-            be quantized to a precision of 0.01 (10**(-2)). See
-            http://www.esrl.noaa.gov/psd/data/gridded/conventions/cdc_netcdf_standard.shtml
-            for details. When used with `compression level`, this will result in lossy
-            compression.
-        fill_value:
-            If specified, will set the fill value for missing data. If not specified,
-            the default fill value for the data type will be used. If the data is not masked then
-            the numpy array's fill value will retain the default value while the _FillValue attribute
-            in the NetCDF file will be updated.
+        **kwargs:
+            Additional keyword arguments to pass to iris.fileformats.netcdf.save.
 
     Raises:
         ValueError:
@@ -96,10 +90,27 @@ def save_netcdf(
     Warns:
         If cubelist contains cubes of varying dimensions.
     """
-    if isinstance(cubelist, iris.cube.Cube):
-        cubelist = iris.cube.CubeList([cubelist])
-    elif not isinstance(cubelist, iris.cube.CubeList):
-        cubelist = iris.cube.CubeList(cubelist)
+    cubelist = as_cubelist(cubelist)
+
+    if "compression_level" in kwargs:
+        warnings.warn(
+            "The 'compression_level' argument is deprecated and will be removed in a future release. "
+            "Please use 'complevel' instead.",
+            DeprecationWarning,
+        )
+    complevel = kwargs.pop("compression_level", None)
+    complevel = kwargs.pop("complevel", complevel)
+    if complevel is None:
+        complevel = 1
+    else:
+        complevel = int(complevel)
+        if complevel not in range(10):
+            # iris does no validation of the compression level, so we do it here
+            raise ValueError(
+                "Compression level must be an integer value between 0 and 9 (0 to disable compression)"
+            )
+    zlib = kwargs.pop("zlib", complevel > 0 if complevel is not None else False)
+    shuffle = kwargs.pop("shuffle", True)
 
     for cube in cubelist:
         _order_cell_methods(cube)
@@ -111,22 +122,18 @@ def save_netcdf(
         cube.attributes.pop("least_significant_digit", None)
         _cube_attributes_for_save(cube)
 
-    # If all xy slices are the same shape, use this to determine
-    # the chunksize for the netCDF (eg. 1, 1, 970, 1042)
-    chunksizes = None
-    if len({cube.shape[:2] for cube in cubelist}) == 1:
-        cube = cubelist[0]
-        if cube.ndim >= 2:
-            xy_chunksizes = [cube.shape[-2], cube.shape[-1]]
-            chunksizes = tuple([1] * (cube.ndim - 2) + xy_chunksizes)
-    else:
-        msg = "Chunksize not set as cubelist contains cubes of varying dimensions"
-        warnings.warn(msg)
-
-    if compression_level not in range(10):
-        raise ValueError(
-            "Compression level must be an integer value between 0 and 9 (0 to disable compression)"
-        )
+    chunksizes = kwargs.pop("chunksizes", None)
+    if chunksizes is None:
+        if len({cube.shape[:2] for cube in cubelist}) == 1:
+            cube = cubelist[0]
+            if cube.ndim >= 2:
+                # If all xy slices are the same shape, use this to determine
+                # the chunksize for the netCDF (eg. 1, 1, 970, 1042)
+                xy_chunksizes = [cube.shape[-2], cube.shape[-1]]
+                chunksizes = tuple([1] * (cube.ndim - 2) + xy_chunksizes)
+        else:
+            msg = "Chunksize not set as cubelist contains cubes of varying dimensions"
+            warnings.warn(msg)
 
     # save atomically by writing to a unique temporary file of the form <filename>-<unique>.tmp
     with tempfile.NamedTemporaryFile(
@@ -139,12 +146,11 @@ def save_netcdf(
             iris.fileformats.netcdf.save(
                 cubelist,
                 tmp_filename,
-                complevel=compression_level,
-                shuffle=True,
-                zlib=compression_level > 0,
+                complevel=complevel,
+                shuffle=shuffle,
+                zlib=zlib,
                 chunksizes=chunksizes,
-                least_significant_digit=least_significant_digit,
-                fill_value=fill_value,
+                **kwargs,
             )
         os.rename(tmp_filename, filename)
         os.chmod(filename, 0o644)

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -683,7 +683,7 @@ def create_netcdf_file(tmp_path):
     output_dir = tmp_path / "netcdf_files"
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = str(output_dir / "forecast.nc")
-    save_netcdf(cubelist=cube, filename=output_path, compression_level=0)
+    save_netcdf(cubelist=cube, filename=output_path, complevel=0)
 
     return cube, output_path
 

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -194,7 +194,9 @@ class Test_with_output(unittest.TestCase):
         compression_level=1 and default least_significant_digit=None"""
         save_object = Cube([0])
         result = wrapped_with_output.cli("argv[0]", [save_object], "--output=foo")
-        m.assert_called_with(save_object, "foo", 1, None)
+        m.assert_called_with(
+            save_object, "foo", complevel=1, least_significant_digit=None
+        )
         self.assertEqual(result, None)
 
     @patch("os.rename")
@@ -214,7 +216,9 @@ class Test_with_output(unittest.TestCase):
         result = wrapped_with_output.cli(
             "argv[0]", [save_object], "--output=foo", "--compression-level=9"
         )
-        m.assert_called_with(save_object, "foo", 9, None)
+        m.assert_called_with(
+            save_object, "foo", complevel=9, least_significant_digit=None
+        )
         self.assertEqual(result, None)
 
     @patch("improver.utilities.save.save_netcdf")
@@ -224,7 +228,9 @@ class Test_with_output(unittest.TestCase):
         result = wrapped_with_output.cli(
             "argv[0]", [save_object], "--output=foo", "--compression-level=0"
         )
-        m.assert_called_with(save_object, "foo", 0, None)
+        m.assert_called_with(
+            save_object, "foo", complevel=0, least_significant_digit=None
+        )
         self.assertEqual(result, None)
 
     @patch("improver.utilities.save.save_netcdf")
@@ -238,7 +244,7 @@ class Test_with_output(unittest.TestCase):
             "--compression-level=0",
             "--least-significant-digit=2",
         )
-        m.assert_called_with(save_object, "foo", 0, 2)
+        m.assert_called_with(save_object, "foo", complevel=0, least_significant_digit=2)
         self.assertEqual(result, None)
 
 

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -7,6 +7,7 @@
 import copy
 import os
 import unittest
+import unittest.mock
 from datetime import datetime
 from tempfile import mkdtemp
 
@@ -98,7 +99,7 @@ class Test_save_netcdf(unittest.TestCase):
     def test_compression_level(self):
         """Test data gets compressed with complevel provided by compression_level
         when saved"""
-        save_netcdf(self.cube, self.filepath, compression_level=3)
+        save_netcdf(self.cube, self.filepath, complevel=3)
 
         data = Dataset(self.filepath, mode="r")
         filters = data.variables["air_temperature"].filters()
@@ -108,7 +109,7 @@ class Test_save_netcdf(unittest.TestCase):
 
     def test_no_compression(self):
         """Test data does not get compressed when saved with compression_level 0"""
-        save_netcdf(self.cube, self.filepath, compression_level=0)
+        save_netcdf(self.cube, self.filepath, complevel=0)
 
         data = Dataset(self.filepath, mode="r")
         filters = data.variables["air_temperature"].filters()
@@ -118,12 +119,14 @@ class Test_save_netcdf(unittest.TestCase):
     def test_compression_level_invalid(self):
         """Test ValueError raised when invalid compression_level"""
         with self.assertRaises(ValueError):
-            save_netcdf(self.cube, self.filepath, compression_level="one")
+            save_netcdf(self.cube, self.filepath, complevel="one")
 
     def test_compression_level_out_of_range(self):
         """Test ValueError raised when compression_level out of range"""
-        with self.assertRaises(ValueError):
-            save_netcdf(self.cube, self.filepath, compression_level=10)
+        with self.assertRaises(
+            ValueError, match="Compression level must be an integer value"
+        ):
+            save_netcdf(self.cube, self.filepath, complevel=10)
 
     def test_basic_cube_list(self):
         """
@@ -292,7 +295,7 @@ def test_least_significant_digit(bitshaving_cube, tmp_path, lsd, compress):
     save_netcdf(
         bitshaving_cube,
         filepath,
-        compression_level=compress,
+        complevel=compress,
         least_significant_digit=lsd,
     )
 
@@ -425,6 +428,125 @@ def test_save_netcdf_succeeds_with_int_time_dtype(tmp_path):
 
     save_netcdf(result_cube, filepath)
     assert filepath.exists()
+
+
+@unittest.mock.patch("iris.fileformats.netcdf.save")
+def test_default_values(mock_save):
+    """Test default values provided to iris save function are set correctly"""
+    cubes = iris.cube.CubeList([set_up_test_cube()])
+    save_netcdf(cubes, "test.nc")
+    assert mock_save.call_args[0][0] == cubes
+    assert mock_save.call_args[1] == {
+        "complevel": 1,
+        "shuffle": True,
+        "zlib": True,
+        "chunksizes": [1, 3, 3],
+    }
+
+
+@unittest.mock.patch("iris.fileformats.netcdf.save")
+def test_deviation_from_default(mock_save):
+    """Test that non-default values provided to iris save function are set correctly"""
+    cubes = iris.cube.CubeList([set_up_test_cube()])
+    shuffle = False
+    chunksizes = (1, 2, 2)
+    zlib = False
+    complevel = 3
+    save_netcdf(
+        cubes,
+        "test.nc",
+        complevel=complevel,
+        zlib=zlib,
+        shuffle=shuffle,
+        chunksizes=chunksizes,
+    )
+    assert mock_save.call_args[0][0] == cubes
+    assert mock_save.call_args[1] == {
+        "complevel": complevel,
+        "shuffle": shuffle,
+        "zlib": zlib,
+        "chunksizes": chunksizes,
+    }
+
+
+def _transpose(cube, order):
+    ncube = cube.copy()
+    ncube.transpose(order)
+    return ncube
+
+
+testdata = [
+    (
+        set_up_variable_cube(
+            np.ones((1, 4, 3), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+        set_up_variable_cube(
+            np.ones((2, 4, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+    ),
+    (
+        set_up_variable_cube(
+            np.ones((1, 3, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+        set_up_variable_cube(
+            np.ones((2, 4, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+    ),
+    (
+        set_up_variable_cube(
+            np.ones((4, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+        set_up_variable_cube(
+            np.ones((1, 4, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+    ),
+    (
+        _transpose(
+            set_up_variable_cube(
+                np.ones((4, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+            ),
+            [1, 0],
+        ),
+        set_up_variable_cube(
+            np.ones((4, 4), dtype=np.float32), standard_grid_metadata="uk_ens"
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "cube1,cube2",
+    testdata,
+    ids=[
+        "different_y_shapes",
+        "different_x_shapes",
+        "different_ndims",
+        "different_xy_mapping",
+    ],
+)
+@unittest.mock.patch("iris.fileformats.netcdf.save")
+def test_chunksizes_not_set(mock_save, cube1, cube2):
+    """Test that chunksizes are not set based on some condition not met."""
+    cubelist = iris.cube.CubeList([cube1, cube2])
+    with pytest.warns(UserWarning, match=r"Chunksize not set"):
+        save_netcdf(cubelist, "test.nc")
+    assert mock_save.call_args[1]["chunksizes"] is None
+
+
+@unittest.mock.patch("iris.fileformats.netcdf.save")
+def test_compression_level_deprecated(mock_save):
+    """
+    Test that compression_level deprecation warning is issues
+    but overrides complevel usage
+    """
+    cubes = iris.cube.CubeList([set_up_test_cube()])
+    with pytest.warns(
+        DeprecationWarning, match=r"The 'compression_level' argument is deprecated"
+    ):
+        save_netcdf(cubes, "test.nc", complevel=2, compression_level=3)
+    assert mock_save.call_args[0][0] == cubes
+    assert mock_save.call_args[1]["complevel"] == 3
+    assert "compression_level" not in mock_save.call_args[1]
 
 
 if __name__ == "__main__":

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -516,23 +516,16 @@ testdata = [
 ]
 
 
-@pytest.mark.parametrize(
-    "cube1,cube2",
-    testdata,
-    ids=[
-        "different_y_shapes",
-        "different_x_shapes",
-        "different_ndims",
-        "different_xy_mapping",
-    ],
-)
-@unittest.mock.patch("iris.fileformats.netcdf.save")
-def test_chunksizes_not_set(mock_save, cube1, cube2):
+def test_chunksizes_not_set():
     """Test that chunksizes are not set based on some condition not met."""
-    cubelist = iris.cube.CubeList([cube1, cube2])
-    with pytest.warns(UserWarning, match=r"Chunksize not set"):
-        save_netcdf(cubelist, "test.nc")
-    assert mock_save.call_args[1]["chunksizes"] is None
+    # Note that pytest.mark.parametrize causes a segmentation fault in this case with
+    # our cubes.
+    for cube1, cube2 in testdata:
+        cubelist = iris.cube.CubeList([cube1, cube2])
+        with unittest.mock.patch("iris.fileformats.netcdf.save") as mock_save:
+            with pytest.warns(UserWarning, match=r"Chunksize not set"):
+                save_netcdf(cubelist, "test.nc")
+            assert mock_save.call_args[1]["chunksizes"] is None
 
 
 @unittest.mock.patch("iris.fileformats.netcdf.save")

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -559,5 +559,21 @@ def test_complevel_float(mock_save):
         save_netcdf(cubes, "test.nc", complevel=2.5)
 
 
+@unittest.mock.patch("iris.fileformats.netcdf.save")
+def test_chunksizes_aux_xy_coord(mock_save):
+    """Test that chunksizes are not set when x and y are not dimension coordinates."""
+    cube = set_up_variable_cube(
+        np.ones((3, 4, 4), dtype=np.float32),
+        standard_grid_metadata="uk_ens",
+    )
+    x = cube.coord(axis="x")
+    iris.util.demote_dim_coord_to_aux_coord(cube, x.name())
+    y = cube.coord(axis="y")
+    iris.util.demote_dim_coord_to_aux_coord(cube, y.name())
+    cubes = iris.cube.CubeList([cube])
+    save_netcdf(cubes, "test.nc")
+    assert mock_save.call_args[1]["chunksizes"] is None
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -433,10 +433,10 @@ def test_save_netcdf_succeeds_with_int_time_dtype(tmp_path):
 
 
 @unittest.mock.patch("iris.fileformats.netcdf.save")
-def test_default_values(mock_save):
+def test_default_values(mock_save, tmp_path):
     """Test default values provided to iris save function are set correctly"""
     cubes = iris.cube.CubeList([set_up_test_cube()])
-    save_netcdf(cubes, "test.nc")
+    save_netcdf(cubes, tmp_path / "test.nc")
     assert mock_save.call_args[0][0] == cubes
     assert mock_save.call_args[1] == {
         "complevel": 1,
@@ -447,7 +447,7 @@ def test_default_values(mock_save):
 
 
 @unittest.mock.patch("iris.fileformats.netcdf.save")
-def test_deviation_from_default(mock_save):
+def test_deviation_from_default(mock_save, tmp_path):
     """Test that non-default values provided to iris save function are set correctly"""
     cubes = iris.cube.CubeList([set_up_test_cube()])
     shuffle = False
@@ -456,7 +456,7 @@ def test_deviation_from_default(mock_save):
     complevel = 3
     save_netcdf(
         cubes,
-        "test.nc",
+        tmp_path / "test.nc",
         complevel=complevel,
         zlib=zlib,
         shuffle=shuffle,
@@ -516,7 +516,7 @@ testdata = [
 ]
 
 
-def test_chunksizes_not_set():
+def test_chunksizes_not_set(tmp_path):
     """Test that chunksizes are not set based on some condition not met."""
     # Note that pytest.mark.parametrize causes a segmentation fault in this case with
     # our cubes.
@@ -524,12 +524,12 @@ def test_chunksizes_not_set():
         cubelist = iris.cube.CubeList([cube1, cube2])
         with unittest.mock.patch("iris.fileformats.netcdf.save") as mock_save:
             with pytest.warns(UserWarning, match=r"Chunksize not set"):
-                save_netcdf(cubelist, "test.nc")
+                save_netcdf(cubelist, tmp_path / "test.nc")
             assert mock_save.call_args[1]["chunksizes"] is None
 
 
 @unittest.mock.patch("iris.fileformats.netcdf.save")
-def test_compression_level_deprecated(mock_save):
+def test_compression_level_deprecated(mock_save, tmp_path):
     """
     Test that compression_level deprecation warning is issues
     but overrides complevel usage
@@ -538,22 +538,22 @@ def test_compression_level_deprecated(mock_save):
     with pytest.warns(
         DeprecationWarning, match=r"The 'compression_level' argument is deprecated"
     ):
-        save_netcdf(cubes, "test.nc", complevel=2, compression_level=3)
+        save_netcdf(cubes, tmp_path / "test.nc", complevel=2, compression_level=3)
     assert mock_save.call_args[0][0] == cubes
     assert mock_save.call_args[1]["complevel"] == 3
     assert "compression_level" not in mock_save.call_args[1]
 
 
 @unittest.mock.patch("iris.fileformats.netcdf.save")
-def test_complevel_float(mock_save):
+def test_complevel_float(mock_save, tmp_path):
     """Test that complevel that is a float raises a ValueError"""
     cubes = iris.cube.CubeList([set_up_test_cube()])
     with pytest.raises(ValueError, match="Compression level must be an integer value"):
-        save_netcdf(cubes, "test.nc", complevel=2.5)
+        save_netcdf(cubes, tmp_path / "test.nc", complevel=2.5)
 
 
 @unittest.mock.patch("iris.fileformats.netcdf.save")
-def test_chunksizes_aux_xy_coord(mock_save):
+def test_chunksizes_aux_xy_coord(mock_save, tmp_path):
     """Test that chunksizes are not set when x and y are not dimension coordinates."""
     cube = set_up_variable_cube(
         np.ones((3, 4, 4), dtype=np.float32),
@@ -564,7 +564,7 @@ def test_chunksizes_aux_xy_coord(mock_save):
     y = cube.coord(axis="y")
     iris.util.demote_dim_coord_to_aux_coord(cube, y.name())
     cubes = iris.cube.CubeList([cube])
-    save_netcdf(cubes, "test.nc")
+    save_netcdf(cubes, tmp_path / "test.nc")
     assert mock_save.call_args[1]["chunksizes"] is None
 
 

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -118,12 +118,14 @@ class Test_save_netcdf(unittest.TestCase):
 
     def test_compression_level_invalid(self):
         """Test ValueError raised when invalid compression_level"""
-        with self.assertRaises(ValueError):
+        with pytest.raises(
+            ValueError, match="Compression level must be an integer value"
+        ):
             save_netcdf(self.cube, self.filepath, complevel="one")
 
     def test_compression_level_out_of_range(self):
         """Test ValueError raised when compression_level out of range"""
-        with self.assertRaises(
+        with pytest.raises(
             ValueError, match="Compression level must be an integer value"
         ):
             save_netcdf(self.cube, self.filepath, complevel=10)
@@ -547,6 +549,14 @@ def test_compression_level_deprecated(mock_save):
     assert mock_save.call_args[0][0] == cubes
     assert mock_save.call_args[1]["complevel"] == 3
     assert "compression_level" not in mock_save.call_args[1]
+
+
+@unittest.mock.patch("iris.fileformats.netcdf.save")
+def test_complevel_float(mock_save):
+    """Test that complevel that is a float raises a ValueError"""
+    cubes = iris.cube.CubeList([set_up_test_cube()])
+    with pytest.raises(ValueError, match="Compression level must be an integer value"):
+        save_netcdf(cubes, "test.nc", complevel=2.5)
 
 
 if __name__ == "__main__":

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -442,7 +442,7 @@ def test_default_values(mock_save, tmp_path):
         "complevel": 1,
         "shuffle": True,
         "zlib": True,
-        "chunksizes": [1, 3, 3],
+        "chunksizes": (1, 3, 3),
     }
 
 
@@ -536,7 +536,7 @@ def test_compression_level_deprecated(mock_save, tmp_path):
     """
     cubes = iris.cube.CubeList([set_up_test_cube()])
     with pytest.warns(
-        DeprecationWarning, match=r"The 'compression_level' argument is deprecated"
+        FutureWarning, match=r"The 'compression_level' argument is deprecated"
     ):
         save_netcdf(cubes, tmp_path / "test.nc", complevel=2, compression_level=3)
     assert mock_save.call_args[0][0] == cubes


### PR DESCRIPTION
This change retains support for existing use of save while aligning it with `iris.fileformats.netcdf.save`
Enables projects which utilise this function to override the chunking in particular (motivated by EPP).

- `save_netcdf` now passes kwargs to the underlying `iris.fileformats.netcdf.save` function.
- Total refactor of the function as there were significant pre-existing issues:
  - Derivation of chunksizes is now constrained properly without making assumptions of which dimensions the grid are mapped to, or assuming consistent grid shape between cubes within the CubeList.
  - Constrained to dimension grid coordinates.
  - `save_netcdf` call permutations missing from testing are now tested.
  - `compression_level` keyword argument from `save_netcdf` still supported and takes precedence but is deprecated in order to better align with its name from `iris.fileformats.netcdf.save` (i.e. `complevel`).
  - `with_output` from `improver/cli/__init__.py` has been updated to call `save_netcdf` with `complevel` but `compression_level` keyword argument has been kept the same here so as not to break existing workflows that are reliant on the cli (clize, paraflow).