### PR TITLE
Fix cluster matching for "partial" secondary inputs

### DIFF
--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1126,23 +1126,36 @@ class RealizationClusterAndMatch(BasePlugin):
                 **{self.model_id_attr: candidate_name}
             )
 
+            # Perform matching once across ALL forecast periods so that each
+            # realization is assigned to the same cluster at every lead time.
+            # This mirrors how _process_full_realization_inputs works.
+            fp_constr_all = iris.Constraint(forecast_period=forecast_periods)
+            all_candidate_cubes = cubes.extract(model_id_constr & fp_constr_all)
+            merged_candidate_cube = MergeCubes()(all_candidate_cubes)
+            enforce_coordinate_ordering(merged_candidate_cube, ["realization"])
+            merged_candidate_cube = self._ensure_forecast_period_is_dimension(
+                merged_candidate_cube
+            )
+            regridded_merged_candidate_cube = self._maybe_regrid_candidate_cube(
+                merged_candidate_cube, target_grid_cube
+            )
+            clustered_all_fps_cube = regridded_clustered_primary_cube.extract(
+                fp_constr_all
+            )
+            clustered_all_fps_cube = self._ensure_forecast_period_is_dimension(
+                clustered_all_fps_cube
+            )
+            cluster_indices, realization_indices = RealizationToClusterMatcher()(
+                clustered_all_fps_cube,
+                regridded_merged_candidate_cube,
+            )
+
             for fp in forecast_periods:
                 fp_constr = iris.Constraint(forecast_period=fp)
                 candidate_cube = cubes.extract_cube(model_id_constr & fp_constr)
 
-                regridded_candidate_cube = self._maybe_regrid_candidate_cube(
-                    candidate_cube, target_grid_cube
-                )
-
-                # Get the matching cluster indices from the matcher
-                clustered_fp_cube = regridded_clustered_primary_cube.extract(fp_constr)
-
-                cluster_indices, realization_indices = RealizationToClusterMatcher()(
-                    clustered_fp_cube,
-                    regridded_candidate_cube,
-                )
-
-                # Index the candidate cube using the realization indices
+                # Index the candidate cube using the realization indices determined
+                # from the combined match across all forecast periods.
                 matched_cube = candidate_cube[realization_indices]
                 matched_cube.coord("realization").points = cluster_indices
 

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -697,6 +697,15 @@ class RealizationClusterAndMatch(BasePlugin):
             ]
             valid_fp_cube_pairs = sorted(valid_fp_cube_pairs, key=lambda x: x[0])
 
+            if not valid_fp_cube_pairs:
+                warnings.warn(
+                    f"Secondary input '{candidate_name}' has no forecast periods "
+                    "that overlap with primary input "
+                    f"'{self.hierarchy['primary_input']}'. This input will be skipped.",
+                    UserWarning,
+                )
+                continue  # No valid forecast periods after filtering
+
             # Track forecast periods in requested range but missing from primary input.
             secondary_fps = {fp for fp, _ in fp_cube_pairs}
             missing_fps = secondary_fps - primary_fps
@@ -707,15 +716,6 @@ class RealizationClusterAndMatch(BasePlugin):
                     f"{sorted(missing_fps)} not present in primary input. "
                     "These will be ignored."
                 )
-
-            if not valid_fp_cube_pairs:
-                warnings.warn(
-                    f"Secondary input '{candidate_name}' has no forecast periods "
-                    "that overlap with primary input "
-                    f"'{self.hierarchy['primary_input']}'. This input will be skipped.",
-                    UserWarning,
-                )
-                continue  # No valid forecast periods after filtering
 
             # Determine the expected realization count from the earliest valid
             # forecast period and truncate this secondary input if the count changes
@@ -853,7 +853,7 @@ class RealizationClusterAndMatch(BasePlugin):
                 cluster_sources[cluster_idx][candidate_name].append(fp)
 
     def _maybe_regrid_candidate_cube(
-        self, candidate_cube: Cube, target_grid_cube: Cube
+        self, candidate_cube: Cube, target_grid_cube: Cube | None
     ) -> Cube:
         """Regrid the candidate cube if regrid_for_clustering is True, otherwise
         return as is.
@@ -861,7 +861,7 @@ class RealizationClusterAndMatch(BasePlugin):
         Args:
             candidate_cube: The input candidate Cube to potentially regrid.
             target_grid_cube: The target grid Cube to regrid onto if regridding
-                is enabled.
+                is enabled. Can be None when regrid_for_clustering is False.
 
         Returns:
             The regridded candidate Cube if regrid_for_clustering is True, otherwise
@@ -1009,10 +1009,14 @@ class RealizationClusterAndMatch(BasePlugin):
         """Record tracking metadata after matching a secondary input at one forecast
         period.
 
-        Updates replaced_realizations, cluster_sources, and
-        secondary_input_realizations_to_clusters in-place. Called from the
-        per-forecast-period loop in both _process_full_realization_inputs and
-        _process_partial_realization_inputs.
+        Updates the following variables in-place: replaced_realizations,
+        cluster_sources, and secondary_input_realizations_to_clusters. These
+        variables are used to track which clusters have been replaced, which model
+        provided data for each cluster, and which secondary realizations correspond to
+        each cluster, respectively. This information will be added later as attributes
+        to the final output cube.
+        Called from the per-forecast-period loop in both
+        _process_full_realization_inputs and _process_partial_realization_inputs.
 
         Args:
             fp: Forecast period in seconds.
