### PR TITLE
Warn in Combine plugin for new variable name not matching CF conventions

### DIFF
--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -4,6 +4,8 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Module containing plugins for combining cubes"""
 
+import re
+import warnings
 from operator import eq
 from typing import Callable, List, Union
 
@@ -133,6 +135,14 @@ class Combine(BasePlugin):
 
         if self.new_name is None:
             self.new_name = cubes[0].name()
+        else:
+            # Warn if the new variable name does not start with a letter
+            if re.match(r"^[^a-zA-Z]", self.new_name):
+                msg = (
+                    f"The new variable name ({self.new_name}) does not start with a letter. "
+                    "Iris will add 'var_' as a prefix to it."
+                )
+                warnings.warn(msg)
 
         if self.minimum_realizations is None:
             filtered_cubes = cubes

--- a/improver/cube_combiner.py
+++ b/improver/cube_combiner.py
@@ -139,7 +139,8 @@ class Combine(BasePlugin):
             # Warn if the new variable name does not start with a letter
             if re.match(r"^[^a-zA-Z]", self.new_name):
                 msg = (
-                    f"The new variable name ({self.new_name}) does not start with a letter. "
+                    f"The new variable name ({self.new_name}) does not start with a letter, "
+                    "and so is contrary to the CF convention for variable names. "
                     "Iris will add 'var_' as a prefix to it."
                 )
                 warnings.warn(msg)


### PR DESCRIPTION
The `cube_combiner.py` plugin `Combine` allows for a new name to be given to the variable in the combined cube. It will allow for one that doesn't conform to the CF conventions on variable names (https://cfconventions.org/Data/cf-standard-names/docs/guidelines.html) - allowing a name starting with a digit. An invalid variable name will subsequently be silently modified by `iris` with `var_` added as a prefix.

This change to IMPROVER will add a warning to inform that the variable name is contrary to the CF naming conventions, and that Iris will add a prefix to the name. **The `new_name` value is not modified - simply warned about.**

The output of this message is as a user warning, e.g.:
`UserWarning: improver.api.Combine during execution: The new variable name (10m_ratio_wind_speed_of_gust) does not start with a letter, and so is contrary to the CF convention for variable names. Iris will add 'var_' as a prefix to it.`

Testing:

- [x] Ran unit tests and they passed OK
- [x] Tested with an application that uses the `Combine` plugin and sets a `new_name` argument starting with a digit