### PR TITLE
Correct realization numbering bug in temporal interpolation

### DIFF
--- a/improver/cli/forecast_trajectory_gap_filler.py
+++ b/improver/cli/forecast_trajectory_gap_filler.py
@@ -39,6 +39,9 @@ def process(
     forecast_period coordinates are increasing. The time and forecast_period coordinates
     should be associated with each other, so share a dimension if the input is an
     iris Cube.
+    Multi-realization cubes are supported for interpolation-only gap filling.
+    If source-transition regeneration is enabled via cluster_sources_attribute
+    and a regeneration window, inputs must be single-realization.
 
     Args:
         cubes (iris.cube.CubeList or iris.cube.Cube):
@@ -46,7 +49,10 @@ def process(
             coordinate, and increasing time and forecast_period coordinates. The
             time and forecast_period coordinates should be associated (share a
             dimension if a Cube). The input may have missing points in the
-            forecast trajectory.
+            forecast trajectory. Multi-realization cubes are supported for
+            interpolation-only gap filling. If source-transition regeneration
+            is enabled via cluster_sources_attribute and a regeneration window,
+            inputs must be single-realization.
         interval_in_minutes (int):
             The expected interval between points in the forecast trajectory (in
             minutes). Used to identify gaps in the sequence. If not provided,

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -1470,9 +1470,14 @@ class ForecastTrajectoryGapFiller(BasePlugin):
         if not cluster_sources:
             return []
 
-        # Get all realization indices
+        # Get all realization indices from the cube's realization coordinate values
         if first_cube.coords("realization"):
-            realization_indices = range(first_cube.coord("realization").points.size)
+            real_coord = first_cube.coord("realization")
+            # Handle both scalar and dimension coordinates
+            if real_coord.shape == ():  # scalar coordinate
+                realization_indices = [int(real_coord.points)]
+            else:
+                realization_indices = [int(r) for r in real_coord.points]
         else:
             return []
 

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -1445,7 +1445,14 @@ class ForecastTrajectoryGapFiller(BasePlugin):
         """Identify periods to regenerate based on cluster source transitions.
 
         Args:
-            cubelist: List of input cubes.
+            cubelist: List of input cubes. Only the first cube is used to read the
+            cluster-source metadata and the realization coordinate values. This is
+            sufficient because the source-transition logic is performed per
+            realization, and the realization index to inspect is taken from that
+            cube's realization metadata rather than from the cubelist length. In
+            the normal use case, each call to this method is made for a
+            single-realization input cube, so the first cube is effectively the
+            realization being evaluated.
 
         Returns:
             List of tuples (transition_period, expected_t0, expected_t1) where

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -1479,12 +1479,9 @@ class ForecastTrajectoryGapFiller(BasePlugin):
 
         # Get all realization indices from the cube's realization coordinate values
         if first_cube.coords("realization"):
-            real_coord = first_cube.coord("realization")
-            # Handle both scalar and dimension coordinates
-            if real_coord.shape == ():  # scalar coordinate
-                realization_indices = [int(real_coord.points)]
-            else:
-                realization_indices = [int(r) for r in real_coord.points]
+            realization_indices = (
+                first_cube.coord("realization").points.astype(int).tolist()
+            )
         else:
             return []
 
@@ -1595,7 +1592,7 @@ class ForecastTrajectoryGapFiller(BasePlugin):
                 or self.interpolation_window_by_source_pair_seconds
             )
             if regeneration_enabled and cube.coords("realization"):
-                n_realizations = len(cube.coord("realization").points)
+                n_realizations = cube.coord("realization").points.size
                 if n_realizations > 1:
                     raise ValueError(
                         "Regeneration mode (cluster_sources_attribute with "

--- a/improver/utilities/temporal_interpolation.py
+++ b/improver/utilities/temporal_interpolation.py
@@ -1569,6 +1569,8 @@ class ForecastTrajectoryGapFiller(BasePlugin):
             ValueError: If cubes do not have multiple, different
                 forecast_periods and times.
             ValueError: If cubes do not all have the same forecast_reference_time.
+            ValueError: If regeneration mode is enabled and any input cube
+                contains multiple realizations.
         """
         if not cubelist or len(cubelist) < 2:
             raise ValueError(
@@ -1585,6 +1587,22 @@ class ForecastTrajectoryGapFiller(BasePlugin):
                     f"All cubes must have {', '.join(required_coords)} "
                     f"coordinates for gap filling. Missing from cube: {missing}"
                 )
+
+            # Regeneration currently targets forecast periods globally rather
+            # than selecting periods per realization.
+            regeneration_enabled = self.cluster_sources_attribute is not None and (
+                self.interpolation_window_in_seconds is not None
+                or self.interpolation_window_by_source_pair_seconds
+            )
+            if regeneration_enabled and cube.coords("realization"):
+                n_realizations = len(cube.coord("realization").points)
+                if n_realizations > 1:
+                    raise ValueError(
+                        "Regeneration mode (cluster_sources_attribute with "
+                        "interpolation_window_in_minutes or "
+                        "interpolation_window_by_source_pair) currently "
+                        "requires single-realization input cubes."
+                    )
 
         # Extract forecast_periods, times, and forecast_reference_times from each cube
         forecast_periods = [
@@ -1868,6 +1886,10 @@ class ForecastTrajectoryGapFiller(BasePlugin):
                 All cubes should have the same validity time coordinate structure and
                 dimensions (except for forecast_period and time), and are expected to
                 all have the same forecast_reference_time.
+                Multi-realization cubes are supported for interpolation-only
+                gap filling. If source-transition regeneration is enabled via
+                cluster_sources_attribute and a regeneration window, inputs
+                must be single-realization.
 
         Returns:
             A single merged Cube with gaps filled using temporal interpolation.

--- a/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
+++ b/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
@@ -576,6 +576,39 @@ def test_process_triggers_source_transitions(input_hours, cluster_sources, expec
     )
 
 
+def test_identify_periods_to_regenerate_non_zero_realization_index():
+    """Test that no regeneration is triggered when the input cube's realization has
+    no source transition, even if another realization in cluster_sources does.
+
+    This guards against an off-by-one style bug where the realization coordinate
+    size (always 1 for a single-realization cube) is used as the index instead of
+    the actual realization value. For a cube carrying realization 2, size=1 would
+    cause the plugin to look up cluster_sources["0"] and incorrectly find the
+    transition that belongs to realization 0.
+    """
+    # Realization 0 has a UKV->MOGREPS-UK transition; realization 2 does not.
+    cluster_sources = {
+        "0": {"uk_det": [7200, 10800], "uk_ens": [14400, 18000]},
+        "2": {"uk_ens": [7200, 10800, 14400, 18000]},
+    }
+    # Build a cubelist for realization 2 only (no transition expected).
+    cubelist = setup_cubes_with_gaps(hours=[2, 3, 4, 5], realizations=[2])
+    for cube in cubelist:
+        cube.attributes["cluster_sources"] = json.dumps(cluster_sources)
+
+    plugin = ForecastTrajectoryGapFiller(
+        interval_in_minutes=60,
+        cluster_sources_attribute="cluster_sources",
+        interpolation_window_in_minutes=60,
+    )
+
+    periods_to_regenerate = plugin._identify_periods_to_regenerate(cubelist)
+    assert periods_to_regenerate == [], (
+        "Expected no regeneration periods for a realization with no source "
+        f"transition, but got: {periods_to_regenerate}"
+    )
+
+
 def test_identify_periods_to_regenerate_uses_source_pair_window_override():
     """Test source-pair window override is used when matching transition exists."""
     cubelist = setup_cubes_with_gaps(hours=[2, 3, 4, 5], realizations=[0])

--- a/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
+++ b/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
@@ -351,6 +351,22 @@ def test_validate_input_different_forecast_reference_time():
         plugin._validate_input(cubelist)
 
 
+def test_validate_input_regeneration_rejects_multi_realization_cube():
+    """Test _validate_input raises when regeneration mode gets multi-realization input."""
+    plugin = ForecastTrajectoryGapFiller(
+        interval_in_minutes=60,
+        cluster_sources_attribute="cluster_sources",
+        interpolation_window_in_minutes=60,
+    )
+    cubelist = setup_cubes_with_gaps(hours=[3, 6], realizations=[0, 1])
+
+    with pytest.raises(
+        ValueError,
+        match="Regeneration mode .* currently requires single-realization input cubes",
+    ):
+        plugin._validate_input(cubelist)
+
+
 @pytest.mark.parametrize(
     "parallel_backend,n_workers",
     [
@@ -612,12 +628,12 @@ def test_identify_periods_to_regenerate_none_identified():
 def test_identify_periods_to_regenerate_one_identified():
     """Test that regeneration is triggered when the input cube's realization has
     a source transition, even if another realization in cluster_sources does not."""
-    # Realization 0 has a UKV->MOGREPS-UK transition; realization 2 does not.
+    # Realization 2 has a UKV->MOGREPS-UK transition; realization 0 does not.
     cluster_sources = {
         "0": {"uk_ens": [7200, 10800, 14400, 18000]},
         "2": {"uk_det": [7200, 10800], "uk_ens": [14400, 18000]},
     }
-    # Build a cubelist for realization 2 only (no transition expected).
+    # Build a cubelist for realization 2 where a transition is expected.
     cubelist = setup_cubes_with_gaps(hours=[2, 3, 4, 5], realizations=[2])
     for cube in cubelist:
         cube.attributes["cluster_sources"] = json.dumps(cluster_sources)
@@ -629,6 +645,10 @@ def test_identify_periods_to_regenerate_one_identified():
     )
 
     periods_to_regenerate = plugin._identify_periods_to_regenerate(cubelist)
+    # The periods_to_regenerate is a list of tuples:
+    # (transition_period, expected_t0, expected_t1) where transition_period is the
+    # forecast period at the source transition, expected_t0 is (transition - window),
+    # and expected_t1 is (transition + window).
     assert periods_to_regenerate == [(10800, 7200, 14400)], (
         "Expected regeneration periods for a realization with a source "
         f"transition, but got: {periods_to_regenerate}"

--- a/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
+++ b/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
@@ -602,7 +602,7 @@ def test_identify_periods_to_regenerate_none_identified():
     cause the plugin to look up cluster_sources["0"] and incorrectly find the
     transition that belongs to realization 0.
     """
-    # Realization 0 has a UKV->MOGREPS-UK transition; realization 2 does not.
+    # Realization 0 has a uk_det->uk_ens transition; realization 2 does not.
     cluster_sources = {
         "0": {"uk_det": [7200, 10800], "uk_ens": [14400, 18000]},
         "2": {"uk_ens": [7200, 10800, 14400, 18000]},

--- a/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
+++ b/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
@@ -576,7 +576,7 @@ def test_process_triggers_source_transitions(input_hours, cluster_sources, expec
     )
 
 
-def test_identify_periods_to_regenerate_non_zero_realization_index():
+def test_identify_periods_to_regenerate_none_identified():
     """Test that no regeneration is triggered when the input cube's realization has
     no source transition, even if another realization in cluster_sources does.
 
@@ -605,6 +605,32 @@ def test_identify_periods_to_regenerate_non_zero_realization_index():
     periods_to_regenerate = plugin._identify_periods_to_regenerate(cubelist)
     assert periods_to_regenerate == [], (
         "Expected no regeneration periods for a realization with no source "
+        f"transition, but got: {periods_to_regenerate}"
+    )
+
+
+def test_identify_periods_to_regenerate_one_identified():
+    """Test that regeneration is triggered when the input cube's realization has
+    a source transition, even if another realization in cluster_sources does not."""
+    # Realization 0 has a UKV->MOGREPS-UK transition; realization 2 does not.
+    cluster_sources = {
+        "0": {"uk_ens": [7200, 10800, 14400, 18000]},
+        "2": {"uk_det": [7200, 10800], "uk_ens": [14400, 18000]},
+    }
+    # Build a cubelist for realization 2 only (no transition expected).
+    cubelist = setup_cubes_with_gaps(hours=[2, 3, 4, 5], realizations=[2])
+    for cube in cubelist:
+        cube.attributes["cluster_sources"] = json.dumps(cluster_sources)
+
+    plugin = ForecastTrajectoryGapFiller(
+        interval_in_minutes=60,
+        cluster_sources_attribute="cluster_sources",
+        interpolation_window_in_minutes=60,
+    )
+
+    periods_to_regenerate = plugin._identify_periods_to_regenerate(cubelist)
+    assert periods_to_regenerate == [(10800, 7200, 14400)], (
+        "Expected regeneration periods for a realization with a source "
         f"transition, but got: {periods_to_regenerate}"
     )
 

--- a/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
+++ b/improver_tests/utilities/test_ForecastTrajectoryGapFiller.py
@@ -628,7 +628,7 @@ def test_identify_periods_to_regenerate_none_identified():
 def test_identify_periods_to_regenerate_one_identified():
     """Test that regeneration is triggered when the input cube's realization has
     a source transition, even if another realization in cluster_sources does not."""
-    # Realization 2 has a UKV->MOGREPS-UK transition; realization 0 does not.
+    # Realization 2 has a uk_det->uk_ens transition; realization 0 does not.
     cluster_sources = {
         "0": {"uk_ens": [7200, 10800, 14400, 18000]},
         "2": {"uk_det": [7200, 10800], "uk_ens": [14400, 18000]},


### PR DESCRIPTION
Related https://github.com/metoppv/mo-blue-team/issues/1244

Description
This PR fixes a bug where, as realizations are processed separately through temporal interpolation, that whether a realization was being temporally interpolated or not was being controlled by the cluster_sources attribute for the zeroth realization only, rather than correctly selecting the appropriate realization. This meant that temporal interpolation was either being applied to all realizations, or to none. This was noticeable when "partial" realization inputs were being processed.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)