### PR TITLE
CI: Test-Coverage failure - failing environment creation for latest.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       if: steps.report-cache-restore.outputs.cache-hit != 'true'
       uses: mamba-org/setup-micromamba@v3
       env:
+        # https://github.com/metoppv/improver/pull/2430
         CONDA_OVERRIDE_CUDA: "0"
       with:
         environment-file: envs/latest.yml
@@ -204,6 +205,7 @@ jobs:
     - name: Environment creation
       uses: mamba-org/setup-micromamba@v3
       env:
+        # https://github.com/metoppv/improver/pull/2430
         CONDA_OVERRIDE_CUDA: "0"
       with:
         environment-file: envs/${{ matrix.env }}.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
     - name: Environment creation
       if: steps.report-cache-restore.outputs.cache-hit != 'true'
       uses: mamba-org/setup-micromamba@v3
+      env:
+        CONDA_OVERRIDE_CUDA: "0"
       with:
         environment-file: envs/latest.yml
         init-shell: bash
@@ -201,6 +203,8 @@ jobs:
 
     - name: Environment creation
       uses: mamba-org/setup-micromamba@v3
+      env:
+        CONDA_OVERRIDE_CUDA: "0"
       with:
         environment-file: envs/${{ matrix.env }}.yml
         init-shell: bash


### PR DESCRIPTION
Setting `CONDA_OVERRIDE_CUDA="0"` disables CUDA detection and forces Conda to resolve a CPU-only tensorflow build.

I chose this approach rather than explicitly installing tensorflow-cpu because we may still need the GPU-enabled tensorflow package for PS48. The issue we're addressing here appears to be specific to the CI workflow rather than the Conda environment itself, since the GitHub runners used by IMPROVER do not have GPU hardware available.

Although environment creation has completed successfully in the past, I noticed dependency resolution was taking around 1 hour 25 minutes, suggesting CUDA detection may have been causing problems even before the failures we're now seeing.

After adding the override to prevent CUDA detection, environment resolution time dropped from approximately 85 minutes to 12 minutes.

An example failure can be seen here: [CI workflow failure](https://github.com/metoppv/improver/actions/runs/32136130851/job/95707764204#step:7:1)

<img width="515" height="87" alt="image" src="https://github.com/user-attachments/assets/c39e7302-6733-4c2a-aa7f-c109a894c7b6" />

---

<img width="456" height="177" alt="image" src="https://github.com/user-attachments/assets/da5169d8-547a-475d-bf6e-c67e056bd916" />

## Background

Conda-forge guidance: https://conda-forge.org/docs/user/tipsandtricks/#installing-cuda-enabled-packages-like-tensorflow-and-pytorch

The TensorFlow documentation notes that when Conda is run on a machine without a GPU, it attempts to make a best guess at the required CUDA libraries and may select older package versions for compatibility. It recommends setting CONDA_OVERRIDE_CUDA to an appropriate CUDA version when installing GPU-enabled TensorFlow.

This suggests we should not need to disable CUDA detection entirely, and that the behaviour may instead be a Conda or TensorFlow packaging/resolution issue.

See: https://docs.hpc.qmul.ac.uk/apps/ml/tensorflow/#conda-gpu-version