### PR TITLE
Modify precedence ordering when clustering

### DIFF
--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1081,6 +1081,81 @@ class RealizationClusterAndMatch(BasePlugin):
             candidate_cube,
         )
 
+    def _build_model_precedence(self) -> dict[str, int]:
+        """Build precedence ranks for all models in the hierarchy.
+
+        Lower rank means higher precedence.
+
+        Returns:
+            Mapping of model name to precedence rank.
+        """
+        secondary_names = list(self.hierarchy["secondary_inputs"].keys())
+        precedence = {name: rank for rank, name in enumerate(secondary_names)}
+        # Primary input acts as the fallback source and has lowest precedence.
+        precedence[self.hierarchy["primary_input"]] = len(secondary_names)
+        return precedence
+
+    @staticmethod
+    def _source_for_cluster_forecast_period(
+        cluster_sources: dict[int, dict[str, list[int]]], cluster_idx: int, fp: int
+    ) -> str | None:
+        """Get the current source model for a cluster at a forecast period.
+
+        Args:
+            cluster_sources: Tracking structure keyed by cluster then model.
+            cluster_idx: Cluster index to inspect.
+            fp: Forecast period in seconds.
+
+        Returns:
+            Model name currently providing this cluster at this forecast period,
+            or None if no source is recorded.
+        """
+        for model_name, fps in cluster_sources.get(cluster_idx, {}).items():
+            if fp in fps:
+                return model_name
+        return None
+
+    def _filter_cluster_updates_by_precedence(
+        self,
+        cluster_indices: list[int],
+        realization_indices: list[int],
+        candidate_name: str,
+        fp: int,
+        cluster_sources: dict[int, dict[str, list[int]]],
+        model_precedence: dict[str, int],
+    ) -> tuple[list[int], list[int]]:
+        """Filter cluster updates to enforce hierarchy precedence globally.
+
+        Lower-priority inputs cannot overwrite clusters already provided by
+        higher-priority inputs at the same forecast period.
+
+        Args:
+            cluster_indices: Candidate cluster indices to update.
+            realization_indices: Candidate realization indices paired to clusters.
+            candidate_name: Name of model proposing the updates.
+            fp: Forecast period in seconds.
+            cluster_sources: Current source tracking.
+            model_precedence: Model precedence mapping, lower is higher priority.
+
+        Returns:
+            Filtered (cluster_indices, realization_indices) that are allowed to
+            update.
+        """
+        allowed_cluster_indices = []
+        allowed_realization_indices = []
+        candidate_rank = model_precedence.get(candidate_name, len(model_precedence))
+
+        for cluster_idx, realization_idx in zip(cluster_indices, realization_indices):
+            current_source = self._source_for_cluster_forecast_period(
+                cluster_sources, cluster_idx, fp
+            )
+            current_rank = model_precedence.get(current_source, len(model_precedence))
+            if current_source is None or candidate_rank <= current_rank:
+                allowed_cluster_indices.append(cluster_idx)
+                allowed_realization_indices.append(realization_idx)
+
+        return allowed_cluster_indices, allowed_realization_indices
+
     def _extract_merge_and_match(
         self,
         candidate_name: str,
@@ -1251,6 +1326,7 @@ class RealizationClusterAndMatch(BasePlugin):
         matched_cubes: CubeList,
         cluster_sources: dict[int, dict[str, list[int]]],
         secondary_input_realizations_to_clusters: dict[str, dict[int, list[int]]],
+        model_precedence: dict[str, int],
     ) -> None:
         """Process partial realization inputs in reverse precedence order.
 
@@ -1280,6 +1356,8 @@ class RealizationClusterAndMatch(BasePlugin):
                 Modified in-place.
                 Format: {secondary_input_name:
                 {forecast_period: {cluster_index: [realization_indices]}}}
+            model_precedence: Model precedence mapping, lower rank means higher
+                precedence.
         """
         # Process in reverse order (lowest precedence first)
         for candidate_name, forecast_periods in reversed(partial_realization_inputs):
@@ -1303,6 +1381,19 @@ class RealizationClusterAndMatch(BasePlugin):
                 fp_constr = iris.Constraint(forecast_period=fp)
                 candidate_cube = cubes.extract_cube(model_id_constr & fp_constr)
 
+                allowed_cluster_indices, allowed_realization_indices = (
+                    self._filter_cluster_updates_by_precedence(
+                        cluster_indices,
+                        realization_indices,
+                        candidate_name,
+                        fp,
+                        cluster_sources,
+                        model_precedence,
+                    )
+                )
+                if not allowed_cluster_indices:
+                    continue
+
                 # Index the candidate cube using the realization indices determined
                 # from the combined match across all forecast periods.
                 matched_cube = candidate_cube[realization_indices]
@@ -1318,13 +1409,17 @@ class RealizationClusterAndMatch(BasePlugin):
 
                 # Replace data for the specific cluster indices with the new data
                 result_data = existing_fp_cube.data.copy()
