### PR TITLE
Allow the Extract CLI to return None upon extraction failure

### DIFF
--- a/improver/cli/extract.py
+++ b/improver/cli/extract.py
@@ -17,6 +17,7 @@ def process(
     constraints: parameters.multi(min=1),
     units: cli.comma_separated_list = None,
     ignore_failure=False,
+    return_none_on_failure=False,
 ):
     """Extract a subset of a single cube.
 
@@ -46,6 +47,9 @@ def process(
         ignore_failure (bool):
             Option to ignore constraint match failure and return the input
             cube.
+        return_none_on_failure (bool):
+            Option to ignore constraint match failure and return None without
+            writing an output file.
 
     Returns:
         iris.cube.Cube:
@@ -54,6 +58,11 @@ def process(
     """
     from improver.utilities.cube_extraction import ExtractSubCube
 
-    plugin = ExtractSubCube(constraints, units=units, ignore_failure=ignore_failure)
+    plugin = ExtractSubCube(
+        constraints,
+        units=units,
+        ignore_failure=ignore_failure,
+        return_none_on_failure=return_none_on_failure,
+    )
     result = plugin.process(cube)
     return result

--- a/improver/utilities/cube_extraction.py
+++ b/improver/utilities/cube_extraction.py
@@ -281,6 +281,7 @@ class ExtractSubCube(BasePlugin):
         units: Optional[List[str]] = None,
         use_original_units: bool = True,
         ignore_failure: bool = False,
+        return_none_on_failure: bool = False,
     ) -> None:
         """
         Set up the ExtractSubCube plugin.
@@ -301,11 +302,20 @@ class ExtractSubCube(BasePlugin):
             ignore_failure:
                 Option to ignore constraint match failure and return the input
                 cube.
+            return_none_on_failure:
+                Option to ignore constraint match failure and return None instead of
+                the input cube.
         """
+        if ignore_failure and return_none_on_failure:
+            raise ValueError(
+                "ignore_failure and return_none_on_failure are mutually exclusive"
+            )
+
         self._constraints = constraints
         self._units = units
         self._use_original_units = use_original_units
         self._ignore_failure = ignore_failure
+        self._return_none_on_failure = return_none_on_failure
 
     def process(self, cube: Cube):
         """Perform the subcube extraction.
@@ -325,9 +335,11 @@ class ExtractSubCube(BasePlugin):
             cube, self._constraints, self._units, self._use_original_units
         )
         if res is None:
-            res = cube
-            if not self._ignore_failure:
-                raise ValueError("Constraint(s) could not be matched in input cube")
+            if self._ignore_failure:
+                return cube
+            if self._return_none_on_failure:
+                return None
+            raise ValueError("Constraint(s) could not be matched in input cube")
         return res
 
 
@@ -496,7 +508,7 @@ class ExtractLevel(BasePlugin):
             )
         else:
             template_cube.rename(
-                "height_at_" f"{self.value_of_level}{variable_on_levels.units}"
+                f"height_at_{self.value_of_level}{variable_on_levels.units}"
             )
 
         template_cube.units = variable_on_levels.coord(self.coordinate).units

--- a/improver_tests/acceptance/test_extract.py
+++ b/improver_tests/acceptance/test_extract.py
@@ -26,6 +26,40 @@ def test_basic(tmp_path):
     acc.compare(output_path, kgo_path)
 
 
+def test_ignore_failure(tmp_path):
+    """Test extraction with ignore failure"""
+    kgo_dir = acc.kgo_root() / "extract/basic"
+    input_path = kgo_dir / "input.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        "--constraints",
+        "realization=6",
+        "--ignore-failure",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    acc.compare(output_path, input_path, exclude_attributes=["calendar"])
+
+
+def test_return_none_on_failure(tmp_path):
+    """Test extraction with return none on failure"""
+    kgo_dir = acc.kgo_root() / "extract/basic"
+    input_path = kgo_dir / "input.nc"
+    output_path = tmp_path / "output.nc"
+    args = [
+        input_path,
+        "--constraints",
+        "realization=6",
+        "--return-none-on-failure",
+        "--output",
+        output_path,
+    ]
+    run_cli(args)
+    assert not output_path.exists()
+
+
 def test_change_units(tmp_path):
     """Test extraction and unit conversion"""
     kgo_dir = acc.kgo_root() / "extract/change_units"

--- a/improver_tests/utilities/cube_extraction/test_ExtractSubCube.py
+++ b/improver_tests/utilities/cube_extraction/test_ExtractSubCube.py
@@ -46,3 +46,21 @@ def test_no_matching_constraint_ignore():
     src_cube = Cube(0)
     res = plugin(src_cube)
     assert res is src_cube
+
+
+def test_no_matching_constraint_return_none():
+    """Test that None is returned when no constraints match and silent failure requested."""
+    plugin = ExtractSubCube(["dummy_name=dummy_value"], return_none_on_failure=True)
+    src_cube = Cube(0)
+    res = plugin(src_cube)
+    assert res is None
+
+
+def test_no_matching_constraint_conflicting_failures_invalid():
+    """Test that conflicting failure-handling options are rejected."""
+    with pytest.raises(ValueError, match="return_none_on_failure"):
+        ExtractSubCube(
+            ["dummy_name=dummy_value"],
+            ignore_failure=True,
+            return_none_on_failure=True,
+        )


### PR DESCRIPTION
Description
This PR adds an extra option to the Extract CLI, so that an extraction failure can return None. This is in contrast to the existing argument `ignore_failure`, which supports returning the input cube. Using the `return_none_on_failure` argument can be helpful, when you don't want the processing to continue, if the constraint fails, and returning the input cube doesn't make sense given the context.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