@@ -1048,7 +1052,7 @@ class RealizationClusterAndMatch(BasePlugin):
         candidate_name: str,
         fps: list[int],
         cubes: CubeList,
-        target_grid_cube: Cube,
+        target_grid_cube: Cube | None,
         regridded_clustered_primary_cube: Cube,
         ensure_fp_dim: bool = False,
     ) -> tuple[list[int], list[int], Cube]:
@@ -1063,7 +1067,8 @@ class RealizationClusterAndMatch(BasePlugin):
             candidate_name: Name of the secondary input.
             fps: Forecast period values in seconds to extract.
             cubes: CubeList containing all input cubes.
-            target_grid_cube: Target grid cube for optional regridding.
+            target_grid_cube: Target grid cube for optional regridding. Can be
+                None when regrid_for_clustering is False.
             regridded_clustered_primary_cube: The regridded clustered primary cube.
             ensure_fp_dim: If True, promote forecast_period to a dimension coordinate
                 on both the candidate and primary slices before matching. Required
@@ -1101,7 +1106,7 @@ class RealizationClusterAndMatch(BasePlugin):
         self,
         full_realization_inputs: list[tuple[str, list[int]]],
         cubes: CubeList,
-        target_grid_cube: Cube,
+        target_grid_cube: Cube | None,
         regridded_clustered_primary_cube: Cube,
         replaced_realizations: dict[int, set[int]],
         matched_cubes: CubeList,
@@ -1119,7 +1124,8 @@ class RealizationClusterAndMatch(BasePlugin):
             full_realization_inputs: List of (name, forecast_periods) tuples for
                 inputs with full realization sets.
             cubes: The input CubeList containing all data.
-            target_grid_cube: The target grid cube for regridding.
+            target_grid_cube: The target grid cube for regridding. Can be None
+                when regrid_for_clustering is False.
             regridded_clustered_primary_cube: The regridded clustered primary cube.
             replaced_realizations: Dictionary tracking which (forecast_period, cluster)
                 pairs have been replaced. Modified in-place.
@@ -1205,7 +1211,7 @@ class RealizationClusterAndMatch(BasePlugin):
         self,
         partial_realization_inputs: list[tuple[str, list[int]]],
         cubes: CubeList,
-        target_grid_cube: Cube,
+        target_grid_cube: Cube | None,
         regridded_clustered_primary_cube: Cube,
         replaced_realizations: dict[int, set[int]],
         matched_cubes: CubeList,
@@ -1226,7 +1232,8 @@ class RealizationClusterAndMatch(BasePlugin):
                 for clustering and matching. Each cube must have the model_id_attr
                 attribute set, and all relevant models, forecast periods, and
                 realizations to be processed or matched should be included.
-            target_grid_cube: The target grid cube for regridding.
+            target_grid_cube: The target grid cube for regridding. Can be None
+                when regrid_for_clustering is False.
             regridded_clustered_primary_cube: The regridded clustered primary cube.
             replaced_realizations: Dictionary tracking which (forecast_period, cluster)
                 pairs have been replaced. Modified in-place.

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -657,6 +657,15 @@ class RealizationClusterAndMatch(BasePlugin):
                     for the relevant forecast periods. The forecast_periods are the
                     forecast periods (in seconds) that exist in the cubes within the
                     specified hour range and are present in the primary input.
