### PR TITLE
Harmonise coordinates in clustering

### DIFF
--- a/improver/blending/utilities.py
+++ b/improver/blending/utilities.py
@@ -101,6 +101,23 @@ def get_coords_to_remove(cube: Cube, blend_coord: str) -> List[str]:
     return crds_to_remove
 
 
+def remove_blend_time(cube: Cube) -> Cube:
+    """Remove an existing blend_time coordinate if present."""
+    if cube.coords("blend_time"):
+        cube.remove_coord("blend_time")
+    return cube
+
+
+def remove_deprecation_warnings(cube: Cube) -> Cube:
+    """Remove deprecation warnings from forecast time coordinates."""
+    for coord in ["forecast_period", "forecast_reference_time"]:
+        try:
+            cube.coord(coord).attributes.pop("deprecation_message", None)
+        except CoordinateNotFoundError:
+            pass
+    return cube
+
+
 def update_blended_metadata(
     cube: Cube,
     blend_coord: str,

--- a/improver/blending/weighted_blend.py
+++ b/improver/blending/weighted_blend.py
@@ -18,7 +18,12 @@ from numpy import ndarray
 
 from improver import BasePlugin, PostProcessingPlugin
 from improver.blending import MODEL_BLEND_COORD, MODEL_NAME_COORD
-from improver.blending.utilities import find_blend_dim_coord, store_record_run_as_coord
+from improver.blending.utilities import (
+    find_blend_dim_coord,
+    remove_blend_time,
+    remove_deprecation_warnings,
+    store_record_run_as_coord,
+)
 from improver.metadata.constants import FLOAT_DTYPE, PERC_COORD
 from improver.metadata.forecast_times import rebadge_forecasts_as_latest_cycle
 from improver.utilities.complex_conversion import complex_to_deg, deg_to_complex
@@ -26,7 +31,6 @@ from improver.utilities.cube_manipulation import (
     MergeCubes,
     collapsed,
     enforce_coordinate_ordering,
-    get_coord_names,
     get_dim_coord_names,
     sort_coord_in_cube,
 )
@@ -131,25 +135,6 @@ class MergeCubesForWeightedBlending(BasePlugin):
             cube.add_aux_coord(new_model_id_coord)
             cube.add_aux_coord(new_model_coord)
 
-    @staticmethod
-    def _remove_blend_time(cube: Cube) -> Cube:
-        """If present on input, remove existing blend time coordinate (as this will
-        be replaced on blending)"""
-        if "blend_time" in get_coord_names(cube):
-            cube.remove_coord("blend_time")
-        return cube
-
-    @staticmethod
-    def _remove_deprecation_warnings(cube: Cube) -> Cube:
-        """Remove deprecation warnings from forecast period and forecast reference
-        time coordinates so that these can be merged before blending"""
-        for coord in ["forecast_period", "forecast_reference_time"]:
-            try:
-                cube.coord(coord).attributes.pop("deprecation_message", None)
-            except CoordinateNotFoundError:
-                pass
-        return cube
-
     def process(
         self,
         cubes_in: Union[List[Cube], Cube, CubeList],
@@ -187,8 +172,8 @@ class MergeCubesForWeightedBlending(BasePlugin):
             )
 
         if "model" in self.blend_coord:
-            cubelist = [self._remove_blend_time(cube) for cube in cubelist]
-            cubelist = [self._remove_deprecation_warnings(cube) for cube in cubelist]
+            cubelist = [remove_blend_time(cube) for cube in cubelist]
+            cubelist = [remove_deprecation_warnings(cube) for cube in cubelist]
             if (
                 self.weighting_coord is not None
                 and "forecast_period" in self.weighting_coord

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -17,6 +17,7 @@ from iris.cube import Cube, CubeList
 from iris.util import new_axis, promote_aux_coord_to_dim_coord
 
 from improver import BasePlugin
+from improver.blending.utilities import remove_blend_time, remove_deprecation_warnings
 from improver.clustering.clustering import FitClustering
 from improver.regrid.landsea import RegridLandSea
 from improver.utilities.cube_manipulation import (
@@ -1554,11 +1555,8 @@ class RealizationClusterAndMatch(BasePlugin):
         # Remove / harmonise known scalar coords that can differ across sources
         # and otherwise prevent the final merge. This can occur if some of the
         # primary or secondary inputs have already been blended.
-        for cube in matched_cubes:
-            if cube.coords("blend_time"):
-                cube.remove_coord("blend_time")
-            if cube.coords("forecast_reference_time"):
-                cube.coord("forecast_reference_time").attributes = {}
+        matched_cubes = [remove_blend_time(cube) for cube in matched_cubes]
+        matched_cubes = [remove_deprecation_warnings(cube) for cube in matched_cubes]
 
         result_cube = MergeCubes()(
             CubeList([iris.util.squeeze(c) for c in matched_cubes])
@@ -1934,22 +1932,6 @@ class RealizationSelection(BasePlugin):
             selected_cubes.append(selected)
         return selected_cubes
 
-    def _remove_blend_time_from_selected_cubes(
-        self, selected_cubes: list[Cube]
-    ) -> None:
-        """Remove blend_time coordinate from all selected cubes if present on any.
-
-        blend_time is removed to avoid ambiguity in the merged output, as selected
-        cubes may come from different source models with differing blend_time values.
-
-        Args:
-            selected_cubes:
-                Realization-selected cubes, modified in place.
-        """
-        for cube in selected_cubes:
-            if cube.coords("blend_time"):
-                cube.remove_coord("blend_time")
-
     def process(self, cubes: CubeList) -> Cube:
         """
         Select realizations from input forecast cubes according to cluster assignments
@@ -1996,10 +1978,8 @@ class RealizationSelection(BasePlugin):
         )
         # Remove blend time and sanitise forecast_reference_time attributes to
         # support merging.
-        self._remove_blend_time_from_selected_cubes(selected_cubes)
-        for cube in selected_cubes:
-            if cube.coords("forecast_reference_time"):
-                cube.coord("forecast_reference_time").attributes = {}
+        selected_cubes = [remove_blend_time(cube) for cube in selected_cubes]
+        selected_cubes = [remove_deprecation_warnings(cube) for cube in selected_cubes]
 
         result_cube = MergeCubes()(CubeList(selected_cubes))
         if "cluster_sources" in cluster_cube.attributes:

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1551,6 +1551,15 @@ class RealizationClusterAndMatch(BasePlugin):
             secondary_input_realizations_to_clusters,
         )
 
+        # Remove / harmonise known scalar coords that can differ across sources
+        # and otherwise prevent the final merge. This can occur if some of the
+        # primary or secondary inputs have already been blended.
+        for cube in matched_cubes:
+            if cube.coords("blend_time"):
+                cube.remove_coord("blend_time")
+            if cube.coords("forecast_reference_time"):
+                cube.coord("forecast_reference_time").attributes = {}
+
         result_cube = MergeCubes()(
             CubeList([iris.util.squeeze(c) for c in matched_cubes])
         )

--- a/improver_tests/blending/test_utilities.py
+++ b/improver_tests/blending/test_utilities.py
@@ -24,12 +24,15 @@ from improver.blending.utilities import (
     find_blend_dim_coord,
     get_coords_to_remove,
     record_run_coord_to_attr,
+    remove_blend_time,
+    remove_deprecation_warnings,
     store_record_run_as_coord,
     update_blended_metadata,
     update_record_run_weights,
 )
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
 from improver.metadata.constants.time_types import DT_FORMAT
+from improver.metadata.forecast_times import add_blend_time
 from improver.synthetic_data.set_up_test_cubes import set_up_probability_cube
 
 
@@ -208,6 +211,32 @@ def test_get_coords_to_remove_noop(cycle_cube):
     """Test time coordinates are not removed"""
     result = get_coords_to_remove(cycle_cube, "forecast_reference_time")
     assert not result
+
+
+def test_remove_blend_time(model_cube):
+    """Test blend-time coordinate removal."""
+    cube = model_cube.copy()
+    add_blend_time(cube, "20171110T0200Z")
+
+    remove_blend_time(cube)
+
+    assert not cube.coords("blend_time")
+
+
+def test_remove_deprecation_warnings(model_cube):
+    """Test removal of deprecation warnings from forecast time coordinates."""
+    cube = model_cube.copy()
+    cube.coord("forecast_period").attributes["deprecation_message"] = (
+        "forecast_period will be removed in future and should not be used"
+    )
+    cube.coord("forecast_reference_time").attributes["deprecation_message"] = (
+        "forecast_reference_time will be removed in future and should not be used"
+    )
+
+    remove_deprecation_warnings(cube)
+
+    assert "deprecation_message" not in cube.coord("forecast_period").attributes
+    assert "deprecation_message" not in cube.coord("forecast_reference_time").attributes
 
 
 def test_get_coords_to_remove_scalar(model_cube, model_cube_with_blend_record):

--- a/improver_tests/blending/test_utilities.py
+++ b/improver_tests/blending/test_utilities.py
@@ -216,11 +216,23 @@ def test_get_coords_to_remove_noop(cycle_cube):
 def test_remove_blend_time(model_cube):
     """Test blend-time coordinate removal."""
     cube = model_cube.copy()
+    attributes_before = cube.attributes.copy()
+    forecast_reference_time = cube.coord("forecast_reference_time").copy()
+    time = cube.coord("time").copy()
+
     add_blend_time(cube, "20171110T0200Z")
 
     remove_blend_time(cube)
 
     assert not cube.coords("blend_time")
+    assert cube.attributes == attributes_before
+    assert (
+        cube.coord("forecast_reference_time").points == forecast_reference_time.points
+    )
+    assert cube.coord("forecast_reference_time").attributes == (
+        forecast_reference_time.attributes
+    )
+    assert cube.coord("time").points == time.points
 
 
 def test_remove_deprecation_warnings(model_cube):

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -3297,7 +3297,10 @@ def test_clusterandmatch_secondary_scalar_realization_coord():
     ["partial_deterministic", "full_ensemble"],
 )
 def test_clusterandmatch_secondary_with_deprecation_message_merges(secondary_kind):
-    """Test merge succeeds when secondary metadata includes deprecation message.
+    """Test that the merging of cubes from different forecast sources succeeds,
+    even if the some of the forecast sources have already been blended, and
+    therefore additional metadata is present e.g. a blend_time coordinate and a
+    deprecation message on the forecast_reference_time coordinate.
 
     This exercises both matching routes:
     - partial_deterministic: secondary has no realization dimension (< n_clusters)
@@ -3382,6 +3385,9 @@ def test_clusterandmatch_secondary_with_deprecation_message_merges(secondary_kin
 
     result = plugin.process(cubes)
 
+    # Check that no blend_time coordinate is present on the result and that
+    # forecast_reference_time attributes are cleared. This metadata can sometimes
+    # exist on the inputs but can prevent merging if not removed.
     assert not result.coords("blend_time")
     assert result.coord("forecast_reference_time").attributes == {}
 

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import iris
 import numpy as np
 import pytest
-from iris.coords import DimCoord
+from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
 from iris.util import promote_aux_coord_to_dim_coord
 
@@ -3290,6 +3290,100 @@ def test_clusterandmatch_secondary_scalar_realization_coord():
     np.testing.assert_array_equal(
         result.coord("forecast_period").points, [0, 6 * 3600]
     )
+
+
+@pytest.mark.parametrize(
+    "secondary_kind",
+    ["partial_deterministic", "full_ensemble"],
+)
+def test_clusterandmatch_secondary_with_deprecation_message_merges(secondary_kind):
+    """Test merge succeeds when secondary metadata includes deprecation message.
+
+    This exercises both matching routes:
+    - partial_deterministic: secondary has no realization dimension (< n_clusters)
+    - full_ensemble: secondary has >= n_clusters realizations
+    """
+    pytest.importorskip("kmedoids")
+    pytest.importorskip("esmf_regrid")
+
+    cubes = CubeList()
+    spatial_shape = (3, 3)
+
+    # Primary ensemble input.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=4,
+            forecast_periods=[0, 6],
+            y_dim=spatial_shape[0],
+            x_dim=spatial_shape[1],
+            base_value=100.0,
+            model_id="primary_model",
+            merge=False,
+        )
+    )
+
+    if secondary_kind == "partial_deterministic":
+        for fp_hours in [0, 6]:
+            sec_data = np.full(spatial_shape, 500.0 + fp_hours, dtype=np.float32)
+            sec_cube = set_up_variable_cube(
+                sec_data,
+                name="air_temperature",
+                units="K",
+                spatial_grid="equalarea",
+            )
+            sec_cube.attributes["model_id"] = "secondary_model"
+            sec_cube.coord("forecast_period").points = [fp_hours * 3600]
+            sec_cube.coord("time").points = [
+                sec_cube.coord("forecast_reference_time").points[0] + fp_hours * 3600
+            ]
+            cubes.append(sec_cube)
+    else:
+        cubes.extend(
+            _create_4d_realization_cube(
+                n_realizations=4,
+                forecast_periods=[0, 6],
+                y_dim=spatial_shape[0],
+                x_dim=spatial_shape[1],
+                base_value=500.0,
+                model_id="secondary_model",
+                merge=False,
+            )
+        )
+
+    # Add metadata known to cause merge mismatches when not harmonised.
+    for cube in cubes:
+        if cube.attributes.get("model_id") != "secondary_model":
+            continue
+        frt_coord = cube.coord("forecast_reference_time")
+        frt_coord.attributes["deprecation_message"] = (
+            "forecast_reference_time will be removed in future and should not be used"
+        )
+        cube.add_aux_coord(
+            AuxCoord(
+                frt_coord.points.copy(),
+                long_name="blend_time",
+                units=frt_coord.units,
+            )
+        )
+
+    cubes.append(_create_target_grid_cube(spatial_shape=spatial_shape))
+
+    plugin = RealizationClusterAndMatch(
+        hierarchy={
+            "primary_input": "primary_model",
+            "secondary_inputs": {"secondary_model": [0, 6]},
+        },
+        model_id_attr="model_id",
+        clustering_method="KMedoids",
+        target_grid_name="target_grid",
+        n_clusters=2,
+        random_state=42,
+    )
+
+    result = plugin.process(cubes)
+
+    assert not result.coords("blend_time")
+    assert result.coord("forecast_reference_time").attributes == {}
 
 
 def test_select_realizations_for_kmedoid_clusters_too_many_clusters():


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/1244, https://github.com/metoppv/improver/pull/2431

Description
This PR builds on top of https://github.com/metoppv/improver/pull/2431. (Only this commit is relevant: https://github.com/metoppv/improver/pull/2434/commits/c754c4129c414ed245b16063fb7cab4453eadb59). As part of testing the inclusion of a nowcast ensemble, this highlighted an issue, where if a nowcast followed the "full realization" pathway, rather than the "partial realization" pathway, the metadata from the nowcast would then end up being used within the final matched cubes. Due to the blending that occurs between the nowcast and an NWP model to create a full domain forecast, the nowcast has additional metadata (a blend time coordinate and a deprecation message on the forecast reference time coordinate) that are not present on other inputs. This PR strips off these additional bits of metadata that prevents merging.
 
Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

