### PR TITLE
Enforce realization units in StandardiseMetadata

### DIFF
--- a/improver/standardise.py
+++ b/improver/standardise.py
@@ -245,6 +245,10 @@ class StandardiseMetadata(BasePlugin):
 
         cube.data = as_correct_dtype(cube.data, get_required_dtype(cube))
         for coord in cube.coords():
+            # Ensure realization coordinate has units of 1 (dimensionless) rather than
+            # 'unknown' or another unit.
+            if coord.name() == "realization":
+                coord.units = "1"
             if coord.name() in TIME_COORDS and not check_units(coord):
                 coord.convert_units(get_required_units(coord))
             req_dtype = get_required_dtype(coord)

--- a/improver_tests/standardise/test_StandardiseMetadata.py
+++ b/improver_tests/standardise/test_StandardiseMetadata.py
@@ -434,6 +434,15 @@ class Test_process(ImproverTest):
         self.assertEqual(result.coord("realization").points, 1)
         self.assertEqual(result.coord("realization").attributes["positive"], "up")
 
+    def test_assign_realization_units(self):
+        """Test that realization coordinate is assigned units of 1."""
+        cube = self.cube.copy()
+        cube.add_aux_coord(DimCoord([0], standard_name="realization", units="unknown"))
+
+        result = StandardiseMetadata().process(cube)
+
+        self.assertEqual(result.coord("realization").units, "1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR introduces enforcement of the units of realization coordinates in the `StandardiseMetadata` plugin. The motivation for this is described in this comment: https://github.com/metoppv/mo-blue-team/issues/1037#issuecomment-5092398062. There is currently no way to centrally enforce that a realization coordinate on a cube conforms to expected IMRPOVER metadata standards by using units of `1`.

Another PR (https://github.com/metoppv/improver/pull/2414) makes a related change within `improver/clustering/realization_clustering.py`, however I think it makes sense to introduce a more centralised fix, rather than attempt to fix this issue every time it arises.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