+
+        Warns:
+            UserWarning: If a secondary input has forecast periods not present in
+                the primary input; those periods are ignored.
+            UserWarning: If a secondary input has no forecast periods that overlap
+                with the primary input; that input is skipped entirely.
+            UserWarning: If a secondary input has an inconsistent realization count
+                compared to its earliest valid forecast period; all forecast periods
+                from the first mismatch onwards are dropped for that input.
         """
         full_realization_inputs = []
         partial_realization_inputs = []
@@ -676,13 +685,20 @@ class RealizationClusterAndMatch(BasePlugin):
             if not model_cubes:
                 continue  # No cubes found in this range for this model
 
-            # Get all forecast periods present in the cubes
-            forecast_periods_in_range = [
-                int(cube.coord("forecast_period").points.item()) for cube in model_cubes
+            # Get forecast period and cube pairs for this model.
+            fp_cube_pairs = [
+                (int(cube.coord("forecast_period").points.item()), cube)
+                for cube in model_cubes
             ]
 
-            # Check which forecast periods from secondary are not in primary
-            secondary_fps = set(forecast_periods_in_range)
+            # Keep only forecast periods present in the primary and sort by lead time.
+            valid_fp_cube_pairs = [
+                (fp, cube) for fp, cube in fp_cube_pairs if fp in primary_fps
+            ]
+            valid_fp_cube_pairs = sorted(valid_fp_cube_pairs, key=lambda x: x[0])
+
+            # Track forecast periods in requested range but missing from primary input.
+            secondary_fps = {fp for fp, _ in fp_cube_pairs}
             missing_fps = secondary_fps - primary_fps
 
             if missing_fps:
@@ -691,12 +707,8 @@ class RealizationClusterAndMatch(BasePlugin):
                     f"{sorted(missing_fps)} not present in primary input. "
                     "These will be ignored."
                 )
-                # Filter out missing forecast periods
-                forecast_periods_in_range = [
-                    fp for fp in forecast_periods_in_range if fp not in missing_fps
-                ]
 
-            if not forecast_periods_in_range:
+            if not valid_fp_cube_pairs:
                 warnings.warn(
                     f"Secondary input '{candidate_name}' has no forecast periods "
                     "that overlap with primary input "
@@ -705,8 +717,31 @@ class RealizationClusterAndMatch(BasePlugin):
                 )
                 continue  # No valid forecast periods after filtering
 
-            # Check first forecast period to determine realization count
-            n_realizations = len(model_cubes[0].coord("realization").points)
+            # Determine the expected realization count from the earliest valid
+            # forecast period and truncate this secondary input if the count changes
+            # at later lead times. This avoids a source pulsing in/out and keeps
+            # all periods for this source mergeable for consistent multi-period
+            # matching.
+            first_fp, first_cube = valid_fp_cube_pairs[0]
+            n_realizations = len(first_cube.coord("realization").points)
+            forecast_periods_in_range = []
+            for idx, (fp, cube) in enumerate(valid_fp_cube_pairs):
+                n_realizations_at_fp = len(cube.coord("realization").points)
+                if n_realizations_at_fp != n_realizations:
+                    dropped_fps = [
+                        future_fp for future_fp, _ in valid_fp_cube_pairs[idx:]
+                    ]
+                    warnings.warn(
+                        f"Secondary input '{candidate_name}' has inconsistent "
+                        "realization counts across forecast periods. Using "
+                        f"{n_realizations} realizations based on forecast period "
+                        f"{first_fp}, but found {n_realizations_at_fp} realizations "
+                        f"at forecast period {fp}. Forecast periods "
+                        f"{dropped_fps} will be ignored for this input.",
+                        UserWarning,
+                    )
+                    break
+                forecast_periods_in_range.append(fp)
 
             if n_realizations >= n_clusters:
                 full_realization_inputs.append(

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -692,9 +692,7 @@ class RealizationClusterAndMatch(BasePlugin):
             ]
 
             # Keep only forecast periods present in the primary and sort by lead time.
-            valid_fp_cube_pairs = [
-                (fp, cube) for fp, cube in fp_cube_pairs if fp in primary_fps
-            ]
+            valid_fp_cube_pairs = [x for x in fp_cube_pairs if x[0] in primary_fps]
             valid_fp_cube_pairs = sorted(valid_fp_cube_pairs, key=lambda x: x[0])
 
             if not valid_fp_cube_pairs:
@@ -1013,7 +1011,10 @@ class RealizationClusterAndMatch(BasePlugin):
         cluster_sources, and secondary_input_realizations_to_clusters. These
         variables are used to track which clusters have been replaced, which model
         provided data for each cluster, and which secondary realizations correspond to
-        each cluster, respectively. This information will be added later as attributes
+        each cluster, respectively. Cluster replacement refers to where the medoid
+        realization representing a cluster is replaced with the most pattern-similar
+        realization from a secondary input.
+        This information will be added later as attributes
         to the final output cube.
         Called from the per-forecast-period loop in both
         _process_full_realization_inputs and _process_partial_realization_inputs.

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -995,6 +995,108 @@ class RealizationClusterAndMatch(BasePlugin):
                 cluster_idx
             ].append(int(candidate_cube.coord("realization").points[realization_idx]))
 
+    def _record_match_for_forecast_period(
+        self,
+        fp: int,
+        cluster_indices: list[int],
+        realization_indices: list[int],
+        candidate_name: str,
+        candidate_cube: Cube,
+        replaced_realizations: dict[int, set[int]],
+        cluster_sources: dict[int, dict[str, list[int]]],
+        secondary_input_realizations_to_clusters: dict[str, dict[int, list[int]]],
+    ) -> None:
+        """Record tracking metadata after matching a secondary input at one forecast
+        period.
+
+        Updates replaced_realizations, cluster_sources, and
+        secondary_input_realizations_to_clusters in-place. Called from the
+        per-forecast-period loop in both _process_full_realization_inputs and
+        _process_partial_realization_inputs.
+
+        Args:
+            fp: Forecast period in seconds.
+            cluster_indices: Cluster indices that were assigned.
+            realization_indices: Realization indices from the candidate cube
+                corresponding to each cluster.
+            candidate_name: Name of the secondary input.
+            candidate_cube: The secondary input cube for this forecast period.
+            replaced_realizations: Tracks which cluster indices have been replaced
+                per forecast period. Modified in-place.
+            cluster_sources: Tracks which input model provided data for each cluster
+                at each forecast period. Modified in-place.
+            secondary_input_realizations_to_clusters: Tracks which secondary
+                realizations correspond to each cluster. Modified in-place.
+        """
+        if fp not in replaced_realizations:
+            replaced_realizations[fp] = set()
+        replaced_realizations[fp].update(cluster_indices)
+        self._update_cluster_sources(
+            cluster_sources, cluster_indices, candidate_name, fp
+        )
+        self.track_secondary_realizations_to_clusters(
+            secondary_input_realizations_to_clusters,
+            cluster_indices,
+            realization_indices,
+            candidate_name,
+            fp,
+            candidate_cube,
+        )
+
+    def _extract_merge_and_match(
+        self,
+        candidate_name: str,
+        fps: list[int],
+        cubes: CubeList,
+        target_grid_cube: Cube,
+        regridded_clustered_primary_cube: Cube,
+        ensure_fp_dim: bool = False,
+    ) -> tuple[list[int], list[int], Cube]:
+        """Extract, merge, regrid and match a secondary input against the clustered
+        primary.
+
+        Extracts cubes for the given candidate and forecast periods, merges them
+        into a single cube, optionally ensures forecast_period is a dimension
+        coordinate, regrids to the target grid, and calls RealizationToClusterMatcher.
+
+        Args:
+            candidate_name: Name of the secondary input.
+            fps: Forecast period values in seconds to extract.
+            cubes: CubeList containing all input cubes.
+            target_grid_cube: Target grid cube for optional regridding.
+            regridded_clustered_primary_cube: The regridded clustered primary cube.
+            ensure_fp_dim: If True, promote forecast_period to a dimension coordinate
+                on both the candidate and primary slices before matching. Required
+                when fps are provided as separate 3D cubes (the partial realization
+                path). Defaults to False.
+
+        Returns:
+            Tuple (cluster_indices, realization_indices, merged_candidate_cube):
+                cluster_indices: Cluster indices assigned to each realization.
+                realization_indices: Realization indices from the candidate cube
+                    assigned to each cluster.
+                merged_candidate_cube: The merged (pre-regrid) candidate cube, needed
+                    by callers for per-forecast-period indexing.
+        """
+        model_id_constr = iris.AttributeConstraint(
+            **{self.model_id_attr: candidate_name}
+        )
+        fp_constr = iris.Constraint(forecast_period=fps)
+        candidate_cube = MergeCubes()(cubes.extract(model_id_constr & fp_constr))
+        enforce_coordinate_ordering(candidate_cube, ["realization"])
+        if ensure_fp_dim:
+            candidate_cube = self._ensure_forecast_period_is_dimension(candidate_cube)
+        regridded_candidate_cube = self._maybe_regrid_candidate_cube(
+            candidate_cube, target_grid_cube
+        )
+        primary_slice = regridded_clustered_primary_cube.extract(fp_constr)
+        if ensure_fp_dim:
+            primary_slice = self._ensure_forecast_period_is_dimension(primary_slice)
+        cluster_indices, realization_indices = RealizationToClusterMatcher()(
+            primary_slice, regridded_candidate_cube
+        )
+        return cluster_indices, realization_indices, candidate_cube
+
     def _process_full_realization_inputs(
         self,
         full_realization_inputs: list[tuple[str, list[int]]],
@@ -1051,24 +1153,15 @@ class RealizationClusterAndMatch(BasePlugin):
             if not fps_to_process:
                 continue
 
-            model_id_constr = iris.AttributeConstraint(
-                **{self.model_id_attr: candidate_name}
+            cluster_indices, realization_indices, candidate_cube = (
+                self._extract_merge_and_match(
+                    candidate_name,
+                    fps_to_process,
+                    cubes,
+                    target_grid_cube,
+                    regridded_clustered_primary_cube,
+                )
             )
-            fp_constr = iris.Constraint(forecast_period=fps_to_process)
-            candidate_cubes = cubes.extract(model_id_constr & fp_constr)
-
-            candidate_cube = MergeCubes()(candidate_cubes)
-            enforce_coordinate_ordering(candidate_cube, ["realization"])
-
-            regridded_candidate_cube = self._maybe_regrid_candidate_cube(
-                candidate_cube, target_grid_cube
-            )
-
-            cluster_indices, realization_indices = RealizationToClusterMatcher()(
-                regridded_clustered_primary_cube.extract(fp_constr),
-                regridded_candidate_cube,
-            )
-
             # Index the candidate cube using the realization indices
             matched_cube = candidate_cube[realization_indices]
             matched_cube.coord("realization").points = cluster_indices
@@ -1097,23 +1190,15 @@ class RealizationClusterAndMatch(BasePlugin):
                 # Replace in-place
                 matched_cubes[idx] = fp_matched_cube
 
-                # Track which forecast periods have been fully replaced
-                if fp not in replaced_realizations:
-                    replaced_realizations[fp] = set()
-                replaced_realizations[fp].update(cluster_indices)
-
-                # Track cluster sources: update which input was used for each cluster
-                self._update_cluster_sources(
-                    cluster_sources, cluster_indices, candidate_name, fp
-                )
-                # Track which secondary realizations contributed to each cluster
-                self.track_secondary_realizations_to_clusters(
-                    secondary_input_realizations_to_clusters,
+                self._record_match_for_forecast_period(
+                    fp,
                     cluster_indices,
                     realization_indices,
                     candidate_name,
-                    fp,
                     candidate_cube,
+                    replaced_realizations,
+                    cluster_sources,
+                    secondary_input_realizations_to_clusters,
                 )
 
     def _process_partial_realization_inputs(
@@ -1161,28 +1246,16 @@ class RealizationClusterAndMatch(BasePlugin):
                 **{self.model_id_attr: candidate_name}
             )
 
-            # Perform matching once across ALL forecast periods so that each
+            # Perform matching once across all forecast periods so that each
             # realization is assigned to the same cluster at every lead time.
             # This mirrors how _process_full_realization_inputs works.
-            fp_constr_all = iris.Constraint(forecast_period=forecast_periods)
-            all_candidate_cubes = cubes.extract(model_id_constr & fp_constr_all)
-            merged_candidate_cube = MergeCubes()(all_candidate_cubes)
-            enforce_coordinate_ordering(merged_candidate_cube, ["realization"])
-            merged_candidate_cube = self._ensure_forecast_period_is_dimension(
-                merged_candidate_cube
-            )
-            regridded_merged_candidate_cube = self._maybe_regrid_candidate_cube(
-                merged_candidate_cube, target_grid_cube
-            )
-            clustered_all_fps_cube = regridded_clustered_primary_cube.extract(
-                fp_constr_all
-            )
-            clustered_all_fps_cube = self._ensure_forecast_period_is_dimension(
-                clustered_all_fps_cube
-            )
-            cluster_indices, realization_indices = RealizationToClusterMatcher()(
-                clustered_all_fps_cube,
-                regridded_merged_candidate_cube,
+            cluster_indices, realization_indices, _ = self._extract_merge_and_match(
+                candidate_name,
+                forecast_periods,
+                cubes,
+                target_grid_cube,
+                regridded_clustered_primary_cube,
+                ensure_fp_dim=True,
             )
 
             for fp in forecast_periods:
@@ -1220,23 +1293,15 @@ class RealizationClusterAndMatch(BasePlugin):
                 merged_cube = self._ensure_forecast_period_is_dimension(merged_cube)
                 matched_cubes[idx] = merged_cube
 
-                # Mark which cluster indices were replaced
-                if fp not in replaced_realizations:
-                    replaced_realizations[fp] = set()
-                replaced_realizations[fp].update(cluster_indices)
-
-                # Track cluster sources: update which input was used for each cluster
-                self._update_cluster_sources(
-                    cluster_sources, cluster_indices, candidate_name, fp
-                )
-                # Track which secondary realizations contributed to each cluster
-                self.track_secondary_realizations_to_clusters(
-                    secondary_input_realizations_to_clusters,
+                self._record_match_for_forecast_period(
+                    fp,
                     cluster_indices,
                     realization_indices,
                     candidate_name,
-                    fp,
                     candidate_cube,
+                    replaced_realizations,
+                    cluster_sources,
+                    secondary_input_realizations_to_clusters,
                 )
 
     def process(self, cubes: CubeList) -> Cube:

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -2366,6 +2366,170 @@ def test_clusterandmatch_partial_input_consistent_cluster_across_forecast_period
     )
 
 
+def test_clusterandmatch_partial_input_inconsistent_realization_counts_truncates():
+    """Partial input is truncated at first realization-count mismatch."""
+    pytest.importorskip("kmedoids")
+
+    cubes = CubeList()
+    # Primary with 6 realizations across two forecast periods.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=6,
+            forecast_periods=[0, 6],
+            y_dim=4,
+            x_dim=4,
+            model_id="primary_model",
+            base_value=100.0,
+            merge=False,
+        )
+    )
+
+    # Partial secondary: 4 realizations at fp=0, then 3 at fp=6.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=4,
+            forecast_periods=[0],
+            y_dim=4,
+            x_dim=4,
+            model_id="secondary_model",
+            base_value=200.0,
+            merge=False,
+        )
+    )
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=3,
+            forecast_periods=[6],
+            y_dim=4,
+            x_dim=4,
+            model_id="secondary_model",
+            base_value=200.0,
+            merge=False,
+        )
+    )
+
+    plugin = RealizationClusterAndMatch(
+        hierarchy={
+            "primary_input": "primary_model",
+            "secondary_inputs": {"secondary_model": [0, 6]},
+        },
+        model_id_attr="model_id",
+        clustering_method="KMedoids",
+        regrid_for_clustering=False,
+        n_clusters=5,
+        random_state=42,
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r"Secondary input 'secondary_model' has inconsistent realization counts "
+            r"across forecast periods"
+        ),
+    ):
+        result = plugin.process(cubes)
+
+    secondary_map = json.loads(
+        result.attributes["secondary_input_realizations_to_clusters"]
+    )["secondary_model"]
+    mapped_fps = sorted(
+        {
+            fp
+            for entries in secondary_map.values()
+            for entry in entries
+            for fp in entry["forecast_periods"]
+        }
+    )
+    assert mapped_fps == [0]
+
+    fp_6_data = result.extract(iris.Constraint(forecast_period=6 * 3600)).data
+    assert np.allclose(fp_6_data, 106.0, atol=5.0), (
+        "fp=6 should fall back to clustered primary when secondary is truncated"
+    )
+
+
+def test_clusterandmatch_full_input_inconsistent_realization_counts_truncates():
+    """Full input is truncated at first realization-count mismatch."""
+    pytest.importorskip("kmedoids")
+
+    cubes = CubeList()
+    # Primary with 4 realizations across two forecast periods.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=4,
+            forecast_periods=[0, 6],
+            y_dim=4,
+            x_dim=4,
+            model_id="primary_model",
+            base_value=100.0,
+            merge=False,
+        )
+    )
+
+    # Full secondary relative to n_clusters=2: 3 realizations at fp=0, then 2 at fp=6.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=3,
+            forecast_periods=[0],
+            y_dim=4,
+            x_dim=4,
+            model_id="secondary_model",
+            base_value=200.0,
+            merge=False,
+        )
+    )
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=2,
+            forecast_periods=[6],
+            y_dim=4,
+            x_dim=4,
+            model_id="secondary_model",
+            base_value=200.0,
+            merge=False,
+        )
+    )
+
+    plugin = RealizationClusterAndMatch(
+        hierarchy={
+            "primary_input": "primary_model",
+            "secondary_inputs": {"secondary_model": [0, 6]},
+        },
+        model_id_attr="model_id",
+        clustering_method="KMedoids",
+        regrid_for_clustering=False,
+        n_clusters=2,
+        random_state=42,
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r"Secondary input 'secondary_model' has inconsistent realization counts "
+            r"across forecast periods"
+        ),
+    ):
+        result = plugin.process(cubes)
+
+    secondary_map = json.loads(
+        result.attributes["secondary_input_realizations_to_clusters"]
+    )["secondary_model"]
+    mapped_fps = sorted(
+        {
+            fp
+            for entries in secondary_map.values()
+            for entry in entries
+            for fp in entry["forecast_periods"]
+        }
+    )
+    assert mapped_fps == [0]
+
+    fp_6_data = result.extract(iris.Constraint(forecast_period=6 * 3600)).data
+    assert np.allclose(fp_6_data, 106.0, atol=5.0), (
+        "fp=6 should fall back to clustered primary when secondary is truncated"
+    )
+
+
 def test_clusterandmatch_categorise_mixed_realizations():
     """Test categorisation with mix of full and partial realizations.
 

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -2258,6 +2258,114 @@ def test_clusterandmatch_multiple_partial_secondary_same_forecast_period():
     )
 
 
