### PR TITLE
Correct equality used in ECC transformation approach

### DIFF
--- a/improver/cli/generate_realizations.py
+++ b/improver/cli/generate_realizations.py
@@ -91,10 +91,10 @@ def process(
             the probability distribution. Type of distribution to fit
             (currently only 'gamma' is supported).
         nan_mask_value (float):
-            Valid if the "transformation" option is selected for
-            sampling the probability distribution. Value to mask as NaN before
-            calculating mean and std. This option might be most useful for a
-            diagnostic, such as precipitation rate, where there is a high
+            Valid if the "transformation" option is selected for sampling the
+            probability distribution. Value to mask (and all values below it)
+            as NaN before calculating mean and std. This option might be most useful
+            for a diagnostic, such as precipitation rate, where there is a high
             frequency of zero values. If None, no masking is performed.
             Default is 0.0.
         scale_percentiles_to_probability_lower_bound (bool):

--- a/improver/ensemble_copula_coupling/utilities.py
+++ b/improver/ensemble_copula_coupling/utilities.py
@@ -71,10 +71,11 @@ class CalculatePercentilesFromIntensityDistribution(BasePlugin):
         Args:
             distribution: Type of distribution to fit
                 (currently only 'gamma' is supported).
-            nan_mask_value: Value to mask as NaN before calculating mean and std.
-                This option might be most useful for a diagnostic, such as
-                precipitation rate, where there is a high frequency of zero values.
-                If None, no masking is performed. Default is 0.0.
+            nan_mask_value: Value to mask (and all values below it) as NaN before
+                calculating mean and std. This option might be most useful for a
+                diagnostic, such as precipitation rate, where there is a high frequency
+                of zero values. Values <= nan_mask_value will be masked. If None, no
+                masking is performed. Default is 0.0.
             scale_percentiles_to_probability_lower_bound: If True, the minimum value
                 of the calculated percentiles will be set to the minimum CDF
                 probability implied by the input probabilities, rather than zero.
@@ -114,8 +115,9 @@ class CalculatePercentilesFromIntensityDistribution(BasePlugin):
         Args:
             percentiles: Array of percentiles to be rescaled.
             probabilities: Array of probabilities for scaling.
-            nan_mask_value: Value to mask as NaN before rescaling. If None,
-                no masking is performed.
+            nan_mask_value: Value to mask (and all values below it) as NaN before
+                rescaling. Values <= nan_mask_value will be masked. If None, no
+                masking is performed.
 
         Returns:
             Rescaled percentiles array.
@@ -126,7 +128,7 @@ class CalculatePercentilesFromIntensityDistribution(BasePlugin):
         lower_limit = cdf_probabilities[0]
         upper_limit = np.ones(lower_limit.shape)
         if nan_mask_value is not None:
-            percentiles_nan[percentiles_nan == nan_mask_value] = np.nan
+            percentiles_nan[percentiles_nan <= nan_mask_value] = np.nan
         percentiles_nan[:, np.all(probabilities == 0, axis=0)] = np.nan
         scaled_percentiles_nan = (
             (upper_limit - lower_limit) * percentiles_nan
@@ -159,7 +161,6 @@ class CalculatePercentilesFromIntensityDistribution(BasePlugin):
             Wilks, D. S., 2019: Statistical Methods in the Atmospheric Sciences,
             Academic Press.
         """
-
         from scipy.stats import gamma
 
         if intensity_cube.ndim < 2:
@@ -170,7 +171,7 @@ class CalculatePercentilesFromIntensityDistribution(BasePlugin):
         # Optionally mask a value as NaN before calculating mean and std
         cube_nan = intensity_cube.copy()
         if self.nan_mask_value is not None:
-            cube_nan.data[cube_nan.data == self.nan_mask_value] = np.nan
+            cube_nan.data[cube_nan.data <= self.nan_mask_value] = np.nan
         mean = np.nanmean(cube_nan.data, axis=0)
         std = np.nanstd(cube_nan.data, axis=0)
         # Avoid zero mean or std causing issues.
@@ -247,8 +248,9 @@ def choose_set_of_percentiles(
         probability_cube: Cube containing probability data at a range of thresholds.
         intensity_cube: Cube containing the intensity data to be mapped to percentiles.
         distribution: Type of distribution to fit (currently only 'gamma' is supported).
-        nan_mask_value: Value to mask as NaN before calculating mean and std.
-            If None, no masking is performed. Default is 0.0.
+        nan_mask_value: Value to mask (and all values below it) as NaN before
+            calculating mean and std. Values <= nan_mask_value will be masked. If None,
+            no masking is performed. Default is 0.0.
         scale_percentiles_to_probability_lower_bound: If True, the minimum value
             of the calculated percentiles will be set to the minimum CDF
             probability implied by the input probabilities, rather than zero.

--- a/improver_tests/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_utilities.py
@@ -895,6 +895,77 @@ def test_process_2d_spot_data(rescale, nan_mask_value):
     np.testing.assert_array_almost_equal(result, expected, decimal=3)
 
 
+def test_process_negative_values_masked_with_nan_mask_value():
+    """Test that negative values (representing stochastic noise) are masked when
+    nan_mask_value is set, and do not contribute to gamma distribution fitting.
+
+    This tests the fix for ensuring that negative stochastic noise values used only
+    for ensemble reordering are excluded from gamma distribution mean/std calculation.
+    When nan_mask_value <= 0 is set, values <= 0 should be masked as NaN before
+    computing mean and std.
+    """
+    # Create intensity data with negative stochastic noise mixed with positive values
+    # Column 1: [-0.3, 4.0, 6.0] - negative noise masked, mean/std from [4.0, 6.0]
+    # Column 2: [2.0, 8.0, 10.0] - all positive, mean/std from all values
+    intensity_data = np.array(
+        [
+            [-0.3, 2.0],  # Negative noise (should be masked), positive value
+            [4.0, 8.0],
+            [6.0, 10.0],
+        ],
+        dtype=np.float32,
+    )
+
+    thresholds = [0.5, 1.0, 2.0, 4.0]
+    probability_data = np.array(
+        [
+            [[0.6, 0.9]],
+            [[0.5, 0.6]],
+            [[0.4, 0.4]],
+            [[0.3, 0.3]],
+        ],
+        dtype=np.float32,
+    )
+
+    intensity_cube, probability_cube = _create_intensity_and_probability_cubes(
+        intensity_data, thresholds, probability_data
+    )
+
+    # Process with nan_mask_value=0.0 (should mask values <= 0.0)
+    plugin = CalculatePercentilesFromIntensityDistribution(
+        nan_mask_value=0.0,
+        scale_percentiles_to_probability_lower_bound=False,
+    )
+
+    result = plugin.process(probability_cube, intensity_cube)
+
+    # Verify result shape and type
+    assert isinstance(result, np.ndarray)
+    assert result.shape == intensity_data.shape
+    assert result.dtype == np.float32
+
+    # The key assertion: negative values in input produce very low percentiles (near 0)
+    # because gamma CDF on negative values returns 0. This confirms negative values
+    # are masked in mean/std calculation but still evaluated by gamma CDF.
+    # The left column has a negative value (-0.3), so its first row should be near 0.
+    np.testing.assert_allclose(
+        result[0, 0],
+        0.0,
+        atol=1e-6,
+        err_msg="Negative intensity value should map to approximately zero in gamma CDF",
+    )
+    # The right column has positive value (2.0) and should map to a percentile
+    # close to 0.037 for this test setup.
+    np.testing.assert_allclose(
+        result[0, 1],
+        0.037,
+        atol=1e-3,
+        err_msg="Positive intensity value should map to approximately 0.037",
+    )
+    # Check that all values are finite
+    assert np.all(np.isfinite(result))
+
+
 def test_process_1d_input_raises_error():
     """Test that process method with 1D input raises appropriate error."""
     from iris.cube import Cube

--- a/improver_tests/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_utilities.py
@@ -953,7 +953,10 @@ def test_process_negative_values_masked_with_nan_mask_value():
         result[:, 0],
         [0.0, 0.157, 0.843],
         atol=1e-3,
-        err_msg="Negative intensity value should map to zero in gamma CDF",
+        err_msg=(
+            "Negative intensity value should map to zero, and positive values "
+            "to 0.157 and 0.843 in gamma CDF"
+        ),
     )
 
     # The right column has positive values [2.0, 8.0, 10.0] and should map to quantiles

--- a/improver_tests/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_utilities.py
@@ -944,23 +944,30 @@ def test_process_negative_values_masked_with_nan_mask_value():
     assert result.shape == intensity_data.shape
     assert result.dtype == np.float32
 
-    # The key assertion: negative values in input produce very low percentiles (near 0)
-    # because gamma CDF on negative values returns 0. This confirms negative values
-    # are masked in mean/std calculation but still evaluated by gamma CDF.
-    # The left column has a negative value (-0.3), so its first row should be near 0.
+    # Negative values in input are masked ahead of gamma distribution fitting.
+    # The left column has negative values [-0.3, 4.0, 6.0], so only [4.0, 6.0] are used
+    # for mean/std calculation. The negative value maps to a percentile value of
+    # 0.0 (0th percentile), 4.0 maps to 0.157 (15.7th percentile) and 6 maps to 0.843
+    # (84.3rd percentile).
     np.testing.assert_allclose(
-        result[0, 0],
-        0.0,
-        atol=1e-6,
-        err_msg="Negative intensity value should map to approximately zero in gamma CDF",
-    )
-    # The right column has positive value (2.0) and should map to a percentile
-    # close to 0.037 for this test setup.
-    np.testing.assert_allclose(
-        result[0, 1],
-        0.037,
+        result[:, 0],
+        [0.0, 0.157, 0.843],
         atol=1e-3,
-        err_msg="Positive intensity value should map to approximately 0.037",
+        err_msg="Negative intensity value should map to zero in gamma CDF",
+    )
+
+    # The right column has positive values [2.0, 8.0, 10.0] and should map to quantiles
+    # close to 0.037 (3.7th percentile), 0.704 (70.4th percentile),
+    # 0.846 (84.6th percentile) for this test setup i.e. where a gamma distribution
+    # is approximated using the mean and standard deviation of [2.0, 8.0, 10.0].
+    np.testing.assert_allclose(
+        result[:, 1],
+        [0.037, 0.704, 0.846],
+        atol=1e-3,
+        err_msg=(
+            "Positive intensity values should map to approximately 0.037, 0.704, "
+            "0.846 in gamma CDF"
+        ),
     )
     # Check that all values are finite
     assert np.all(np.isfinite(result))

--- a/improver_tests/ensemble_copula_coupling/test_utilities.py
+++ b/improver_tests/ensemble_copula_coupling/test_utilities.py
@@ -972,8 +972,6 @@ def test_process_negative_values_masked_with_nan_mask_value():
             "0.846 in gamma CDF"
         ),
     )
-    # Check that all values are finite
-    assert np.all(np.isfinite(result))
 
 
 def test_process_1d_input_raises_error():


### PR DESCRIPTION
Related issues: https://github.com/metoppv/improver/pull/2303

Description
This PR modifies an equality that is used as part of the gamma distribution fitting, which is part of the ECC transformation approach, where a gamma distribution is fitted for each grid point. The issue was that stochastic noise (as a negative value) had been added to the realization forecast prior to this step, however, this negative stochastic noise wasn't intended to affect the gamma distribution fitting, which has only intended for "real" precipitation forecast values. The presence of negative values in the inputs was skewing the mean and standard deviation estimate for the gamma distribution and giving output that didn't look quite as intended i.e. higher precipitation values than expected. To address this the equality used when considering the `nan_mask_value` argument has been made "<=", so that values equal to and less than this value will be set to NaN for the gamma distribution fitting section.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

