### PR TITLE
Update blend-times  / FRTs for inputs to veravis

### DIFF
--- a/improver/visibility/visibility_combine_cloud_base.py
+++ b/improver/visibility/visibility_combine_cloud_base.py
@@ -11,6 +11,7 @@ from iris.cube import Cube, CubeList
 
 from improver import PostProcessingPlugin
 from improver.cube_combiner import Combine
+from improver.metadata.forecast_times import rebadge_forecasts_as_latest_cycle
 from improver.metadata.probabilistic import (
     find_threshold_coordinate,
     is_probability,
@@ -162,6 +163,11 @@ class VisibilityCombineCloudBase(PostProcessingPlugin):
         """
 
         visibility_cube, cloud_base_ground_cube = self.separate_input_cubes(cubes)
+        # Update forecast reference time and blend time to the latest of the two
+        # input cubes.
+        visibility_cube, cloud_base_ground_cube = rebadge_forecasts_as_latest_cycle(
+            [visibility_cube, cloud_base_ground_cube]
+        )
 
         for cube in [visibility_cube, cloud_base_ground_cube]:
             if not is_probability(cube):


### PR DESCRIPTION
Force the two diagnostics being combined in constructing visibilities to share a forecast reference time and blend time so that the output reflects the latest of these from the inputs.

After making changes in https://github.com/MetOffice/improver_suite/pull/2809 to fix an operational issue, the change was pushed into the BBC patch test suites running under ppdev. This led to a failure in the `build_forecast_tables` step.

https://cylchub/services/cylc-review/view/ppdev?&suite=bbc_patch%2Fimmix&no_fuzzy_time=0&path=log/job/20260828T2345Z/build_forecast_tables/03/job.err

This is a result of a vera-visibility output being constructed from `visnocld` and `cldbase10m4p5` inputs from cycles either side of midnight; the `visnocld` input being from before midnight. It is the vis input that is used to define the metadata of the output, including the forecast reference time / blend time. As a result, despite the diagnostic being updated in an e.g. 0015Z cycle on the 28th August, the `veravis` output has an e.g. 2345Z cycle on the 27th as its reference time. This gets spot extracted and converted to a parquet table in the `build_forecast_tables` step. Finally, the `build_calibration_tables` step ingests the whole day's worth of data for the 28th August, and as part of that ensures that only data from that day is being ingested. The data that has been updated on the 28th but labelled as the 27th causes this check to fail.

The solution is to ensure that any new `veravis` output created uses the newest of the input forecast reference times / blend times from the inputs, as we do elsewhere when combining diagnositcs.

Testing:

- [x] Ran tests and they passed OK
- [ ] Added new tests for the new feature(s) [covered by existing tests for the function used].

## Example

From the suite that failed above I have taken some data for testing. This doesn't actually span midnight, but it shows the same issue relating to the FRT / blend time coordinates.

vis input:
```
probability_of_visibility_in_air_below_threshold / (1) (visibility_in_air: 44; projection_y_coordinate: 970; projection_x_coordinate: 1042)
    Dimension coordinates:
        ...
    Scalar coordinates:
        blend_time                                     2026-08-29 00:00:00
        forecast_period                                320400 seconds
        forecast_reference_time                        2026-08-29 00:00:00
        height                                         1.5 m
        time                                           2026-09-01 17:00:00
    ...
```

cloud input:
```
probability_of_cloud_base_height_assuming_only_consider_cloud_area_fraction_greater_than_4p5_oktas_below_threshold / (1) (projection_y_coordinate: 970; projection_x_coordinate: 1042)
    Dimension coordinates:
        ...                                                                                                                -                             x
    Scalar coordinates:
        blend_time                                     2026-08-29 00:15:00
        cloud_base_height_assuming...                  10.0 m
        forecast_period                                319500 seconds
        forecast_reference_time                        2026-08-29 00:15:00
        time                                           2026-09-01 17:00:00
    ...
```

output without this change:
```
probability_of_visibility_in_air_below_threshold / (1) (visibility_in_air: 44; projection_y_coordinate: 970; projection_x_coordinate: 1042)
    Dimension coordinates:
        ...
    Scalar coordinates:
        blend_time                                     2026-08-29 00:00:00
        forecast_period                                320400 seconds
        forecast_reference_time                        2026-08-29 00:00:00
        height                                         1.5 m
        time                                           2026-09-01 17:00:00
    ...
```

output with this change:
```
probability_of_visibility_in_air_below_threshold / (1) (visibility_in_air: 44; projection_y_coordinate: 970; projection_x_coordinate: 1042)
    Dimension coordinates:
        ...
    Scalar coordinates:
        blend_time                                     2026-08-29 00:15:00
        forecast_period                                319500 seconds
        forecast_reference_time                        2026-08-29 00:15:00
        height                                         1.5 m
        time                                           2026-09-01 17:00:00
    ...
```