+def test_clusterandmatch_partial_input_consistent_cluster_across_forecast_periods():
+    """Partial inputs must assign the same cluster at every lead time.
+
+    A partial secondary input (fewer realizations than n_clusters) was previously
+    matched independently per forecast period, allowing the same realization to be
+    assigned to different clusters at different lead times depending on which
+    spatial pattern was locally closest.
+
+    The primary is designed with two clusters whose spatial patterns swap between
+    forecast periods:
+    - Cluster A: value~10 at fp=0, value~100 at fp=6
+    - Cluster B: value~100 at fp=0, value~10 at fp=6
+
+    The secondary has a single realization with value 12 at fp=0 and 15 at fp=6.
+
+    Per-fp MSE:
+    - fp=0: secondary (12) vs cluster A (10) => MSE=4; vs cluster B (100) => MSE=7744
+            => old code assigns to cluster A   (consistent)
+    - fp=6: secondary (15) vs cluster A (100) => MSE=7225; vs cluster B (10) => MSE=25
+            => old code assigns to cluster B   (inconsistent)
+
+    Cross-fp avg MSE (new code):
+    - vs cluster A: (4 + 7225)/2 = 3614.5
+    - vs cluster B: (7744 + 25)/2 = 3884.5
+    => new code assigns to cluster A at both fps
+    """
+    pytest.importorskip("kmedoids")
+
+    # Primary: 4 realizations, 2 fps. Patterns A and B swap between fps.
+    primary_fp0 = _create_4d_realization_cube(
+        n_realizations=4,
+        forecast_periods=[0],
+        y_dim=3,
+        x_dim=3,
+        model_id="primary_model",
+        realization_values=[10.0, 11.0, 100.0, 101.0],
+        merge=False,
+    )
+    primary_fp6 = _create_4d_realization_cube(
+        n_realizations=4,
+        forecast_periods=[6],
+        y_dim=3,
+        x_dim=3,
+        model_id="primary_model",
+        realization_values=[100.0, 101.0, 10.0, 11.0],
+        merge=False,
+    )
+
+    # Secondary: 1 realization (< 2 clusters => partial), values differ between fps.
+    # At fp=0 value=12 is close to cluster A (value~10).
+    # At fp=6 value=15 is close to cluster B (value~10), NOT cluster A (value~100).
+    secondary_fp0 = _create_4d_realization_cube(
+        n_realizations=1,
+        forecast_periods=[0],
+        y_dim=3,
+        x_dim=3,
+        model_id="secondary_model",
+        realization_values=[12.0],
+        merge=False,
+    )
+    secondary_fp6 = _create_4d_realization_cube(
+        n_realizations=1,
+        forecast_periods=[6],
+        y_dim=3,
+        x_dim=3,
+        model_id="secondary_model",
+        realization_values=[15.0],
+        merge=False,
+    )
+
+    cubes = CubeList(primary_fp0 + primary_fp6 + secondary_fp0 + secondary_fp6)
+
+    plugin = RealizationClusterAndMatch(
+        hierarchy={
+            "primary_input": "primary_model",
+            "secondary_inputs": {"secondary_model": [0, 6]},
+        },
+        model_id_attr="model_id",
+        clustering_method="KMedoids",
+        regrid_for_clustering=False,
+        n_clusters=2,
+        random_state=42,
+    )
+
+    result = plugin.process(cubes)
+
+    secondary_map = json.loads(
+        result.attributes["secondary_input_realizations_to_clusters"]
+    )["secondary_model"]
+
+    # With consistent cross-fp matching the single secondary realization should
+    # appear in exactly one cluster key, covering both forecast periods.
+    # With the old per-fp matching it would appear in two different cluster keys
+    # (one for fp=0 and a different one for fp=6), failing this assertion.
+    assert len(secondary_map) == 1, (
+        f"Expected the secondary realization to be assigned to exactly one cluster "
+        f"across all forecast periods, but got assignments to "
+        f"{len(secondary_map)} clusters: {secondary_map}"
+    )
+    cluster_key = next(iter(secondary_map))
+    entries = secondary_map[cluster_key]
+    assert len(entries) == 1
+    assert sorted(entries[0]["forecast_periods"]) == [0, 6 * 3600], (
+        f"Expected the secondary realization to cover both forecast periods "
+        f"[0, {6 * 3600}], got: {entries[0]['forecast_periods']}"
+    )
+
+
 def test_clusterandmatch_categorise_mixed_realizations():
     """Test categorisation with mix of full and partial realizations.
 

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -2262,7 +2262,7 @@ def test_clusterandmatch_partial_input_consistent_cluster_across_forecast_period
     """Partial inputs must assign the same cluster at every lead time.
 
     A partial secondary input (fewer realizations than n_clusters) was previously
