### PR TITLE
Add NAME model global attributes

### DIFF
--- a/improver/utilities/save.py
+++ b/improver/utilities/save.py
@@ -160,13 +160,16 @@ def _cube_attributes_for_save(cube: Cube):
             The cube for which the attributes are to be separated.
     """
     global_keys = [
+        "Conventions",
+        "grid_id",
+        "history",
+        "institution",
+        "name_netcdf_out_vers",
+        "name_version",
+        "reference",
+        "source",
         "title",
         "um_version",
-        "grid_id",
-        "source",
-        "Conventions",
-        "institution",
-        "history",
     ]
     global_keys.extend([key for key in cube.attributes.keys() if "mosg__" in key])
     global_attributes = {k: v for k, v in cube.attributes.items() if k in global_keys}

--- a/improver_tests/utilities/test_save.py
+++ b/improver_tests/utilities/test_save.py
@@ -33,6 +33,7 @@ def set_up_test_cube():
         "Conventions": "CF-1.5",
         "institution": "Met Office",
         "history": "",
+        "reference": "Any global reference to the Met Office Unified Model",
     }
 
     cube = set_up_variable_cube(
@@ -59,6 +60,7 @@ class Test_save_netcdf(unittest.TestCase):
             "Conventions",
             "institution",
             "history",
+            "reference",
         ]
         self.directory = mkdtemp()
         self.filepath = os.path.join(self.directory, "temp.nc")
@@ -200,7 +202,7 @@ class Test_save_netcdf(unittest.TestCase):
         cube_list = [self.cube, self.cube]
         save_netcdf(cube_list, self.filepath)
         global_keys_in_file = Dataset(self.filepath, mode="r").ncattrs()
-        self.assertEqual(len(global_keys_in_file), 9)
+        self.assertEqual(len(global_keys_in_file), 10)
         self.assertTrue(all(key in self.global_keys_ref for key in global_keys_in_file))
 
     def test_error_unknown_units(self):


### PR DESCRIPTION
In `improver.utilities.save`  there is a list of attributes that are to be identified as global, rather than local, when a NetCDF file is saved. This list is being extended to include the following attributes that originate in data from the NAME model:

```
"name_netcdf_out_vers"
"name_version"
"reference"
```

Testing:

- [x] Ran tests and they passed OK
- [x] Updated tests for the new attributes
- [x] Use modified IMPROVER in a workflow that processes NAME data, and confirm that attributes are correctly classified as global
