### PR TITLE
Edits to protect QRF training from mismatches in unique_site_id_key arising solely from spaces

### DIFF
--- a/improver/calibration/load_and_train_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_train_quantile_regression_random_forest.py
@@ -156,7 +156,10 @@ class LoadForTrainQRF(PostProcessingPlugin):
         return [fp * 3600 for fp in forecast_periods]
 
     def _strip_unique_site_id_whitespace(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Strip whitespace from string-valued unique site ID columns.
+        """Strip whitespace from string-valued unique site ID columns. This is
+        to ensure that additional whitespace doesn't prevent sites from matching
+        between different forecast inputs and between the forecast and truth data
+        (e.g. "03003" vs "03003   ").
 
         Args:
             df: DataFrame containing the forecast or truth data.
@@ -243,28 +246,26 @@ class LoadForTrainQRF(PostProcessingPlugin):
                 engine="pyarrow",
             )
 
-            if forecast_df is None:
-                # If processing the first diagnostic, use it to create the base
-                # DataFrame.
-                if additional_df.empty:
-                    return None, None
-                additional_df.rename(columns={"forecast": cf_name}, inplace=True)
-                additional_df = self._strip_unique_site_id_whitespace(additional_df)
-                forecast_df = additional_df
-                continue
-
-            # Convert additional features from rows to columns.
-            representation = (
-                "percentile" if "percentile" in additional_df.columns else "realization"
-            )
-
             if additional_df.empty:
+                if forecast_df is None:
+                    return None, None
                 msg = (
                     "The requested parquet diagnostic name is not present in the "
                     f"forecast parquet file: {parquet_diagnostic_name}."
                 )
                 raise ValueError(msg)
 
+            # Single shared strip call for every forecast dataframe loaded.
+            additional_df = self._strip_unique_site_id_whitespace(additional_df)
+
+            if forecast_df is None:
+                additional_df.rename(columns={"forecast": cf_name}, inplace=True)
+                forecast_df = additional_df
+                continue
+
+            representation = (
+                "percentile" if "percentile" in additional_df.columns else "realization"
+            )
             merge_on = [
                 *self.unique_site_id_keys,
                 "forecast_reference_time",
@@ -275,8 +276,6 @@ class LoadForTrainQRF(PostProcessingPlugin):
             # If e.g. percentile is all NaN as this is a deterministic diagnostic, remove this column.
             if additional_df[representation].isna().all():
                 merge_on.remove(representation)
-
-            additional_df = self._strip_unique_site_id_whitespace(additional_df)
 
             forecast_df = add_feature_from_df_to_df(
                 forecast_df,

--- a/improver/calibration/load_and_train_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_train_quantile_regression_random_forest.py
@@ -155,6 +155,21 @@ class LoadForTrainQRF(PostProcessingPlugin):
         forecast_periods = sorted(set(all_periods))
         return [fp * 3600 for fp in forecast_periods]
 
+    def _strip_unique_site_id_whitespace(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Strip whitespace from string-valued unique site ID columns.
+
+        Args:
+            df: DataFrame containing the forecast or truth data.
+
+        Returns:
+            DataFrame with whitespace stripped from string-valued unique site ID
+            columns.
+        """
+        for key in self.unique_site_id_keys:
+            if key in df.columns and pd.api.types.is_string_dtype(df[key]):
+                df[key] = df[key].str.strip()
+        return df
+
     def _read_parquet_files(
         self,
         forecast_table_path: pathlib.Path | str,
@@ -234,6 +249,7 @@ class LoadForTrainQRF(PostProcessingPlugin):
                 if additional_df.empty:
                     return None, None
                 additional_df.rename(columns={"forecast": cf_name}, inplace=True)
+                additional_df = self._strip_unique_site_id_whitespace(additional_df)
                 forecast_df = additional_df
                 continue
 
@@ -260,6 +276,8 @@ class LoadForTrainQRF(PostProcessingPlugin):
             if additional_df[representation].isna().all():
                 merge_on.remove(representation)
 
+            additional_df = self._strip_unique_site_id_whitespace(additional_df)
+
             forecast_df = add_feature_from_df_to_df(
                 forecast_df,
                 additional_df.rename(columns={"forecast": cf_name}),
@@ -283,14 +301,6 @@ class LoadForTrainQRF(PostProcessingPlugin):
         for column in ["forecast_period", "period"]:
             forecast_df[column] = pd.to_timedelta(forecast_df[column], unit="ns")
             forecast_df[column] = forecast_df[column].astype("timedelta64[ns]")
-        # Standardise unique site ID key columns by stripping whitespace, so that
-        # differences in string padding (e.g. '03003' vs '03003   ') do not prevent
-        # matching between forecast and truth DataFrames.
-        for key in self.unique_site_id_keys:
-            if key in forecast_df.columns and pd.api.types.is_string_dtype(
-                forecast_df[key]
-            ):
-                forecast_df[key] = forecast_df[key].str.strip()
 
         # Load truths from parquet file filtering by diagnostic.
         filters = [[("diagnostic", "==", self.parquet_diagnostic_names[0])]]
@@ -304,9 +314,7 @@ class LoadForTrainQRF(PostProcessingPlugin):
         truth_df["time"] = pd.to_datetime(truth_df["time"], unit="ns", utc=True)
         truth_df["time"] = truth_df["time"].astype("datetime64[ns, UTC]")
 
-        for key in self.unique_site_id_keys:
-            if key in truth_df.columns and pd.api.types.is_string_dtype(truth_df[key]):
-                truth_df[key] = truth_df[key].str.strip()
+        truth_df = self._strip_unique_site_id_whitespace(truth_df)
 
         if truth_df.empty:
             msg = (

--- a/improver/calibration/load_and_train_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_train_quantile_regression_random_forest.py
@@ -283,6 +283,14 @@ class LoadForTrainQRF(PostProcessingPlugin):
         for column in ["forecast_period", "period"]:
             forecast_df[column] = pd.to_timedelta(forecast_df[column], unit="ns")
             forecast_df[column] = forecast_df[column].astype("timedelta64[ns]")
+        # Standardise unique site ID key columns by stripping whitespace, so that
+        # differences in string padding (e.g. '03003' vs '03003   ') do not prevent
+        # matching between forecast and truth DataFrames.
+        for key in self.unique_site_id_keys:
+            if key in forecast_df.columns and pd.api.types.is_string_dtype(
+                forecast_df[key]
+            ):
+                forecast_df[key] = forecast_df[key].str.strip()
 
         # Load truths from parquet file filtering by diagnostic.
         filters = [[("diagnostic", "==", self.parquet_diagnostic_names[0])]]
@@ -295,6 +303,10 @@ class LoadForTrainQRF(PostProcessingPlugin):
 
         truth_df["time"] = pd.to_datetime(truth_df["time"], unit="ns", utc=True)
         truth_df["time"] = truth_df["time"].astype("datetime64[ns, UTC]")
+
+        for key in self.unique_site_id_keys:
+            if key in truth_df.columns and pd.api.types.is_string_dtype(truth_df[key]):
+                truth_df[key] = truth_df[key].str.strip()
 
         if truth_df.empty:
             msg = (

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
@@ -544,20 +544,6 @@ def test_load_for_qrf(
     )
     truth_path, expected_truth_df = truth_creation(tmp_path)
 
-    if "wmo_id" in site_id:
-        # Mimic fixed-width parquet strings with trailing whitespace.
-        padded_forecast_df = base_expected_forecast_df.copy()
-        padded_forecast_df["wmo_id"] = padded_forecast_df["wmo_id"].astype(str) + "   "
-        padded_forecast_df.to_parquet(
-            forecast_path / "forecast.parquet", index=False, engine="pyarrow"
-        )
-
-        padded_truth_df = expected_truth_df.copy()
-        padded_truth_df["wmo_id"] = padded_truth_df["wmo_id"].astype(str) + "   "
-        padded_truth_df.to_parquet(
-            truth_path / "truth.parquet", index=False, engine="pyarrow"
-        )
-
     file_paths = [forecast_path, truth_path]
 
     if include_dynamic:
@@ -623,6 +609,66 @@ def test_load_for_qrf(
         assert len(cube_inputs) == 1
         assert cube_inputs[0].name() == "distance_to_water"
         np.testing.assert_almost_equal(cube_inputs[0].data, expected_cube.data)
+
+
+def test_load_for_qrf_with_mixed_whitespace_padding_in_forecast_inputs(tmp_path):
+    """Test that dynamic forecast diagnostics merge when site IDs have
+    different whitespace padding across inputs."""
+
+    forecast_path, base_expected_forecast_df, _ = (
+        _create_multi_site_forecast_parquet_file(tmp_path, representation="percentile")
+    )
+    truth_path, expected_truth_df = _create_multi_site_truth_parquet_file(tmp_path)
+
+    padded_forecast_df = base_expected_forecast_df.copy()
+    wind_mask = padded_forecast_df["diagnostic"] == "wind_speed_at_10m"
+    wind_site_ids = padded_forecast_df.loc[wind_mask, "wmo_id"].astype(str)
+    padded_forecast_df.loc[wind_mask, "wmo_id"] = [
+        f"{site_id}{' ' * (index % 3 + 1)}"
+        for index, site_id in enumerate(wind_site_ids)
+    ]
+    padded_forecast_df.to_parquet(
+        forecast_path / "forecast.parquet", index=False, engine="pyarrow"
+    )
+
+    plugin = LoadForTrainQRF(
+        experiments=["latestblend", "recentblend"],
+        feature_config={
+            "air_temperature": ["mean", "std", "altitude"],
+            "wind_speed": ["mean", "std"],
+        },
+        parquet_diagnostic_names=["temperature_at_screen_level", "wind_speed_at_10m"],
+        cf_names=["air_temperature", "wind_speed"],
+        forecast_periods="6:18:6",
+        cycletime="20170103T0000Z",
+        training_length=2,
+        unique_site_id_keys="wmo_id",
+    )
+
+    forecast_df, truth_df, _ = plugin([forecast_path, truth_path])
+
+    expected_forecast_df = amend_expected_forecast_df(
+        base_expected_forecast_df.copy(),
+        "6:18:6",
+        ["temperature_at_screen_level", "wind_speed_at_10m"],
+        ["air_temperature", "wind_speed"],
+        "percentile",
+        ["wmo_id"],
+    )
+    expected_truth_df = amend_expected_truth_df(
+        expected_truth_df, "temperature_at_screen_level"
+    )
+
+    pd.testing.assert_frame_equal(
+        forecast_df,
+        expected_forecast_df,
+        check_dtype=False,
+        check_datetimelike_compat=True,
+    )
+    pd.testing.assert_frame_equal(
+        truth_df, expected_truth_df, check_dtype=False, check_datetimelike_compat=True
+    )
+    assert forecast_df["wind_speed"].notna().all()
 
 
 @pytest.mark.parametrize("make_files", [False, True])

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
@@ -83,13 +83,13 @@ def add_wind_data_to_forecasts(
     """
     # Add wind speed to demonstrate filtering.
     wind_speed_dict = data_dict.copy()
-    wind_speed_dict["forecast"] = wind_speed_values
+    wind_speed_dict["forecast"] = np.asarray(wind_speed_values, dtype=np.float32)
     wind_speed_dict["cf_name"] = "wind_speed"
     wind_speed_dict["units"] = "m s-1"
     wind_speed_dict["diagnostic"] = "wind_speed_at_10m"
     wind_speed_dict["experiment"] = "recentblend"
     wind_dir_dict = data_dict.copy()
-    wind_dir_dict["forecast"] = wind_dir_values
+    wind_dir_dict["forecast"] = np.asarray(wind_dir_values, dtype=np.float32)
     wind_dir_dict["cf_name"] = "wind_from_direction"
     wind_dir_dict["units"] = "degrees"
     wind_dir_dict["diagnostic"] = "wind_direction_at_10m"
@@ -112,7 +112,7 @@ def add_wind_data_to_truth(data_dict, wind_speed_values):
         A DataFrame containing the original data along with wind speed data.
     """
     wind_speed_dict = data_dict.copy()
-    wind_speed_dict["ob_value"] = wind_speed_values
+    wind_speed_dict["ob_value"] = np.asarray(wind_speed_values, dtype=np.float32)
     wind_speed_dict["diagnostic"] = "wind_speed_at_10m"
     data_df = pd.DataFrame(data_dict)
     wind_speed_df = pd.DataFrame(wind_speed_dict)
@@ -133,7 +133,7 @@ def modify_representation(data_dict, representation, values):
         Amended dictionary.
     """
     if representation == "realization":
-        data_dict["realization"] = values
+        data_dict["realization"] = np.array(values, dtype=np.int64)
         data_dict.pop("percentile")
     elif representation == "kittens":
         data_dict["kittens"] = values
@@ -152,14 +152,20 @@ def _create_multi_site_forecast_parquet_file(tmp_path, representation=None):
     """
     wmo_ids = ["03001", "03002", "03003", "03004", "03005"]
     data_dict = {
-        "percentile": np.repeat(50.0, 5),
-        "forecast": [281.0, 272.0, 287.0, 280.0, 290.0],
-        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "percentile": np.repeat(50.0, 5).astype(np.float64),
+        "forecast": np.array([281.0, 272.0, 287.0, 280.0, 290.0], dtype=np.float32),
+        "altitude": np.array(
+            [ALTITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "blend_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
         "forecast_period": [6 * 3.6e12] * 5,
         "forecast_reference_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
-        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "latitude": np.array(
+            [LATITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "longitude": np.array(
+            [LONGITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "time": [pd.Timestamp("2017-01-02 06:00:00", tz="utc")] * 5,
         "wmo_id": wmo_ids,
         "station_id": [f"{int(_id):08}" for _id in wmo_ids],
@@ -167,7 +173,7 @@ def _create_multi_site_forecast_parquet_file(tmp_path, representation=None):
         "units": ["K"] * 5,
         "experiment": ["latestblend"] * 5,
         "period": [pd.NA] * 5,
-        "height": [1.5] * 5,
+        "height": np.repeat(np.float32(1.5), 5),
         "diagnostic": ["temperature_at_screen_level"] * 5,
     }
     # Other representations used for testing.
@@ -197,14 +203,22 @@ def _create_multi_percentile_forecast_parquet_file(tmp_path, representation=None
     """
     wmo_ids = ["03001"] * 5
     data_dict = {
-        "percentile": [16 + 2 / 3, 33 + 1 / 3, 50, 66 + 2 / 3, 83 + 1 / 3],
-        "forecast": [272.0, 274.0, 275.0, 277.0, 280.0],
-        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "percentile": np.array(
+            [16 + 2 / 3, 33 + 1 / 3, 50, 66 + 2 / 3, 83 + 1 / 3], dtype=np.float64
+        ),
+        "forecast": np.array([272.0, 274.0, 275.0, 277.0, 280.0], dtype=np.float32),
+        "altitude": np.array(
+            [ALTITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "blend_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
         "forecast_period": [6 * 3.6e12] * 5,
         "forecast_reference_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
-        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "latitude": np.array(
+            [LATITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "longitude": np.array(
+            [LONGITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "time": [pd.Timestamp("2017-01-02 06:00:00", tz="utc")] * 5,
         "wmo_id": wmo_ids,
         "station_id": [f"{int(_id):08}" for _id in wmo_ids],
@@ -212,7 +226,7 @@ def _create_multi_percentile_forecast_parquet_file(tmp_path, representation=None
         "units": ["K"] * 5,
         "experiment": ["latestblend"] * 5,
         "period": [pd.NA] * 5,
-        "height": [1.5] * 5,
+        "height": np.repeat(np.float32(1.5), 5),
         "diagnostic": ["temperature_at_screen_level"] * 5,
     }
     # Other representations used for testing.
@@ -242,9 +256,11 @@ def _create_multi_forecast_period_forecast_parquet_file(tmp_path, representation
     """
     wmo_ids = ["03001", "03002", "03001", "03002"]
     data_dict = {
-        "percentile": [50.0, 50.0, 50.0, 50.0],
-        "forecast": [277.0, 270.0, 280.0, 269.0],
-        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "percentile": np.array([50.0, 50.0, 50.0, 50.0], dtype=np.float64),
+        "forecast": np.array([277.0, 270.0, 280.0, 269.0], dtype=np.float32),
+        "altitude": np.array(
+            [ALTITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "blend_time": [pd.Timestamp("2017-01-02 00:00:00")] * 4,
         "forecast_period": np.repeat(
             [
@@ -254,8 +270,12 @@ def _create_multi_forecast_period_forecast_parquet_file(tmp_path, representation
             2,
         ),
         "forecast_reference_time": [pd.Timestamp("2017-01-02 00:00:00")] * 4,
-        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "latitude": np.array(
+            [LATITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "longitude": np.array(
+            [LONGITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "time": np.repeat(
             [pd.Timestamp("2017-01-02 06:00:00"), pd.Timestamp("2017-01-02 12:00:00")],
             2,
@@ -266,7 +286,7 @@ def _create_multi_forecast_period_forecast_parquet_file(tmp_path, representation
         "units": ["K"] * 4,
         "experiment": ["latestblend"] * 4,
         "period": [pd.NA] * 4,
-        "height": [1.5] * 4,
+        "height": np.repeat(np.float32(1.5), 4),
         "diagnostic": ["temperature_at_screen_level"] * 4,
     }
     data_dict = modify_representation(data_dict, representation, [0, 1, 0, 1])
@@ -284,13 +304,19 @@ def _create_multi_site_truth_parquet_file(tmp_path):
     wmo_ids = ["03001", "03002", "03003", "03004", "03005"]
     data_dict = {
         "diagnostic": ["temperature_at_screen_level"] * 5,
-        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "latitude": np.array(
+            [LATITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "longitude": np.array(
+            [LONGITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "altitude": np.array(
+            [ALTITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "time": [pd.Timestamp("2017-01-02 06:00:00")] * 5,
         "wmo_id": wmo_ids,
         "station_id": [f"{int(_id):08}" for _id in wmo_ids],
-        "ob_value": [276.0, 270.0, 289.0, 290.0, 301.0],
+        "ob_value": np.array([276.0, 270.0, 289.0, 290.0, 301.0], dtype=np.float32),
     }
     joined_df = add_wind_data_to_truth(data_dict, [3, 22, 24, 11, 9])
     output_dir = write_to_parquet(
@@ -303,13 +329,13 @@ def _create_multi_percentile_truth_parquet_file(tmp_path):
     """Create a parquet file with multi-percentile truth data."""
     data_dict = {
         "diagnostic": ["temperature_at_screen_level"],
-        "latitude": [60.1],
-        "longitude": [1.0],
-        "altitude": [10.0],
+        "latitude": np.array([60.1], dtype=np.float32),
+        "longitude": np.array([1.0], dtype=np.float32),
+        "altitude": np.array([10.0], dtype=np.float32),
         "time": [pd.Timestamp("2017-01-02 06:00:00")],
         "wmo_id": ["03001"],
         "station_id": ["00003001"],
-        "ob_value": [276.0],
+        "ob_value": np.array([276.0], dtype=np.float32),
     }
     joined_df = add_wind_data_to_truth(data_dict, [9])
     output_dir = write_to_parquet(
@@ -323,16 +349,22 @@ def _create_multi_forecast_period_truth_parquet_file(tmp_path):
     wmo_ids = ["03001", "03002", "03001", "03002"]
     data_dict = {
         "diagnostic": ["temperature_at_screen_level"] * 4,
-        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "latitude": np.array(
+            [LATITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "longitude": np.array(
+            [LONGITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "altitude": np.array(
+            [ALTITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "time": np.repeat(
             [pd.Timestamp("2017-01-02 06:00:00"), pd.Timestamp("2017-01-02 12:00:00")],
             2,
         ),
         "wmo_id": wmo_ids,
         "station_id": [f"{int(_id):08}" for _id in wmo_ids],
-        "ob_value": [280, 273, 284, 275],
+        "ob_value": np.array([280, 273, 284, 275], dtype=np.float32),
     }
     joined_df = add_wind_data_to_truth(data_dict, [2.0, 11.0, 10.0, 14.0])
     output_dir = write_to_parquet(
@@ -346,13 +378,19 @@ def _create_multi_site_truth_parquet_file_alt(tmp_path, site_id="wmo_id"):
     wmo_ids = ["03001", "03002", "03003", "03004", "03005"]
     data_dict = {
         "diagnostic": ["wind_speed_at_10m"] * 5,
-        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
-        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "latitude": np.array(
+            [LATITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "longitude": np.array(
+            [LONGITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
+        "altitude": np.array(
+            [ALTITUDE_LOOKUP[_id] for _id in wmo_ids], dtype=np.float32
+        ),
         "time": [pd.Timestamp("2017-01-02 06:00:00")] * 5,
         "wmo_id": wmo_ids,
         "station_id": [f"{int(_id):08}" for _id in wmo_ids],
-        "ob_value": [10.0, 25.0, 4.0, 3.0, 11.0],
+        "ob_value": np.array([10.0, 25.0, 4.0, 3.0, 11.0], dtype=np.float32),
     }
     joined_df = add_wind_data_to_truth(data_dict, [3.0, 22.0, 24.0, 11.0, 9.0])
     output_dir = write_to_parquet(
@@ -458,6 +496,12 @@ def amend_expected_forecast_df(
             how="left",
         )
     forecast_df = base_df
+
+    if representation == "realization" and "realization" in forecast_df.columns:
+        # In the test source data this column can be upcast to float64 when rows
+        # from diagnostics without a realization are concatenated. Cast back to
+        # match parquet schema output (int64).
+        forecast_df["realization"] = forecast_df["realization"].astype(np.int64)
 
     forecast_df.rename(columns={"forecast": "air_temperature"}, inplace=True)
     return forecast_df
@@ -598,11 +642,11 @@ def test_load_for_qrf(
     pd.testing.assert_frame_equal(
         forecast_df,
         expected_forecast_df,
-        check_dtype=False,
+        check_dtype=True,
         check_datetimelike_compat=True,
     )
     pd.testing.assert_frame_equal(
-        truth_df, expected_truth_df, check_dtype=False, check_datetimelike_compat=True
+        truth_df, expected_truth_df, check_dtype=True, check_datetimelike_compat=True
     )
     if include_static:
         assert isinstance(cube_inputs, iris.cube.CubeList)
@@ -658,17 +702,15 @@ def test_load_for_qrf_with_mixed_whitespace_padding_in_forecast_inputs(tmp_path)
     expected_truth_df = amend_expected_truth_df(
         expected_truth_df, "temperature_at_screen_level"
     )
-
     pd.testing.assert_frame_equal(
         forecast_df,
         expected_forecast_df,
-        check_dtype=False,
+        check_dtype=True,
         check_datetimelike_compat=True,
     )
     pd.testing.assert_frame_equal(
-        truth_df, expected_truth_df, check_dtype=False, check_datetimelike_compat=True
+        truth_df, expected_truth_df, check_dtype=True, check_datetimelike_compat=True
     )
-    assert forecast_df["wind_speed"].notna().all()
 
 
 @pytest.mark.parametrize("make_files", [False, True])

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
@@ -544,6 +544,20 @@ def test_load_for_qrf(
     )
     truth_path, expected_truth_df = truth_creation(tmp_path)
 
+    if "wmo_id" in site_id:
+        # Mimic fixed-width parquet strings with trailing whitespace.
+        padded_forecast_df = base_expected_forecast_df.copy()
+        padded_forecast_df["wmo_id"] = padded_forecast_df["wmo_id"].astype(str) + "   "
+        padded_forecast_df.to_parquet(
+            forecast_path / "forecast.parquet", index=False, engine="pyarrow"
+        )
+
+        padded_truth_df = expected_truth_df.copy()
+        padded_truth_df["wmo_id"] = padded_truth_df["wmo_id"].astype(str) + "   "
+        padded_truth_df.to_parquet(
+            truth_path / "truth.parquet", index=False, engine="pyarrow"
+        )
+
     file_paths = [forecast_path, truth_path]
 
     if include_dynamic:


### PR DESCRIPTION
Addresses https://github.com/metoppv/mo-blue-team/issues/1258

Description
QRF training can fail due to mismatches in the unique_site_id_key arising from the presence of additional spaces. This PR strips spaces from the WMO ID coordinate in the forecast and the truths, so that this possible mismatch can be avoided.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