-    matched independently per forecast period, allowing the same realization to be
+    matched independently per forecast period (fp), allowing the same realization to be
     assigned to different clusters at different lead times depending on which
     spatial pattern was locally closest.
 
@@ -2273,13 +2273,13 @@ def test_clusterandmatch_partial_input_consistent_cluster_across_forecast_period
 
     The secondary has a single realization with value 12 at fp=0 and 15 at fp=6.
 
-    Per-fp MSE:
+    Per-fp MSE (lower MSE indicates a closer match):
     - fp=0: secondary (12) vs cluster A (10) => MSE=4; vs cluster B (100) => MSE=7744
             => old code assigns to cluster A   (consistent)
     - fp=6: secondary (15) vs cluster A (100) => MSE=7225; vs cluster B (10) => MSE=25
             => old code assigns to cluster B   (inconsistent)
 
-    Cross-fp avg MSE (new code):
+    Cross-fp avg MSE (new code where lower MSE indicates a closer match):
     - vs cluster A: (4 + 7225)/2 = 3614.5
     - vs cluster B: (7744 + 25)/2 = 3884.5
     => new code assigns to cluster A at both fps
@@ -2366,15 +2366,48 @@ def test_clusterandmatch_partial_input_consistent_cluster_across_forecast_period
     )
 
 