-                for i, cluster_idx in enumerate(cluster_indices):
+                for cluster_idx in allowed_cluster_indices:
                     # Find which position cluster_idx is in the existing cube
                     pos = np.where(
                         existing_fp_cube.coord("realization").points == cluster_idx
                     )[0]
                     if len(pos) > 0:
-                        result_data[pos[0]] = matched_cube.data[i]
+                        matched_pos = np.where(
+                            matched_cube.coord("realization").points == cluster_idx
+                        )[0]
+                        if len(matched_pos) > 0:
+                            result_data[pos[0]] = matched_cube.data[matched_pos[0]]
 
                 # Create a new cube with the merged data
                 merged_cube = existing_fp_cube.copy(data=result_data)
@@ -1336,8 +1431,8 @@ class RealizationClusterAndMatch(BasePlugin):
 
                 self._record_match_for_forecast_period(
                     fp,
-                    cluster_indices,
-                    realization_indices,
+                    allowed_cluster_indices,
+                    allowed_realization_indices,
                     candidate_name,
                     candidate_cube,
                     replaced_realizations,
@@ -1506,6 +1601,7 @@ class RealizationClusterAndMatch(BasePlugin):
         # forecast period
         # Format: {cluster_idx: {model_name: [fp1, fp2, ...]}}
         cluster_sources = {}
+        model_precedence = self._build_model_precedence()
 
         # Start with the clustered primary cube as the base for all forecast periods
         # This ensures we always have a full set of realizations to work with
@@ -1549,6 +1645,7 @@ class RealizationClusterAndMatch(BasePlugin):
             matched_cubes,
             cluster_sources,
             secondary_input_realizations_to_clusters,
+            model_precedence,
         )
 
         result_cube = MergeCubes()(

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1084,7 +1084,10 @@ class RealizationClusterAndMatch(BasePlugin):
     def _build_model_precedence(self) -> dict[str, int]:
         """Build precedence ranks for all models in the hierarchy.
 
-        Lower rank means higher precedence.
+        Lower rank means higher precedence, for example, a precedence mapping of
+        {'nowcast': 0, 'uk_det': 1, 'uk_ens': 2, 'gl_ens': 3, 'ecgl_ens': 4}
+        would indicate that 'nowcast' has the highest precedence and
+        'ecgl_ens' has the lowest precedence.
 
         Returns:
             Mapping of model name to precedence rank.
@@ -1102,7 +1105,9 @@ class RealizationClusterAndMatch(BasePlugin):
         """Get the current source model for a cluster at a forecast period.
 
         Args:
-            cluster_sources: Tracking structure keyed by cluster then model.
+            cluster_sources: Dictionary tracking which input was used for each
+                cluster at each forecast period. Modified in-place.
+                Format: {cluster_idx: {model_name: [fp1, fp2, ...]}}
             cluster_idx: Cluster index to inspect.
             fp: Forecast period in seconds.
 
@@ -1134,12 +1139,25 @@ class RealizationClusterAndMatch(BasePlugin):
             realization_indices: Candidate realization indices paired to clusters.
             candidate_name: Name of model proposing the updates.
             fp: Forecast period in seconds.
-            cluster_sources: Current source tracking.
+            cluster_sources: Dictionary tracking which input was used for each
+                cluster at each forecast period. Modified in-place.
+                Format: {cluster_idx: {model_name: [fp1, fp2, ...]}}
             model_precedence: Model precedence mapping, lower is higher priority.
+                For example, a precedence mapping of
+                {'nowcast': 0, 'uk_det': 1, 'uk_ens': 2, 'gl_ens': 3, 'ecgl_ens': 4}
+                would indicate that 'nowcast' has the highest precedence and 'ecgl_ens'
+                has the lowest precedence.
 
         Returns:
             Filtered (cluster_indices, realization_indices) that are allowed to
-            update.
+            update. For example, with a precedence mapping of
+            {'nowcast': 0, 'uk_det': 1, 'uk_ens': 2, 'gl_ens': 3, 'ecgl_ens': 4}
+            and a candidate name of "uk_det", any clusters currently represented by
+            "nowcast" at the same forecast period would not be allowed to update. For
+            example, if cluster_indices = [0, 1, 2] and realization_indices = [3, 4, 5],
+            and cluster 1 is currently provided by "nowcast", the returned values
+            would be ([0, 2], [3, 5]), indicating that only clusters 0 and 2 are
+            allowed to update with realizations 3 and 5, respectively.
         """
         allowed_cluster_indices = []
         allowed_realization_indices = []
@@ -1357,7 +1375,10 @@ class RealizationClusterAndMatch(BasePlugin):
                 Format: {secondary_input_name:
                 {forecast_period: {cluster_index: [realization_indices]}}}
             model_precedence: Model precedence mapping, lower rank means higher
-                precedence.
+                precedence. For example, a precedence mapping of
+                {'nowcast': 0, 'uk_det': 1, 'uk_ens': 2, 'gl_ens': 3, 'ecgl_ens': 4}
+                would indicate that 'nowcast' has the highest precedence and
+                'ecgl_ens' has the lowest precedence.
         """
         # Process in reverse order (lowest precedence first)
         for candidate_name, forecast_periods in reversed(partial_realization_inputs):

--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -1099,7 +1099,7 @@ class RealizationClusterAndMatch(BasePlugin):
         return precedence
 
     @staticmethod
-    def _source_for_cluster_forecast_period(
+    def _get_source_for_cluster_forecast_period(
         cluster_sources: dict[int, dict[str, list[int]]], cluster_idx: int, fp: int
     ) -> str | None:
         """Get the current source model for a cluster at a forecast period.
@@ -1164,11 +1164,11 @@ class RealizationClusterAndMatch(BasePlugin):
         candidate_rank = model_precedence.get(candidate_name, len(model_precedence))
 
         for cluster_idx, realization_idx in zip(cluster_indices, realization_indices):
-            current_source = self._source_for_cluster_forecast_period(
+            current_source = self._get_source_for_cluster_forecast_period(
                 cluster_sources, cluster_idx, fp
             )
             current_rank = model_precedence.get(current_source, len(model_precedence))
-            if current_source is None or candidate_rank <= current_rank:
+            if current_source is None or candidate_rank < current_rank:
                 allowed_cluster_indices.append(cluster_idx)
                 allowed_realization_indices.append(realization_idx)
 

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -1694,6 +1694,86 @@ def test_clusterandmatch_precedence_order(
     _assert_secondary_input_realizations_to_clusters(result, expected_secondary_mapping)
 
 
+def test_clusterandmatch_global_precedence_full_over_partial():
+    """A lower-precedence partial input must not overwrite higher-precedence full.
+
+    secondary_model_1 is full and higher precedence. secondary_model_2 is partial
+    and lower precedence at the same forecast period.
+    """
+    pytest.importorskip("kmedoids")
+    pytest.importorskip("esmf_regrid")
+
+    cubes = CubeList()
+    spatial_shape = (5, 5)
+
+    # Primary input designed to produce three clusters.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=6,
+            forecast_periods=[0],
+            y_dim=spatial_shape[0],
+            x_dim=spatial_shape[1],
+            model_id="primary_model",
+            realization_values=[0.0, 0.2, 100.0, 100.2, 200.0, 200.2],
+            merge=False,
+        )
+    )
+
+    # Higher-precedence full secondary input (n_realizations >= n_clusters).
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=3,
+            forecast_periods=[0],
+            y_dim=spatial_shape[0],
+            x_dim=spatial_shape[1],
+            model_id="secondary_model_1",
+            realization_values=[0.0, 100.0, 200.0],
+            merge=False,
+        )
+    )
+
+    # Lower-precedence partial deterministic input for the same forecast period.
+    det_cube = set_up_variable_cube(
+        np.full(spatial_shape, 20.0, dtype=np.float32),
+        name="air_temperature",
+        units="K",
+        spatial_grid="equalarea",
+    )
+    det_cube.attributes["model_id"] = "secondary_model_2"
+    det_cube.coord("forecast_period").points = [0]
+    det_cube.coord("time").points = [det_cube.coord("forecast_reference_time").points[0]]
+    cubes.append(det_cube)
+
+    cubes.append(_create_target_grid_cube())
+
+    hierarchy = {
+        "primary_input": "primary_model",
+        "secondary_inputs": {
+            "secondary_model_1": [0],
+            "secondary_model_2": [0],
+        },
+    }
+
+    result = RealizationClusterAndMatch(
+        hierarchy=hierarchy,
+        model_id_attr="model_id",
+        clustering_method="KMedoids",
+        target_grid_name="target_grid",
+        n_clusters=3,
+        random_state=42,
+    ).process(cubes)
+
+    # Lower-precedence deterministic value should not appear in output.
+    fp_data = result.extract(iris.Constraint(forecast_period=0)).data
+    assert not np.isclose(fp_data, 20.0, atol=1.0).any(), (
+        "Lower-precedence partial input should not overwrite full input clusters"
+    )
+
+    # All clusters should be sourced from the higher-precedence full input.
+    expected_sources = {(cluster_idx, 0): "secondary_model_1" for cluster_idx in range(3)}
+    _assert_cluster_sources_attribute(result, expected_sources)
+
+
 def test_clusterandmatch_overlapping_forecast_periods():
     """Test handling of overlapping forecast periods with different precedence."""
     pytest.importorskip("kmedoids")


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/1244

Description
This PR builds on top of https://github.com/metoppv/improver/pull/2431. At the moment, there's an implicit assumption that inputs with a "partial" realization coverage will have a higher precedence than inputs with "full" realization coverage. This isn't necessarily true e.g. a nowcast ensemble could have the highest precedence and have full realization coverage. This PR therefore modifies the `RealizationClusterAndMatch` plugin, so that the partial realization coverage route checks the precedence before making an update, so that an input with partial realization coverage won't just automatically overwrite a higher precedence input with full realization coverage. This check is performed for each forecast period separately, so that if e.g. a nowcast is present a short leadtimes, but not longer leadtimes, the partial realization coverage input could still contribute when the nowcast is no longer available.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

