### PR TITLE
Improve cluster sources bookkeeping

### DIFF
--- a/improver/clustering/realization_clustering.py
+++ b/improver/clustering/realization_clustering.py
@@ -855,9 +855,10 @@ class RealizationClusterAndMatch(BasePlugin):
         """Update cluster sources tracking when replacing data from one model
         with another.
 
-        This method removes the forecast period from the primary input's tracking
-        and adds it to the secondary input for the specified clusters, maintaining a
-        record of which model provided data for each cluster at each forecast_period.
+        This method removes the forecast period from whichever model currently owns
+        the cluster and adds it to the incoming model for the specified clusters,
+        maintaining a record of the final source for each cluster at each forecast
+        period.
 
         Args:
             cluster_sources: Dictionary tracking which input was used for each
@@ -868,16 +869,15 @@ class RealizationClusterAndMatch(BasePlugin):
                 e.g. 'secondary_input1'.
             fp: Forecast period value in seconds.
         """
-        primary_name = self.hierarchy["primary_input"]
         for cluster_idx in cluster_indices:
             cluster_sources.setdefault(cluster_idx, {})
-            # Remove this forecast period from primary input
-            if primary_name in cluster_sources[cluster_idx]:
-                if fp in cluster_sources[cluster_idx][primary_name]:
-                    cluster_sources[cluster_idx][primary_name].remove(fp)
-                # Clean up empty lists
-                if not cluster_sources[cluster_idx][primary_name]:
-                    del cluster_sources[cluster_idx][primary_name]
+            # Remove this forecast period from any model currently recorded for
+            # this cluster before recording the replacement source.
+            for source_name in list(cluster_sources[cluster_idx].keys()):
+                if fp in cluster_sources[cluster_idx][source_name]:
+                    cluster_sources[cluster_idx][source_name].remove(fp)
+                    if not cluster_sources[cluster_idx][source_name]:
+                        del cluster_sources[cluster_idx][source_name]
             # Add to secondary input
             if candidate_name not in cluster_sources[cluster_idx]:
                 cluster_sources[cluster_idx][candidate_name] = []

--- a/improver_tests/clustering/test_realization_clustering.py
+++ b/improver_tests/clustering/test_realization_clustering.py
@@ -1774,6 +1774,92 @@ def test_clusterandmatch_global_precedence_full_over_partial():
     _assert_cluster_sources_attribute(result, expected_sources)
 
 
+def test_clusterandmatch_cluster_sources_are_replaced_on_partial_overwrite():
+    """A higher-precedence partial input should replace lower-precedence full sources.
+
+    The output data already reflects the overwrite, but this regression test checks
+    that cluster_sources is updated to remove the earlier source for the overwritten
+    forecast period rather than leaving both sources listed.
+    """
+    pytest.importorskip("kmedoids")
+
+    cubes = CubeList()
+    spatial_shape = (5, 5)
+
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=6,
+            forecast_periods=[0],
+            y_dim=spatial_shape[0],
+            x_dim=spatial_shape[1],
+            model_id="primary_model",
+            realization_values=[0.0, 0.2, 100.0, 100.2, 200.0, 200.2],
+            merge=False,
+        )
+    )
+
+    # Lower-precedence full input.
+    cubes.extend(
+        _create_4d_realization_cube(
+            n_realizations=3,
+            forecast_periods=[0],
+            y_dim=spatial_shape[0],
+            x_dim=spatial_shape[1],
+            model_id="secondary_model_1",
+            realization_values=[0.0, 100.0, 200.0],
+            merge=False,
+        )
+    )
+
+    # Higher-precedence partial deterministic input for the same forecast period.
+    det_cube = set_up_variable_cube(
+        np.full(spatial_shape, 20.0, dtype=np.float32),
+        name="air_temperature",
+        units="K",
+        spatial_grid="equalarea",
+    )
+    det_cube.attributes["model_id"] = "secondary_model_2"
+    det_cube.coord("forecast_period").points = [0]
+    det_cube.coord("time").points = [
+        det_cube.coord("forecast_reference_time").points[0]
+    ]
+    cubes.append(det_cube)
+
+    hierarchy = {
+        "primary_input": "primary_model",
+        "secondary_inputs": {
+            "secondary_model_2": [0],
+            "secondary_model_1": [0],
+        },
+    }
+
+    result = RealizationClusterAndMatch(
+        hierarchy=hierarchy,
+        model_id_attr="model_id",
+        clustering_method="KMedoids",
+        regrid_for_clustering=False,
+        n_clusters=3,
+        random_state=42,
+    ).process(cubes)
+
+    cluster_sources = json.loads(result.attributes["cluster_sources"])
+    fp0 = int(result.coord("forecast_period").points[0])
+
+    partial_clusters = []
+    for cluster_idx, sources in cluster_sources.items():
+        owners = [name for name, fps in sources.items() if fp0 in fps]
+        assert len(owners) == 1, (
+            f"Cluster {cluster_idx} at forecast period {fp0} still has multiple "
+            f"sources recorded: {owners}"
+        )
+        if owners[0] == "secondary_model_2":
+            partial_clusters.append(cluster_idx)
+
+    assert partial_clusters, "Expected the partial input to overwrite at least one cluster"
+    for cluster_idx in partial_clusters:
+        assert fp0 not in cluster_sources[cluster_idx].get("secondary_model_1", [])
+
+
 def test_clusterandmatch_overlapping_forecast_periods():
     """Test handling of overlapping forecast periods with different precedence."""
     pytest.importorskip("kmedoids")


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/1244

Description
This builds on https://github.com/metoppv/improver/pull/2431 and https://github.com/metoppv/improver/pull/2435. Only [this commit](https://github.com/metoppv/improver/commit/fbfc5541f840b995af6394207ecab1206b21b4b0) is actually relevant. This PR modifies the bookkeeping of the cluster_sources attribute within the RealizationClusterAndMatch plugin, so that a given forecast_period only appears in one forecast source, rather than below where 3600 appears in multiple forecast sources. This can cause an issue later, within the temporal interpolation, if there are more than two forecast sources, as it's not clear what we should be temporally interpolating between.

> {'ecgl_ens': [np.int32(691200), np.int32(734400), np.int32(777600), np.int32(820800), np.int32(864000), np.int32(907200), np.int32(950400), np.int32(993600), np.int32(1036800), np.int32(1080000), np.int32(1123200), np.int32(1166400), np.int32(1209600), np.int32(1252800)], 'gl_ens': [475200, 518400, 561600, 604800, 648000], 'uk_ens': [3600, 21600, 43200, 86400, 129600, 172800, 216000, 259200, 302400, 345600, 388800, 432000], 'uk_det': [3600, 21600], 'nc_det uk_det': [3600]}

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