-def test_clusterandmatch_partial_input_inconsistent_realization_counts_truncates():
-    """Partial input is truncated at first realization-count mismatch."""
+@pytest.mark.parametrize(
+    "primary_n_realizations,n_clusters,secondary_fp0_n,secondary_fp6_n,case_desc",
+    [
+        # Partial case: secondary starts below n_clusters and drops again
+        (6, 5, 4, 3, "partial"),
+        # Full case: secondary starts at/above n_clusters and then drops
+        (4, 2, 3, 2, "full"),
+    ],
+)
+def test_clusterandmatch_inconsistent_realization_counts_truncates(
+    primary_n_realizations,
+    n_clusters,
+    secondary_fp0_n,
+    secondary_fp6_n,
+    case_desc,
+):
+    """Secondary input is truncated at the first realization-count mismatch.
+
+    This parameterized test covers both:
+    - a partial-secondary case (secondary starts with fewer realizations than
+        n_clusters), and
+    - a full-secondary case (secondary starts with at least n_clusters
+        realizations).
+
+    In both cases, the secondary input has a different realization count at the
+    next forecast period. This can happen, for example, when a cycle blended forecast
+    source is reaching the end of its leadtime range. Rather than continuing to use the
+    secondary input with a different realization count, the plugin should not use it,
+    and revert to using the clustered primary data.
+    The plugin should therefore:
+    1. Issue a warning about inconsistent realization counts.
+    2. Keep only forecast periods up to (but excluding) the first mismatch for
+        that secondary input.
+    3. Fall back to clustered primary data at the mismatched and later forecast
+        periods.
+    """
     pytest.importorskip("kmedoids")
 
     cubes = CubeList()
