### PR TITLE
Ensure consistent units of the realization coordinate in RealizationClusterAndMatch

### DIFF
--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1374,7 +1374,8 @@ class RealizationClusterAndMatch(BasePlugin):
             cluster_sources,
             secondary_input_realizations_to_clusters,
         )
-
+        for cube in matched_cubes:
+            cube.coord("realization").units = "1"
         result_cube = MergeCubes()(
             CubeList([iris.util.squeeze(c) for c in matched_cubes])
         )

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1197,7 +1197,8 @@ class RealizationClusterAndMatch(BasePlugin):
         This method clusters the primary input realizations and matches secondary input
         realizations to the resulting clusters, according to the specified hierarchy
         and precedence. The realizations in the primary input can be renumbered
-        if desired.
+        if desired. The units of the realization coordinate are enforced to be
+        dimensionless ("1") to avoid inconsistencies between different forecast sources.
 
         Args:
             cubes: The input CubeList containing all primary and secondary input

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1374,6 +1374,7 @@ class RealizationClusterAndMatch(BasePlugin):
             cluster_sources,
             secondary_input_realizations_to_clusters,
         )
+        # Ensure the realization coordinate has the same units to avoid merge issues.
         for cube in matched_cubes:
             cube.coord("realization").units = "1"
         result_cube = MergeCubes()(

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -1384,7 +1384,9 @@ def test_clusterandmatch_nonmonotonic_realization_slicing_with_full_matching():
     result in the dimension coordinate for the dimension being indexed to be
     demoted to an auxiliary coordinate. This unit test therefore ensures that this
     coordinate is promoted back to a dimension coordinate when the secondary input
-    contains more realizations than the primary input.
+    contains more realizations than the primary input. It also demonstrates that
+    input cubes can carry realization units of "unknown" while processing still
+    succeeds because output realization units are normalised prior to merging.
     """
     pytest.importorskip("kmedoids")
 
@@ -1423,6 +1425,15 @@ def test_clusterandmatch_nonmonotonic_realization_slicing_with_full_matching():
         )
     )
 
+    # Force unknown realization units on the secondary input cubes. After matching,
+    # matched_cubes contains a mix: primary-derived cubes retain units "1" while
+    # secondary-matched cubes inherit units "unknown". The normalisation loop in
+    # RealizationClusterAndMatch.process sets all realization units to "1" before
+    # the final MergeCubes call, which would otherwise fail on this mismatch.
+    for cube in cubes:
+        if cube.attributes.get("model_id") == "secondary_model_1":
+            cube.coord("realization").units = "unknown"
+
     result = RealizationClusterAndMatch(
         hierarchy={
             "primary_input": "primary_model",
@@ -1436,6 +1447,7 @@ def test_clusterandmatch_nonmonotonic_realization_slicing_with_full_matching():
     ).process(cubes)
 
     assert result.coords("realization", dim_coords=True)
+    assert str(result.coord("realization").units) == "1"
     np.testing.assert_array_almost_equal(
         result[0, :, 0, 0].data,
         np.array([100.022, 200.004, 0.023, 300.017], dtype=np.float32), decimal=3

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -1386,7 +1386,7 @@ def test_clusterandmatch_nonmonotonic_realization_slicing_with_full_matching():
     coordinate is promoted back to a dimension coordinate when the secondary input
     contains more realizations than the primary input. It also demonstrates that
     input cubes can carry realization units of "unknown" while processing still
-    succeeds because output realization units are normalised prior to merging.
+    succeeds because output realization units are unified prior to merging.
     """
     pytest.importorskip("kmedoids")
 


### PR DESCRIPTION
Related issues: https://github.com/metoppv/improver/pull/2259, https://github.com/metoppv/improver/pull/2305, https://github.com/metoppv/improver/pull/2332, https://github.com/metoppv/improver/pull/2340, https://github.com/metoppv/improver/pull/2359, https://github.com/metoppv/improver/pull/2361

Description
This PR makes a minor edit to ensure the the realization coordinate units are consistent prior to attempting to merge cubes together from different sources. These forecast sources should have the same units for the realization coordinate, however, this can sometimes not be true, with some forecast sources having a realization coordinate with units of "1" and some forecast sources having a realization coordinate with units of `unknown`. To avoid this resulting in merge failures, the units of the realization coordinate is manually set to "1".

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