-    # Primary with 6 realizations across two forecast periods.
     cubes.extend(
         _create_4d_realization_cube(
-            n_realizations=6,
+            n_realizations=primary_n_realizations,
             forecast_periods=[0, 6],
             y_dim=4,
             x_dim=4,
@@ -2383,11 +2416,9 @@ def test_clusterandmatch_partial_input_inconsistent_realization_counts_truncates
             merge=False,
         )
     )
-
-    # Partial secondary: 4 realizations at fp=0, then 3 at fp=6.
     cubes.extend(
         _create_4d_realization_cube(
-            n_realizations=4,
+            n_realizations=secondary_fp0_n,
             forecast_periods=[0],
             y_dim=4,
             x_dim=4,
@@ -2398,7 +2429,7 @@ def test_clusterandmatch_partial_input_inconsistent_realization_counts_truncates
     )
     cubes.extend(
         _create_4d_realization_cube(
-            n_realizations=3,
+            n_realizations=secondary_fp6_n,
             forecast_periods=[6],
             y_dim=4,
             x_dim=4,
@@ -2416,7 +2447,7 @@ def test_clusterandmatch_partial_input_inconsistent_realization_counts_truncates
         model_id_attr="model_id",
         clustering_method="KMedoids",
         regrid_for_clustering=False,
-        n_clusters=5,
+        n_clusters=n_clusters,
         random_state=42,
     )
 
@@ -2440,93 +2471,15 @@ def test_clusterandmatch_partial_input_inconsistent_realization_counts_truncates
             for fp in entry["forecast_periods"]
         }
     )
-    assert mapped_fps == [0]
+    assert mapped_fps == [0], f"{case_desc}: only fp=0 should be mapped"
 
     fp_6_data = result.extract(iris.Constraint(forecast_period=6 * 3600)).data
+    # Asserting that the result at T+6 is close to 106 demonstrates that the
+    # plugin has fallen back to using the clustered primary data (base_value + 6),
+    # rather than using the secondary input where the number of realizations at T+6
+    # has dropped relative to T+0.
     assert np.allclose(fp_6_data, 106.0, atol=5.0), (
-        "fp=6 should fall back to clustered primary when secondary is truncated"
-    )
-
-
-def test_clusterandmatch_full_input_inconsistent_realization_counts_truncates():
-    """Full input is truncated at first realization-count mismatch."""
-    pytest.importorskip("kmedoids")
-
-    cubes = CubeList()
-    # Primary with 4 realizations across two forecast periods.
-    cubes.extend(
-        _create_4d_realization_cube(
-            n_realizations=4,
-            forecast_periods=[0, 6],
-            y_dim=4,
-            x_dim=4,
-            model_id="primary_model",
-            base_value=100.0,
-            merge=False,
-        )
-    )
-
-    # Full secondary relative to n_clusters=2: 3 realizations at fp=0, then 2 at fp=6.
-    cubes.extend(
-        _create_4d_realization_cube(
-            n_realizations=3,
-            forecast_periods=[0],
-            y_dim=4,
-            x_dim=4,
-            model_id="secondary_model",
-            base_value=200.0,
-            merge=False,
-        )
-    )
-    cubes.extend(
-        _create_4d_realization_cube(
-            n_realizations=2,
-            forecast_periods=[6],
-            y_dim=4,
-            x_dim=4,
-            model_id="secondary_model",
-            base_value=200.0,
-            merge=False,
-        )
-    )
-
-    plugin = RealizationClusterAndMatch(
-        hierarchy={
-            "primary_input": "primary_model",
-            "secondary_inputs": {"secondary_model": [0, 6]},
-        },
-        model_id_attr="model_id",
-        clustering_method="KMedoids",
-        regrid_for_clustering=False,
-        n_clusters=2,
-        random_state=42,
-    )
-
-    with pytest.warns(
-        UserWarning,
-        match=(
-            r"Secondary input 'secondary_model' has inconsistent realization counts "
-            r"across forecast periods"
-        ),
-    ):
-        result = plugin.process(cubes)
-
-    secondary_map = json.loads(
-        result.attributes["secondary_input_realizations_to_clusters"]
-    )["secondary_model"]
-    mapped_fps = sorted(
-        {
-            fp
-            for entries in secondary_map.values()
-            for entry in entries
-            for fp in entry["forecast_periods"]
-        }
-    )
-    assert mapped_fps == [0]
-
-    fp_6_data = result.extract(iris.Constraint(forecast_period=6 * 3600)).data
-    assert np.allclose(fp_6_data, 106.0, atol=5.0), (
-        "fp=6 should fall back to clustered primary when secondary is truncated"
+        f"{case_desc}: fp=6 should fall back to clustered primary when truncated"
     )
 
 


### PR DESCRIPTION
Related issues: https://github.com/metoppv/improver/pull/2259, https://github.com/metoppv/improver/pull/2305, https://github.com/metoppv/improver/pull/2332, https://github.com/metoppv/improver/pull/2340, https://github.com/metoppv/improver/pull/2359, https://github.com/metoppv/improver/pull/2361

Description
This PR consists of 3 commits to address issues with the current clustering logic.

Commit 1:  This addresses the primary goal because I noticed that it was possible for secondary inputs (e.g. UKV), that only have enough realizations to cover a subset of the total number of clusters, to match to different clusters at different forecast periods e.g. see the output below. This wasn't the intention but was arising from the fact that the call to RealizationToClusterMatcher was inside the loop over forecast period in `_process_partial_realization_inputs`. This was unlike the methodology in `_process_full_realization_inputs` where RealizationToClusterMatcher was called prior to the for loop over forecast period, so that the realization to cluster matching used all forecast periods. This commit therefore makes `_process_partial_realization_inputs` more like `_process_full_realization_inputs`, so that secondary inputs with a "partial" set of realizations are matched to the clusters using all the forecast periods.

> json.loads(ccube.attributes["secondary_input_realizations_to_clusters"])["uk_det"]
> {'10': [{'realization': 3, 'forecast_periods': [3600]}, {'realization': 1, 'forecast_periods': [21600]}], '11': [{'realization': 2, 'forecast_periods': [3600]}], '13': [{'realization': 0, 'forecast_periods': [3600]}], '15': [{'realization': 1, 'forecast_periods': [3600]}], '0': [{'realization': 2, 'forecast_periods': [21600]}], '5': [{'realization': 3, 'forecast_periods': [21600]}], '17': [{'realization': 0, 'forecast_periods': [21600]}]}

Commit 2: This addresses an issue that was found in testing commit 1, where it was possible for a secondary input to have an inconsistent number of realizations at different forecast periods. This led to an inability to merge the secondary inputs across forecast periods in `_process_partial_realization_inputs`. This hadn't been an issue previously because different "partial" forecast sources were being matched independently at each forecast period.

```python
iris.exceptions.MergeError: failed to merge into a single cube.
  cube.shape differs: (4, 970, 1042) != (3, 970, 1042)
```

To fix this issue, I've modified the _categorise_secondary_inputs method, which was previously only checking the number of realizations present on the first cube. This has been extended, so that if the number of realizations changes across forecast periods within the secondary input then the secondary input will be truncated, so as to avoid a possible pulsing if a forecast source is missing particular forecast periods.

Commit 3: This commit does some refactoring to centralise some of the code present in `_process_partial_realization_inputs` and `_process_full_realization_inputs` and avoid duplication where possible.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

